### PR TITLE
Better express version configuration in the type system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         run: cargo test --features=logging,dangerous_configuration,quic,tls12
         env:
           RUST_BACKTRACE: 1
+          PERNOSCO_ENABLE: 1
 
       - name: cargo test (debug; all features)
         if: ${{ matrix.rust == 'nightly' }}

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -132,7 +132,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsCipherSuites> {
             state: WantsVerifier {
                 cipher_suites: DEFAULT_CIPHER_SUITES.to_vec(),
                 kx_groups: ALL_KX_GROUPS.to_vec(),
-                versions: versions::EnabledVersions::new(versions::DEFAULT_VERSIONS),
+                versions: versions::EnabledVersions::default(), // All enabled versions (depending on `cfg(feature = "tls12")`)
             },
             side: self.side,
         }
@@ -229,11 +229,17 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
             return Err(Error::General("no kx groups configured".into()));
         }
 
+        // The error condition is unreachable, because `any_usable_suite` would be false.
+        let versions = versions::EnabledVersions::new(versions)
+            .ok_or_else(|| Error::General("no versions configured".into()))?;
+
+        dbg!(&versions);
+
         Ok(ConfigBuilder {
             state: WantsVerifier {
                 cipher_suites: self.state.cipher_suites,
                 kx_groups: self.state.kx_groups,
-                versions: versions::EnabledVersions::new(versions),
+                versions,
             },
             side: self.side,
         })

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -221,6 +221,8 @@ fn emit_client_hello_for_retry(
 
     dbg!(&supported_versions);
 
+    dbg!(&supported_versions);
+
     let mut exts = Vec::new();
     if !supported_versions.is_empty() {
         exts.push(ClientExtension::SupportedVersions(supported_versions));


### PR DESCRIPTION
`EnabledVersions` becomes an enum which guarantees that at least
one version is enabled. This was already enforced by the config
builder, which will error out if there are no usable cipher suites
(where one aspect of "usable" is whether the suite's version is
enabled).

At the expense of 19 extra lines of code, we can make it clear in the type system that the builder enforces that we always have at least one version enabled.

This is an alternative to #903. Fixes #904.