### PR TITLE
Support for feature(read_buf)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,18 @@ jobs:
           persist-credentials: false
 
       - name: Install ${{ matrix.rust }} toolchain
+        if: ${{ matrix.rust != 'nightly' }}
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install ${{ matrix.rust }} toolchain (with Miri)
+        if: ${{ matrix.rust == 'nightly' }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: miri
           override: true
 
       - name: cargo build (debug; default features)
@@ -43,6 +52,10 @@ jobs:
         run: cargo test --all-features
         env:
           RUST_BACKTRACE: 1
+
+      - name: Miri test
+        if: ${{ matrix.rust == 'nightly' }}
+        run: cargo miri test --features=read_buf --lib -- vecbuf
 
 
   features:
@@ -68,12 +81,6 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-      - name: cargo test (debug; all features)
-        run: cargo test --all-features
-        env:
-          RUST_BACKTRACE: 1
-          RUSTFLAGS: -D warnings
-
       - name: cargo build (debug; no default features)
         run: cargo build --no-default-features
         working-directory: rustls
@@ -84,6 +91,18 @@ jobs:
 
       - name: cargo test (release; no run)
         run: cargo test --release --no-run
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+
+      - name: cargo test (debug; all features)
+        run: cargo test --all-features
+        env:
+          RUST_BACKTRACE: 1
+          RUSTFLAGS: -D warnings
 
 
   bogo:
@@ -275,7 +294,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -p rustls --all-features -- -D warnings
+          args: -p rustls --features="logging,dangerous_configuration,quic,tls12" -- -D warnings
 
   clippy-nightly:
     name: Clippy (Nightly)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,14 @@ jobs:
       - name: cargo build (debug; default features)
         run: cargo build
 
+      - name: cargo test (debug; stable features)
+        if: ${{ matrix.rust != 'nightly' }}
+        run: cargo test --features=logging,dangerous_configuration,quic,tls12
+        env:
+          RUST_BACKTRACE: 1
+
       - name: cargo test (debug; all features)
+        if: ${{ matrix.rust == 'nightly' }}
         run: cargo test --all-features
         env:
           RUST_BACKTRACE: 1
@@ -294,7 +301,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -p rustls --features="logging,dangerous_configuration,quic,tls12" -- -D warnings
+          args: -p rustls --features=logging,dangerous_configuration,quic,tls12 -- -D warnings
 
   clippy-nightly:
     name: Clippy (Nightly)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,18 +31,9 @@ jobs:
           persist-credentials: false
 
       - name: Install ${{ matrix.rust }} toolchain
-        if: ${{ matrix.rust != 'nightly' }}
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-
-      - name: Install ${{ matrix.rust }} toolchain (with Miri)
-        if: ${{ matrix.rust == 'nightly' }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: miri
           override: true
 
       - name: cargo build (debug; default features)
@@ -59,10 +50,6 @@ jobs:
         run: cargo test --all-features
         env:
           RUST_BACKTRACE: 1
-
-      - name: Miri test
-        if: ${{ matrix.rust == 'nightly' }}
-        run: cargo miri test --features=read_buf --lib -- vecbuf
 
 
   features:

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -23,6 +23,7 @@ logging = ["log"]
 dangerous_configuration = []
 quic = []
 tls12 = []
+read_buf = []
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -251,9 +251,14 @@
 //!   it for your application. If you want to disable TLS 1.2 for security reasons,
 //!   consider explicitly enabling TLS 1.3 only in the config builder API.
 //!
+//! - `read_buf`: this nightly-only feature adds support for the unstable
+//!   `std::io::ReadBuf` and related APIs. This reduces costs from initializing
+//!   buffers.
 
 // Require docs for public APIs, deny unsafe code, etc.
-#![forbid(unsafe_code, unused_must_use, unstable_features)]
+#![forbid(unused_must_use)]
+#![deny(unsafe_code)]
+#![cfg_attr(not(feature = "read_buf"), forbid(unsafe_code, unstable_features))]
 #![deny(
     clippy::clone_on_ref_ptr,
     clippy::use_self,
@@ -284,6 +289,8 @@
 )]
 // Enable documentation for all features on docs.rs
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Early testing of the read_buf nightly feature
+#![cfg_attr(feature = "read_buf", feature(read_buf))]
 
 // log for logging (optional).
 #[cfg(feature = "logging")]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -256,9 +256,8 @@
 //!   buffers.
 
 // Require docs for public APIs, deny unsafe code, etc.
