### PR TITLE
Fix deprecation notice

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -499,7 +499,7 @@ pub type ResolvesServerCertUsingSNI = server::ResolvesServerCertUsingSni;
 pub type WebPKIVerifier = client::WebPkiVerifier;
 #[allow(clippy::upper_case_acronyms)]
 #[doc(hidden)]
-#[deprecated(since = "0.20.0", note = "Use TlsError")]
+#[deprecated(since = "0.20.0", note = "Use Error")]
 pub type TLSError = Error;
 #[doc(hidden)]
 #[deprecated(since = "0.20.0", note = "Use ClientConnection")]


### PR DESCRIPTION
The previous notice said to use `TlsError` instead of the deprecated `TLSError`, while the actual exported type is named `Error`.