### PR TITLE
Split `KeyLogFile` into its own submodule & make it optional.

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -18,7 +18,8 @@ sct = "0.7.0"
 webpki = { version = "0.22.0", features = ["alloc", "std"] }
 
 [features]
-default = ["logging", "tls12"]
+default = ["keylogfile", "logging", "tls12"]
+keylogfile = []
 logging = ["log"]
 dangerous_configuration = []
 quic = []

--- a/rustls/src/keylog.rs
+++ b/rustls/src/keylog.rs
@@ -1,13 +1,3 @@
-use std::env;
-use std::fs::{File, OpenOptions};
-use std::io;
-use std::io::Write;
-use std::path::PathBuf;
-use std::sync::Mutex;
-
-#[cfg(feature = "logging")]
-use crate::log::warn;
-
 /// This trait represents the ability to do something useful
 /// with key material, such as logging it to a file for debugging.
 ///
@@ -18,8 +8,8 @@ use crate::log::warn;
 /// You'll likely want some interior mutability in your
 /// implementation to make this useful.
 ///
-/// See [`KeyLogFile`] that implements the standard `SSLKEYLOGFILE`
-/// environment variable behaviour.
+/// See [`KeyLogFile`](crate::KeyLogFile) that implements the standard
+/// `SSLKEYLOGFILE` environment variable behaviour.
 pub trait KeyLog: Send + Sync {
     /// Log the given `secret`.  `client_random` is provided for
     /// session identification.  `label` describes precisely what
@@ -61,146 +51,5 @@ impl KeyLog for NoKeyLog {
     #[inline]
     fn will_log(&self, _label: &str) -> bool {
         false
-    }
-}
-
-// Internal mutable state for KeyLogFile
-struct KeyLogFileInner {
-    path: Option<PathBuf>,
-    file: Option<File>,
-    buf: Vec<u8>,
-}
-
-impl KeyLogFileInner {
-    fn new(var: Result<String, env::VarError>) -> Self {
-        let path = match var {
-            Ok(ref s) => Some(PathBuf::from(s)),
-            Err(env::VarError::NotUnicode(ref s)) => Some(PathBuf::from(s)),
-            Err(env::VarError::NotPresent) => None,
-        };
-
-        Self {
-            path,
-            file: None,
-            buf: Vec::new(),
-        }
-    }
-
-    fn try_write(&mut self, label: &str, client_random: &[u8], secret: &[u8]) -> io::Result<()> {
-        if let Some(path) = self.path.take() {
-            #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
-            match OpenOptions::new()
-                .append(true)
-                .create(true)
-                .open(&path)
-            {
-                Ok(f) => self.file = Some(f),
-                Err(e) => warn!("unable to create key log file {:?}: {}", path, e),
-            }
-        }
-
-        let mut file = match self.file {
-            None => {
-                return Ok(());
-            }
-            Some(ref f) => f,
-        };
-
-        self.buf.truncate(0);
-        write!(self.buf, "{} ", label)?;
-        for b in client_random.iter() {
-            write!(self.buf, "{:02x}", b)?;
-        }
-        write!(self.buf, " ")?;
-        for b in secret.iter() {
-            write!(self.buf, "{:02x}", b)?;
-        }
-        writeln!(self.buf)?;
-        file.write_all(&self.buf)
-    }
-}
-
-/// [`KeyLog`] implementation that opens a file whose name is
-/// given by the `SSLKEYLOGFILE` environment variable, and writes
-/// keys into it.
-///
-/// If `SSLKEYLOGFILE` is not set, this does nothing.
-///
-/// If such a file cannot be opened, or cannot be written then
-/// this does nothing but logs errors at warning-level.
-pub struct KeyLogFile(Mutex<KeyLogFileInner>);
-
-impl KeyLogFile {
-    /// Makes a new `KeyLogFile`.  The environment variable is
-    /// inspected and the named file is opened during this call.
-    pub fn new() -> Self {
-        let var = env::var("SSLKEYLOGFILE");
-        Self(Mutex::new(KeyLogFileInner::new(var)))
-    }
-}
-
-impl KeyLog for KeyLogFile {
-    fn log(&self, label: &str, client_random: &[u8], secret: &[u8]) {
-        #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
-        match self
-            .0
-            .lock()
-            .unwrap()
-            .try_write(label, client_random, secret)
-        {
-            Ok(()) => {}
-            Err(e) => {
-                warn!("error writing to key log file: {}", e);
-            }
-        }
-    }
-}
-
-#[cfg(all(test, target_os = "linux"))]
-mod test {
-    use super::*;
-
-    fn init() {
-        let _ = env_logger::builder()
-            .is_test(true)
-            .try_init();
-    }
-
-    #[test]
-    fn test_env_var_is_not_unicode() {
-        init();
-        let mut inner = KeyLogFileInner::new(Err(env::VarError::NotUnicode(
-            "/tmp/keylogfileinnertest".into(),
-        )));
-        assert!(inner
-            .try_write("label", b"random", b"secret")
-            .is_ok());
-    }
-
-    #[test]
-    fn test_env_var_is_not_set() {
-        init();
-        let mut inner = KeyLogFileInner::new(Err(env::VarError::NotPresent));
-        assert!(inner
-            .try_write("label", b"random", b"secret")
-            .is_ok());
-    }
-
-    #[test]
-    fn test_env_var_cannot_be_opened() {
-        init();
-        let mut inner = KeyLogFileInner::new(Ok("/dev/does-not-exist".into()));
-        assert!(inner
-            .try_write("label", b"random", b"secret")
-            .is_ok());
-    }
-
-    #[test]
-    fn test_env_var_cannot_be_written() {
-        init();
-        let mut inner = KeyLogFileInner::new(Ok("/dev/full".into()));
-        assert!(inner
-            .try_write("label", b"random", b"secret")
-            .is_err());
     }
 }

--- a/rustls/src/keylogfile.rs
+++ b/rustls/src/keylogfile.rs
@@ -1,0 +1,151 @@
+use crate::KeyLog;
+use std::env;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+#[cfg(feature = "logging")]
+use crate::log::warn;
+
+// Internal mutable state for KeyLogFile
+struct KeyLogFileInner {
+    path: Option<PathBuf>,
+    file: Option<File>,
+    buf: Vec<u8>,
+}
+
+impl KeyLogFileInner {
+    fn new(var: Result<String, env::VarError>) -> Self {
+        let path = match var {
+            Ok(ref s) => Some(PathBuf::from(s)),
+            Err(env::VarError::NotUnicode(ref s)) => Some(PathBuf::from(s)),
+            Err(env::VarError::NotPresent) => None,
+        };
+
+        Self {
+            path,
+            file: None,
+            buf: Vec::new(),
+        }
+    }
+
+    fn try_write(&mut self, label: &str, client_random: &[u8], secret: &[u8]) -> io::Result<()> {
+        if let Some(path) = self.path.take() {
+            #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
+            match OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(&path)
+            {
+                Ok(f) => self.file = Some(f),
+                Err(e) => warn!("unable to create key log file {:?}: {}", path, e),
+            }
+        }
+
+        let mut file = match self.file {
+            None => {
+                return Ok(());
+            }
+            Some(ref f) => f,
+        };
+
+        self.buf.truncate(0);
+        write!(self.buf, "{} ", label)?;
+        for b in client_random.iter() {
+            write!(self.buf, "{:02x}", b)?;
+        }
+        write!(self.buf, " ")?;
+        for b in secret.iter() {
+            write!(self.buf, "{:02x}", b)?;
+        }
+        writeln!(self.buf)?;
+        file.write_all(&self.buf)
+    }
+}
+
+/// [`KeyLog`] implementation that opens a file whose name is
+/// given by the `SSLKEYLOGFILE` environment variable, and writes
+/// keys into it.
+///
+/// If `SSLKEYLOGFILE` is not set, this does nothing.
+///
+/// If such a file cannot be opened, or cannot be written then
+/// this does nothing but logs errors at warning-level.
+pub struct KeyLogFile(Mutex<KeyLogFileInner>);
+
+impl KeyLogFile {
+    /// Makes a new `KeyLogFile`.  The environment variable is
+    /// inspected and the named file is opened during this call.
+    pub fn new() -> Self {
+        let var = env::var("SSLKEYLOGFILE");
+        Self(Mutex::new(KeyLogFileInner::new(var)))
+    }
+}
+
+impl KeyLog for KeyLogFile {
+    fn log(&self, label: &str, client_random: &[u8], secret: &[u8]) {
+        #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
+        match self
+            .0
+            .lock()
+            .unwrap()
+            .try_write(label, client_random, secret)
+        {
+            Ok(()) => {}
+            Err(e) => {
+                warn!("error writing to key log file: {}", e);
+            }
+        }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod test {
+    use super::*;
+
+    fn init() {
+        let _ = env_logger::builder()
+            .is_test(true)
+            .try_init();
+    }
+
+    #[test]
+    fn test_env_var_is_not_unicode() {
+        init();
+        let mut inner = KeyLogFileInner::new(Err(env::VarError::NotUnicode(
+            "/tmp/keylogfileinnertest".into(),
+        )));
+        assert!(inner
+            .try_write("label", b"random", b"secret")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_env_var_is_not_set() {
+        init();
+        let mut inner = KeyLogFileInner::new(Err(env::VarError::NotPresent));
+        assert!(inner
+            .try_write("label", b"random", b"secret")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_env_var_cannot_be_opened() {
+        init();
+        let mut inner = KeyLogFileInner::new(Ok("/dev/does-not-exist".into()));
+        assert!(inner
+            .try_write("label", b"random", b"secret")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_env_var_cannot_be_written() {
+        init();
+        let mut inner = KeyLogFileInner::new(Ok("/dev/full".into()));
+        assert!(inner
+            .try_write("label", b"random", b"secret")
+            .is_err());
+    }
+}

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -330,6 +330,8 @@ mod bs_debug;
 mod builder;
 mod key;
 mod keylog;
+#[cfg(feature = "keylogfile")]
+mod keylogfile;
 mod kx;
 mod suites;
 mod ticketer;
@@ -358,7 +360,9 @@ pub use crate::conn::{
 };
 pub use crate::error::Error;
 pub use crate::key::{Certificate, PrivateKey};
-pub use crate::keylog::{KeyLog, KeyLogFile, NoKeyLog};
+pub use crate::keylog::{KeyLog, NoKeyLog};
+#[cfg(feature = "keylogfile")]
+pub use crate::keylogfile::KeyLogFile;
 pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
 pub use crate::msgs::enums::CipherSuite;
 pub use crate::msgs::enums::ProtocolVersion;


### PR DESCRIPTION
Split `KeyLogFile` into its own module to make it clearer that
`KeyLog` doesn't depend on `std::{env,fs,io,path,sync}`.

Add a feature flag to allow disabling the `KeyLogFile` feature. Make it
a default feature for API backward compatibility. In the next breaking
release, we should consider making it a non-default feature.

Use `git diff main:rustls/src/keylog.rs rustls/src/keylogfile.rs` to
verify that none of the `KeyLogFile` code has changed at all.