### PR TITLE
client: version-specific session resumption values

### DIFF
--- a/fuzz/fuzzers/persist.rs
+++ b/fuzz/fuzzers/persist.rs
@@ -11,6 +11,7 @@ fn try_type<T>(data: &[u8]) where T: Codec {
 }
 
 fuzz_target!(|data: &[u8]| {
-    try_type::<persist::ClientSessionValue>(data);
+    try_type::<persist::Tls12ClientSessionValue>(data);
+    try_type::<persist::Tls13ClientSessionValue>(data);
     try_type::<persist::ServerSessionValue>(data);
 });

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -24,14 +24,18 @@ fn clientsessionkey_cannot_be_read() {
 
 #[test]
 fn clientsessionvalue_is_debug() {
-    let csv = ClientSessionValueWithResolvedCipherSuite::new(
-        ResumeVersionWithSessionId::Tls13,
-        TLS13_AES_128_GCM_SHA256,
+    let csv = ClientSessionValue::from(Tls13ClientSessionValue::new(
+        TLS13_AES_128_GCM_SHA256
+            .tls13()
+            .unwrap(),
         vec![],
         vec![1, 2, 3],
         vec![Certificate(b"abc".to_vec()), Certificate(b"def".to_vec())],
         TimeBase::now().unwrap(),
-    );
+        15,
+        10,
+        128,
+    ));
     println!("{:?}", csv);
 }
 

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -259,12 +259,12 @@ mod test {
         assert!(TLS13_AES_128_GCM_SHA256
             .tls13()
             .unwrap()
-            .can_resume_from(TLS13_CHACHA20_POLY1305_SHA256)
+            .can_resume_from(crate::tls13::TLS13_CHACHA20_POLY1305_SHA256_INTERNAL)
             .is_some());
         assert!(TLS13_AES_256_GCM_SHA384
             .tls13()
             .unwrap()
-            .can_resume_from(TLS13_CHACHA20_POLY1305_SHA256)
+            .can_resume_from(crate::tls13::TLS13_CHACHA20_POLY1305_SHA256_INTERNAL)
             .is_none());
     }
 }

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -103,15 +103,8 @@ impl Tls13CipherSuite {
     }
 
     /// Can a session using suite self resume from suite prev?
-    pub fn can_resume_from(&self, prev: SupportedCipherSuite) -> Option<&'static Self> {
-        match prev {
-            SupportedCipherSuite::Tls13(inner)
-                if inner.hash_algorithm() == self.hash_algorithm() =>
-            {
-                Some(inner)
-            }
-            _ => None,
-        }
+    pub fn can_resume_from(&self, prev: &'static Self) -> Option<&'static Self> {
+        (prev.hash_algorithm() == self.hash_algorithm()).then(|| prev)
     }
 }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -13,7 +13,7 @@ use std::sync::Mutex;
 use rustls;
 
 use rustls::client::ResolvesClientCert;
-use rustls::internal::msgs::{codec::Codec, persist::ClientSessionValue};
+use rustls::internal::msgs::{codec::Codec, persist::Tls13ClientSessionValue};
 #[cfg(feature = "quic")]
 use rustls::quic::{self, ClientQuicExt, QuicExt, ServerQuicExt};
 use rustls::server::{ClientHello, ResolvesServerCert};
@@ -3025,8 +3025,9 @@ fn early_data_is_available_on_resumption() {
         .storage
         .get(&session_key)
         .unwrap();
-    let mut session_value = ClientSessionValue::read_bytes(&session_value_bytes).unwrap();
-    session_value.max_early_data_size = 128;
+
+    let mut session_value = Tls13ClientSessionValue::read_bytes(&session_value_bytes).unwrap();
+    session_value.set_max_early_data_size(128);
 
     storage
         .storage


### PR DESCRIPTION
Use a similar approach to #724 to differentiate between TLS 1.2/1.3 `ClientSessionValue`s: encode as an enum (variant keyed on the cipher suite, so we don't need to encode the protocol version specifically). This avoids having fields and/or methods accessible to both 1.2 and 1.3 code when only one of the versions needs it. It also takes a more principled approach to (the third commit in) #799, by tracking the version of resumption information at the type level.