### PR TITLE
Fix deny-by-default Clippy lints in examples and api.rs

### DIFF
--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -117,7 +117,7 @@ impl TlsClient {
             plaintext.resize(io_state.plaintext_bytes_to_read(), 0u8);
             self.tls_conn
                 .reader()
-                .read(&mut plaintext)
+                .read_exact(&mut plaintext)
                 .unwrap();
             io::stdout()
                 .write_all(&plaintext)

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -245,7 +245,7 @@ impl OpenConnection {
 
                 self.tls_conn
                     .reader()
-                    .read(&mut buf)
+                    .read_exact(&mut buf)
                     .unwrap();
 
                 debug!("plaintext read {:?}", buf.len());

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -555,7 +555,10 @@ fn bench_memory(params: &BenchmarkParam, conn_count: u64) {
     {
         transfer(client, server);
         let mut buf = [0u8; 1024];
-        server.reader().read(&mut buf).unwrap();
+        server
+            .reader()
+            .read_exact(&mut buf)
+            .unwrap();
     }
 }
 

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -38,7 +38,7 @@ fn main() {
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
-    tls.write(
+    tls.write_all(
         concat!(
             "GET / HTTP/1.1\r\n",
             "Host: google.com\r\n",

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1686,7 +1686,7 @@ fn client_complete_io_for_read() {
 
         server
             .writer()
-            .write(b"01234567890123456789")
+            .write_all(b"01234567890123456789")
             .unwrap();
         {
             let mut pipe = OtherSession::new(&mut server);


### PR DESCRIPTION
`rust-analyzer` running Clippy on save was continuously lighting up some examples as errors, so I applied the appropriate lints. After this PR, `cargo clippy --all-targets` completes successfully, although the warning lints were left as-is.