### PR TITLE
Implement std::error::Error for InvalidDnsNameError

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -21,6 +21,7 @@ use super::hs;
 use crate::quic;
 
 use std::convert::TryFrom;
+use std::error::Error as StdError;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -258,6 +259,14 @@ impl TryFrom<&str> for ServerName {
 
 #[derive(Debug)]
 pub struct InvalidDnsNameError;
+
+impl fmt::Display for InvalidDnsNameError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid dns name")
+    }
+}
+
+impl StdError for InvalidDnsNameError {}
 
 /// Container for unsafe APIs
 #[cfg(feature = "dangerous_configuration")]


### PR DESCRIPTION
Noticed this when porting something like

```rust
fn main() -> Result<(), Box<dyn Error>> {
    let server_name = webpki::DNSNameRef::try_from_ascii_str(domain)?; // rustls 0.19
    // ...
}
```

to rustls 0.20.0:

```rust
fn main() -> Result<(), Box<dyn Error>> {
    let server_name = rustls::ServerName::try_from(domain)?;
    // ...
}
```

Additionally, the type is currently not exported from the crate, so it's not possible to explicitly refer to it. I did not address that, because I wasn't sure if it should be reexported from the root of the crate or some module.