-#![forbid(unused_must_use)]
-#![deny(unsafe_code)]
-#![cfg_attr(not(feature = "read_buf"), forbid(unsafe_code, unstable_features))]
+#![forbid(unsafe_code, unused_must_use)]
+#![cfg_attr(not(feature = "read_buf"), forbid(unstable_features))]
 #![deny(
     clippy::clone_on_ref_ptr,
     clippy::use_self,

--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -72,6 +72,31 @@ where
 
         self.conn.reader().read(buf)
     }
+
+    #[cfg(feature = "read_buf")]
+    fn read_buf(&mut self, buf: &mut std::io::ReadBuf<'_>) -> Result<()> {
+        self.complete_prior_io()?;
+
+        // We call complete_io() in a loop since a single call may read only
+        // a partial packet from the underlying transport. A full packet is
+        // needed to get more plaintext, which we must do if EOF has not been
+        // hit. Otherwise, we will prematurely signal EOF by returning without
+        // writing anything. We determine if EOF has actually been hit by
+        // checking if 0 bytes were read from the underlying transport.
+        while self.conn.wants_read() {
+            let at_eof = self.conn.complete_io(self.sock)?.0 == 0;
+            if at_eof {
+                if let Ok(io_state) = self.conn.process_new_packets() {
+                    if at_eof && io_state.plaintext_bytes_to_read() == 0 {
+                        return Ok(());
+                    }
+                }
+                break;
+            }
+        }
+
+        self.conn.reader().read_buf(buf)
+    }
 }
 
 impl<'a, C, T, S> Write for Stream<'a, C, T>
@@ -182,6 +207,11 @@ where
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         self.as_stream().read(buf)
+    }
+
+    #[cfg(feature = "read_buf")]
+    fn read_buf(&mut self, buf: &mut std::io::ReadBuf<'_>) -> Result<()> {
+        self.as_stream().read_buf(buf)
     }
 }
 

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -99,6 +99,56 @@ impl ChunkVecBuffer {
         Ok(offs)
     }
 
