### PR TITLE
Revert "Disable cargo fuzz smoketest"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,6 @@ jobs:
   fuzz:
     name: Smoke-test fuzzing targets
     runs-on: ubuntu-18.04
-    if: ${{ false }} # disable pending https://github.com/rust-fuzz/cargo-fuzz/issues/276
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
This reverts commit e7a0c51b081904382c797b30d42a654eacedfa8a.

https://github.com/rust-fuzz/cargo-fuzz/issues/276 was fixed in https://github.com/rust-fuzz/cargo-fuzz/pull/277.