### PR TITLE
Reduce the amount of code inlined into callers of `require_handshake_msg[_move]`

### DIFF
--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -15,7 +15,10 @@ macro_rules! require_handshake_msg(
             payload: $payload_type(hm),
             ..
         }) => Ok(hm),
-        payload => Err($crate::check::inappropriate_handshake_message(payload, &[$handshake_type]))
+        payload => Err($crate::check::inappropriate_handshake_message(
+            payload,
+            &[$crate::msgs::enums::ContentType::Handshake],
+            &[$handshake_type]))
     }
   )
 );
@@ -30,7 +33,10 @@ macro_rules! require_handshake_msg_move(
             ..
         }) => Ok(hm),
         ref payload =>
-            Err($crate::check::inappropriate_handshake_message(payload, &[$handshake_type]))
+            Err($crate::check::inappropriate_handshake_message(
+                payload,
+                &[$crate::msgs::enums::ContentType::Handshake],
+                &[$handshake_type]))
     }
   )
 );
@@ -51,7 +57,11 @@ pub(crate) fn check_message(
 
     if let MessagePayload::Handshake(hsp) = &m.payload {
         if !handshake_types.is_empty() && !handshake_types.contains(&hsp.typ) {
-            return Err(inappropriate_handshake_message(&m.payload, handshake_types));
+            return Err(inappropriate_handshake_message(
+                &m.payload,
+                content_types,
+                handshake_types,
+            ));
         }
     }
 
@@ -75,6 +85,7 @@ pub(crate) fn inappropriate_message(
 
 pub(crate) fn inappropriate_handshake_message(
     payload: &MessagePayload,
+    content_types: &[ContentType],
     handshake_types: &[HandshakeType],
 ) -> Error {
     match payload {
@@ -88,6 +99,6 @@ pub(crate) fn inappropriate_handshake_message(
                 got_type: hsp.typ,
             }
         }
-        payload => inappropriate_message(payload, &[ContentType::Handshake]),
+        payload => inappropriate_message(payload, content_types),
     }
 }

--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -10,16 +10,12 @@ use crate::msgs::message::{Message, MessagePayload};
 /// $handshake_type as the expected handshake type.
 macro_rules! require_handshake_msg(
   ( $m:expr, $handshake_type:path, $payload_type:path ) => (
-    match $m.payload {
-        MessagePayload::Handshake(ref hsp) => match hsp.payload {
-            $payload_type(ref hm) => Ok(hm),
-            _ => Err(Error::InappropriateHandshakeMessage {
-                     expect_types: vec![ $handshake_type ],
-                     got_type: hsp.typ})
-        }
-        _ => Err(Error::InappropriateMessage {
-                 expect_types: vec![ ContentType::Handshake ],
-                 got_type: $m.payload.content_type()})
+    match &$m.payload {
+        MessagePayload::Handshake($crate::msgs::handshake::HandshakeMessagePayload {
+            payload: $payload_type(hm),
+            ..
+        }) => Ok(hm),
+        payload => Err($crate::check::inappropriate_handshake_message(payload, &[$handshake_type]))
     }
   )
 );
@@ -29,15 +25,12 @@ macro_rules! require_handshake_msg(
 macro_rules! require_handshake_msg_move(
   ( $m:expr, $handshake_type:path, $payload_type:path ) => (
     match $m.payload {
-        MessagePayload::Handshake(hsp) => match hsp.payload {
-            $payload_type(hm) => Ok(hm),
-            _ => Err(Error::InappropriateHandshakeMessage {
-                     expect_types: vec![ $handshake_type ],
-                     got_type: hsp.typ})
-        }
-        _ => Err(Error::InappropriateMessage {
-                 expect_types: vec![ ContentType::Handshake ],
-                 got_type: $m.payload.content_type()})
+        MessagePayload::Handshake($crate::msgs::handshake::HandshakeMessagePayload {
+            payload: $payload_type(hm),
+            ..
+        }) => Ok(hm),
+        ref payload =>
+            Err($crate::check::inappropriate_handshake_message(payload, &[$handshake_type]))
     }
   )
 );

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1072,8 +1072,11 @@ impl State<ClientConnectionData> for ExpectTraffic {
             MessagePayload::ApplicationData(payload) => cx
                 .common
                 .take_received_plaintext(payload),
-            _ => {
-                return Err(inappropriate_message(&m, &[ContentType::ApplicationData]));
+            payload => {
+                return Err(inappropriate_message(
+                    &payload,
+                    &[ContentType::ApplicationData],
+                ));
             }
         }
         Ok(self)

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1095,23 +1095,23 @@ impl State<ClientConnectionData> for ExpectTraffic {
             MessagePayload::ApplicationData(payload) => cx
                 .common
                 .take_received_plaintext(payload),
-            MessagePayload::Handshake(payload) => match payload.payload {
+            MessagePayload::Handshake(payload) => match &payload.payload {
                 HandshakePayload::NewSessionTicketTLS13(new_ticket) => {
-                    self.handle_new_ticket_tls13(cx, &new_ticket)?
+                    self.handle_new_ticket_tls13(cx, new_ticket)?
                 }
                 HandshakePayload::KeyUpdate(key_update) => {
-                    self.handle_key_update(cx.common, &key_update)?
+                    self.handle_key_update(cx.common, key_update)?
                 }
                 _ => {
                     return Err(inappropriate_handshake_message(
-                        &payload,
+                        &MessagePayload::Handshake(payload),
                         &[HandshakeType::NewSessionTicket, HandshakeType::KeyUpdate],
                     ));
                 }
             },
-            _ => {
+            payload => {
                 return Err(inappropriate_message(
-                    &m,
+                    &payload,
                     &[ContentType::ApplicationData, ContentType::Handshake],
                 ));
             }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -6,7 +6,7 @@ use crate::log::{debug, trace};
 #[cfg(feature = "tls12")]
 use crate::msgs::enums::CipherSuite;
 use crate::msgs::enums::{AlertDescription, Compression, ExtensionType};
-use crate::msgs::enums::{ContentType, HandshakeType, ProtocolVersion, SignatureScheme};
+use crate::msgs::enums::{HandshakeType, ProtocolVersion, SignatureScheme};
 #[cfg(feature = "tls12")]
 use crate::msgs::handshake::SessionID;
 use crate::msgs::handshake::{ClientHelloPayload, Random, ServerExtension};

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -900,8 +900,11 @@ impl State<ServerConnectionData> for ExpectTraffic {
             MessagePayload::ApplicationData(payload) => cx
                 .common
                 .take_received_plaintext(payload),
-            _ => {
-                return Err(inappropriate_message(&m, &[ContentType::ApplicationData]));
+            ref payload => {
+                return Err(inappropriate_message(
+                    payload,
+                    &[ContentType::ApplicationData],
+                ));
             }
         }
         Ok(self)

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1298,21 +1298,15 @@ impl State<ServerConnectionData> for ExpectTraffic {
             MessagePayload::ApplicationData(payload) => cx
                 .common
                 .take_received_plaintext(payload),
-            MessagePayload::Handshake(payload) => match payload.payload {
-                HandshakePayload::KeyUpdate(key_update) => {
-                    self.handle_key_update(cx.common, &key_update)?
-                }
-                _ => {
-                    return Err(inappropriate_handshake_message(
-                        &MessagePayload::Handshake(payload),
-                        &[HandshakeType::KeyUpdate],
-                    ));
-                }
-            },
-            payload => {
-                return Err(inappropriate_message(
-                    &payload,
+            MessagePayload::Handshake(HandshakeMessagePayload {
+                payload: HandshakePayload::KeyUpdate(key_update),
+                ..
+            }) => self.handle_key_update(cx.common, &key_update)?,
+            ref payload => {
+                return Err(inappropriate_handshake_message(
+                    payload,
                     &[ContentType::ApplicationData, ContentType::Handshake],
+                    &[HandshakeType::KeyUpdate],
                 ));
             }
         }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1067,8 +1067,8 @@ impl State<ServerConnectionData> for ExpectEarlyData {
                     send_ticket: self.send_ticket,
                 }))
             }
-            _ => Err(inappropriate_message(
-                &m,
+            payload => Err(inappropriate_message(
+                &payload,
                 &[ContentType::ApplicationData, ContentType::Handshake],
             )),
         }
@@ -1304,14 +1304,14 @@ impl State<ServerConnectionData> for ExpectTraffic {
                 }
                 _ => {
                     return Err(inappropriate_handshake_message(
-                        &payload,
+                        &MessagePayload::Handshake(payload),
                         &[HandshakeType::KeyUpdate],
                     ));
                 }
             },
-            _ => {
+            payload => {
                 return Err(inappropriate_message(
-                    &m,
+                    &payload,
                     &[ContentType::ApplicationData, ContentType::Handshake],
                 ));
             }


### PR DESCRIPTION
Refactor `inappropriate[_handshake]_message` to work better with the pattern matching patterns used in `require_handshake_msg[_move]` and elsewhere in the codebase (including upcoming changes I have queued).

Use the new version of `inappropriate_handshake_message` to reduce the amonut of code that will be inlined into the "caller" of the `require_handshake_msg[_move]` macros.

This is a step towards removing mostly-redundant calls to `check_message` and `is_handshake_type()` (I have a branch that removes both).
