### PR TITLE
Add TLS Certificate Compression (RFC8879) - v2

### DIFF
--- a/bogo/check.py
+++ b/bogo/check.py
@@ -33,15 +33,15 @@ if disabled_tests:
     for disabled_glob in sorted(config['DisabledTests'].keys()):
         tests_matching_glob = fnmatch.filter(disabled_tests, disabled_glob)
         if not tests_matching_glob:
-            print 'DisabledTests glob', disabled_glob, 'matches no tests'
+            print('DisabledTests glob', disabled_glob, 'matches no tests')
 else:
-    print '(DisabledTests unchecked)'
+    print('(DisabledTests unchecked)')
 
-print len(all_tests), 'total tests'
-print len(passed_tests), 'passed'
-print len(failing_tests), 'tests failing'
-print len(unimpl_tests), 'tests not supported'
+print(len(all_tests), 'total tests')
+print(len(passed_tests), 'passed')
+print(len(failing_tests), 'tests failing')
+print(len(unimpl_tests), 'tests not supported')
 
 if test_error_set:
-    print 'unknown TestErrorMap keys', test_error_set
+    print('unknown TestErrorMap keys', test_error_set)
 

--- a/bogo/config.json
+++ b/bogo/config.json
@@ -30,8 +30,6 @@
     "EchoTLS13CompatibilitySessionID": "",
     "ClientOCSPCallback*": "ocsp not supported yet",
     "ServerOCSPCallback*": "",
-    "CertCompression*": "not implemented",
-    "DuplicateCertCompressionExt*": "",
     "ECH-*": "",
     "ALPS-*": "",
     "ExtraClientEncryptedExtension-TLS-TLS13": "uses ALPS",
