### PR TITLE
Fix go 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install golang toolchain
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.17.1"
 
       - name: Run test suite
         working-directory: bogo
@@ -202,7 +202,7 @@ jobs:
       - name: Install golang toolchain
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.17.1"
 
       - name: Build lcov
         run: admin/build-lcov

--- a/bogo/fetch-and-build
+++ b/bogo/fetch-and-build
@@ -17,6 +17,9 @@ EOF
 COMMIT=3fea50a7cb55bb72e4a69d34015f1a6971e7934c
 git fetch --depth=1 https://github.com/rustls/boringssl.git $COMMIT
 git checkout $COMMIT
-(cd ssl/test/runner && go test -c)
+(cd ssl/test/runner &&
+ go mod download golang.org/x/crypto &&
+ go get golang.org/x/crypto/chacha20poly1305@v0.0.0-20200622213623-75b288015ac9 &&
+ go test -c)
 
 popd


### PR DESCRIPTION
I didn't find the documentation or release notes that say these extra build commands are required when upgrading from 1.14 to 1.17, but evidently they are 🤷🏽 