### PR TITLE
Fix error message when the client disabled the server's TLS version

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -523,9 +523,11 @@ impl State for ExpectServerHello {
             _ => {
                 cx.common
                     .send_fatal_alert(AlertDescription::ProtocolVersion);
-                return Err(Error::PeerIncompatibleError(
-                    "server does not support TLS v1.2/v1.3".to_string(),
-                ));
+                let msg = match server_version {
+                    TLSv1_2 | TLSv1_3 => "server's TLS version is disabled in client",
+                    _ => "server does not support TLS v1.2/v1.3",
+                };
+                return Err(Error::PeerIncompatibleError(msg.to_string()));
             }
         };
 


### PR DESCRIPTION
This can for example come up if the client demands v1.3 and the server only has v1.2.