### PR TITLE
Replace `doc(hidden)` with `pub(crate)` where those semantics are intended.

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -159,11 +159,10 @@ impl ClientConfig {
         }
     }
 
-    #[doc(hidden)]
     /// We support a given TLS version if it's quoted in the configured
     /// versions *and* at least one ciphersuite for this version is
     /// also configured.
-    pub fn supports_version(&self, v: ProtocolVersion) -> bool {
+    pub(crate) fn supports_version(&self, v: ProtocolVersion) -> bool {
         self.versions.contains(v)
             && self
                 .cipher_suites

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -288,7 +288,7 @@ impl<'a> io::Read for Reader<'a> {
 
 /// Internal trait implemented by the [`ServerConnection`]/[`ClientConnection`]
 /// allowing them to be the subject of a [`Writer`].
-pub trait PlaintextSink {
+pub(crate) trait PlaintextSink {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize>;
     fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize>;
     fn flush(&mut self) -> io::Result<()>;
@@ -322,8 +322,7 @@ impl<'a> Writer<'a> {
     ///
     /// This is not an external interface.  Get one of these objects
     /// from [`Connection::writer`].
-    #[doc(hidden)]
-    pub fn new(sink: &'a mut dyn PlaintextSink) -> Writer<'a> {
+    pub(crate) fn new(sink: &'a mut dyn PlaintextSink) -> Writer<'a> {
         Writer { sink }
     }
 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -247,11 +247,10 @@ impl ServerConfig {
         }
     }
 
-    #[doc(hidden)]
     /// We support a given TLS version if it's quoted in the configured
     /// versions *and* at least one ciphersuite for this version is
     /// also configured.
-    pub fn supports_version(&self, v: ProtocolVersion) -> bool {
+    pub(crate) fn supports_version(&self, v: ProtocolVersion) -> bool {
         self.versions.contains(v)
             && self
                 .cipher_suites


### PR DESCRIPTION
I think these uses of `doc(hidden)` are trying to implement `pub(crate)`
semantics. Perhaps it was done this way a long time ago when `pub(crate)`
wasn't a think.

This change causes an `unreachable_pub` warning for `PlaintextSink`, so
make that `pub(crate)` too.

Some external users might be using these even though they probably shouldn't
be, so this is technically a breaking change.

There is one `TryFrom` implementation marked `#[doc(hidden)]` that is used by the test suite. Besides that, all the remaining `#[doc(hidden)]` uses are on deprecated type aliases.