### PR TITLE
Simplify state machine & split ConnectionCommon in two parts

### DIFF
--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -10,7 +10,7 @@ use std::net::TcpStream;
 use rustls;
 use webpki_roots;
 
-use rustls::{Connection, OwnedTrustAnchor};
+use rustls::OwnedTrustAnchor;
 
 fn main() {
     let mut root_store = rustls::RootCertStore::empty();

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -16,7 +16,7 @@ use std::net::TcpStream;
 use rustls;
 use webpki_roots;
 
-use rustls::{Connection, OwnedTrustAnchor, RootCertStore};
+use rustls::{OwnedTrustAnchor, RootCertStore};
 
 fn main() {
     let mut root_store = RootCertStore::empty();

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -503,10 +503,7 @@ impl Connection for ClientConnection {
     }
 
     fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
-        self.inner
-            .common_state
-            .suite
-            .or(self.inner.data.resumption_ciphersuite)
+        self.inner.common_state.suite
     }
 
     fn writer(&mut self) -> Writer {

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -11,7 +11,7 @@ use crate::msgs::enums::AlertDescription;
 use crate::msgs::enums::CipherSuite;
 use crate::msgs::enums::ProtocolVersion;
 use crate::msgs::enums::SignatureScheme;
-use crate::msgs::handshake::{CertificatePayload, ClientExtension};
+use crate::msgs::handshake::ClientExtension;
 use crate::sign;
 use crate::suites::SupportedCipherSuite;
 use crate::verify;
@@ -526,16 +526,10 @@ impl Connection for ClientConnection {
     }
 
     fn peer_certificates(&self) -> Option<&[key::Certificate]> {
-        if self
-            .inner
-            .data
-            .server_cert_chain
-            .is_empty()
-        {
-            return None;
-        }
-
-        Some(&self.inner.data.server_cert_chain)
+        self.inner
+            .common_state
+            .peer_certificates
+            .as_deref()
     }
 
     fn alpn_protocol(&self) -> Option<&[u8]> {
@@ -577,7 +571,6 @@ impl Connection for ClientConnection {
 }
 
 pub(super) struct ClientConnectionData {
-    pub(super) server_cert_chain: CertificatePayload,
     pub(super) early_data: EarlyData,
     pub(super) resumption_ciphersuite: Option<SupportedCipherSuite>,
 }
@@ -585,7 +578,6 @@ pub(super) struct ClientConnectionData {
 impl ClientConnectionData {
     fn new() -> Self {
         Self {
-            server_cert_chain: Vec::new(),
             early_data: EarlyData::new(),
             resumption_ciphersuite: None,
         }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -505,7 +505,7 @@ impl Connection for ClientConnection {
     fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
         self.inner
             .common_state
-            .get_suite()
+            .suite
             .or(self.inner.data.resumption_ciphersuite)
     }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -502,10 +502,6 @@ impl Connection for ClientConnection {
             .export_keying_material(output, label, context)
     }
 
-    fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
-        self.inner.common_state.suite
-    }
-
     fn writer(&mut self) -> Writer {
         Writer::new(&mut self.inner)
     }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,5 +1,7 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
-use crate::conn::{Connection, ConnectionCommon, IoState, PlaintextSink, Protocol, Reader, Writer};
+use crate::conn::{
+    CommonState, Connection, ConnectionCommon, IoState, PlaintextSink, Protocol, Reader, Writer,
+};
 use crate::error::Error;
 use crate::key;
 use crate::keylog::KeyLog;
@@ -420,20 +422,22 @@ impl ClientConnection {
         extra_exts: Vec<ClientExtension>,
         proto: Protocol,
     ) -> Result<Self, Error> {
-        let mut new = Self {
-            common: ConnectionCommon::new(config.max_fragment_size, true)?,
-            state: None,
-            data: ClientConnectionData::new(),
-        };
-        new.common.protocol = proto;
+        let mut common_state = CommonState::new(config.max_fragment_size, true)?;
+        common_state.protocol = proto;
+        let mut data = ClientConnectionData::new();
 
         let mut cx = hs::ClientContext {
-            common: &mut new.common,
-            data: &mut new.data,
+            common: &mut common_state,
+            data: &mut data,
         };
 
-        new.state = Some(hs::start_handshake(name, extra_exts, config, &mut cx)?);
-        Ok(new)
+        let state = Some(hs::start_handshake(name, extra_exts, config, &mut cx)?);
+
+        Ok(Self {
+            common: ConnectionCommon::new(common_state),
+            state,
+            data,
+        })
     }
 
     /// Returns an `io::Write` implementer you can write bytes to
@@ -477,6 +481,7 @@ impl ClientConnection {
             .check_write(data.len())
             .map(|sz| {
                 self.common
+                    .common_state
                     .send_early_plaintext(&data[..sz])
             })
     }
@@ -484,11 +489,13 @@ impl ClientConnection {
     fn send_some_plaintext(&mut self, buf: &[u8]) -> usize {
         let mut st = self.state.take();
         if let Some(st) = st.as_mut() {
-            st.perhaps_write_key_update(&mut self.common);
+            st.perhaps_write_key_update(&mut self.common.common_state);
         }
         self.state = st;
 
-        self.common.send_some_plaintext(buf)
+        self.common
+            .common_state
+            .send_some_plaintext(buf)
     }
 }
 
@@ -499,7 +506,7 @@ impl Connection for ClientConnection {
 
     /// Writes TLS messages to `wr`.
     fn write_tls(&mut self, wr: &mut dyn io::Write) -> io::Result<usize> {
-        self.common.write_tls(wr)
+        self.common.common_state.write_tls(wr)
     }
 
     fn process_new_packets(&mut self) -> Result<IoState, Error> {
@@ -508,23 +515,31 @@ impl Connection for ClientConnection {
     }
 
     fn wants_read(&self) -> bool {
-        self.common.wants_read()
+        self.common.common_state.wants_read()
     }
 
     fn wants_write(&self) -> bool {
-        !self.common.sendable_tls.is_empty()
+        !self
+            .common
+            .common_state
+            .sendable_tls
+            .is_empty()
     }
 
     fn is_handshaking(&self) -> bool {
-        !self.common.traffic
+        !self.common.common_state.traffic
     }
 
     fn set_buffer_limit(&mut self, len: Option<usize>) {
-        self.common.set_buffer_limit(len)
+        self.common
+            .common_state
+            .set_buffer_limit(len)
     }
 
     fn send_close_notify(&mut self) {
-        self.common.send_close_notify()
+        self.common
+            .common_state
+            .send_close_notify()
     }
 
     fn peer_certificates(&self) -> Option<&[key::Certificate]> {
@@ -536,11 +551,15 @@ impl Connection for ClientConnection {
     }
 
     fn alpn_protocol(&self) -> Option<&[u8]> {
-        self.common.get_alpn_protocol()
+        self.common
+            .common_state
+            .get_alpn_protocol()
     }
 
     fn protocol_version(&self) -> Option<ProtocolVersion> {
-        self.common.negotiated_version
+        self.common
+            .common_state
+            .negotiated_version
     }
 
     fn export_keying_material(
@@ -557,6 +576,7 @@ impl Connection for ClientConnection {
 
     fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
         self.common
+            .common_state
             .get_suite()
             .or(self.data.resumption_ciphersuite)
     }
@@ -608,6 +628,7 @@ impl ClientConnectionData {
 impl quic::QuicExt for ClientConnection {
     fn quic_transport_parameters(&self) -> Option<&[u8]> {
         self.common
+            .common_state
             .quic
             .params
             .as_ref()
@@ -619,7 +640,11 @@ impl quic::QuicExt for ClientConnection {
             self.data
                 .resumption_ciphersuite
                 .and_then(|suite| suite.tls13())?,
-            self.common.quic.early_secret.as_ref()?,
+            self.common
+                .common_state
+                .quic
+                .early_secret
+                .as_ref()?,
         ))
     }
 
@@ -630,11 +655,11 @@ impl quic::QuicExt for ClientConnection {
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<quic::KeyChange> {
-        quic::write_hs(&mut self.common, buf)
+        quic::write_hs(&mut self.common.common_state, buf)
     }
 
     fn alert(&self) -> Option<AlertDescription> {
-        self.common.quic.alert
+        self.common.common_state.quic.alert
     }
 }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "logging")]
 use crate::bs_debug;
 use crate::check::check_message;
-use crate::conn::{CommonState, ConnectionRandoms};
+use crate::conn::{CommonState, ConnectionRandoms, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHashBuffer;
 use crate::kx;
@@ -35,44 +35,9 @@ use crate::client::client_conn::ClientConnectionData;
 
 use std::sync::Arc;
 
-pub(super) type NextState = Box<dyn State>;
+pub(super) type NextState = Box<dyn State<ClientConnectionData>>;
 pub(super) type NextStateOrError = Result<NextState, Error>;
-
-pub(super) trait State: Send + Sync {
-    /// Each handle() implementation consumes a whole TLS message, and returns
-    /// either an error or the next state.
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> NextStateOrError;
-
-    fn export_keying_material(
-        &self,
-        _output: &mut [u8],
-        _label: &[u8],
-        _context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        Err(Error::HandshakeNotComplete)
-    }
-
-    fn perhaps_write_key_update(&mut self, _common: &mut CommonState) {}
-}
-
-impl crate::conn::HandleState for Box<dyn State> {
-    type Data = ClientConnectionData;
-
-    fn handle(
-        self,
-        message: Message,
-        data: &mut Self::Data,
-        common: &mut CommonState,
-    ) -> Result<Self, Error> {
-        let mut cx = ClientContext { common, data };
-        self.handle(&mut cx, message)
-    }
-}
-
-pub(super) struct ClientContext<'a> {
-    pub(super) common: &'a mut CommonState,
-    pub(super) data: &'a mut ClientConnectionData,
-}
+pub(super) type ClientContext<'a> = crate::conn::Context<'a, ClientConnectionData>;
 
 fn find_session(
     server_name: &ServerName,
@@ -481,7 +446,7 @@ pub(super) fn sct_list_is_invalid(scts: &SCTList) -> bool {
     scts.is_empty() || scts.iter().any(|sct| sct.0.is_empty())
 }
 
-impl State for ExpectServerHello {
+impl State<ClientConnectionData> for ExpectServerHello {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> NextStateOrError {
         let server_hello =
             require_handshake_msg!(m, HandshakeType::ServerHello, HandshakePayload::ServerHello)?;
@@ -788,7 +753,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
     }
 }
 
-impl State for ExpectServerHelloOrHelloRetryRequest {
+impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> NextStateOrError {
         check_message(
             &m,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "logging")]
 use crate::bs_debug;
 use crate::check::check_message;
-use crate::conn::{ConnectionCommon, ConnectionRandoms};
+use crate::conn::{CommonState, ConnectionRandoms};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHashBuffer;
 use crate::kx;
@@ -52,7 +52,7 @@ pub(super) trait State: Send + Sync {
         Err(Error::HandshakeNotComplete)
     }
 
-    fn perhaps_write_key_update(&mut self, _common: &mut ConnectionCommon) {}
+    fn perhaps_write_key_update(&mut self, _common: &mut CommonState) {}
 }
 
 impl crate::conn::HandleState for Box<dyn State> {
@@ -62,7 +62,7 @@ impl crate::conn::HandleState for Box<dyn State> {
         self,
         message: Message,
         data: &mut Self::Data,
-        common: &mut ConnectionCommon,
+        common: &mut CommonState,
     ) -> Result<Self, Error> {
         let mut cx = ClientContext { common, data };
         self.handle(&mut cx, message)
@@ -70,7 +70,7 @@ impl crate::conn::HandleState for Box<dyn State> {
 }
 
 pub(super) struct ClientContext<'a> {
-    pub(super) common: &'a mut ConnectionCommon,
+    pub(super) common: &'a mut CommonState,
     pub(super) data: &'a mut ClientConnectionData,
 }
 
@@ -804,7 +804,7 @@ impl State for ExpectServerHelloOrHelloRetryRequest {
     }
 }
 
-pub(super) fn send_cert_error_alert(common: &mut ConnectionCommon, err: Error) -> Error {
+pub(super) fn send_cert_error_alert(common: &mut CommonState, err: Error) -> Error {
     match err {
         Error::InvalidCertificateEncoding => {
             common.send_fatal_alert(AlertDescription::DecodeError);

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -19,8 +19,8 @@ use crate::ticketer::TimeBase;
 use crate::tls12::{self, ConnectionSecrets, Tls12CipherSuite};
 use crate::{kx, verify};
 
+use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;
-use super::ClientConnectionData;
 use crate::client::common::ClientAuthDetails;
 use crate::client::common::ServerCertDetails;
 use crate::client::{hs, ClientConfig, ServerName};

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms};
+use crate::conn::{CommonState, ConnectionRandoms};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
@@ -447,7 +447,7 @@ impl hs::State for ExpectServerKx {
 fn emit_certificate(
     transcript: &mut HandshakeHash,
     cert_chain: CertificatePayload,
-    common: &mut ConnectionCommon,
+    common: &mut CommonState,
 ) {
     let cert = Message {
         version: ProtocolVersion::TLSv1_2,
@@ -463,7 +463,7 @@ fn emit_certificate(
 
 fn emit_clientkx(
     transcript: &mut HandshakeHash,
-    common: &mut ConnectionCommon,
+    common: &mut CommonState,
     kxd: &kx::KeyExchangeResult,
 ) {
     let mut buf = Vec::new();
@@ -486,7 +486,7 @@ fn emit_clientkx(
 fn emit_certverify(
     transcript: &mut HandshakeHash,
     client_auth: &mut ClientAuthDetails,
-    common: &mut ConnectionCommon,
+    common: &mut CommonState,
 ) -> Result<(), Error> {
     let (signer, message) = match (client_auth.signer.take(), transcript.take_handshake_buf()) {
         (Some(signer), Some(msg)) => (signer, msg),
@@ -518,7 +518,7 @@ fn emit_certverify(
     Ok(())
 }
 
-fn emit_ccs(common: &mut ConnectionCommon) {
+fn emit_ccs(common: &mut CommonState) {
     let ccs = Message {
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
@@ -530,7 +530,7 @@ fn emit_ccs(common: &mut ConnectionCommon) {
 fn emit_finished(
     secrets: &ConnectionSecrets,
     transcript: &mut HandshakeHash,
-    common: &mut ConnectionCommon,
+    common: &mut CommonState,
 ) {
     let vh = transcript.get_current_hash();
     let verify_data = secrets.client_verify_data(&vh);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -265,6 +265,7 @@ pub(super) fn prepare_resumption(
     exts: &mut Vec<ClientExtension>,
     doing_retry: bool,
 ) {
+    cx.common.suite = Some(resuming_suite.into());
     cx.data.resumption_ciphersuite = Some(resuming_suite.into());
     // The EarlyData extension MUST be supplied together with the
     // PreSharedKey extension.

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -431,9 +431,11 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
                     );
             }
 
-            cx.data.server_cert_chain = resuming_session
-                .server_cert_chain
-                .clone();
+            cx.common.peer_certificates = Some(
+                resuming_session
+                    .server_cert_chain
+                    .clone(),
+            );
 
             // We *don't* reverify the certificate chain here: resumption is a
             // continuation of the previous session in terms of security policy.
@@ -729,7 +731,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify {
             )
             .map_err(|err| hs::send_cert_error_alert(cx.common, err))?;
 
-        cx.data.server_cert_chain = self.server_cert.cert_chain;
+        cx.common.peer_certificates = Some(self.server_cert.cert_chain);
         self.transcript.add_message(&m);
 
         Ok(Box::new(ExpectFinished {
@@ -987,7 +989,10 @@ impl ExpectTraffic {
             &SessionID::empty(),
             nst.ticket.0.clone(),
             secret,
-            &cx.data.server_cert_chain,
+            cx.common
+                .peer_certificates
+                .clone()
+                .unwrap_or_default(),
             time_now,
         );
         value.set_times(nst.lifetime, nst.age_add);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_handshake_message, inappropriate_message};
-use crate::conn::{CommonState, ConnectionRandoms};
+use crate::conn::{CommonState, ConnectionRandoms, State};
 use crate::error::Error;
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
 use crate::kx;
@@ -31,6 +31,7 @@ use crate::{conn::Protocol, msgs::base::PayloadU16, quic};
 use crate::{sign, KeyLog};
 
 use super::hs::ClientContext;
+use super::ClientConnectionData;
 use crate::client::common::ServerCertDetails;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails};
 use crate::client::{hs, ClientConfig, ServerName};
@@ -381,7 +382,7 @@ struct ExpectEncryptedExtensions {
     hello: ClientHelloDetails,
 }
 
-impl hs::State for ExpectEncryptedExtensions {
+impl State<ClientConnectionData> for ExpectEncryptedExtensions {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let exts = require_handshake_msg!(
             m,
@@ -477,7 +478,7 @@ struct ExpectCertificateOrCertReq {
     may_send_sct_list: bool,
 }
 
-impl hs::State for ExpectCertificateOrCertReq {
+impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         check_message(
             &m,
@@ -527,7 +528,7 @@ struct ExpectCertificateRequest {
     may_send_sct_list: bool,
 }
 
-impl hs::State for ExpectCertificateRequest {
+impl State<ClientConnectionData> for ExpectCertificateRequest {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let certreq = &require_handshake_msg!(
             m,
@@ -615,7 +616,7 @@ struct ExpectCertificate {
     client_auth: Option<ClientAuthDetails>,
 }
 
-impl hs::State for ExpectCertificate {
+impl State<ClientConnectionData> for ExpectCertificate {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let cert_chain = require_handshake_msg!(
             m,
@@ -686,7 +687,7 @@ struct ExpectCertificateVerify {
     client_auth: Option<ClientAuthDetails>,
 }
 
-impl hs::State for ExpectCertificateVerify {
+impl State<ClientConnectionData> for ExpectCertificateVerify {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let cert_verify = require_handshake_msg!(
             m,
@@ -859,7 +860,7 @@ struct ExpectFinished {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl hs::State for ExpectFinished {
+impl State<ClientConnectionData> for ExpectFinished {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let mut st = *self;
         let finished =
@@ -1073,7 +1074,7 @@ impl ExpectTraffic {
     }
 }
 
-impl hs::State for ExpectTraffic {
+impl State<ClientConnectionData> for ExpectTraffic {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx
@@ -1133,7 +1134,7 @@ impl hs::State for ExpectTraffic {
 struct ExpectQuicTraffic(ExpectTraffic);
 
 #[cfg(feature = "quic")]
-impl hs::State for ExpectQuicTraffic {
+impl State<ClientConnectionData> for ExpectQuicTraffic {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let nst = require_handshake_msg!(
             m,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -30,8 +30,8 @@ use crate::verify;
 use crate::{conn::Protocol, msgs::base::PayloadU16, quic};
 use crate::{sign, KeyLog};
 
+use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;
-use super::ClientConnectionData;
 use crate::client::common::ServerCertDetails;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails};
 use crate::client::{hs, ClientConfig, ServerName};

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -239,11 +239,6 @@ pub trait Connection: DerefMut + Deref<Target = CommonState> + quic::QuicExt + S
         context: Option<&[u8]>,
     ) -> Result<(), Error>;
 
-    /// Retrieves the ciphersuite agreed with the peer.
-    ///
-    /// This returns None until the ciphersuite is agreed.
-    fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite>;
-
     /// This function uses `io` to complete any outstanding IO for
     /// this connection.
     ///
@@ -664,6 +659,13 @@ impl CommonState {
     /// were offered or accepted by the peer).
     pub fn alpn_protocol(&self) -> Option<&[u8]> {
         self.get_alpn_protocol()
+    }
+
+    /// Retrieves the ciphersuite agreed with the peer.
+    ///
+    /// This returns None until the ciphersuite is agreed.
+    pub fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
+        self.suite
     }
 
     /// Retrieves the protocol version agreed with the peer.

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -755,10 +755,6 @@ impl CommonState {
         Error::PeerMisbehavedError(why.to_string())
     }
 
-    pub(crate) fn get_suite(&self) -> Option<SupportedCipherSuite> {
-        self.suite
-    }
-
     pub(crate) fn decrypt_incoming(&mut self, encr: OpaqueMessage) -> Result<PlainMessage, Error> {
         if self
             .record_layer

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -690,7 +690,7 @@ impl ConnectionCommon {
         // In the handshake case we don't have readable plaintext before the handshake has
         // completed, but also don't want to read if we still have sendable tls.
         self.received_plaintext.is_empty()
-            && !self.connection_was_cleanly_closed()
+            && !self.has_received_close_notify
             && (self.traffic || self.sendable_tls.is_empty())
     }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -438,74 +438,24 @@ enum Limit {
 }
 
 pub(crate) struct ConnectionCommon {
-    pub(crate) negotiated_version: Option<ProtocolVersion>,
-    pub(crate) is_client: bool,
-    pub(crate) record_layer: record_layer::RecordLayer,
-    pub(crate) suite: Option<SupportedCipherSuite>,
-    pub(crate) alpn_protocol: Option<Vec<u8>>,
-    /// If the peer has signaled end of stream.
-    has_received_close_notify: bool,
-    has_seen_eof: bool,
-    pub(crate) traffic: bool,
-    pub(crate) early_traffic: bool,
-    sent_fatal_alert: bool,
-    received_middlebox_ccs: bool,
+    pub(crate) common_state: CommonState,
     error: Option<Error>,
     message_deframer: MessageDeframer,
     pub(crate) handshake_joiner: HandshakeJoiner,
-    pub(crate) message_fragmenter: MessageFragmenter,
-    received_plaintext: ChunkVecBuffer,
-    sendable_plaintext: ChunkVecBuffer,
-    pub(crate) sendable_tls: ChunkVecBuffer,
-    #[allow(dead_code)] // only read for QUIC
-    /// Protocol whose key schedule should be used. Unused for TLS < 1.3.
-    pub(crate) protocol: Protocol,
-    #[cfg(feature = "quic")]
-    pub(crate) quic: Quic,
 }
 
 impl ConnectionCommon {
-    pub(crate) fn new(max_fragment_size: Option<usize>, client: bool) -> Result<Self, Error> {
-        Ok(Self {
-            negotiated_version: None,
-            is_client: client,
-            record_layer: record_layer::RecordLayer::new(),
-            suite: None,
-            alpn_protocol: None,
-            has_received_close_notify: false,
-            has_seen_eof: false,
-            traffic: false,
-            early_traffic: false,
-            sent_fatal_alert: false,
-            received_middlebox_ccs: false,
+    pub(crate) fn new(common_state: CommonState) -> Self {
+        Self {
+            common_state,
             error: None,
             message_deframer: MessageDeframer::new(),
             handshake_joiner: HandshakeJoiner::new(),
-            message_fragmenter: MessageFragmenter::new(max_fragment_size)
-                .map_err(|_| Error::BadMaxFragmentSize)?,
-            received_plaintext: ChunkVecBuffer::new(None),
-            sendable_plaintext: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
-            sendable_tls: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
-            protocol: Protocol::Tcp,
-            #[cfg(feature = "quic")]
-            quic: Quic::new(),
-        })
+        }
     }
 
     pub(crate) fn reader(&mut self) -> Reader {
         Reader { common: self }
-    }
-
-    fn current_io_state(&self) -> IoState {
-        IoState {
-            tls_bytes_to_write: self.sendable_tls.len(),
-            plaintext_bytes_to_read: self.received_plaintext.len(),
-            peer_has_closed: self.has_received_close_notify,
-        }
-    }
-
-    pub(crate) fn is_tls13(&self) -> bool {
-        matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
     }
 
     fn process_msg(&mut self, msg: OpaqueMessage) -> Result<Option<MessageType>, Error> {
@@ -514,21 +464,30 @@ impl ConnectionCommon {
         // - prior to determining the version (it's illegal as a first message)
         // - if it's not a CCS at all
         // - if we've finished the handshake
-        if msg.typ == ContentType::ChangeCipherSpec && !self.traffic && self.is_tls13() {
-            if self.received_middlebox_ccs {
+        if msg.typ == ContentType::ChangeCipherSpec
+            && !self.common_state.traffic
+            && self.common_state.is_tls13()
+        {
+            if self.common_state.received_middlebox_ccs {
                 return Err(Error::PeerMisbehavedError(
                     "illegal middlebox CCS received".into(),
                 ));
             } else {
-                self.received_middlebox_ccs = true;
+                self.common_state.received_middlebox_ccs = true;
                 trace!("Dropping CCS");
                 return Ok(None);
             }
         }
 
         // Decrypt if demanded by current state.
-        let msg = match self.record_layer.is_decrypting() {
-            true => self.decrypt_incoming(msg)?,
+        let msg = match self
+            .common_state
+            .record_layer
+            .is_decrypting()
+        {
+            true => self
+                .common_state
+                .decrypt_incoming(msg)?,
             false => msg.into_plain_message(),
         };
 
@@ -538,7 +497,8 @@ impl ConnectionCommon {
             self.handshake_joiner
                 .take_message(msg)
                 .ok_or_else(|| {
-                    self.send_fatal_alert(AlertDescription::DecodeError);
+                    self.common_state
+                        .send_fatal_alert(AlertDescription::DecodeError);
                     Error::CorruptMessagePayload(ContentType::Handshake)
                 })?;
             return Ok(Some(MessageType::Handshake));
@@ -549,7 +509,10 @@ impl ConnectionCommon {
 
         // For alerts, we have separate logic.
         if let MessagePayload::Alert(alert) = &msg.payload {
-            return self.process_alert(alert).map(|()| None);
+            return self
+                .common_state
+                .process_alert(alert)
+                .map(|()| None);
         }
 
         Ok(Some(MessageType::Data(msg)))
@@ -575,7 +538,9 @@ impl ConnectionCommon {
                     Some(MessageType::Handshake) => {
                         self.process_new_handshake_messages(state, data)
                     }
-                    Some(MessageType::Data(msg)) => self.process_main_protocol(msg, state, data),
+                    Some(MessageType::Data(msg)) => self
+                        .common_state
+                        .process_main_protocol(msg, state, data),
                     None => Ok(()),
                 });
 
@@ -585,7 +550,7 @@ impl ConnectionCommon {
             }
         }
 
-        Ok(self.current_io_state())
+        Ok(self.common_state.current_io_state())
     }
 
     pub(crate) fn process_new_handshake_messages<S: HandleState>(
@@ -593,11 +558,120 @@ impl ConnectionCommon {
         state: &mut Option<S>,
         data: &mut S::Data,
     ) -> Result<(), Error> {
+        self.common_state.aligned_handshake = self.handshake_joiner.is_empty();
         while let Some(msg) = self.handshake_joiner.frames.pop_front() {
-            self.process_main_protocol(msg, state, data)?;
+            self.common_state
+                .process_main_protocol(msg, state, data)?;
         }
 
         Ok(())
+    }
+
+    /// Are we done? i.e., have we processed all received messages,
+    /// and received a close_notify to indicate that no new messages
+    /// will arrive?
+    fn connection_was_cleanly_closed(&self) -> bool {
+        self.common_state
+            .has_received_close_notify
+            && !self.message_deframer.has_pending()
+    }
+
+    /// Read TLS content from `rd`.  This method does internal
+    /// buffering, so `rd` can supply TLS messages in arbitrary-
+    /// sized chunks (like a socket or pipe might).
+    pub(crate) fn read_tls(&mut self, rd: &mut dyn io::Read) -> io::Result<usize> {
+        let res = self.message_deframer.read(rd);
+        if let Ok(0) = res {
+            self.common_state.has_seen_eof = true;
+        }
+        res
+    }
+
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let len = self
+            .common_state
+            .received_plaintext
+            .read(buf)?;
+
+        if len == 0 && !buf.is_empty() {
+            // No bytes available:
+            match (
+                self.connection_was_cleanly_closed(),
+                self.common_state.has_seen_eof,
+            ) {
+                (true, _) => {
+                    // cleanly closed; don't care about TCP EOF: express this as Ok(0)
+                }
+                (false, true) => {
+                    // unclean closure
+                    return Err(io::ErrorKind::UnexpectedEof.into());
+                }
+                (false, false) => {
+                    // connection still going, but need more data: signal `WouldBlock` so that
+                    // the caller knows this
+                    return Err(io::ErrorKind::WouldBlock.into());
+                }
+            }
+        }
+
+        Ok(len)
+    }
+}
+
+pub(crate) struct CommonState {
+    pub(crate) negotiated_version: Option<ProtocolVersion>,
+    pub(crate) is_client: bool,
+    pub(crate) record_layer: record_layer::RecordLayer,
+    pub(crate) suite: Option<SupportedCipherSuite>,
+    pub(crate) alpn_protocol: Option<Vec<u8>>,
+    aligned_handshake: bool,
+    pub(crate) traffic: bool,
+    pub(crate) early_traffic: bool,
+    sent_fatal_alert: bool,
+    /// If the peer has signaled end of stream.
+    has_received_close_notify: bool,
+    has_seen_eof: bool,
+    received_middlebox_ccs: bool,
+    message_fragmenter: MessageFragmenter,
+    received_plaintext: ChunkVecBuffer,
+    sendable_plaintext: ChunkVecBuffer,
+    pub(crate) sendable_tls: ChunkVecBuffer,
+    #[allow(dead_code)] // only read for QUIC
+    /// Protocol whose key schedule should be used. Unused for TLS < 1.3.
+    pub(crate) protocol: Protocol,
+    #[cfg(feature = "quic")]
+    pub(crate) quic: Quic,
+}
+
+impl CommonState {
+    pub(crate) fn new(max_fragment_size: Option<usize>, is_client: bool) -> Result<Self, Error> {
+        Ok(Self {
+            negotiated_version: None,
+            is_client,
+            record_layer: record_layer::RecordLayer::new(),
+            suite: None,
+            alpn_protocol: None,
+            aligned_handshake: true,
+            traffic: false,
+            early_traffic: false,
+            sent_fatal_alert: false,
+            has_received_close_notify: false,
+            has_seen_eof: false,
+            received_middlebox_ccs: false,
+            message_fragmenter: MessageFragmenter::new(max_fragment_size)
+                .map_err(|_| Error::BadMaxFragmentSize)?,
+            received_plaintext: ChunkVecBuffer::new(Some(0)),
+            sendable_plaintext: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
+            sendable_tls: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
+
+            protocol: Protocol::Tcp,
+            #[cfg(feature = "quic")]
+            quic: Quic::new(),
+        })
+    }
+
+    pub(crate) fn is_tls13(&self) -> bool {
+        matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
     }
 
     /// Process `msg`.  First, we get the current state.  Then we ask what messages
@@ -637,12 +711,33 @@ impl ConnectionCommon {
         }
     }
 
+    /// Send plaintext application data, fragmenting and
+    /// encrypting it as it goes out.
+    ///
+    /// If internal buffers are too small, this function will not accept
+    /// all the data.
+    pub(crate) fn send_some_plaintext(&mut self, data: &[u8]) -> usize {
+        self.send_plain(data, Limit::Yes)
+    }
+
+    pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
+        debug_assert!(self.early_traffic);
+        debug_assert!(self.record_layer.is_encrypting());
+
+        if data.is_empty() {
+            // Don't send empty fragments.
+            return 0;
+        }
+
+        self.send_appdata_encrypt(data, Limit::Yes)
+    }
+
     // Changing the keys must not span any fragmented handshake
     // messages.  Otherwise the defragmented messages will have
     // been protected with two different record layer protections,
     // which is illegal.  Not mentioned in RFC.
     pub(crate) fn check_aligned_handshake(&mut self) -> Result<(), Error> {
-        if !self.handshake_joiner.is_empty() {
+        if !self.aligned_handshake {
             self.send_fatal_alert(AlertDescription::UnexpectedMessage);
             Err(Error::PeerMisbehavedError(
                 "key epoch or handshake flight with pending fragment".to_string(),
@@ -661,12 +756,6 @@ impl ConnectionCommon {
         self.suite
     }
 
-    pub(crate) fn get_alpn_protocol(&self) -> Option<&[u8]> {
-        self.alpn_protocol
-            .as_ref()
-            .map(AsRef::as_ref)
-    }
-
     pub(crate) fn decrypt_incoming(&mut self, encr: OpaqueMessage) -> Result<PlainMessage, Error> {
         if self
             .record_layer
@@ -680,51 +769,6 @@ impl ConnectionCommon {
             self.send_fatal_alert(AlertDescription::RecordOverflow);
         }
         rc
-    }
-
-    pub(crate) fn wants_read(&self) -> bool {
-        // We want to read more data all the time, except when we have unprocessed plaintext.
-        // This provides back-pressure to the TCP buffers. We also don't want to read more after
-        // the peer has sent us a close notification.
-        //
-        // In the handshake case we don't have readable plaintext before the handshake has
-        // completed, but also don't want to read if we still have sendable tls.
-        self.received_plaintext.is_empty()
-            && !self.has_received_close_notify
-            && (self.traffic || self.sendable_tls.is_empty())
-    }
-
-    pub(crate) fn set_buffer_limit(&mut self, limit: Option<usize>) {
-        self.sendable_plaintext.set_limit(limit);
-        self.sendable_tls.set_limit(limit);
-    }
-
-    fn process_alert(&mut self, alert: &AlertMessagePayload) -> Result<(), Error> {
-        // Reject unknown AlertLevels.
-        if let AlertLevel::Unknown(_) = alert.level {
-            self.send_fatal_alert(AlertDescription::IllegalParameter);
-        }
-
-        // If we get a CloseNotify, make a note to declare EOF to our
-        // caller.
-        if alert.description == AlertDescription::CloseNotify {
-            self.has_received_close_notify = true;
-            return Ok(());
-        }
-
-        // Warnings are nonfatal for TLS1.2, but outlawed in TLS1.3
-        // (except, for no good reason, user_cancelled).
-        if alert.level == AlertLevel::Warning {
-            if self.is_tls13() && alert.description != AlertDescription::UserCanceled {
-                self.send_fatal_alert(AlertDescription::DecodeError);
-            } else {
-                warn!("TLS alert warning received: {:#?}", alert);
-                return Ok(());
-            }
-        }
-
-        error!("TLS alert received: {:#?}", alert);
-        Err(Error::AlertReceived(alert.description))
     }
 
     /// Fragment `m`, encrypt the fragments, and then queue
@@ -787,47 +831,8 @@ impl ConnectionCommon {
         self.queue_tls_message(em);
     }
 
-    /// Are we done? i.e., have we processed all received messages,
-    /// and received a close_notify to indicate that no new messages
-    /// will arrive?
-    fn connection_was_cleanly_closed(&self) -> bool {
-        self.has_received_close_notify && !self.message_deframer.has_pending()
-    }
-
-    /// Read TLS content from `rd`.  This method does internal
-    /// buffering, so `rd` can supply TLS messages in arbitrary-
-    /// sized chunks (like a socket or pipe might).
-    pub(crate) fn read_tls(&mut self, rd: &mut dyn io::Read) -> io::Result<usize> {
-        let res = self.message_deframer.read(rd);
-        if let Ok(0) = res {
-            self.has_seen_eof = true;
-        }
-        res
-    }
-
     pub(crate) fn write_tls(&mut self, wr: &mut dyn io::Write) -> io::Result<usize> {
         self.sendable_tls.write_to(wr)
-    }
-
-    /// Send plaintext application data, fragmenting and
-    /// encrypting it as it goes out.
-    ///
-    /// If internal buffers are too small, this function will not accept
-    /// all the data.
-    pub(crate) fn send_some_plaintext(&mut self, data: &[u8]) -> usize {
-        self.send_plain(data, Limit::Yes)
-    }
-
-    pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
-        debug_assert!(self.early_traffic);
-        debug_assert!(self.record_layer.is_encrypting());
-
-        if data.is_empty() {
-            // Don't send empty fragments.
-            return 0;
-        }
-
-        self.send_appdata_encrypt(data, Limit::Yes)
     }
 
     /// Encrypt and send some plaintext `data`.  `limit` controls
@@ -863,6 +868,11 @@ impl ConnectionCommon {
     pub(crate) fn start_traffic(&mut self) {
         self.traffic = true;
         self.flush_plaintext();
+    }
+
+    pub(crate) fn set_buffer_limit(&mut self, limit: Option<usize>) {
+        self.sendable_plaintext.set_limit(limit);
+        self.sendable_tls.set_limit(limit);
     }
 
     /// Send any buffered plaintext.  Plaintext is buffered if
@@ -919,30 +929,6 @@ impl ConnectionCommon {
         self.received_plaintext.append(bytes.0);
     }
 
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let len = self.received_plaintext.read(buf)?;
-
-        if len == 0 && !buf.is_empty() {
-            // No bytes available:
-            match (self.connection_was_cleanly_closed(), self.has_seen_eof) {
-                (true, _) => {
-                    // cleanly closed; don't care about TCP EOF: express this as Ok(0)
-                }
-                (false, true) => {
-                    // unclean closure
-                    return Err(io::ErrorKind::UnexpectedEof.into());
-                }
-                (false, false) => {
-                    // connection still going, but need more data: signal `WouldBlock` so that
-                    // the caller knows this
-                    return Err(io::ErrorKind::WouldBlock.into());
-                }
-            }
-        }
-
-        Ok(len)
-    }
-
     #[cfg(feature = "tls12")]
     pub(crate) fn start_encryption_tls12(&mut self, secrets: &ConnectionSecrets) {
         let (dec, enc) = secrets.make_cipher_pair();
@@ -963,6 +949,34 @@ impl ConnectionCommon {
         self.send_warning_alert_no_log(desc);
     }
 
+    fn process_alert(&mut self, alert: &AlertMessagePayload) -> Result<(), Error> {
+        // Reject unknown AlertLevels.
+        if let AlertLevel::Unknown(_) = alert.level {
+            self.send_fatal_alert(AlertDescription::IllegalParameter);
+        }
+
+        // If we get a CloseNotify, make a note to declare EOF to our
+        // caller.
+        if alert.description == AlertDescription::CloseNotify {
+            self.has_received_close_notify = true;
+            return Ok(());
+        }
+
+        // Warnings are nonfatal for TLS1.2, but outlawed in TLS1.3
+        // (except, for no good reason, user_cancelled).
+        if alert.level == AlertLevel::Warning {
+            if self.is_tls13() && alert.description != AlertDescription::UserCanceled {
+                self.send_fatal_alert(AlertDescription::DecodeError);
+            } else {
+                warn!("TLS alert warning received: {:#?}", alert);
+                return Ok(());
+            }
+        }
+
+        error!("TLS alert received: {:#?}", alert);
+        Err(Error::AlertReceived(alert.description))
+    }
+
     pub(crate) fn send_fatal_alert(&mut self, desc: AlertDescription) {
         warn!("Sending fatal alert {:?}", desc);
         debug_assert!(!self.sent_fatal_alert);
@@ -979,6 +993,32 @@ impl ConnectionCommon {
     fn send_warning_alert_no_log(&mut self, desc: AlertDescription) {
         let m = Message::build_alert(AlertLevel::Warning, desc);
         self.send_msg(m, self.record_layer.is_encrypting());
+    }
+
+    pub(crate) fn get_alpn_protocol(&self) -> Option<&[u8]> {
+        self.alpn_protocol
+            .as_ref()
+            .map(AsRef::as_ref)
+    }
+
+    pub(crate) fn wants_read(&self) -> bool {
+        // We want to read more data all the time, except when we have unprocessed plaintext.
+        // This provides back-pressure to the TCP buffers. We also don't want to read more after
+        // the peer has sent us a close notification.
+        //
+        // In the handshake case we don't have readable plaintext before the handshake has
+        // completed, but also don't want to read if we still have sendable tls.
+        self.received_plaintext.is_empty()
+            && !self.has_received_close_notify
+            && (self.traffic || self.sendable_tls.is_empty())
+    }
+
+    fn current_io_state(&self) -> IoState {
+        IoState {
+            tls_bytes_to_write: self.sendable_tls.len(),
+            plaintext_bytes_to_read: self.received_plaintext.len(),
+            peer_has_closed: self.has_received_close_notify,
+        }
     }
 
     pub(crate) fn is_quic(&self) -> bool {
@@ -998,7 +1038,7 @@ pub(crate) trait HandleState: Sized {
         self,
         message: Message,
         data: &mut Self::Data,
-        common: &mut ConnectionCommon,
+        common: &mut CommonState,
     ) -> Result<Self, Error>;
 }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -686,6 +686,7 @@ pub(crate) struct CommonState {
     has_received_close_notify: bool,
     has_seen_eof: bool,
     received_middlebox_ccs: bool,
+    pub(crate) peer_certificates: Option<Vec<key::Certificate>>,
     message_fragmenter: MessageFragmenter,
     received_plaintext: ChunkVecBuffer,
     sendable_plaintext: ChunkVecBuffer,
@@ -712,6 +713,7 @@ impl CommonState {
             has_received_close_notify: false,
             has_seen_eof: false,
             received_middlebox_ccs: false,
+            peer_certificates: None,
             message_fragmenter: MessageFragmenter::new(max_fragment_size)
                 .map_err(|_| Error::BadMaxFragmentSize)?,
             received_plaintext: ChunkVecBuffer::new(Some(0)),

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -324,7 +324,7 @@ pub use crate::anchors::{OwnedTrustAnchor, RootCertStore};
 pub use crate::builder::{
     ConfigBuilder, ConfigSide, WantsCipherSuites, WantsKxGroups, WantsVerifier, WantsVersions,
 };
-pub use crate::conn::{Connection, IoState, Reader, Writer};
+pub use crate::conn::{CommonState, Connection, IoState, Reader, Writer};
 pub use crate::error::Error;
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::keylog::{KeyLog, KeyLogFile, NoKeyLog};

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -1,4 +1,5 @@
 use crate::client::ServerName;
+use crate::key;
 use crate::msgs::base::{PayloadU8, PayloadU16};
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{CipherSuite, ProtocolVersion};
@@ -149,7 +150,7 @@ impl ClientSessionValueWithResolvedCipherSuite {
         sessid: &SessionID,
         ticket: Vec<u8>,
         ms: Vec<u8>,
-        server_cert_chain: &CertificatePayload,
+        server_cert_chain: Vec<key::Certificate>,
         time_now: TimeBase,
     ) -> Self {
         Self {
@@ -164,7 +165,7 @@ impl ClientSessionValueWithResolvedCipherSuite {
                 age_add: 0,
                 extended_ms: false,
                 max_early_data_size: 0,
-                server_cert_chain: server_cert_chain.to_owned(),
+                server_cert_chain,
             },
             supported_cipher_suite: cipher_suite,
             time_retrieved: time_now,
@@ -307,7 +308,7 @@ impl ServerSessionValue {
         v: ProtocolVersion,
         cs: CipherSuite,
         ms: Vec<u8>,
-        cert_chain: &Option<CertificatePayload>,
+        client_cert_chain: Option<CertificatePayload>,
         alpn: Option<Vec<u8>>,
         application_data: Vec<u8>,
     ) -> Self {
@@ -317,7 +318,7 @@ impl ServerSessionValue {
             cipher_suite: cs,
             master_secret: PayloadU8::new(ms),
             extended_ms: false,
-            client_cert_chain: cert_chain.clone(),
+            client_cert_chain,
             alpn: alpn.map(PayloadU8::new),
             application_data: PayloadU16::new(application_data),
         }

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -31,7 +31,7 @@ fn clientsessionvalue_is_debug() {
         &SessionID::random().unwrap(),
         vec![],
         vec![1, 2, 3],
-        &vec![Certificate(b"abc".to_vec()), Certificate(b"def".to_vec())],
+        vec![Certificate(b"abc".to_vec()), Certificate(b"def".to_vec())],
         TimeBase::now().unwrap(),
     );
     println!("{:?}", csv);
@@ -44,7 +44,7 @@ fn serversessionvalue_is_debug() {
         ProtocolVersion::TLSv1_3,
         CipherSuite::TLS13_AES_128_GCM_SHA256,
         vec![1, 2, 3],
-        &None,
+        None,
         None,
         vec![4, 5, 6],
     );

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -1,7 +1,7 @@
 /// This module contains optional APIs for implementing QUIC TLS.
 use crate::cipher::{Iv, IvLen};
 pub use crate::client::ClientQuicExt;
-use crate::conn::ConnectionCommon;
+use crate::conn::{CommonState, ConnectionCommon};
 use crate::error::Error;
 use crate::msgs::base::Payload;
 use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
@@ -409,13 +409,13 @@ pub(crate) fn read_hs(this: &mut ConnectionCommon, plaintext: &[u8]) -> Result<(
         })
         .is_none()
     {
-        this.quic.alert = Some(AlertDescription::DecodeError);
+        this.common_state.quic.alert = Some(AlertDescription::DecodeError);
         return Err(Error::CorruptMessage);
     }
     Ok(())
 }
 
-pub(crate) fn write_hs(this: &mut ConnectionCommon, buf: &mut Vec<u8>) -> Option<KeyChange> {
+pub(crate) fn write_hs(this: &mut CommonState, buf: &mut Vec<u8>) -> Option<KeyChange> {
     while let Some((_, msg)) = this.quic.hs_queue.pop_front() {
         buf.extend_from_slice(&msg);
         if let Some(&(true, _)) = this.quic.hs_queue.front() {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -1,11 +1,9 @@
 /// This module contains optional APIs for implementing QUIC TLS.
 use crate::cipher::{Iv, IvLen};
 pub use crate::client::ClientQuicExt;
-use crate::conn::{CommonState, ConnectionCommon};
+use crate::conn::CommonState;
 use crate::error::Error;
-use crate::msgs::base::Payload;
-use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
-use crate::msgs::message::PlainMessage;
+use crate::msgs::enums::AlertDescription;
 pub use crate::server::ServerQuicExt;
 use crate::suites::BulkAlgorithm;
 use crate::tls13::key_schedule::hkdf_expand;
@@ -397,22 +395,6 @@ impl Keys {
             remote: DirectionalKeys::new(secrets.suite, remote),
         }
     }
-}
-
-pub(crate) fn read_hs(this: &mut ConnectionCommon, plaintext: &[u8]) -> Result<(), Error> {
-    if this
-        .handshake_joiner
-        .take_message(PlainMessage {
-            typ: ContentType::Handshake,
-            version: ProtocolVersion::TLSv1_3,
-            payload: Payload::new(plaintext.to_vec()),
-        })
-        .is_none()
-    {
-        this.common_state.quic.alert = Some(AlertDescription::DecodeError);
-        return Err(Error::CorruptMessage);
-    }
-    Ok(())
 }
 
 pub(crate) fn write_hs(this: &mut CommonState, buf: &mut Vec<u8>) -> Option<KeyChange> {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -1,4 +1,4 @@
-use crate::conn::{CommonState, ConnectionRandoms};
+use crate::conn::{CommonState, ConnectionRandoms, State};
 use crate::error::Error;
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
 #[cfg(feature = "logging")]
@@ -27,42 +27,9 @@ use crate::server::tls13;
 
 use std::sync::Arc;
 
-pub(super) type NextState = Box<dyn State>;
+pub(super) type NextState = Box<dyn State<ServerConnectionData>>;
 pub(super) type NextStateOrError = Result<NextState, Error>;
-
-pub(super) trait State: Send + Sync {
-    fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> NextStateOrError;
-
-    fn export_keying_material(
-        &self,
-        _output: &mut [u8],
-        _label: &[u8],
-        _context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        Err(Error::HandshakeNotComplete)
-    }
-
-    fn perhaps_write_key_update(&mut self, _common: &mut CommonState) {}
-}
-
-impl<'a> crate::conn::HandleState for Box<dyn State> {
-    type Data = ServerConnectionData;
-
-    fn handle(
-        self,
-        message: Message,
-        data: &mut Self::Data,
-        common: &mut CommonState,
-    ) -> Result<Self, Error> {
-        let mut cx = ServerContext { common, data };
-        self.handle(&mut cx, message)
-    }
-}
-
-pub(super) struct ServerContext<'a> {
-    pub(super) common: &'a mut CommonState,
-    pub(super) data: &'a mut ServerConnectionData,
-}
+pub(super) type ServerContext<'a> = crate::conn::Context<'a, ServerConnectionData>;
 
 pub(super) fn incompatible(common: &mut CommonState, why: &str) -> Error {
     common.send_fatal_alert(AlertDescription::HandshakeFailure);
@@ -306,7 +273,7 @@ impl ExpectClientHello {
     }
 }
 
-impl State for ExpectClientHello {
+impl State<ServerConnectionData> for ExpectClientHello {
     fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> NextStateOrError {
         let client_hello =
             require_handshake_msg!(m, HandshakeType::ClientHello, HandshakePayload::ClientHello)?;

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -367,8 +367,8 @@ impl Connection for ServerConnection {
 
     fn peer_certificates(&self) -> Option<&[key::Certificate]> {
         self.inner
-            .data
-            .client_cert_chain
+            .common_state
+            .peer_certificates
             .as_deref()
     }
 
@@ -419,7 +419,6 @@ pub(super) struct ServerConnectionData {
     pub(super) sni: Option<webpki::DnsName>,
     pub(super) received_resumption_data: Option<Vec<u8>>,
     pub(super) resumption_data: Vec<u8>,
-    pub(super) client_cert_chain: Option<Vec<key::Certificate>>,
 
     #[allow(dead_code)] // only supported for QUIC currently
     /// Whether to reject early data even if it would otherwise be accepted

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,6 +1,6 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
 use crate::conn::{
-    CommonState, Connection, ConnectionCommon, IoState, PlaintextSink, Reader, Writer,
+    CommonState, Connection, ConnectionCommon, IoState, PlaintextSink, Reader, State, Writer,
 };
 use crate::error::Error;
 use crate::key;
@@ -243,7 +243,7 @@ impl ServerConfig {
 /// Read data from the peer using the `io::Read` trait implementation.
 pub struct ServerConnection {
     common: ConnectionCommon,
-    state: Option<Box<dyn hs::State>>,
+    state: Option<Box<dyn State<ServerConnectionData>>>,
     data: ServerConnectionData,
 }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,7 +1,6 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
 use crate::conn::{CommonState, Connection, ConnectionCommon, IoState, Reader, Writer};
 use crate::error::Error;
-use crate::key;
 use crate::keylog::KeyLog;
 use crate::kx::SupportedKxGroup;
 #[cfg(feature = "quic")]
@@ -18,6 +17,7 @@ use crate::{conn::Protocol, quic};
 use super::hs;
 
 use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -328,60 +328,8 @@ impl Connection for ServerConnection {
         self.inner.read_tls(rd)
     }
 
-    /// Writes TLS messages to `wr`.
-    fn write_tls(&mut self, wr: &mut dyn io::Write) -> io::Result<usize> {
-        self.inner.common_state.write_tls(wr)
-    }
-
     fn process_new_packets(&mut self) -> Result<IoState, Error> {
         self.inner.process_new_packets()
-    }
-
-    fn wants_read(&self) -> bool {
-        self.inner.common_state.wants_read()
-    }
-
-    fn wants_write(&self) -> bool {
-        !self
-            .inner
-            .common_state
-            .sendable_tls
-            .is_empty()
-    }
-
-    fn is_handshaking(&self) -> bool {
-        !self.inner.common_state.traffic
-    }
-
-    fn set_buffer_limit(&mut self, len: Option<usize>) {
-        self.inner
-            .common_state
-            .set_buffer_limit(len)
-    }
-
-    fn send_close_notify(&mut self) {
-        self.inner
-            .common_state
-            .send_close_notify()
-    }
-
-    fn peer_certificates(&self) -> Option<&[key::Certificate]> {
-        self.inner
-            .common_state
-            .peer_certificates
-            .as_deref()
-    }
-
-    fn alpn_protocol(&self) -> Option<&[u8]> {
-        self.inner
-            .common_state
-            .get_alpn_protocol()
-    }
-
-    fn protocol_version(&self) -> Option<ProtocolVersion> {
-        self.inner
-            .common_state
-            .negotiated_version
     }
 
     fn export_keying_material(
@@ -411,6 +359,20 @@ impl fmt::Debug for ServerConnection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("ServerConnection")
             .finish()
+    }
+}
+
+impl Deref for ServerConnection {
+    type Target = CommonState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.common_state
+    }
+}
+
+impl DerefMut for ServerConnection {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner.common_state
     }
 }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -343,7 +343,7 @@ impl Connection for ServerConnection {
     }
 
     fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
-        self.inner.common_state.get_suite()
+        self.inner.common_state.suite
     }
 
     fn writer(&mut self) -> Writer {
@@ -414,7 +414,7 @@ impl quic::QuicExt for ServerConnection {
         Some(quic::DirectionalKeys::new(
             self.inner
                 .common_state
-                .get_suite()
+                .suite
                 .and_then(|suite| suite.tls13())?,
             self.inner
                 .common_state

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -342,10 +342,6 @@ impl Connection for ServerConnection {
             .export_keying_material(output, label, context)
     }
 
-    fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
-        self.inner.common_state.suite
-    }
-
     fn writer(&mut self) -> Writer {
         Writer::new(&mut self.inner)
     }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -278,7 +278,7 @@ mod client_hello {
             );
             cx.common
                 .start_encryption_tls12(&secrets);
-            cx.data.client_cert_chain = resumedata.client_cert_chain;
+            cx.common.peer_certificates = resumedata.client_cert_chain;
 
             if self.send_ticket {
                 emit_ticket(
@@ -678,7 +678,7 @@ impl State<ServerConnectionData> for ExpectCertificateVerify {
         }
 
         trace!("client CertificateVerify OK");
-        cx.data.client_cert_chain = Some(self.client_cert);
+        cx.common.peer_certificates = Some(self.client_cert);
 
         self.transcript.add_message(&m);
         Ok(Box::new(ExpectCcs {
@@ -741,7 +741,7 @@ fn get_server_connection_value_tls12(
         version,
         secrets.suite().common.suite,
         secret,
-        &cx.data.client_cert_chain,
+        cx.common.peer_certificates.clone(),
         cx.common.alpn_protocol.clone(),
         cx.data.resumption_data.clone(),
     );

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms};
+use crate::conn::{CommonState, ConnectionRandoms};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
@@ -357,7 +357,7 @@ mod client_hello {
 
     fn emit_certificate(
         transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
+        common: &mut CommonState,
         cert_chain: &[Certificate],
     ) {
         let c = Message {
@@ -372,11 +372,7 @@ mod client_hello {
         common.send_msg(c, false);
     }
 
-    fn emit_cert_status(
-        transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
-        ocsp: &[u8],
-    ) {
+    fn emit_cert_status(transcript: &mut HandshakeHash, common: &mut CommonState, ocsp: &[u8]) {
         let st = CertificateStatus::new(ocsp.to_owned());
 
         let c = Message {
@@ -393,7 +389,7 @@ mod client_hello {
 
     fn emit_server_kx(
         transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
+        common: &mut CommonState,
         sigschemes: Vec<SignatureScheme>,
         skxg: &'static kx::SupportedKxGroup,
         signing_key: &dyn sign::SigningKey,
@@ -476,7 +472,7 @@ mod client_hello {
         Ok(true)
     }
 
-    fn emit_server_hello_done(transcript: &mut HandshakeHash, common: &mut ConnectionCommon) {
+    fn emit_server_hello_done(transcript: &mut HandshakeHash, common: &mut CommonState) {
         let m = Message {
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
@@ -787,7 +783,7 @@ fn emit_ticket(
     cx.common.send_msg(m, false);
 }
 
-fn emit_ccs(common: &mut ConnectionCommon) {
+fn emit_ccs(common: &mut CommonState) {
     let m = Message {
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
@@ -799,7 +795,7 @@ fn emit_ccs(common: &mut ConnectionCommon) {
 fn emit_finished(
     secrets: &ConnectionSecrets,
     transcript: &mut HandshakeHash,
-    common: &mut ConnectionCommon,
+    common: &mut CommonState,
 ) {
     let vh = transcript.get_current_hash();
     let verify_data = secrets.server_verify_data(&vh);

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{CommonState, ConnectionRandoms};
+use crate::conn::{CommonState, ConnectionRandoms, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
@@ -18,7 +18,7 @@ use crate::{kx, verify};
 
 use super::common::ActiveCertifiedKey;
 use super::hs::{self, ServerContext};
-use super::{ProducesTickets, ServerConfig};
+use super::{ProducesTickets, ServerConfig, ServerConnectionData};
 
 use ring::constant_time;
 
@@ -498,7 +498,7 @@ struct ExpectCertificate {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectCertificate {
+impl State<ServerConnectionData> for ExpectCertificate {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         self.transcript.add_message(&m);
         let cert_chain = require_handshake_msg_move!(
@@ -573,7 +573,7 @@ struct ExpectClientKx {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectClientKx {
+impl State<ServerConnectionData> for ExpectClientKx {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let client_kx = require_handshake_msg!(
             m,
@@ -642,7 +642,7 @@ struct ExpectCertificateVerify {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectCertificateVerify {
+impl State<ServerConnectionData> for ExpectCertificateVerify {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let rc = {
             let sig = require_handshake_msg!(
@@ -704,7 +704,7 @@ struct ExpectCcs {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectCcs {
+impl State<ServerConnectionData> for ExpectCcs {
     fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         check_message(&m, &[ContentType::ChangeCipherSpec], &[])?;
 
@@ -823,7 +823,7 @@ struct ExpectFinished {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectFinished {
+impl State<ServerConnectionData> for ExpectFinished {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
@@ -892,7 +892,7 @@ struct ExpectTraffic {
 
 impl ExpectTraffic {}
 
-impl hs::State for ExpectTraffic {
+impl State<ServerConnectionData> for ExpectTraffic {
     fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -18,7 +18,7 @@ use crate::{kx, verify};
 
 use super::common::ActiveCertifiedKey;
 use super::hs::{self, ServerContext};
-use super::{ProducesTickets, ServerConfig, ServerConnectionData};
+use super::server_conn::{ProducesTickets, ServerConfig, ServerConnectionData};
 
 use ring::constant_time;
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "quic")]
 use crate::check::check_message;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms};
+use crate::conn::{CommonState, ConnectionRandoms};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
@@ -463,7 +463,7 @@ mod client_hello {
         Ok(key_schedule)
     }
 
-    fn emit_fake_ccs(common: &mut ConnectionCommon) {
+    fn emit_fake_ccs(common: &mut CommonState) {
         if common.is_quic() {
             return;
         }
@@ -477,7 +477,7 @@ mod client_hello {
     fn emit_hello_retry_request(
         transcript: &mut HandshakeHash,
         suite: &'static Tls13CipherSuite,
-        common: &mut ConnectionCommon,
+        common: &mut CommonState,
         group: NamedGroup,
     ) {
         let mut req = HelloRetryRequest {
@@ -596,7 +596,7 @@ mod client_hello {
 
     fn emit_certificate_tls13(
         transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
+        common: &mut CommonState,
         cert_chain: &[Certificate],
         ocsp_response: Option<&[u8]>,
         sct_list: Option<&[u8]>,
@@ -645,7 +645,7 @@ mod client_hello {
 
     fn emit_certificate_verify_tls13(
         transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
+        common: &mut CommonState,
         signing_key: &dyn sign::SigningKey,
         schemes: &[SignatureScheme],
     ) -> Result<(), Error> {
@@ -1012,7 +1012,7 @@ struct ExpectTraffic {
 impl ExpectTraffic {
     fn handle_key_update(
         &mut self,
-        common: &mut ConnectionCommon,
+        common: &mut CommonState,
         kur: &KeyUpdateRequest,
     ) -> Result<(), Error> {
         #[cfg(feature = "quic")]
@@ -1091,7 +1091,7 @@ impl hs::State for ExpectTraffic {
             .export_keying_material(output, label, context)
     }
 
-    fn perhaps_write_key_update(&mut self, common: &mut ConnectionCommon) {
+    fn perhaps_write_key_update(&mut self, common: &mut CommonState) {
         if self.want_write_key_update {
             self.want_write_key_update = false;
             common.send_msg_encrypt(Message::build_key_update_notify().into());

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -24,7 +24,7 @@ use crate::verify;
 use crate::{conn::Protocol, msgs::handshake::NewSessionTicketExtension};
 
 use super::hs::{self, HandshakeHashOrBuffer, ServerContext};
-use super::ServerConnectionData;
+use super::server_conn::ServerConnectionData;
 
 use std::sync::Arc;
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -277,7 +277,7 @@ mod client_hello {
 
             if let Some(ref resume) = resumedata {
                 cx.data.received_resumption_data = Some(resume.application_data.0.clone());
-                cx.data.client_cert_chain = resume.client_cert_chain.clone();
+                cx.common.peer_certificates = resume.client_cert_chain.clone();
             }
 
             let full_handshake = resumedata.is_none();
@@ -835,7 +835,7 @@ impl State<ServerConnectionData> for ExpectCertificateVerify {
         }
 
         trace!("client CertificateVerify OK");
-        cx.data.client_cert_chain = Some(self.client_cert);
+        cx.common.peer_certificates = Some(self.client_cert);
 
         self.transcript.add_message(&m);
         Ok(Box::new(ExpectFinished {
@@ -867,7 +867,7 @@ fn get_server_session_value(
         version,
         suite.common.suite,
         secret,
-        &cx.data.client_cert_chain,
+        cx.common.peer_certificates.clone(),
         cx.common.alpn_protocol.clone(),
         cx.data.resumption_data.clone(),
     )

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -1,5 +1,5 @@
 use crate::cipher::{MessageDecrypter, MessageEncrypter};
-use crate::conn::ConnectionCommon;
+use crate::conn::CommonState;
 use crate::conn::ConnectionRandoms;
 use crate::kx;
 use crate::msgs::codec::{Codec, Reader};
@@ -420,11 +420,11 @@ fn join_randoms(first: &[u8; 32], second: &[u8; 32]) -> [u8; 64] {
 type MessageCipherPair = (Box<dyn MessageDecrypter>, Box<dyn MessageEncrypter>);
 
 pub(crate) fn decode_ecdh_params<T: Codec>(
-    conn: &mut ConnectionCommon,
+    common: &mut CommonState,
     kx_params: &[u8],
 ) -> Result<T, Error> {
     decode_ecdh_params_::<T>(kx_params).ok_or_else(|| {
-        conn.send_fatal_alert(AlertDescription::DecodeError);
+        common.send_fatal_alert(AlertDescription::DecodeError);
         Error::CorruptMessagePayload(ContentType::Handshake)
     })
 }


### PR DESCRIPTION
This combines the main change from #691 with some of the changes from #710 to split up the `ConnectionCommon` type to separate out interfaces that the state machine states use to write into the `ConnectionCommon` type. This addresses the feedback from #691 that we should ditch the context types and move the data types into the `ConnectionCommon`.

Splitting the `ConnectionCommon` type also enables a bunch of borrowing because it separates the `handshake_joiner` and `message_deframer` from the state the state machine wants to write to.

I think this represents a good step towards the final situation while focusing on the larger changes. While this doesn't impact the public API directly, some of the borrowing changes might (for example due to the peer certificates return type changes).