### PR TITLE
Clarify when `may_receive_application_data` is set.

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1113,12 +1113,8 @@ impl CommonState {
         self.flush_plaintext();
     }
 
-    pub(crate) fn start_incoming_traffic(&mut self) {
-        self.may_receive_application_data = true;
-    }
-
     pub(crate) fn start_traffic(&mut self) {
-        self.start_incoming_traffic();
+        self.may_receive_application_data = true;
         self.start_outgoing_traffic();
     }
 


### PR DESCRIPTION
`start_incoming_traffic()` doesn't need to exist as a `pub(crate)`
function, or at all, because it is only used by the function right
below it. Inline it into that function to make it clearer when
`may_receive_application_data` is set.