### PR TITLE
Don't reference ALL_CIPHER_SUITES from ClientSessionValue methods

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -55,20 +55,11 @@ fn find_session(
             None
         })?;
 
-    let mut reader = Reader::init(&value[..]);
+    #[allow(unused_mut)]
+    let mut reader = Reader::init(&value[2..]);
     CipherSuite::read_bytes(&value[..2])
         .and_then(|suite| {
-            config
-                .cipher_suites
-                .iter()
-                .find(|s| s.suite() == suite)
-        })
-        .and_then(|suite| match suite {
-            SupportedCipherSuite::Tls13(_) => persist::Tls13ClientSessionValue::read(&mut reader)
-                .map(persist::ClientSessionValue::from),
-            #[cfg(feature = "tls12")]
-            SupportedCipherSuite::Tls12(_) => persist::Tls12ClientSessionValue::read(&mut reader)
-                .map(persist::ClientSessionValue::from),
+            persist::ClientSessionValue::read(&mut reader, suite, &config.cipher_suites)
         })
         .and_then(|resuming| {
             let retrieved = persist::Retrieved::new(resuming, TimeBase::now().ok()?);

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -108,9 +108,9 @@ pub(super) fn start_handshake(
         None
     };
 
-    if let Some(resuming) = &mut resuming_session {
+    if let Some(_resuming) = &mut resuming_session {
         #[cfg(feature = "tls12")]
-        if let persist::ClientSessionValue::Tls12(inner) = &mut resuming.value {
+        if let persist::ClientSessionValue::Tls12(inner) = &mut _resuming.value {
             // If we have a ticket, we use the sessionid as a signal that
             // we're  doing an abbreviated handshake.  See section 3.4 in
             // RFC5077.

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -983,6 +983,7 @@ impl ExpectTraffic {
 
         let time_now = match TimeBase::now() {
             Ok(t) => t,
+            #[allow(unused_variables)]
             Err(e) => {
                 debug!("Session not saved: {}", e);
                 return Ok(());

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1,5 +1,6 @@
 //! Assorted public API tests.
 use std::convert::TryFrom;
+#[cfg(feature = "tls12")]
 use std::convert::TryInto;
 use std::env;
 use std::fmt;
@@ -3034,6 +3035,7 @@ fn early_data_is_available_on_resumption() {
         .find(|supported| supported.suite() == cs)
         .unwrap()
     {
+        #[cfg(feature = "tls12")]
         SupportedCipherSuite::Tls12(_) => unreachable!(),
         SupportedCipherSuite::Tls13(inner) => inner,
     };


### PR DESCRIPTION
This will prevent link-time elimination of unused cipher suites.
The new approach also prevents double-parsing of the CipherSuite,
at the expense of moving Codec methods to inherent implementations.

Fixes #846.