### PR TITLE
Respect the SSLKEYLOGFILE variable by default

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -4,7 +4,7 @@ use crate::client::handy;
 use crate::client::{ClientConfig, ResolvesClientCert};
 use crate::error::Error;
 use crate::key;
-use crate::keylog::NoKeyLog;
+use crate::keylog::KeyLogFile;
 use crate::kx::SupportedKxGroup;
 use crate::suites::SupportedCipherSuite;
 use crate::verify::{self, CertificateTransparencyPolicy};
@@ -181,7 +181,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             versions: self.state.versions,
             enable_sni: true,
             verifier: self.state.verifier,
-            key_log: Arc::new(NoKeyLog {}),
+            key_log: Arc::new(KeyLogFile::new()),
             enable_early_data: false,
         }
     }


### PR DESCRIPTION
Currently, to look at traffic in wireshark, you have to opt-in not just by setting the env variable,
but also opting-in in the application itself. This makes it possible to debug the traffic with just
the env variable, which is the same default behavior as curl and openssl.