### PR TITLE
Stricter builder checks on cipher suite/version compatibility

### DIFF
--- a/rustls-mio/tests/client_suites.rs
+++ b/rustls-mio/tests/client_suites.rs
@@ -14,6 +14,7 @@ fn ecdhe_rsa_aes_128_gcm_sha256() {
     server
         .client()
         .verbose()
+        .version("1.2")
         .suite("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
         .expect("Ciphers common between both SSL end points:\nECDHE-RSA-AES128-GCM-SHA256")
         .go();
@@ -29,6 +30,7 @@ fn ecdhe_rsa_aes_256_gcm_sha384() {
     server
         .client()
         .verbose()
+        .version("1.2")
         .suite("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
         .expect("Ciphers common between both SSL end points:\nECDHE-RSA-AES256-GCM-SHA384")
         .go();
@@ -44,6 +46,7 @@ fn ecdhe_ecdsa_aes_128_gcm_sha256() {
     server
         .client()
         .verbose()
+        .version("1.2")
         .suite("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
         .expect("Ciphers common between both SSL end points:\nECDHE-ECDSA-AES128-GCM-SHA256")
         .go();
@@ -59,6 +62,7 @@ fn ecdhe_ecdsa_aes_256_gcm_sha384() {
     server
         .client()
         .verbose()
+        .version("1.2")
         .suite("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")
         .expect("Ciphers common between both SSL end points:\nECDHE-ECDSA-AES256-GCM-SHA384")
         .go();

--- a/rustls-mio/tests/common/mod.rs
+++ b/rustls-mio/tests/common/mod.rs
@@ -261,6 +261,7 @@ pub struct TlsClient {
     pub client_auth_key: Option<PathBuf>,
     pub client_auth_certs: Option<PathBuf>,
     pub cache: Option<String>,
+    pub versions: Vec<String>,
     pub suites: Vec<String>,
     pub protos: Vec<Vec<u8>>,
     pub no_tickets: bool,
@@ -288,6 +289,7 @@ impl TlsClient {
             insecure: false,
             verbose: false,
             max_fragment_size: None,
+            versions: Vec::new(),
             suites: Vec::new(),
             protos: Vec::new(),
             expect_fails: false,
@@ -351,6 +353,11 @@ impl TlsClient {
     pub fn expect_log(&mut self, expect: &str) -> &mut TlsClient {
         self.verbose = true;
         self.expect_log.push(expect.to_string());
+        self
+    }
+
+    pub fn version(&mut self, version: &str) -> &mut TlsClient {
+        self.versions.push(version.to_string());
         self
     }
 
@@ -430,6 +437,11 @@ impl TlsClient {
                     .to_str()
                     .unwrap(),
             );
+        }
+
+        for version in &self.versions {
+            args.push("--protover");
+            args.push(version.as_ref());
         }
 
         for suite in &self.suites {
@@ -618,6 +630,7 @@ pub struct TlsServer {
     pub certs: PathBuf,
     pub key: PathBuf,
     pub cafile: PathBuf,
+    pub versions: Vec<String>,
     pub suites: Vec<String>,
     pub protos: Vec<Vec<u8>>,
     used_suites: Vec<String>,
@@ -646,6 +659,7 @@ impl TlsServer {
                 .join("end.fullchain"),
             cafile: test_ca.join(keytype).join("ca.cert"),
             verbose: false,
+            versions: Vec::new(),
             suites: Vec::new(),
             protos: Vec::new(),
             used_suites: Vec::new(),
@@ -677,6 +691,11 @@ impl TlsServer {
 
     pub fn port(&mut self, port: u16) -> &mut Self {
         self.port = port;
+        self
+    }
+
+    pub fn version(&mut self, version: &str) -> &mut Self {
+        self.versions.push(version.to_string());
         self
     }
 
@@ -719,6 +738,11 @@ impl TlsServer {
         args.push(self.key.to_str().unwrap());
         args.push("--certs");
         args.push(self.certs.to_str().unwrap());
+
+        for version in &self.versions {
+            args.push("--protover");
+            args.push(version.as_ref());
+        }
 
         self.used_suites = self.suites.clone();
         for suite in &self.used_suites {

--- a/rustls-mio/tests/server_suites.rs
+++ b/rustls-mio/tests/server_suites.rs
@@ -13,6 +13,7 @@ fn ecdhe_rsa_aes_128_gcm_sha256() {
 
     server
         .echo_mode()
+        .version("1.2")
         .suite("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
         .run();
 
@@ -32,6 +33,7 @@ fn ecdhe_rsa_aes_256_gcm_sha384() {
 
     server
         .echo_mode()
+        .version("1.2")
         .suite("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
         .run();
 
@@ -51,6 +53,7 @@ fn ecdhe_ecdsa_aes_128_gcm_sha256() {
 
     server
         .echo_mode()
+        .version("1.2")
         .suite("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
         .run();
 
@@ -70,6 +73,7 @@ fn ecdhe_ecdsa_aes_256_gcm_sha384() {
 
     server
         .echo_mode()
+        .version("1.2")
         .suite("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")
         .run();
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -165,10 +165,6 @@ impl ClientConfig {
     /// also configured.
     pub fn supports_version(&self, v: ProtocolVersion) -> bool {
         self.versions.contains(v)
-            && self
-                .cipher_suites
-                .iter()
-                .any(|cs| cs.version().version == v)
     }
 
     /// Access configuration options whose use is dangerous and requires

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -89,6 +89,9 @@ pub trait ResolvesClientCert: Send + Sync {
 #[derive(Clone)]
 pub struct ClientConfig {
     /// List of ciphersuites, in preference order.
+    ///
+    /// Invariants enforced by the builder: the version matching a given configured cipher suite
+    /// is also enabled.
     pub(super) cipher_suites: Vec<SupportedCipherSuite>,
 
     /// List of supported key exchange algorithms, in preference order -- the
@@ -124,8 +127,10 @@ pub struct ClientConfig {
     /// The default is true.
     pub enable_tickets: bool,
 
-    /// Supported versions, in no particular order.  The default
-    /// is all supported versions.
+    /// Supported protocol versions, in no particular order.
+    ///
+    /// The default is all supported versions. Invariants enforced by the builder: at least one
+    /// version is enabled, and cipher suites matching the enabled versions are also configured.
     pub(super) versions: versions::EnabledVersions,
 
     /// Whether to send the Server Name Indication (SNI) extension
@@ -159,10 +164,9 @@ impl ClientConfig {
         }
     }
 
-    #[doc(hidden)]
-    /// We support a given TLS version if it's quoted in the configured
-    /// versions *and* at least one ciphersuite for this version is
-    /// also configured.
+    /// We support a given TLS version if it was configured through the builder.
+    ///
+    /// (The builder ensures that matching cipher suites are configured as well.)
     pub fn supports_version(&self, v: ProtocolVersion) -> bool {
         self.versions.contains(v)
     }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -244,10 +244,6 @@ impl ServerConfig {
     /// also configured.
     pub fn supports_version(&self, v: ProtocolVersion) -> bool {
         self.versions.contains(v)
-            && self
-                .cipher_suites
-                .iter()
-                .any(|cs| cs.version().version == v)
     }
 }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -175,6 +175,9 @@ impl<'a> ClientHello<'a> {
 #[derive(Clone)]
 pub struct ServerConfig {
     /// List of ciphersuites, in preference order.
+    ///
+    /// Invariants enforced by the builder: the version matching a given configured cipher suite
+    /// is also enabled.
     pub(super) cipher_suites: Vec<SupportedCipherSuite>,
 
     /// List of supported key exchange groups.
@@ -211,7 +214,9 @@ pub struct ServerConfig {
     pub alpn_protocols: Vec<Vec<u8>>,
 
     /// Supported protocol versions, in no particular order.
-    /// The default is all supported versions.
+    ///
+    /// The default is all supported versions. Invariants enforced by the builder: at least one
+    /// version is enabled, and cipher suites matching the enabled versions are also configured.
     pub(super) versions: crate::versions::EnabledVersions,
 
     /// How to verify client certificates.
@@ -238,10 +243,9 @@ impl ServerConfig {
         }
     }
 
-    #[doc(hidden)]
-    /// We support a given TLS version if it's quoted in the configured
-    /// versions *and* at least one ciphersuite for this version is
-    /// also configured.
+    /// We support a given TLS version if it was configured through the builder.
+    ///
+    /// (The builder ensures that matching cipher suites are configured as well.)
     pub fn supports_version(&self, v: ProtocolVersion) -> bool {
         self.versions.contains(v)
     }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -207,7 +207,21 @@ fn config_builder_for_client_rejects_empty_cipher_suites() {
             .with_safe_default_kx_groups()
             .with_safe_default_protocol_versions()
             .err(),
-        Some(Error::General("no usable cipher suites configured".into()))
+        Some(Error::General(
+            "no cipher suite for version TLSv1_3 configured".into()
+        ))
+    );
+}
+
+#[test]
+fn config_builder_for_client_rejects_empty_versions() {
+    assert_eq!(
+        ClientConfig::builder()
+            .with_cipher_suites(&[])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[])
+            .err(),
+        Some(Error::General("no versions configured".into()))
     );
 }
 
@@ -220,7 +234,42 @@ fn config_builder_for_client_rejects_incompatible_cipher_suites() {
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS12])
             .err(),
-        Some(Error::General("no usable cipher suites configured".into()))
+        Some(Error::General(
+            "no version matching cipher suite TLS13_AES_256_GCM_SHA384".into()
+        ))
+    );
+}
+
+#[cfg(feature = "tls12")]
+#[test]
+fn config_builder_for_client_rejects_version_without_compatible_cipher_suite() {
+    assert_eq!(
+        ClientConfig::builder()
+            .with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384.into()])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS12, &rustls::version::TLS13])
+            .err(),
+        Some(Error::General(
+            "no cipher suite for version TLSv1_2 configured".into()
+        ))
+    );
+}
+
+#[cfg(feature = "tls12")]
+#[test]
+fn config_builder_for_client_rejects_cipher_suite_without_matching_version() {
+    assert_eq!(
+        ClientConfig::builder()
+            .with_cipher_suites(&[
+                rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                rustls::cipher_suite::TLS13_AES_256_GCM_SHA384.into()
+            ])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS12])
+            .err(),
+        Some(Error::General(
+            "no version matching cipher suite TLS13_AES_256_GCM_SHA384".into()
+        ))
     );
 }
 
@@ -244,7 +293,21 @@ fn config_builder_for_server_rejects_empty_cipher_suites() {
             .with_safe_default_kx_groups()
             .with_safe_default_protocol_versions()
             .err(),
-        Some(Error::General("no usable cipher suites configured".into()))
+        Some(Error::General(
+            "no cipher suite for version TLSv1_3 configured".into()
+        ))
+    );
+}
+
+#[test]
+fn config_builder_for_server_rejects_empty_versions() {
+    assert_eq!(
+        ServerConfig::builder()
+            .with_cipher_suites(&[])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[])
+            .err(),
+        Some(Error::General("no versions configured".into()))
     );
 }
 
@@ -257,7 +320,42 @@ fn config_builder_for_server_rejects_incompatible_cipher_suites() {
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS12])
             .err(),
-        Some(Error::General("no usable cipher suites configured".into()))
+        Some(Error::General(
+            "no version matching cipher suite TLS13_AES_256_GCM_SHA384".into()
+        ))
+    );
+}
+
+#[cfg(feature = "tls12")]
+#[test]
+fn config_builder_for_server_rejects_version_without_compatible_cipher_suite() {
+    assert_eq!(
+        ServerConfig::builder()
+            .with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384.into()])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS12, &rustls::version::TLS13])
+            .err(),
+        Some(Error::General(
+            "no cipher suite for version TLSv1_2 configured".into()
+        ))
+    );
+}
+
+#[cfg(feature = "tls12")]
+#[test]
+fn config_builder_for_server_rejects_cipher_suite_without_matching_version() {
+    assert_eq!(
+        ServerConfig::builder()
+            .with_cipher_suites(&[
+                rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                rustls::cipher_suite::TLS13_AES_256_GCM_SHA384.into()
+            ])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS12])
+            .err(),
+        Some(Error::General(
+            "no version matching cipher suite TLS13_AES_256_GCM_SHA384".into()
+        ))
     );
 }
 
@@ -700,7 +798,7 @@ fn check_sigalgs_reduced_by_ciphersuite(
         ClientConfig::builder()
             .with_cipher_suites(&[find_suite(suite)])
             .with_safe_default_kx_groups()
-            .with_safe_default_protocol_versions()
+            .with_protocol_versions(&[&rustls::version::TLS12])
             .unwrap(),
     );
 
@@ -1952,7 +2050,7 @@ fn make_disjoint_suite_configs() -> (ClientConfig, ServerConfig) {
         ServerConfig::builder()
             .with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
             .with_safe_default_kx_groups()
-            .with_safe_default_protocol_versions()
+            .with_protocol_versions(&[&rustls::version::TLS13])
             .unwrap(),
     );
 
@@ -1961,7 +2059,7 @@ fn make_disjoint_suite_configs() -> (ClientConfig, ServerConfig) {
         ClientConfig::builder()
             .with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
             .with_safe_default_kx_groups()
-            .with_safe_default_protocol_versions()
+            .with_protocol_versions(&[&rustls::version::TLS13])
             .unwrap(),
     );
 


### PR DESCRIPTION
We did not yet check that each configured version had matching cipher suites configured.

Make `Config::supports_version()` explicitly public. We would like to use this in Quinn to check that TLS configurations have 1.3 enabled.