### PR TITLE
Use clap macro for rustls-mio examples

### DIFF
--- a/rustls-mio/Cargo.toml
+++ b/rustls-mio/Cargo.toml
@@ -20,13 +20,11 @@ rustls-pemfile = "0.2.0"
 sct = "0.7"
 
 [dev-dependencies]
+clap = { version = "3", features = ["derive"] }
 ct-logs = "0.9"
-docopt = "~1.1"
 env_logger = "0.9.0"
 mio = { version = "0.8", features = ["net", "os-poll"] }
 regex = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
 webpki-roots = "0.22"
 ring = "0.16.20"
 


### PR DESCRIPTION
docopt is no longer maintained. Meanwhile, structopt provides a nice way of declaratively setting up the CLI options and arguments.

```
tlsclient 0.0.1
The default `port` is 443. By default, this reads a request from stdin (to EOF) before making the connection.  --http
replaces this with a basic HTTP GET request for /.

If --cafile is not supplied, a built-in set of CA certificates are used from the webpki-roots crate.

USAGE:
    tlsclient [FLAGS] [OPTIONS] <hostname>

FLAGS:
    -h, --help          
            Prints help information

        --http          
            Send a basic HTTP GET request for /

        --insecure      
            Disable certificate verification

        --no-sni        
            Disable server name indication support

        --no-tickets    
            Disable session ticket support

    -V, --version       
            Prints version information

        --verbose       
            Emit log output


OPTIONS:
        --auth-certs <auth-certs>          
            Read client authentication certificates from `auth-certs`.
            
            `auth-certs` must match up with `auth-key`.
        --auth-key <auth-key>              
            Read client authentication key from `auth-key`

        --cache <cache>                    
            Save session cache to file `cache`

        --cafile <cafile>                  
            Read root certificates from `cafile`

        --max-frag-size <max-frag-size>    
            Limit outgoing messages to `max_frag_size` bytes

    -p, --port <port>                      
            Connect to `port` [default: 443]

        --proto <proto>...                 
            Send ALPN extension containing `proto`. May be used multiple times to offer several protocols

        --protover <protover>...           
            Disable default TLS version list, and use `protover` instead. May be used multiple times

        --suite <suite>...                 
            Disable default cipher suite list, and use `suite` instead. May be used multiple times


ARGS:
    <hostname>
```

```
rustls-mio 0.0.1
Runs a TLS server on :port.  The default port is 443.

`--certs' names the full certificate chain, `--key' provides the RSA private key.

USAGE:
    tlsserver [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help            
            Prints help information

        --require-auth    
            Send a fatal alert if the client does not complete client authentication

        --resumption      
            Support session resumption

        --tickets         
            Support tickets

    -V, --version         
            Prints version information

        --verbose         
            Emit log output


OPTIONS:
        --auth <auth>               
            Enable client authentication, and accept certificates signed by those roots provided in `certs`

        --certs <certs>             
            Read server certificates from `certs`.
            
            This should contain PEM-format certificates in the right order (the first certificate should certify `key`,
            the last should be a root CA).
        --key <key>                 
            Read private key from `key`.
            
            This should be an RSA private key or PKCS8-encoded private key, in PEM format.
        --ocsp <ocsp>               
            Read DER-encoded OCSP response from OCSP and stable to certificate. Optional

    -p, --port <port>               
            Listen on `port` [default: 443]

        --proto <proto>...          
            Send ALPN extension containing `proto`. May be used multiple times to offer several protocols

        --protover <protover>...    
            Disable default TLS version list, and use `protover` instead. May be used multiple times

        --suite <suite>...          
            Disable default cipher suite list, and use `suite` instead. May be used multiple times


SUBCOMMANDS:
    echo       Write back received bytes
    forward    Forward traffic to/from given port on localhost
    help       Prints this message or the help of the given subcommand(s)
    http       Do one read, then write a bodged HTTP response and cleanly close the connection
```