### PR TITLE
docs: Be explicit about how to not pass a list of DNs for client auth

### DIFF
--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -201,7 +201,8 @@ pub trait ClientCertVerifier: Send + Sync {
     /// Returns the subject names of the client authentication trust anchors to
     /// share with the client when requesting client authentication.
     ///
-    /// Return `None` to abort the connection.
+    /// Return `None` to abort the connection. Return an empty `Vec` to continue
+    /// the handshake without passing a list of CA DNs.
     fn client_auth_root_subjects(&self) -> Option<DistinguishedNames>;
 
     /// Verify the end-entity certificate `end_entity` is valid for the


### PR DESCRIPTION
It took me way longer than I care to admit to figure this out, so I
thought I'd spare others the trouble.

Fixes #828.