### PR TITLE
Reworked ticketswitcher to reduce time mutex is held.

### DIFF
--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -107,6 +107,7 @@ impl ProducesTickets for AeadTicketer {
 }
 
 struct TicketSwitcherState {
+    next: Option<Box<dyn ProducesTickets>>,
     current: Box<dyn ProducesTickets>,
     previous: Option<Box<dyn ProducesTickets>>,
     next_switch_time: u64,
@@ -135,6 +136,7 @@ impl TicketSwitcher {
             generator,
             lifetime,
             state: Mutex::new(TicketSwitcherState {
+                next: Some(generator()?),
                 current: generator()?,
                 previous: None,
                 next_switch_time: now.as_secs() + u64::from(lifetime),
@@ -143,22 +145,83 @@ impl TicketSwitcher {
     }
 
     /// If it's time, demote the `current` ticketer to `previous` (so it
-    /// does no new encryptions but can do decryption) and make a fresh
-    /// `current` ticketer.
+    /// does no new encryptions but can do decryption) and use next for a
+    /// new `current` ticketer.
     ///
     /// Calling this regularly will ensure timely key erasure.  Otherwise,
     /// key erasure will be delayed until the next encrypt/decrypt call.
-    fn maybe_roll(
-        &self,
-        now: TimeBase,
-        state: &mut MutexGuard<TicketSwitcherState>,
-    ) -> Result<(), rand::GetRandomFailed> {
+    ///
+    /// For efficiency, this is also responsible for locking the state mutex
+    /// and returning the mutexguard.
+    fn maybe_roll(&self, now: TimeBase) -> Option<MutexGuard<TicketSwitcherState>> {
+        // The code below aims to make switching as efficient as possible
+        // in the common case that the generator never fails. To achieve this
+        // we run the following steps:
+        //  1. If no switch is necessary, just return the mutexguard
+        //  2. Shift over all of the ticketers (so current becomes previous,
+        //     and next becomes current). After this, other threads can
+        //     start using the new current ticketer.
+        //  3. unlock mutex and generate new ticketer.
+        //  4. Place new ticketer in next and return current
+        //
+        // There are a few things to note here. First, we don't check whether
+        // a new switch might be needed in step 4, even though, due to locking
+        // and entropy collection, significant amounts of time may have passed.
+        // This is to guarantee that the thread doing the switch will eventually
+        // make progress.
+        //
+        // Second, because next may be None, step 2 can fail. In that case
+        // we enter a recovery mode where we generate 2 new ticketers, one for
+        // next and one for the current ticketer. We then take the mutex a
+        // second time and redo the time check to see if a switch is still
+        // necessary.
+        //
+        // This somewhat convoluted approach ensures good availability of the
+        // mutex, by ensuring that the state is usable and the mutex not held
+        // during generation. It also ensures that, so long as the inner
+        // ticketer never generates panics during encryption/decryption,
+        // we are guaranteed to never panic when holding the mutex.
+
         let now = now.as_secs();
-        if now > state.next_switch_time {
-            state.previous = Some(mem::replace(&mut state.current, (self.generator)()?));
-            state.next_switch_time = now + u64::from(self.lifetime);
+        let mut are_recovering = false; // Are we recovering from previous failure?
+        {
+            // Scope the mutex so we only take it for as long as needed
+            let mut state = self.state.lock().ok()?;
+
+            // Fast path in case we do not need to switch to the next ticketer yet
+            if now <= state.next_switch_time {
+                return Some(state);
+            }
+
+            // Make the switch, or mark for recovery if not possible
+            if let Some(next) = state.next.take() {
+                state.previous = Some(mem::replace(&mut state.current, next));
+                state.next_switch_time = now + u64::from(self.lifetime);
+            } else {
+                are_recovering = true;
+            }
         }
-        Ok(())
+
+        // We always need a next, so generate it now
+        let next = (self.generator)().ok()?;
+        if !are_recovering {
+            // Normal path, generate new next and place it in the state
+            let mut state = self.state.lock().ok()?;
+            state.next = Some(next);
+            Some(state)
+        } else {
+            // Recovering, generate also a new current ticketer, and modify state
+            // as needed. (we need to redo the time check, otherwise this might
+            // result in very rapid switching of ticketers)
+            let new_current = (self.generator)().ok()?;
+            let mut state = self.state.lock().ok()?;
+            state.next = Some(next);
+            if now > state.next_switch_time {
+                state.previous = Some(mem::replace(&mut state.current, new_current));
+                state.next_switch_time = now + u64::from(self.lifetime);
+            }
+            Some(state)
+        }
     }
 }
 
@@ -172,18 +235,13 @@ impl ProducesTickets for TicketSwitcher {
     }
 
     fn encrypt(&self, message: &[u8]) -> Option<Vec<u8>> {
-        let mut state = self.state.lock().ok()?;
-        self.maybe_roll(TimeBase::now().ok()?, &mut state)
-            .ok()?;
+        let state = self.maybe_roll(TimeBase::now().ok()?)?;
 
         state.current.encrypt(message)
     }
 
     fn decrypt(&self, ciphertext: &[u8]) -> Option<Vec<u8>> {
-        let mut state = self.state.lock().ok()?;
-
-        self.maybe_roll(TimeBase::now().ok()?, &mut state)
-            .ok()?;
+        let state = self.maybe_roll(TimeBase::now().ok()?)?;
 
         // Decrypt with the current key; if that fails, try with the previous.
         state
@@ -222,4 +280,27 @@ fn basic_pairwise_test() {
     let cipher = t.encrypt(b"hello world").unwrap();
     let plain = t.decrypt(&cipher).unwrap();
     assert_eq!(plain, b"hello world");
+}
+
+#[test]
+fn ticketswitcher_switching_test() {
+    let t = Arc::new(TicketSwitcher::new(1, generate_inner).unwrap());
+    let now = TimeBase::now().unwrap();
+    let cipher1 = t.encrypt(b"ticket 1").unwrap();
+    assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+    {
+        // Trigger new ticketer
+        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(10)));
+    }
+    let cipher2 = t.encrypt(b"ticket 2").unwrap();
+    assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+    assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+    {
+        // Trigger new ticketer
+        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(20)));
+    }
+    let cipher3 = t.encrypt(b"ticket 3").unwrap();
+    assert!(t.decrypt(&cipher1).is_none());
+    assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+    assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
 }


### PR DESCRIPTION
This PR aims to reduce the amount of time the ticketswitcher mutex is held, by excluding generation of new ticketers from the period that the mutex is held, solving #656. This also gives a secondary advantage that a panic during generation will not poison the mutex.

This implementation works better towards those goals then PR #849 because it avoids the potential of multiple threads generating a next ticketer in the common case where generation does not fail and is fast enough to complete within the switching period of the ticketer.

However, in order to ensure the next ticketer is available timely, it is generated ahead of time, just after the previous switch. This means that the ticketer keys are in memory for an extra period of 6 hours (though unused during that period), so we should evaluate whether that is acceptable from a security point of view.