### PR TITLE
macros: point as_str at enum LHS, not RHS

### DIFF
--- a/rustls/src/msgs/enums_test.rs
+++ b/rustls/src/msgs/enums_test.rs
@@ -92,3 +92,10 @@ fn test_enums() {
     );
     test_enum8::<CertificateStatusType>(CertificateStatusType::OCSP, CertificateStatusType::OCSP);
 }
+
+#[test]
+fn test_string_macro() {
+    let suite = CipherSuite::TLS13_AES_256_GCM_SHA384;
+    let s = suite.as_str().unwrap();
+    assert_eq!(s, "TLS13_AES_256_GCM_SHA384")
+}

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -62,7 +62,7 @@ macro_rules! enum_builder {
 
             pub fn as_str(&self) -> Option<&'static str> {
                 match self {
-                    $( $enum_name::$enum_var => Some(stringify!($enum_val))),*
+                    $( $enum_name::$enum_var => Some(stringify!($enum_var))),*
                     ,$enum_name::Unknown(_) => None,
                 }
             }


### PR DESCRIPTION
Previously we'd print out the integer constant for an enum, instead
of its name, which is more descriptive ("TLS13_AES_256_GCM_SHA384"
instead of "0x1302", for example). I believe that this was the
originally intended behavior in #831.

Add a test to expose the issue and verify the patch works as expected.