### PR TITLE
Pull request exposing strictly what is needed to provide the ability to statically decrypt TLS 1.3 messages from external users of the library

### DIFF
--- a/rustls/src/cipher.rs
+++ b/rustls/src/cipher.rs
@@ -5,7 +5,9 @@ use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 use ring::{aead, hkdf};
 
 /// Objects with this trait can decrypt TLS messages.
-pub(crate) trait MessageDecrypter: Send + Sync {
+pub trait MessageDecrypter: Send + Sync {
+    /// Perform the decryption over the concerned TLS message.
+
     fn decrypt(&self, m: OpaqueMessage, seq: u64) -> Result<PlainMessage, Error>;
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -340,7 +340,7 @@ pub mod internal {
     }
     /// Low-level TLS message decryption functions.
     pub mod cipher {
-        pub use crate::cipher::*;
+        pub use crate::cipher::MessageDecrypter;
     }
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -338,6 +338,10 @@ pub mod internal {
     pub mod msgs {
         pub use crate::msgs::*;
     }
+    /// Low-level TLS message decryption functions.
+    pub mod cipher {
+        pub use crate::cipher::*;
+    }
 }
 
 // The public interface is:

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -85,7 +85,9 @@ impl Tls13CipherSuite {
         })
     }
 
-    pub(crate) fn derive_decrypter(&self, secret: &hkdf::Prk) -> Box<dyn MessageDecrypter> {
+    /// Derive a `MessageDecrypter` object from the concerned TLS 1.3
+    /// cipher suite.
+    pub fn derive_decrypter(&self, secret: &hkdf::Prk) -> Box<dyn MessageDecrypter> {
         let key = derive_traffic_key(secret, self.common.aead_algorithm);
         let iv = derive_traffic_iv(secret);
 


### PR DESCRIPTION
Hello,

This pull request is created following this issue: https://github.com/rustls/rustls/issues/786 

And has been submitted after it has been requested to do it in this comment: https://github.com/rustls/rustls/issues/786#issuecomment-914988853

It intends to make public what is needed to give to external users of the library the ability to statically decrypt TLS 1.3 messages. It does not include encrypting messages or supporting TLS 1.2 because it was not the original request, but can be added if needed.

It makes the `rustls::cipher::internal::MessageDecrypter` trait as well as the `rustls::tls13::Tls13CipherSuite::derive_decrypter` structure method public.

Regards,