### PR TITLE
WIP: RFC8701 Support

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -23,6 +23,7 @@ default = ["logging"]
 logging = ["log"]
 dangerous_configuration = []
 quic = []
+grease = []
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/rustls/src/client/grease.rs
+++ b/rustls/src/client/grease.rs
@@ -1,0 +1,49 @@
+//! Implement [RFC8701](https://tools.ietf.org/html/rfc8701)
+//!
+//! This module provides two implementations of RFC8701: one which effectively represents
+//! disabling GREASE and another which chooses a single GREASE value for each supported field.
+
+use crate::msgs::enums::CipherSuite;
+use crate::rand;
+
+/// Generate a GREASE cipher of the the form 0xRaRa, where R is random.
+fn generate_grease_cipher_suite() -> CipherSuite {
+    // Generate the lower byte of a u16 in the form 0xRa, where R is a uniformly random
+    // four bits. Then, copy the lower byte to the upper byte to get 0xRaRa.
+    let low: u16 = (rand::random_u8().overflowing_shl(4).0 | 0x0a) as u16;
+    CipherSuite::Unknown(low | low << 8)
+}
+
+// Use the `grease` feature flag to determine whether GREASE is enabled by default.
+#[cfg(not(feature = "grease"))]
+pub type DefaultGreaseGenerator = NoGrease;
+#[cfg(feature = "grease")]
+pub type DefaultGreaseGenerator = SingleGreaseEntry;
+
+/// Abstracts over multiple implementations of RFC8701, allowing these implementations to be
+/// configured by the user.
+pub trait GreaseGenerator: Send + Sync {
+    /// Generate the initial ciphers of the ClientHello cipher list, choosing zero or more GREASE
+    /// ciphers for inclusion.
+    fn cipher_suites(&self) -> Vec<CipherSuite>;
+}
+
+/// Do not add any GREASE values. Using this implementation effectively disables GREASE.
+#[derive(Clone, Default)]
+pub struct NoGrease {}
+
+impl GreaseGenerator for NoGrease {
+    fn cipher_suites(&self) -> Vec<CipherSuite> {
+        Vec::new()
+    }
+}
+
+/// Prepend a single GREASE value before all other entries.
+#[derive(Clone, Default)]
+pub struct SingleGreaseEntry {}
+
+impl GreaseGenerator for SingleGreaseEntry {
+    fn cipher_suites(&self) -> Vec<CipherSuite> {
+        vec![generate_grease_cipher_suite()]
+    }
+}

--- a/rustls/src/client/grease.rs
+++ b/rustls/src/client/grease.rs
@@ -3,15 +3,17 @@
 //! This module provides two implementations of RFC8701: one which effectively represents
 //! disabling GREASE and another which chooses a single GREASE value for each supported field.
 
-use crate::msgs::enums::CipherSuite;
+use crate::msgs::base::Payload;
+use crate::msgs::enums::{CipherSuite, ExtensionType};
+use crate::msgs::handshake::{ClientExtension, UnknownExtension};
 use crate::rand;
 
