### PR TITLE
Make side handling more obvious

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,5 +1,5 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
-use crate::conn::{CommonState, ConnectionCommon, Protocol};
+use crate::conn::{CommonState, ConnectionCommon, Protocol, Side};
 use crate::error::Error;
 use crate::kx::SupportedKxGroup;
 #[cfg(feature = "logging")]
@@ -431,7 +431,7 @@ impl ClientConnection {
         extra_exts: Vec<ClientExtension>,
         proto: Protocol,
     ) -> Result<Self, Error> {
-        let mut common_state = CommonState::new(config.max_fragment_size, true)?;
+        let mut common_state = CommonState::new(config.max_fragment_size, Side::Client)?;
         common_state.protocol = proto;
         let mut data = ClientConnectionData::new();
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -591,7 +591,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
             .start_hash(suite.hash_algorithm());
         transcript.add_message(&m);
 
-        let randoms = ConnectionRandoms::new(self.random, server_hello.random, cx.common.side);
+        let randoms = ConnectionRandoms::new(self.random, server_hello.random);
         // For TLS1.3, start message encryption using
         // handshake_traffic_secret.
         match suite {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -591,7 +591,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
             .start_hash(suite.hash_algorithm());
         transcript.add_message(&m);
 
-        let randoms = ConnectionRandoms::new(self.random, server_hello.random, true);
+        let randoms = ConnectionRandoms::new(self.random, server_hello.random, cx.common.side);
         // For TLS1.3, start message encryption using
         // handshake_traffic_secret.
         match suite {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -61,11 +61,10 @@ mod server_hello {
                 .write_slice(&mut self.randoms.server);
 
             // Look for TLS1.3 downgrade signal in server random
-            if tls13_supported
-                && self
-                    .randoms
-                    .has_tls12_downgrade_marker()
-            {
+            // both the server random and TLS12_DOWNGRADE_SENTINEL are
+            // public values and don't require constant time comparison
+            let has_downgrade_marker = self.randoms.server[24..] == tls12::DOWNGRADE_SENTINEL;
+            if tls13_supported && has_downgrade_marker {
                 return Err(cx
                     .common
                     .illegal_param("downgrade to TLS1.2 when TLS1.3 is supported"));

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{CommonState, ConnectionRandoms, State};
+use crate::conn::{CommonState, ConnectionRandoms, Side, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
@@ -133,7 +133,7 @@ mod server_hello {
                         &secrets.master_secret,
                     );
                     cx.common
-                        .start_encryption_tls12(&secrets);
+                        .start_encryption_tls12(&secrets, Side::Client);
 
                     // Since we're resuming, we verified the certificate and
                     // proof of possession in the prior session.
@@ -817,7 +817,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
             &secrets.master_secret,
         );
         cx.common
-            .start_encryption_tls12(&secrets);
+            .start_encryption_tls12(&secrets, Side::Client);
         cx.common
             .record_layer
             .start_encrypting();

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1240,8 +1240,8 @@ impl CommonState {
     }
 
     #[cfg(feature = "tls12")]
-    pub(crate) fn start_encryption_tls12(&mut self, secrets: &ConnectionSecrets) {
-        let (dec, enc) = secrets.make_cipher_pair();
+    pub(crate) fn start_encryption_tls12(&mut self, secrets: &ConnectionSecrets, side: Side) {
+        let (dec, enc) = secrets.make_cipher_pair(side);
         self.record_layer
             .prepare_message_encrypter(enc);
         self.record_layer

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -360,13 +360,9 @@ pub(crate) enum Protocol {
 
 #[derive(Debug)]
 pub(crate) struct ConnectionRandoms {
-    pub(crate) side: Side,
     pub(crate) client: [u8; 32],
     pub(crate) server: [u8; 32],
 }
-
-#[cfg(feature = "tls12")]
-static TLS12_DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01];
 
 /// How many ChangeCipherSpec messages we accept and drop in TLS1.3 handshakes.
 /// The spec says 1, but implementations (namely the boringssl test suite) get
@@ -374,26 +370,11 @@ static TLS12_DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 
 static TLS13_MAX_DROPPED_CCS: u8 = 2u8;
 
 impl ConnectionRandoms {
-    pub(crate) fn new(client: Random, server: Random, side: Side) -> Self {
+    pub(crate) fn new(client: Random, server: Random) -> Self {
         Self {
-            side,
             client: client.0,
             server: server.0,
         }
-    }
-
-    #[cfg(feature = "tls12")]
-    pub(crate) fn set_tls12_downgrade_marker(&mut self) {
-        assert_eq!(self.side, Side::Server);
-        self.server[24..].copy_from_slice(&TLS12_DOWNGRADE_SENTINEL);
-    }
-
-    #[cfg(feature = "tls12")]
-    pub(crate) fn has_tls12_downgrade_marker(&mut self) -> bool {
-        assert_eq!(self.side, Side::Client);
-        // both the server random and TLS12_DOWNGRADE_SENTINEL are
-        // public values and don't require constant time comparison
-        self.server[24..] == TLS12_DOWNGRADE_SENTINEL
     }
 }
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -373,7 +373,7 @@ impl ExpectClientHello {
         };
 
         // Save their Random.
-        let randoms = ConnectionRandoms::new(client_hello.random, Random::new()?, false);
+        let randoms = ConnectionRandoms::new(client_hello.random, Random::new()?, cx.common.side);
         match suite {
             SupportedCipherSuite::Tls13(suite) => tls13::CompleteClientHelloHandling {
                 config: self.config,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -373,7 +373,7 @@ impl ExpectClientHello {
         };
 
         // Save their Random.
-        let randoms = ConnectionRandoms::new(client_hello.random, Random::new()?, cx.common.side);
+        let randoms = ConnectionRandoms::new(client_hello.random, Random::new()?);
         match suite {
             SupportedCipherSuite::Tls13(suite) => tls13::CompleteClientHelloHandling {
                 config: self.config,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,5 +1,5 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
-use crate::conn::{CommonState, ConnectionCommon, State};
+use crate::conn::{CommonState, ConnectionCommon, Side, State};
 use crate::error::Error;
 use crate::kx::SupportedKxGroup;
 #[cfg(feature = "logging")]
@@ -305,7 +305,7 @@ impl ServerConnection {
         config: Arc<ServerConfig>,
         extra_exts: Vec<ServerExtension>,
     ) -> Result<Self, Error> {
-        let common = CommonState::new(config.max_fragment_size, false)?;
+        let common = CommonState::new(config.max_fragment_size, Side::Server)?;
         Ok(Self {
             inner: ConnectionCommon::new(
                 Box::new(hs::ExpectClientHello::new(config, extra_exts)),
@@ -436,7 +436,7 @@ pub struct Acceptor {
 impl Acceptor {
     /// Create a new `Acceptor`.
     pub fn new() -> Result<Self, Error> {
-        let common = CommonState::new(None, false)?;
+        let common = CommonState::new(None, Side::Server)?;
         let state = Box::new(Accepting);
         Ok(Self {
             inner: Some(ConnectionCommon::new(state, Default::default(), common)),

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -89,8 +89,7 @@ mod client_hello {
 
             // -- If TLS1.3 is enabled, signal the downgrade in the server random
             if tls13_enabled {
-                self.randoms
-                    .set_tls12_downgrade_marker();
+                self.randoms.server[24..].copy_from_slice(&tls12::DOWNGRADE_SENTINEL);
             }
 
             // -- Check for resumption --

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{CommonState, ConnectionRandoms, State};
+use crate::conn::{CommonState, ConnectionRandoms, Side, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
@@ -275,7 +275,7 @@ mod client_hello {
                 &secrets.master_secret,
             );
             cx.common
-                .start_encryption_tls12(&secrets);
+                .start_encryption_tls12(&secrets, Side::Server);
             cx.common.peer_certificates = resumedata.client_cert_chain;
 
             if self.send_ticket {
@@ -600,7 +600,7 @@ impl State<ServerConnectionData> for ExpectClientKx {
             &secrets.master_secret,
         );
         cx.common
-            .start_encryption_tls12(&secrets);
+            .start_encryption_tls12(&secrets, Side::Server);
 
         if let Some(client_cert) = self.client_cert {
             Ok(Box::new(ExpectCertificateVerify {

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -440,6 +440,8 @@ fn decode_ecdh_params_<T: Codec>(kx_params: &[u8]) -> Option<T> {
     }
 }
 
+pub(crate) const DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01];
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -1,6 +1,5 @@
 use crate::cipher::{MessageDecrypter, MessageEncrypter};
-use crate::conn::CommonState;
-use crate::conn::ConnectionRandoms;
+use crate::conn::{CommonState, ConnectionRandoms, Side};
 use crate::kx;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, ContentType};
@@ -293,20 +292,19 @@ impl ConnectionSecrets {
         let (client_write_iv, key_block) = key_block.split_at(suite.fixed_iv_len);
         let (server_write_iv, extra) = key_block.split_at(suite.fixed_iv_len);
 
-        let (write_key, write_iv, read_key, read_iv) = if self.randoms.we_are_client {
-            (
+        let (write_key, write_iv, read_key, read_iv) = match self.randoms.side {
+            Side::Client => (
                 client_write_key,
                 client_write_iv,
                 server_write_key,
                 server_write_iv,
-            )
-        } else {
-            (
+            ),
+            Side::Server => (
                 server_write_key,
                 server_write_iv,
                 client_write_key,
                 client_write_iv,
-            )
+            ),
         };
 
         (

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -268,7 +268,7 @@ impl ConnectionSecrets {
 
     /// Make a `MessageCipherPair` based on the given supported ciphersuite `scs`,
     /// and the session's `secrets`.
-    pub(crate) fn make_cipher_pair(&self) -> MessageCipherPair {
+    pub(crate) fn make_cipher_pair(&self, side: Side) -> MessageCipherPair {
         fn split_key<'a>(
             key_block: &'a [u8],
             alg: &'static aead::Algorithm,
@@ -292,7 +292,7 @@ impl ConnectionSecrets {
         let (client_write_iv, key_block) = key_block.split_at(suite.fixed_iv_len);
         let (server_write_iv, extra) = key_block.split_at(suite.fixed_iv_len);
 
-        let (write_key, write_iv, read_key, read_iv) = match self.randoms.side {
+        let (write_key, write_iv, read_key, read_iv) = match side {
             Side::Client => (
                 client_write_key,
                 client_write_iv,


### PR DESCRIPTION
Removes the `ConnectionRandoms::we_are_client` and `CommonState::is_client` fields in favor of getting this state from the context. The former was unused in case TLS 1.2 was disabled, leading to a warning. Saves a few lines of code, 1 bit of state in handshake states, 1 bit of state in `CommonState`, and a branch in `process_main_protocol()`. Also defines an `enum Side { Client, Server }` in favor of using `bool`, which makes the resulting code easier to follow.