### PR TITLE
[Proof of concept]: MSan branch.

### DIFF
--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,0 +1,3 @@
+# if using `cargo test`
+[dependencies.test]
+stage = 1


### PR DESCRIPTION
In looking at the intermittent BoGo failures in #573, I began to suspect data races or uninitialized reads in either Rustls, BoGo, or BoringSSL. I tried Go's data race detection on BoGo and a bunch of different Valgrind tools on BoringSSL in #573, and didn't find anything.

However, I have been able to reliably reproduce two uninitialized reads in Rustls. I've gotten good stacks on linux-x64 now, so I'll post them here. These don't seem to be security problems, but they could be correctness problems if the errors are accurate.

So far, I've found two issues:

```
==973295==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x56274f1ff95e in memcmp /home/sayrer/.cargo/registry/src/github.com-1ecc6299db9ec823/regex-1.4.5/src/dfa.rs:878:19
...
```

and

```
test alpn ... ==973297==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55e17c1d2fe0 in rustls::cipher::unpad_tls13::h38be909cac4e072e /home/sayrer/github/grafica/rustls/rustls/src/cipher.rs:333:18
...
```

I'll follow up with steps to reproduce.

[msan.txt](https://github.com/ctz/rustls/files/6174086/msan.txt)
