### PR TITLE
Derive debug for marker types

### DIFF
--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -32,15 +32,18 @@ static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[
     &webpki::RSA_PKCS1_3072_8192_SHA384,
 ];
 
-/// Marker types.  These are used to bind the fact some verification
-/// (certificate chain or handshake signature) has taken place into
-/// protocol states.  We use this to have the compiler check that there
-/// are no 'goto fail'-style elisions of important checks before we
-/// reach the traffic stage.
-///
-/// These types are public, but cannot be directly constructed.  This
-/// means their origins can be precisely determined by looking
-/// for their `assertion` constructors.
+// Marker types.  These are used to bind the fact some verification
+// (certificate chain or handshake signature) has taken place into
+// protocol states.  We use this to have the compiler check that there
+// are no 'goto fail'-style elisions of important checks before we
+// reach the traffic stage.
+//
+// These types are public, but cannot be directly constructed.  This
+// means their origins can be precisely determined by looking
+// for their `assertion` constructors.
+
+/// Zero-sized marker type representing verification of a signature.
+#[derive(Debug)]
 pub struct HandshakeSignatureValid(());
 
 impl HandshakeSignatureValid {
@@ -50,6 +53,7 @@ impl HandshakeSignatureValid {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct FinishedMessageVerified(());
 
 impl FinishedMessageVerified {
@@ -60,6 +64,7 @@ impl FinishedMessageVerified {
 
 /// Zero-sized marker type representing verification of a server cert chain.
 #[allow(unreachable_pub)]
+#[derive(Debug)]
 pub struct ServerCertVerified(());
 
 #[allow(unreachable_pub)]
@@ -71,7 +76,9 @@ impl ServerCertVerified {
 }
 
 /// Zero-sized marker type representing verification of a client cert chain.
+#[derive(Debug)]
 pub struct ClientCertVerified(());
+
 impl ClientCertVerified {
     /// Make a `ClientCertVerified`
     pub fn assertion() -> Self {


### PR DESCRIPTION
The marker structs (e.g. `CertVerified`) don't implement `Debug`, and so `Result<Marker, E>` don't either. This change also annotates the structs with the \`non_exhaustive\` attribute [preventing them from being constructed outside Rustls](https://doc.rust-lang.org/reference/attributes/type_system.html). Finally, the `HandshakeSignatureValid` docs contained implementation details about all the marker types, which I think was meant to be a regular comment above their definitions.

On a side note, could someone please explain what a 'goto fail'-style elision is and how the `assertion` constructors prevent them?