@@ -135,6 +133,11 @@
     ":ENCRYPTED_LENGTH_TOO_LONG:": ":GARBAGE:"
   },
   "TestErrorMap": {
+    "CertCompressionTooLargeClient-TLS13": ":CERT_DECOMPRESSION_FAILED:",
+    "DuplicateCertCompressionExt-TLS12": ":PEER_MISBEHAVIOUR:",
+    "DuplicateCertCompressionExt2-TLS12": ":PEER_MISBEHAVIOUR:",
+    "DuplicateCertCompressionExt-TLS13": ":PEER_MISBEHAVIOUR:",
+    "DuplicateCertCompressionExt2-TLS13": ":PEER_MISBEHAVIOUR:",
     "EmptyCertificateList": ":NO_CERTS:",
     "SendInvalidRecordType": ":GARBAGE:",
     "NoSharedCipher": ":HANDSHAKE_FAILURE:",

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -294,6 +294,21 @@ fn emit_client_hello_for_retry(
         exts.push(ClientExtension::PresharedKeyModes(psk_modes));
     }
 
+    if support_tls13
+        && !conn
+            .config
+            .certificate_compression_algorithms
+            .is_empty()
+    {
+        exts.push(ClientExtension::CompressCertificate(
+            conn.config
+                .certificate_compression_algorithms
+                .iter()
+                .map(|v| v.alg)
+                .collect(),
+        ))
+    }
+
     if !conn.config.alpn_protocols.is_empty() {
         exts.push(ClientExtension::Protocols(ProtocolNameList::from_slices(
             &conn

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -1,3 +1,4 @@
+use crate::compression::CertificateCompression;
 use crate::conn::{
     Connection, ConnectionCommon, IoState, MessageType, PlaintextSink, Reader, Writer,
 };
@@ -108,6 +109,10 @@ pub struct ClientConfig {
     /// How to decide what client auth certificate/keys to use.
     pub client_auth_cert_resolver: Arc<dyn ResolvesClientCert>,
 
+    /// Certificate compression algorithms.
+    /// If None, certificate compression won't be enabled
+    pub certificate_compression_algorithms: Vec<Arc<CertificateCompression>>,
+
     /// Whether to support RFC5077 tickets.  You must provide a working
     /// `session_persistence` member for this to have any meaningful
     /// effect.
@@ -189,6 +194,7 @@ impl ClientConfig {
             session_persistence: handy::ClientSessionMemoryCache::new(32),
             mtu: None,
             client_auth_cert_resolver: Arc::new(handy::FailResolveClientCert {}),
+            certificate_compression_algorithms: Vec::new(),
             enable_tickets: true,
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
             enable_sni: true,

--- a/rustls/src/compression.rs
+++ b/rustls/src/compression.rs
@@ -1,0 +1,55 @@
+//! Compression related operations
+
+use crate::msgs::enums::CertificateCompressionAlgorithm;
+use std::io::Result;
+
+/// A certificate compression algorithm described
+/// as a pair of compression and decompression
+/// functions used to compress and decompress a certificate
+pub struct CertificateCompression {
+    /// compression algorithm
+    pub alg: CertificateCompressionAlgorithm,
+
+    /// compression function
+    pub compress: CertificateCompress,
+
+    /// decompression function
+    pub decompress: CertificateDecompress,
+}
+
+type CompressionFn = Box<dyn (Fn(Vec<u8>, &[u8]) -> Result<Vec<u8>>) + Send + Sync>;
+
+/// A compression function which returns the compressed representation
+/// of the input
+pub struct CertificateCompress(CompressionFn);
+
+impl CertificateCompress {
+    /// Create a new CertificateCompress
+    pub fn new(compression_fn: CompressionFn) -> Self {
+        Self(compression_fn)
+    }
+
+    /// Call the compression function
+    pub(crate) fn compress(&self, writer: Vec<u8>, input: &[u8]) -> Result<Vec<u8>> {
+        self.0(writer, input)
+    }
+}
+
+type DecompressionFn = CompressionFn;
+
+/// A decompression function which returns the decompressed representation
+/// of the input. The input to this function is a pre-allocated vector
+/// of the expected length of the uncompressed input
+pub struct CertificateDecompress(DecompressionFn);
+
+impl CertificateDecompress {
+    /// Create a new CertificateDecompress
+    pub fn new(decompression_fn: DecompressionFn) -> Self {
+        Self(decompression_fn)
+    }
+
+    /// Call the decompression function
+    pub(crate) fn decompress(&self, writer: Vec<u8>, input: &[u8]) -> Result<Vec<u8>> {
+        self.0(writer, input)
+    }
+}

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -6,6 +6,7 @@ use crate::log::{debug, error, trace, warn};
 use crate::msgs::base::Payload;
 use crate::msgs::codec::Codec;
 use crate::msgs::deframer::MessageDeframer;
+use crate::msgs::enums::CertificateCompressionAlgorithm;
 use crate::msgs::enums::{AlertDescription, AlertLevel, ContentType, ProtocolVersion};
 use crate::msgs::fragmenter::{MessageFragmenter, MAX_FRAGMENT_LEN};
 use crate::msgs::hsjoiner::HandshakeJoiner;
@@ -565,6 +566,7 @@ pub struct ConnectionCommon {
     received_plaintext: ChunkVecBuffer,
     sendable_plaintext: ChunkVecBuffer,
     pub sendable_tls: ChunkVecBuffer,
+    pub certificate_compression_algorithm: Option<CertificateCompressionAlgorithm>,
     /// Protocol whose key schedule should be used. Unused for TLS < 1.3.
     pub protocol: Protocol,
     #[cfg(feature = "quic")]
@@ -591,6 +593,7 @@ impl ConnectionCommon {
             received_plaintext: ChunkVecBuffer::new(),
             sendable_plaintext: ChunkVecBuffer::new(),
             sendable_tls: ChunkVecBuffer::new(),
+            certificate_compression_algorithm: None,
             protocol: Protocol::Tls13,
             #[cfg(feature = "quic")]
             quic: Quic::new(),

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -95,6 +95,15 @@ pub enum Error {
     /// We failed to acquire random bytes from the system.
     FailedToGetRandomBytes,
 
+    /// We failed to perform certificate decompression
+    FailedCertificateDecompression,
+
+    /// We failed to perform certificate compression
+    FailedCertificateCompression,
+
+    /// Unknown certificate compression algorithm
+    UnknownCertCompressionAlg,
+
     /// This function doesn't work until the TLS handshake
     /// is complete.
     HandshakeNotComplete,
@@ -153,6 +162,15 @@ impl fmt::Display for Error {
             Error::InvalidSct(ref err) => write!(f, "invalid certificate timestamp: {:?}", err),
             Error::FailedToGetCurrentTime => write!(f, "failed to get current time"),
             Error::FailedToGetRandomBytes => write!(f, "failed to get random bytes"),
+            Error::FailedCertificateDecompression => {
+                write!(f, "failed to decompress certificate")
+            }
+            Error::FailedCertificateCompression => {
+                write!(f, "failed to compress certificate")
+            }
+            Error::UnknownCertCompressionAlg => {
+                write!(f, "unknown certificate compression algorithm")
+            }
             Error::General(ref err) => write!(f, "unexpected error: {}", err), // (please file a bug)
         }
     }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -19,6 +19,7 @@
 //! * TLS1.2 resumption via tickets ([RFC5077](https://tools.ietf.org/html/rfc5077)).
 //! * TLS1.3 resumption via tickets or session storage.
 //! * TLS1.3 0-RTT data for clients.
+//! * TLS1.3 certificate compression.
 //! * Client authentication by clients.
 //! * Client authentication by servers.
 //! * Extended master secret support ([RFC7627](https://tools.ietf.org/html/rfc7627)).
@@ -267,6 +268,7 @@ mod x509;
 mod check;
 mod bs_debug;
 mod client;
+mod compression;
 mod key;
 mod keylog;
 mod kx;
@@ -289,6 +291,7 @@ pub use crate::client::handy::{ClientSessionMemoryCache, NoClientSessionStorage}
 pub use crate::client::ResolvesClientCert;
 pub use crate::client::StoresClientSessions;
 pub use crate::client::{ClientConfig, ClientConnection, WriteEarlyData};
+pub use crate::compression::{CertificateCompress, CertificateCompression, CertificateDecompress};
 pub use crate::conn::{Connection, Reader, Writer};
 pub use crate::error::Error;
 pub use crate::error::WebPkiOp;
@@ -311,6 +314,7 @@ pub use crate::ticketer::Ticketer;
 pub use crate::verify::{
     AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
 };
+pub use msgs::enums::CertificateCompressionAlgorithm;
 
 /// All defined ciphersuites appear in this module.
 ///

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -122,6 +122,7 @@ enum_builder! {
         CertificateURL => 0x15,
         CertificateStatus => 0x16,
         KeyUpdate => 0x18,
+        CompressedCertificate => 0x19,
         MessageHash => 0xfe
     }
 }
@@ -221,6 +222,7 @@ enum_builder! {
         SCT => 0x0012,
         Padding => 0x0015,
         ExtendedMasterSecret => 0x0017,
+        CompressCertificate => 0x001b,
         SessionTicket => 0x0023,
         PreSharedKey => 0x0029,
         EarlyData => 0x002a,
@@ -789,5 +791,18 @@ enum_builder! {
     EnumName: CertificateStatusType;
     EnumVal{
         OCSP => 0x01
+    }
+}
+
+enum_builder! {
+    /// The `CertificateCompressionAlgorithm` TLS protocol enum.  Values in this enum are taken
+    /// from the various RFCs covering TLS, and are listed by IANA.
+    /// The `Unknown` item is used when processing unrecognised ordinals.
+    @U16
+    EnumName: CertificateCompressionAlgorithm;
+    EnumVal{
+        Zlib => 0x01,
+        Brotli => 0x02,
+        Zstd => 0x03
     }
 }

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -7,7 +7,7 @@ macro_rules! enum_builder {
         EnumVal { $( $enum_var: ident => $enum_val: expr ),* }
     ) => {
         $(#[$comment])*
-        #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+        #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
         pub enum $enum_name {
             $( $enum_var),*
             ,Unknown(u8)
@@ -46,7 +46,7 @@ macro_rules! enum_builder {
         EnumVal { $( $enum_var: ident => $enum_val: expr ),* }
     ) => {
         $(#[$comment])*
-        #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+        #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
         pub enum $enum_name {
             $( $enum_var),*
             ,Unknown(u16)

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -1,3 +1,4 @@
+use crate::compression::CertificateCompression;
 use crate::conn::{
     Connection, ConnectionCommon, IoState, MessageType, PlaintextSink, Reader, Writer,
 };
@@ -177,6 +178,10 @@ pub struct ServerConfig {
     /// How to choose a server cert and key.
     pub cert_resolver: Arc<dyn ResolvesServerCert>,
 
+    /// Certificate compression algorithms.
+    /// Added in order of preference.
+    pub certificate_compression_algorithms: Vec<Arc<CertificateCompression>>,
+
     /// Protocol names we support, most preferred first.
     /// If empty we don't do ALPN at all.
     pub alpn_protocols: Vec<Vec<u8>>,
@@ -242,6 +247,7 @@ impl ServerConfig {
             ticketer: Arc::new(handy::NeverProducesTickets {}),
             alpn_protocols: Vec::new(),
             cert_resolver: Arc::new(handy::FailResolveChain {}),
+            certificate_compression_algorithms: Vec::new(),
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
             verifier: client_cert_verifier,
             key_log: Arc::new(NoKeyLog {}),


### PR DESCRIPTION
I took a different approach after investigating the bogo tests and boringssl. Previous PR: https://github.com/ctz/rustls/pull/445

No longer include compression dependencies and leave this open to the client libraries to use/configure as they wish.

This PR implements [RFC8879](https://tools.ietf.org/html/rfc8879)

Issue: https://github.com/ctz/rustls/issues/436