### PR TITLE
Restore thread-safety to the integration test suite w.r.t. `env::set_var`.

### DIFF
--- a/admin/coverage
+++ b/admin/coverage
@@ -81,7 +81,7 @@ for example in 'bench bogo_shim trytls_shim'.split():
     rustc('--package', 'rustls', '--profile', 'dev', '--example', example)
 
 # crate-level tests
-for test in 'api'.split():
+for test in 'api key_log_file_env'.split():
     rustc('--package', 'rustls', '--profile', 'dev', '--test', test)
     run(test)
 

--- a/admin/coverage-rustc
+++ b/admin/coverage-rustc
@@ -15,7 +15,7 @@ get_crate_name()
 }
 
 case $(get_crate_name "$@") in
-  rustls|tlsclient|tlsserver|features|server_suites|client_suites|errors|api|badssl|bugs|curves|topsites|bogo_shim|trytls_shim|bench)
+  rustls|tlsclient|tlsserver|features|key_log_file_env|server_suites|client_suites|errors|api|badssl|bugs|curves|topsites|bogo_shim|trytls_shim|bench)
     EXTRA=$COVERAGE_OPTIONS
     ;;
   *)

--- a/rustls/tests/key_log_file_env.rs
+++ b/rustls/tests/key_log_file_env.rs
@@ -1,0 +1,104 @@
+//! Tests of [`rustls::KeyLogFile`] that require us to set environment variables.
+//!
+//!                                 vvvv
+//! Every test you add to this file MUST execute through `serialized()`.
+//!                                 ^^^^
+//!
+//! See https://github.com/rust-lang/rust/issues/90308; despite not being marked
+//! `unsafe`, `env::var::set_var` is an unsafe function. These tests are separated
+//! from the rest of the tests so that their use of `set_ver` is less likely to
+//! affect them; as of the time these tests were moved to this file, Cargo will
+//! compile each test suite file to a separate executable, so these will be run
+//! in a completely separate process. This way, executing every test through
+//! `serialized()` will cause them to be run one at a time.
+//!
+//! Note: If/when we add new constructors to `KeyLogFile` to allow constructing
+//! one from a path directly (without using an environment variable), then those
+//! tests SHOULD NOT go in this file.
+//!
+//! XXX: These tests don't actually test the functionality; they just ensure
+//! the code coverage doesn't complain it isn't covered. TODO: Verify that the
+//! file was created successfully, with the right permissions, etc., and that it
+//! contains something like what we expect.
+
+#[allow(dead_code)]
+mod common;
+
+use crate::common::{
+    do_handshake, make_client_config_with_versions, make_pair_for_arc_configs, make_server_config,
+    transfer, KeyType,
+};
+use std::{
+    env,
+    io::Write,
+    sync::{Arc, Mutex, Once},
+};
+
+/// Approximates `#[serial]` from the `serial_test` crate.
+///
+/// No attempt is made to recover from a poisoned mutex, which will
+/// happen when `f` panics. In other words, all the tests that use
+/// `serialized` will start failing after one test panics.
+fn serialized(f: impl FnOnce()) {
+    // Ensure every test is run serialized
+    // TODO: Use `std::sync::Lazy` once that is stable.
+    static mut MUTEX: Option<Mutex<()>> = None;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| unsafe {
+        MUTEX = Some(Mutex::new(()));
+    });
+    let mutex = unsafe { MUTEX.as_mut() };
+
+    let _guard = mutex.unwrap().lock().unwrap();
+
+    // XXX: NOT thread safe.
+    env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt");
+
+    f()
+}
+
+#[test]
+fn exercise_key_log_file_for_client() {
+    serialized(|| {
+        let server_config = Arc::new(make_server_config(KeyType::Rsa));
+        env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt");
+
+        for version in rustls::ALL_VERSIONS {
+            let mut client_config = make_client_config_with_versions(KeyType::Rsa, &[version]);
+            client_config.key_log = Arc::new(rustls::KeyLogFile::new());
+
+            let (mut client, mut server) =
+                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+
+            assert_eq!(5, client.writer().write(b"hello").unwrap());
+
+            do_handshake(&mut client, &mut server);
+            transfer(&mut client, &mut server);
+            server.process_new_packets().unwrap();
+        }
+    })
+}
+
+#[test]
+fn exercise_key_log_file_for_server() {
+    serialized(|| {
+        let mut server_config = make_server_config(KeyType::Rsa);
+
+        env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt");
+        server_config.key_log = Arc::new(rustls::KeyLogFile::new());
+
+        let server_config = Arc::new(server_config);
+
+        for version in rustls::ALL_VERSIONS {
+            let client_config = make_client_config_with_versions(KeyType::Rsa, &[version]);
+            let (mut client, mut server) =
+                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+
+            assert_eq!(5, client.writer().write(b"hello").unwrap());
+
+            do_handshake(&mut client, &mut server);
+            transfer(&mut client, &mut server);
+            server.process_new_packets().unwrap();
+        }
+    })
+}


### PR DESCRIPTION
Serialize all tests that use `std::env::set_var` & isolate them. See the comments in key_log_file_env.rs for details.

Also add notes about the fact that these tests aren't really testing the functionality.

Use a whitespace-smart diff tool to compare the new file to what was in api.rs:
```
git difftool HEAD^1:rustls/tests/api.rs rustls/tests/key_log_file_env.rs
```