### PR TITLE
CommonState::process_main_protocol: Remove misleading comments.

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -893,9 +893,6 @@ impl CommonState {
         matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
     }
 
-    /// Process `msg`.  First, we get the current state.  Then we ask what messages
-    /// that state expects, enforced via `check_message`.  Finally, we ask the handler
-    /// to handle the message.
     fn process_main_protocol<Data>(
         &mut self,
         msg: Message,


### PR DESCRIPTION
The comments are out of date. In particular, `check_message` isn't
used, but also the other comments are misleading. Just remove them.