### PR TITLE
Use the new feature resolver (`resolver = "2"`).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ members = [
   "rustls-mio",
 ]
 exclude = ["admin/rustfmt"]
+resolver = "2"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ name = "rustls-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
+resolver = "2"
 
 [package.metadata]
 cargo-fuzz = true

--- a/rustls-mio/Cargo.toml
+++ b/rustls-mio/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 description = "Rustls example code and tests that depend on mio."
 publish = false
+resolver = "2"
 
 [features]
 default = ["logging"]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/rustls/rustls"
 repository = "https://github.com/rustls/rustls"
 categories = ["network-programming", "cryptography"]
 autobenches = false
+resolver = "2"
 
 [dependencies]
 log = { version = "0.4.4", optional = true }


### PR DESCRIPTION
Use the new feature resolver stablized in Rust 1.51.0 to improve how
features are handled.