### PR TITLE
Fixes for TLS 1.2 session resumption

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -577,6 +577,10 @@ impl State<ClientConnectionData> for ExpectServerHello {
         transcript.add_message(&m);
 
         let randoms = ConnectionRandoms::new(self.random, server_hello.random, true);
+        let resuming_session = self
+            .resuming_session
+            .filter(|resuming| resuming.version.version() == version);
+
         // For TLS1.3, start message encryption using
         // handshake_traffic_secret.
         match suite {
@@ -585,7 +589,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
                     self.config,
                     cx,
                     server_hello,
-                    self.resuming_session,
+                    resuming_session,
                     self.server_name,
                     randoms,
                     suite,
@@ -600,7 +604,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
             #[cfg(feature = "tls12")]
             SupportedCipherSuite::Tls12(suite) => tls12::CompleteServerHelloHandling {
                 config: self.config,
-                resuming_session: self.resuming_session,
+                resuming_session,
                 server_name: self.server_name,
                 randoms,
                 using_ems: self.using_ems,

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -111,7 +111,7 @@ mod server_hello {
 
             // See if we're successfully resuming.
             if let Some(ref resuming) = self.resuming_session {
-                if resuming.session_id == self.session_id {
+                if resuming.session_id() == Some(&self.session_id) {
                     debug!("Server agreed to resume");
 
                     // Is the server telling lies about the ciphersuite?
@@ -1008,9 +1008,8 @@ impl ExpectFinished {
 
         let master_secret = self.secrets.get_master_secret();
         let mut value = persist::ClientSessionValueWithResolvedCipherSuite::new(
-            ProtocolVersion::TLSv1_2,
+            persist::ResumeVersionWithSessionId::Tls12(self.session_id),
             self.secrets.suite().into(),
-            &self.session_id,
             ticket,
             master_secret,
             cx.common

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -17,7 +17,7 @@ use crate::msgs::handshake::EncryptedExtensions;
 use crate::msgs::handshake::NewSessionTicketPayloadTLS13;
 use crate::msgs::handshake::{CertificateEntry, CertificatePayloadTLS13};
 use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
-use crate::msgs::handshake::{HasServerExtensions, ServerHelloPayload, SessionID};
+use crate::msgs::handshake::{HasServerExtensions, ServerHelloPayload};
 use crate::msgs::handshake::{PresharedKeyIdentity, PresharedKeyOffer};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -985,9 +985,8 @@ impl ExpectTraffic {
 
         let time_now = TimeBase::now()?;
         let mut value = persist::ClientSessionValueWithResolvedCipherSuite::new(
-            ProtocolVersion::TLSv1_3,
+            persist::ResumeVersionWithSessionId::Tls13,
             self.suite.into(),
-            &SessionID::empty(),
             nst.ticket.0.clone(),
             secret,
             cx.common

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -1,6 +1,5 @@
 use super::codec::{Codec, Reader};
 use super::enums::*;
-use super::handshake::*;
 use super::persist::*;
 
 use crate::key::Certificate;
@@ -26,9 +25,8 @@ fn clientsessionkey_cannot_be_read() {
 #[test]
 fn clientsessionvalue_is_debug() {
     let csv = ClientSessionValueWithResolvedCipherSuite::new(
-        ProtocolVersion::TLSv1_3,
+        ResumeVersionWithSessionId::Tls13,
         TLS13_AES_128_GCM_SHA256,
-        &SessionID::random().unwrap(),
         vec![],
         vec![1, 2, 3],
         vec![Certificate(b"abc".to_vec()), Certificate(b"def".to_vec())],

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -21,6 +21,9 @@ impl server::StoresServerSessions for NoServerSessionStorage {
     fn take(&self, _id: &[u8]) -> Option<Vec<u8>> {
         None
     }
+    fn can_cache(&self) -> bool {
+        false
+    }
 }
 
 /// An implementer of `StoresServerSessions` that stores everything
@@ -60,6 +63,10 @@ impl server::StoresServerSessions for ServerSessionMemoryCache {
 
     fn take(&self, key: &[u8]) -> Option<Vec<u8>> {
         self.cache.lock().unwrap().remove(key)
+    }
+
+    fn can_cache(&self) -> bool {
+        true
     }
 }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -52,6 +52,11 @@ pub trait StoresServerSessions: Send + Sync {
     /// Find a value with the given `key`.  Return it and delete it;
     /// or None if it doesn't exist.
     fn take(&self, key: &[u8]) -> Option<Vec<u8>>;
+
+    /// Whether the store can cache another session. This is used to indicate to clients
+    /// whether their session can be resumed; the implementation is not required to remember
+    /// a session even if it returns `true` here.
+    fn can_cache(&self) -> bool;
 }
 
 /// A trait for the ability to encrypt and decrypt tickets.

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -174,9 +174,10 @@ mod client_hello {
             let (mut ocsp_response, mut sct_list) =
                 (server_key.get_ocsp(), server_key.get_sct_list());
 
-            // If we're not offered a ticket or a potential connection ID,
-            // allocate a connection ID.
-            if self.session_id.is_empty() && !ticket_received {
+            // If we're not offered a ticket or a potential session ID, allocate a session ID.
+            if !self.config.session_storage.can_cache() {
+                self.session_id = SessionID::empty();
+            } else if self.session_id.is_empty() && !ticket_received {
                 self.session_id = SessionID::random()?;
             }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2809,6 +2809,10 @@ impl rustls::server::StoresServerSessions for ServerStorage {
             .fetch_add(1, Ordering::SeqCst);
         self.storage.take(key)
     }
+
+    fn can_cache(&self) -> bool {
+        true
+    }
 }
 
 struct ClientStorage {


### PR DESCRIPTION
To make testing this easier (and because it seems useful to signal to the client), we add a method to `StoresServerSessions` that allows the implementation to signal whether it's accepting new sessions.

Fixes #797.