-/// Generate a GREASE cipher of the the form 0xRaRa, where R is random.
-fn generate_grease_cipher_suite() -> CipherSuite {
+/// Generate a GREASE value of the form 0xRaRa, where R is random.
+fn generate_grease_value() -> u16 {
     // Generate the lower byte of a u16 in the form 0xRa, where R is a uniformly random
     // four bits. Then, copy the lower byte to the upper byte to get 0xRaRa.
     let low: u16 = (rand::random_u8().overflowing_shl(4).0 | 0x0a) as u16;
-    CipherSuite::Unknown(low | low << 8)
+    low | low << 8
 }
 
 // Use the `grease` feature flag to determine whether GREASE is enabled by default.
@@ -25,6 +27,12 @@ pub type DefaultGreaseGenerator = BoringGrease;
 pub trait GreaseGenerator: Send + Sync {
     /// Add zero or more GREASE ciphers to the list of cipher suites, returning the updated list.
     fn cipher_suites(&self, ciphers: Vec<CipherSuite>) -> Vec<CipherSuite>;
+
+    /// Add zero or more GREASE ciphers to the list of cipher values, returning the updated list.
+    ///
+    /// Implementations must preserve the property that the PSK extension is in the final position
+    /// of the list. This extension is required to always be last.
+    fn client_extensions(&self, extensions: Vec<ClientExtension>) -> Vec<ClientExtension>;
 }
 
 /// Do not add any GREASE values. Using this implementation effectively disables GREASE.
@@ -35,6 +43,10 @@ impl GreaseGenerator for NoGrease {
     fn cipher_suites(&self, ciphers: Vec<CipherSuite>) -> Vec<CipherSuite> {
         ciphers
     }
+
+    fn client_extensions(&self, extensions: Vec<ClientExtension>) -> Vec<ClientExtension> {
+        extensions
+    }
 }
 
 /// Mimics BoringSSL's GREASE implementation choices.
@@ -44,14 +56,52 @@ pub struct BoringGrease {}
 impl GreaseGenerator for BoringGrease {
     /// Insert a single GREASE cipher value at the start of the cipher suites list.
     fn cipher_suites(&self, mut ciphers: Vec<CipherSuite>) -> Vec<CipherSuite> {
-        ciphers.insert(0, generate_grease_cipher_suite());
+        ciphers.insert(0, CipherSuite::Unknown(generate_grease_value()));
         ciphers
+    }
+
+    /// Insert an empty GREASE extension at the start of the extensions list. Insert a non-empty
+    /// GREASE extension at the end of the extensions list.
+    ///
+    /// The chosen values of this implementation are not uniformly random.
+    fn client_extensions(&self, mut extensions: Vec<ClientExtension>) -> Vec<ClientExtension> {
+        let ext1 = generate_grease_value();
+        let mut ext2 = generate_grease_value();
+
+        // Duplicate extensions are now allowed. BoringSSL handles this by XORing the second
+        // extension by a constant to achieve a unique GREASE value.
+        // This has the advantage of being easy to compute, but the disadvantage of not being
+        // uniformly random.
+        if ext1 == ext2 {
+            ext2 ^= 0x1010;
+        }
+
+        extensions.insert(
+            0,
+            ClientExtension::Unknown(UnknownExtension {
+                typ: ExtensionType::Unknown(ext1),
+                payload: Payload(Vec::new()),
+            }),
+        );
+
+        let non_empty_extension = ClientExtension::Unknown(UnknownExtension {
+            typ: ExtensionType::Unknown(ext2),
+            payload: Payload(vec![0]),
+        });
+        if let Some(ClientExtension::PresharedKey(_)) = extensions.last() {
+            extensions.insert(extensions.len() - 1, non_empty_extension)
+        } else {
+            extensions.push(non_empty_extension)
+        }
+
+        extensions
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::msgs::handshake::{PresharedKeyBinders, PresharedKeyIdentities, PresharedKeyOffer};
 
     #[test]
     fn no_grease_does_not_modify_ciphers() {
@@ -73,5 +123,77 @@ mod tests {
             false
         });
         assert_eq!(modified_ciphers[1], ciphers[0]);
+    }
+
+    #[test]
+    fn no_grease_does_not_modify_extensions() {
+        let extensions = vec![ClientExtension::EarlyData];
+        let grease = NoGrease::default();
+        assert_eq!(grease.client_extensions(extensions.clone()).len(), 1);
+    }
+
+    #[test]
+    fn boring_grease_prepends_empty_ext_appends_nonempty_ext() {
+        let extensions = vec![ClientExtension::EarlyData];
+        let grease = BoringGrease::default();
+
+        let modified_extensions = grease.client_extensions(extensions.clone());
+        assert_eq!(modified_extensions.len(), 3);
+        assert!(
+            if let ClientExtension::Unknown(_) = modified_extensions[0] {
+                true
+            } else {
+                false
+            }
+        );
+        assert!(
+            if let ClientExtension::Unknown(_) = modified_extensions[2] {
+                true
+            } else {
+                false
+            }
+        );
+    }
+
+    #[test]
+    fn boring_grease_preserves_psk_placement() {
+        let extensions = vec![
+            ClientExtension::EarlyData,
+            ClientExtension::PresharedKey(PresharedKeyOffer {
+                identities: PresharedKeyIdentities::default(),
+                binders: PresharedKeyBinders::default(),
+            }),
+        ];
+        let grease = BoringGrease::default();
+
+        let modified_extensions = grease.client_extensions(extensions.clone());
+        assert_eq!(modified_extensions.len(), 4);
+        assert!(
+            if let ClientExtension::Unknown(_) = modified_extensions[0] {
+                true
+            } else {
+                false
+            }
+        );
+        assert!(if let ClientExtension::EarlyData = modified_extensions[1] {
+            true
+        } else {
+            false
+        });
+        assert!(
+            if let ClientExtension::Unknown(_) = modified_extensions[2] {
+                true
+            } else {
+                false
+            }
+        );
+        assert!(
+            if let ClientExtension::PresharedKey(_) = modified_extensions[3] {
+                true
+            } else {
+                false
+            },
+            "PresharedKey extension was not the final extension"
+        );
     }
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -257,6 +257,9 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
         false
     };
 
+    // Insert GREASE values into extensions list
+    exts = sess.config.grease.client_extensions(exts);
+
     // Note what extensions we sent.
     hello.sent_extensions = exts.iter()
         .map(ClientExtension::get_type)

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -258,7 +258,7 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
     };
 
     // Insert GREASE values into extensions list
