### PR TITLE
Make `InvalidDnsNameError` part of the public API

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -257,6 +257,8 @@ impl TryFrom<&str> for ServerName {
     }
 }
 
+/// The provided input could not be parsed because
+/// it is not a syntactically-valid DNS Name.
 #[derive(Debug)]
 pub struct InvalidDnsNameError;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -383,6 +383,7 @@ pub mod client {
     #[cfg(feature = "quic")]
     #[cfg_attr(docsrs, doc(cfg(feature = "quic")))]
     pub use client_conn::ClientQuicExt;
+    pub use client_conn::InvalidDnsNameError;
     pub use client_conn::ResolvesClientCert;
     pub use client_conn::ServerName;
     pub use client_conn::StoresClientSessions;


### PR DESCRIPTION
Fixes #840.

This makes `InvalidDnsNameError` part of the public API by re-exporting it as part of `rustls::client`.
It also adds a small docstring to the public Error Type.