### PR TITLE
removing webpki::Error as return type

### DIFF
--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -85,7 +85,7 @@ impl RootCertStore {
     /// Add a single DER-encoded certificate to the store.
     pub fn add(&mut self, der: &key::Certificate) -> Result<(), Error> {
         let ta = webpki::TrustAnchor::try_from_cert_der(&der.0)
-            .map_err(|e| Error::InvalidCertificateData(format!("{}", e)))?;
+            .map_err(|e| Error::FailedToDecodeRootCertData(format!("{}", e)))?;
         let ota = OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject,
             ta.spki,

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -84,7 +84,8 @@ impl RootCertStore {
 
     /// Add a single DER-encoded certificate to the store.
     pub fn add(&mut self, der: &key::Certificate) -> Result<(), Error> {
-        let ta = webpki::TrustAnchor::try_from_cert_der(&der.0).map_err(|e| Error::InvalidCertificateData(format!("{}", e)))?;
+        let ta = webpki::TrustAnchor::try_from_cert_der(&der.0)
+            .map_err(|e| Error::InvalidCertificateData(format!("{}", e)))?;
         let ota = OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject,
             ta.spki,

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -1,3 +1,4 @@
+use crate::error::Error;
 use crate::key;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
@@ -82,8 +83,8 @@ impl RootCertStore {
     }
 
     /// Add a single DER-encoded certificate to the store.
-    pub fn add(&mut self, der: &key::Certificate) -> Result<(), webpki::Error> {
-        let ta = webpki::TrustAnchor::try_from_cert_der(&der.0)?;
+    pub fn add(&mut self, der: &key::Certificate) -> Result<(), Error> {
+        let ta = webpki::TrustAnchor::try_from_cert_der(&der.0).map_err(|e| Error::InvalidCertificateData(format!("{}", e)))?;
         let ota = OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject,
             ta.spki,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -163,7 +163,11 @@ impl fmt::Display for Error {
             Error::BadMaxFragmentSize => {
                 write!(f, "the supplied max_fragment_size was too small or large")
             }
-            Error::FailedToDecodeRootCertData(ref reason) => write!(f, "failed to decode DER-encoded root certificate: {}", reason),
+            Error::FailedToDecodeRootCertData(ref reason) => write!(
+                f,
+                "failed to decode DER-encoded root certificate: {}",
+                reason
+            ),
             Error::General(ref err) => write!(f, "unexpected error: {}", err),
         }
     }

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -97,6 +97,9 @@ pub enum Error {
     /// The `max_fragment_size` value supplied in configuration was too small,
     /// or too large.
     BadMaxFragmentSize,
+
+    /// Failed to decode DER-encoded root certificate
+    FailedToDecodeRootCertData(String),
 }
 
 fn join<T: fmt::Debug>(items: &[T]) -> String {
@@ -160,6 +163,7 @@ impl fmt::Display for Error {
             Error::BadMaxFragmentSize => {
                 write!(f, "the supplied max_fragment_size was too small or large")
             }
+            Error::FailedToDecodeRootCertData(ref reason) => write!(f, "failed to decode DER-encoded root certificate: {}", reason),
             Error::General(ref err) => write!(f, "unexpected error: {}", err),
         }
     }
@@ -217,6 +221,7 @@ mod tests {
             Error::PeerSentOversizedRecord,
             Error::NoApplicationProtocol,
             Error::BadMaxFragmentSize,
+            Error::FailedToDecodeRootCertData("bad DER root cert".to_string()),
         ];
 
         for err in all {


### PR DESCRIPTION
hi,
following I propose a solution for issue #839. As I am new to Rust and the codebase of rustls, I don't have much confidence, that the change doesn't break API or introduces side effects.
I have run the existing tests and no errors were reported. I haven't fuzzed the changed codebase or did any manual testing. 