-    exts = sess.config.grease.client_extensions(exts);
+    sess.config.grease.client_extensions(&mut exts);
 
     // Note what extensions we sent.
     hello.sent_extensions = exts.iter()

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -29,6 +29,7 @@ mod hs;
 mod tls12;
 mod tls13;
 mod common;
+pub mod grease;
 pub mod handy;
 
 /// A trait for the ability to store client session data.
@@ -84,6 +85,9 @@ pub trait ResolvesClientCert : Send + Sync {
 pub struct ClientConfig {
     /// List of ciphersuites, in preference order.
     pub ciphersuites: Vec<&'static SupportedCipherSuite>,
+
+    /// Configurable GREASE implementation.
+    pub grease: Arc<dyn grease::GreaseGenerator>,
 
     /// Collection of root certificates.
     pub root_store: anchors::RootCertStore,
@@ -150,6 +154,7 @@ impl ClientConfig {
     pub fn new() -> ClientConfig {
         ClientConfig {
             ciphersuites: ALL_CIPHERSUITES.to_vec(),
+            grease: Arc::new(grease::DefaultGreaseGenerator::default()),
             root_store: anchors::RootCertStore::empty(),
             alpn_protocols: Vec::new(),
             session_persistence: handy::ClientSessionMemoryCache::new(32),
@@ -402,7 +407,8 @@ impl ClientSessionImpl {
     }
 
     pub fn get_cipher_suites(&self) -> Vec<CipherSuite> {
-        let mut ret = Vec::new();
+        // Initialize cipher suites with GREASE values based on the configured implementation.
+        let mut ret = self.config.grease.cipher_suites();
 
         for cs in &self.config.ciphersuites {
             ret.push(cs.suite);

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -416,7 +416,7 @@ impl ClientSessionImpl {
         // We don't do renegotation at all, in fact.
         ret.push(CipherSuite::TLS_EMPTY_RENEGOTIATION_INFO_SCSV);
 
-        let ret = self.config.grease.cipher_suites(ret);
+        self.config.grease.cipher_suites(&mut ret);
 
         ret
     }

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -407,8 +407,7 @@ impl ClientSessionImpl {
     }
 
     pub fn get_cipher_suites(&self) -> Vec<CipherSuite> {
-        // Initialize cipher suites with GREASE values based on the configured implementation.
-        let mut ret = self.config.grease.cipher_suites();
+        let mut ret = Vec::new();
 
         for cs in &self.config.ciphersuites {
             ret.push(cs.suite);
@@ -416,6 +415,8 @@ impl ClientSessionImpl {
 
         // We don't do renegotation at all, in fact.
         ret.push(CipherSuite::TLS_EMPTY_RENEGOTIATION_INFO_SCSV);
+
+        let ret = self.config.grease.cipher_suites(ret);
 
         ret
     }

--- a/rustls/src/rand.rs
+++ b/rustls/src/rand.rs
@@ -21,6 +21,13 @@ pub fn random_vec(len: usize) -> Vec<u8> {
     v
 }
 
+/// Return a uniformly random u8.
+pub fn random_u8() -> u8 {
+    let mut buf = [0u8; 1];
+    fill_random(&mut buf);
+    buf[0]
+}
+
 /// Return a uniformly random u32.
 pub fn random_u32() -> u32 {
     let mut buf = [0u8; 4];


### PR DESCRIPTION
Implementation of RFC8701 supporting the "client ciphers list" and "client extensions" fields. I've attempted to mirror the implementation choices of BoringSSL in my implementation, but the code is modular to allow swapping in alternative implementations if desired.

Discussion in #357.