+    #[cfg(feature = "read_buf")]
+    #[allow(unsafe_code)]
+    /// Read data out of this object, writing it into `buf`.
+    pub(crate) fn read_buf(&mut self, buf: &mut io::ReadBuf<'_>) -> io::Result<()> {
+        use std::mem::MaybeUninit;
+
+        while !self.is_empty() {
+            // There are three unsafe calls in this block to justify. First,
+            // `ReadBuf::unfilled_mut()` requires that we "not de-initialize portions of the buffer
+            // that have already been initialized." We write to the buffer using
+            // `std::ptr::copy_nonoverlapping`, with a `[u8]` slice from this `ChunkVecBuffer` as
+            // the source. All memory in the `[u8]` slice must be initialized, and the length of
+            // the copy is less than or equal to the length of the `[u8]` slice, so we will not
+            // de-initialize any of the `ReadBuf` buffer by performing this copy.
+            //
+            // Second, `std::ptr::copy_nonoverlapping` has several requirements. First, note that
+            // the source and destination buffers do not overlap because the source is part of
+            // `self`, which is mutably borrowed, so we can assume the other buffer does not alias
+            // it. As we are copying `T=u8`, the alignment requirements on the source and
+            // destination are trivially satisfied. Additionally, `u8` is `Copy`, so creating
+            // bitwise copies is acceptible. The count argument is less than or equal to both the
+            // length of the slice we are copying from, and the length of the unfilled part of the
+            // buffer we are copying to. Thus, the source pointer is valid for reads of this
+            // length, and the destination pointer is valid for writes of this length.
+            //
+            // Lastly, `ReadBuf::assume_init` requires that "the first `n` unfilled bytes of the
+            // buffer have already been initialized". We write into the unfilled part of the buffer
+            // using `std::ptr::copy_nonoverlapping`, and, as argued above, this causes these bytes
+            // to become initialized, since we are copying from another buffer that is initialized.
+            unsafe {
+                let unfilled: &mut [MaybeUninit<u8>] = buf.unfilled_mut();
+                if unfilled.is_empty() {
+                    break;
+                }
+                let chunk = self.chunks[0].as_slice();
+                let used = std::cmp::min(chunk.len(), unfilled.len());
+                let unfilled_ptr: *mut MaybeUninit<u8> = unfilled.as_mut_ptr();
+                // This pointer cast is fine because `MaybeUninit<u8>` and `u8` are guaranteed to
+                // have the same memory layout.
+                let unfilled_ptr = unfilled_ptr as *mut u8;
+                std::ptr::copy_nonoverlapping(chunk.as_ptr(), unfilled_ptr, used);
+                buf.assume_init(used);
+                buf.add_filled(used);
+                self.consume(used);
+            }
+        }
+
+        Ok(())
+    }
+
     fn consume(&mut self, mut used: usize) {
         while let Some(mut buf) = self.chunks.pop_front() {
             if used < buf.len() {
@@ -143,5 +193,49 @@ mod test {
         let mut buf = [0u8; 12];
         assert_eq!(cvb.read(&mut buf).unwrap(), 12);
         assert_eq!(buf.to_vec(), b"helloworldhe".to_vec());
+    }
+
+    #[cfg(feature = "read_buf")]
+    #[test]
+    fn read_buf() {
+        use std::alloc::{self, GlobalAlloc, Layout};
+        use std::{io::ReadBuf, mem::MaybeUninit};
+
+        {
+            let mut cvb = ChunkVecBuffer::new(None);
+            cvb.append(b"test ".to_vec());
+            cvb.append(b"fixture ".to_vec());
+            cvb.append(b"data".to_vec());
+
+            let mut buf = [MaybeUninit::<u8>::uninit(); 8];
+            let mut buf = ReadBuf::uninit(&mut buf);
+            cvb.read_buf(&mut buf).unwrap();
+            assert_eq!(buf.filled(), b"test fix");
+            buf.clear();
+            cvb.read_buf(&mut buf).unwrap();
+            assert_eq!(buf.filled(), b"ture dat");
+            buf.clear();
+            cvb.read_buf(&mut buf).unwrap();
+            assert_eq!(buf.filled(), b"a");
+        }
+
+        #[allow(unsafe_code)]
+        {
+            const BUFFER_SIZE: usize = 1024 * 1024;
+
+            let mut cvb = ChunkVecBuffer::new(None);
+            cvb.append(b"short message".to_vec());
+
+            let layout = Layout::new::<[MaybeUninit<u8>; BUFFER_SIZE]>();
+            let byte_ptr: *mut u8 = unsafe { alloc::System.alloc(layout) };
+            {
+                let ptr = byte_ptr as *mut [MaybeUninit<u8>; BUFFER_SIZE];
+                let buf: &mut [MaybeUninit<u8>; BUFFER_SIZE] = unsafe { &mut *ptr };
+                let mut buf = ReadBuf::uninit(buf.as_mut());
+                cvb.read_buf(&mut buf).unwrap();
+                assert_eq!(buf.filled(), b"short message");
+            }
+            unsafe { alloc::System.dealloc(byte_ptr, layout) };
+        }
     }
 }


### PR DESCRIPTION
This implements what was proposed in #872. I created a new nightly-only Cargo feature to enable the new code. Note that I had to conditionally relax `forbid(unsafe_code)` and `forbid(unstable_features)`. I juggled CI build steps around, to ensure we don't try to enable the read_buf flag via --all-features with a stable toolchain. I also added a step to run a new `ChunkVecBuffer` test in Miri.

The core unsafe buffer writing code is in `ChunkVecBuffer::read_buf()`, and the rest of the changes in `<Reader as Read>::read_buf()`, `<Stream as Read>::read_buf()`, and `<StreamOwned as Read>::read_buf()` are all creating parallel functions to each `read()` that ultimately delegate to `ChunkVecBuffer::read_buf()`.