### PR TITLE
Add Acceptor API for resolving server configuration based on ClientHello

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -194,14 +194,11 @@ impl rustls::server::ClientCertVerifier for DummyClientAuth {
         true
     }
 
-    fn client_auth_mandatory(&self, _sni: Option<&rustls::server::DnsName>) -> Option<bool> {
+    fn client_auth_mandatory(&self) -> Option<bool> {
         Some(self.mandatory)
     }
 
-    fn client_auth_root_subjects(
-        &self,
-        _sni: Option<&rustls::server::DnsName>,
-    ) -> Option<rustls::DistinguishedNames> {
+    fn client_auth_root_subjects(&self) -> Option<rustls::DistinguishedNames> {
         Some(rustls::DistinguishedNames::new())
     }
 
@@ -209,7 +206,6 @@ impl rustls::server::ClientCertVerifier for DummyClientAuth {
         &self,
         _end_entity: &rustls::Certificate,
         _intermediates: &[rustls::Certificate],
-        _sni: Option<&rustls::server::DnsName>,
         _now: SystemTime,
     ) -> Result<rustls::server::ClientCertVerified, rustls::Error> {
         Ok(rustls::server::ClientCertVerified::assertion())

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -420,8 +420,10 @@ pub mod server {
     #[cfg_attr(docsrs, doc(cfg(feature = "quic")))]
     pub use server_conn::ServerQuicExt;
     pub use server_conn::StoresServerSessions;
+    pub use server_conn::{
+        Accepted, Acceptor, ServerConfig, ServerConnection, ServerConnectionData,
+    };
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
-    pub use server_conn::{ServerConfig, ServerConnection, ServerConnectionData};
 
     #[cfg(feature = "dangerous_configuration")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -19,15 +19,9 @@ impl MessageFragmenter {
     /// this includes overhead. A `max_fragment_size` of 10 will produce TLS fragments
     /// up to 10 bytes.
     pub fn new(max_fragment_size: Option<usize>) -> Result<Self, Error> {
-        let max_fragment_len = match max_fragment_size {
-            Some(sz @ 32..=MAX_FRAGMENT_SIZE) => sz - PACKET_OVERHEAD,
-            None => MAX_FRAGMENT_LEN,
-            _ => return Err(Error::BadMaxFragmentSize),
-        };
-
-        Ok(Self {
-            max_frag: max_fragment_len,
-        })
+        let mut new = Self { max_frag: 0 };
+        new.set_max_fragment_size(max_fragment_size)?;
+        Ok(new)
     }
 
     /// Take the Message `msg` and re-fragment it into new
@@ -67,6 +61,15 @@ impl MessageFragmenter {
             };
             out.push_back(cm);
         }
+    }
+
+    pub fn set_max_fragment_size(&mut self, new: Option<usize>) -> Result<(), Error> {
+        self.max_frag = match new {
+            Some(sz @ 32..=MAX_FRAGMENT_SIZE) => sz - PACKET_OVERHEAD,
+            None => MAX_FRAGMENT_LEN,
+            _ => return Err(Error::BadMaxFragmentSize),
+        };
+        Ok(())
     }
 }
 

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -259,16 +259,18 @@ mod test {
     fn test_resolvesservercertusingsni_requires_sni() {
         let rscsni = ResolvesServerCertUsingSni::new();
         assert!(rscsni
-            .resolve(ClientHello::new(None, &[], None))
+            .resolve(ClientHello::new(&None, &[], None))
             .is_none());
     }
 
     #[test]
     fn test_resolvesservercertusingsni_handles_unknown_name() {
         let rscsni = ResolvesServerCertUsingSni::new();
-        let name = webpki::DnsNameRef::try_from_ascii_str("hello.com").unwrap();
+        let name = webpki::DnsNameRef::try_from_ascii_str("hello.com")
+            .unwrap()
+            .to_owned();
         assert!(rscsni
-            .resolve(ClientHello::new(Some(name), &[], None))
+            .resolve(ClientHello::new(&Some(name), &[], None))
             .is_none());
     }
 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -541,12 +541,6 @@ impl ServerConnectionData {
     pub(super) fn get_sni_str(&self) -> Option<&str> {
         self.sni.as_ref().map(AsRef::as_ref)
     }
-
-    pub(super) fn get_sni(&self) -> Option<verify::DnsName> {
-        self.sni
-            .as_ref()
-            .map(|name| verify::DnsName(name.clone()))
-    }
 }
 
 impl crate::conn::SideData for ServerConnectionData {}

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -442,7 +442,7 @@ mod client_hello {
         let verify_schemes = client_auth.supported_verify_schemes();
 
         let names = client_auth
-            .client_auth_root_subjects(cx.data.get_sni().as_ref())
+            .client_auth_root_subjects()
             .ok_or_else(|| {
                 debug!("could not determine root subjects based on SNI");
                 cx.common
@@ -512,7 +512,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         let mandatory = self
             .config
             .verifier
-            .client_auth_mandatory(cx.data.get_sni().as_ref())
+            .client_auth_mandatory()
             .ok_or_else(|| {
                 debug!("could not determine if client auth is mandatory based on SNI");
                 cx.common
@@ -537,7 +537,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
                 let now = std::time::SystemTime::now();
                 self.config
                     .verifier
-                    .verify_client_cert(end_entity, intermediates, cx.data.get_sni().as_ref(), now)
+                    .verify_client_cert(end_entity, intermediates, now)
                     .map_err(|err| {
                         hs::incompatible(&mut cx.common, "certificate invalid");
                         err

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -568,7 +568,7 @@ mod client_hello {
 
         let names = config
             .verifier
-            .client_auth_root_subjects(cx.data.get_sni().as_ref())
+            .client_auth_root_subjects()
             .ok_or_else(|| {
                 debug!("could not determine root subjects based on SNI");
                 cx.common
@@ -752,7 +752,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         let mandatory = self
             .config
             .verifier
-            .client_auth_mandatory(cx.data.get_sni().as_ref())
+            .client_auth_mandatory()
             .ok_or_else(|| {
                 debug!("could not determine if client auth is mandatory based on SNI");
                 cx.common
@@ -784,7 +784,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         let now = std::time::SystemTime::now();
         self.config
             .verifier
-            .verify_client_cert(end_entity, intermediates, cx.data.get_sni().as_ref(), now)
+            .verify_client_cert(end_entity, intermediates, now)
             .map_err(|err| {
                 hs::incompatible(&mut cx.common, "certificate invalid");
                 err

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -119,13 +119,9 @@ mod client_hello {
             cx: &mut ServerContext<'_>,
             server_key: ActiveCertifiedKey,
             chm: &Message,
+            client_hello: &ClientHelloPayload,
+            mut sigschemes_ext: Vec<SignatureScheme>,
         ) -> hs::NextStateOrError {
-            let client_hello = require_handshake_msg!(
-                chm,
-                HandshakeType::ClientHello,
-                HandshakePayload::ClientHello
-            )?;
-
             if client_hello.compression_methods.len() != 1 {
                 return Err(cx
                     .common
@@ -135,13 +131,6 @@ mod client_hello {
             let groups_ext = client_hello
                 .get_namedgroups_extension()
                 .ok_or_else(|| hs::incompatible(&mut cx.common, "client didn't describe groups"))?;
-
-            let mut sigschemes_ext = client_hello
-                .get_sigalgs_extension()
-                .ok_or_else(|| {
-                    hs::incompatible(&mut cx.common, "client didn't describe sigschemes")
-                })?
-                .clone();
 
             let tls13_schemes = sign::supported_sign_tls13();
             sigschemes_ext.retain(|scheme| tls13_schemes.contains(scheme));

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -543,18 +543,11 @@ pub struct MockClientVerifier {
 
 #[cfg(feature = "dangerous_configuration")]
 impl ClientCertVerifier for MockClientVerifier {
-    fn client_auth_mandatory(&self, sni: Option<&rustls::server::DnsName>) -> Option<bool> {
-        // This is just an added 'test' to make sure we plumb through the SNI,
-        // although its valid for it to be None, its just our tests should (as of now) always provide it
-        assert!(sni.is_some());
+    fn client_auth_mandatory(&self) -> Option<bool> {
         self.mandatory
     }
 
-    fn client_auth_root_subjects(
-        &self,
-        sni: Option<&rustls::server::DnsName>,
-    ) -> Option<DistinguishedNames> {
-        assert!(sni.is_some());
+    fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
         self.subjects.as_ref().cloned()
     }
 
@@ -562,10 +555,8 @@ impl ClientCertVerifier for MockClientVerifier {
         &self,
         _end_entity: &Certificate,
         _intermediates: &[Certificate],
-        sni: Option<&rustls::server::DnsName>,
         _now: std::time::SystemTime,
     ) -> Result<ClientCertVerified, Error> {
-        assert!(sni.is_some());
         (self.verified)()
     }
 


### PR DESCRIPTION
This builds on (the current version of) #721 (only the last three commits are new) and adds an API as proposed in #89. The current implementation requires a small change to the lifetimes exposed in the return type of `ClientHello::alpn()`; the final commit proceeds to remove the `sni` argument from `ClientCertVerifier` methods, which should no longer necessary.

Note that this is on my ISRG list, because it's something we'd like to use for the Apache httpd mod_tls project.

Fixes #89.