### PR TITLE
Remove `check_message` and match all incoming messages uniformly

### DIFF
--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -15,7 +15,10 @@ macro_rules! require_handshake_msg(
             payload: $payload_type(hm),
             ..
         }) => Ok(hm),
-        payload => Err($crate::check::inappropriate_handshake_message(payload, &[$handshake_type]))
+        payload => Err($crate::check::inappropriate_handshake_message(
+            payload,
+            &[$crate::msgs::enums::ContentType::Handshake],
+            &[$handshake_type]))
     }
   )
 );
@@ -30,7 +33,10 @@ macro_rules! require_handshake_msg_move(
             ..
         }) => Ok(hm),
         ref payload =>
-            Err($crate::check::inappropriate_handshake_message(payload, &[$handshake_type]))
+            Err($crate::check::inappropriate_handshake_message(
+                payload,
+                &[$crate::msgs::enums::ContentType::Handshake],
+                &[$handshake_type]))
     }
   )
 );
@@ -51,7 +57,11 @@ pub(crate) fn check_message(
 
     if let MessagePayload::Handshake(hsp) = &m.payload {
         if !handshake_types.is_empty() && !handshake_types.contains(&hsp.typ) {
-            return Err(inappropriate_handshake_message(&m.payload, handshake_types));
+            return Err(inappropriate_handshake_message(
+                &m.payload,
+                content_types,
+                handshake_types,
+            ));
         }
     }
 
@@ -75,6 +85,7 @@ pub(crate) fn inappropriate_message(
 
 pub(crate) fn inappropriate_handshake_message(
     payload: &MessagePayload,
+    content_types: &[ContentType],
     handshake_types: &[HandshakeType],
 ) -> Error {
     match payload {
@@ -88,6 +99,6 @@ pub(crate) fn inappropriate_handshake_message(
                 got_type: hsp.typ,
             }
         }
-        payload => inappropriate_message(payload, &[ContentType::Handshake]),
+        payload => inappropriate_message(payload, content_types),
     }
 }

--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 #[cfg(feature = "logging")]
 use crate::log::warn;
 use crate::msgs::enums::{ContentType, HandshakeType};
-use crate::msgs::message::{Message, MessagePayload};
+use crate::msgs::message::MessagePayload;
 
 /// For a Message $m, and a HandshakePayload enum member $payload_type,
 /// return Ok(payload) if $m is both a handshake message and one that
@@ -40,33 +40,6 @@ macro_rules! require_handshake_msg_move(
     }
   )
 );
-
-/// Validate the message `m`: return an error if:
-///
-/// - the type of m does not appear in `content_types`.
-/// - if m is a handshake message, the handshake message type does
-///   not appear in `handshake_types`.
-pub(crate) fn check_message(
-    m: &Message,
-    content_types: &[ContentType],
-    handshake_types: &[HandshakeType],
-) -> Result<(), Error> {
-    if !content_types.contains(&m.payload.content_type()) {
-        return Err(inappropriate_message(&m.payload, content_types));
-    }
-
-    if let MessagePayload::Handshake(hsp) = &m.payload {
-        if !handshake_types.is_empty() && !handshake_types.contains(&hsp.typ) {
-            return Err(inappropriate_handshake_message(
-                &m.payload,
-                content_types,
-                handshake_types,
-            ));
-        }
-    }
-
-    Ok(())
-}
 
 pub(crate) fn inappropriate_message(
     payload: &MessagePayload,

--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -10,16 +10,12 @@ use crate::msgs::message::{Message, MessagePayload};
 /// $handshake_type as the expected handshake type.
 macro_rules! require_handshake_msg(
   ( $m:expr, $handshake_type:path, $payload_type:path ) => (
-    match $m.payload {
-        MessagePayload::Handshake(ref hsp) => match hsp.payload {
-            $payload_type(ref hm) => Ok(hm),
-            _ => Err(Error::InappropriateHandshakeMessage {
-                     expect_types: vec![ $handshake_type ],
-                     got_type: hsp.typ})
-        }
-        _ => Err(Error::InappropriateMessage {
-                 expect_types: vec![ ContentType::Handshake ],
-                 got_type: $m.payload.content_type()})
+    match &$m.payload {
+        MessagePayload::Handshake($crate::msgs::handshake::HandshakeMessagePayload {
+            payload: $payload_type(hm),
+            ..
+        }) => Ok(hm),
+        payload => Err($crate::check::inappropriate_handshake_message(payload, &[$handshake_type]))
     }
   )
 );
@@ -29,15 +25,12 @@ macro_rules! require_handshake_msg(
 macro_rules! require_handshake_msg_move(
   ( $m:expr, $handshake_type:path, $payload_type:path ) => (
     match $m.payload {
-        MessagePayload::Handshake(hsp) => match hsp.payload {
-            $payload_type(hm) => Ok(hm),
-            _ => Err(Error::InappropriateHandshakeMessage {
-                     expect_types: vec![ $handshake_type ],
-                     got_type: hsp.typ})
-        }
-        _ => Err(Error::InappropriateMessage {
-                 expect_types: vec![ ContentType::Handshake ],
-                 got_type: $m.payload.content_type()})
+        MessagePayload::Handshake($crate::msgs::handshake::HandshakeMessagePayload {
+            payload: $payload_type(hm),
+            ..
+        }) => Ok(hm),
+        ref payload =>
+            Err($crate::check::inappropriate_handshake_message(payload, &[$handshake_type]))
     }
   )
 );

--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -32,9 +32,9 @@ macro_rules! require_handshake_msg_move(
             payload: $payload_type(hm),
             ..
         }) => Ok(hm),
-        ref payload =>
+        payload =>
             Err($crate::check::inappropriate_handshake_message(
-                payload,
+                &payload,
                 &[$crate::msgs::enums::ContentType::Handshake],
                 &[$handshake_type]))
     }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -11,7 +11,9 @@ use crate::msgs::base::Payload;
 #[cfg(feature = "quic")]
 use crate::msgs::base::PayloadU16;
 use crate::msgs::codec::{Codec, Reader};
-use crate::msgs::enums::{AlertDescription, CipherSuite, Compression, ProtocolVersion};
+use crate::msgs::enums::{
+    AlertDescription, CipherSuite, Compression, ContentType, ProtocolVersion,
+};
 use crate::msgs::enums::{ECPointFormat, PSKKeyExchangeMode};
 use crate::msgs::enums::{ExtensionType, HandshakeType};
 use crate::msgs::handshake::{CertificateStatusRequest, ClientSessionTicket, SCTList};
@@ -802,6 +804,7 @@ impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
             }) => self.handle_hello_retry_request(cx, m),
             ref payload => Err(inappropriate_handshake_message(
                 payload,
+                &[ContentType::Handshake],
                 &[HandshakeType::ServerHello, HandshakeType::HelloRetryRequest],
             )),
         }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -802,8 +802,8 @@ impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
                 payload: HandshakePayload::HelloRetryRequest(..),
                 ..
             }) => self.handle_hello_retry_request(cx, m),
-            ref payload => Err(inappropriate_handshake_message(
-                payload,
+            payload => Err(inappropriate_handshake_message(
+                &payload,
                 &[ContentType::Handshake],
                 &[HandshakeType::ServerHello, HandshakeType::HelloRetryRequest],
             )),

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1072,8 +1072,11 @@ impl State<ClientConnectionData> for ExpectTraffic {
             MessagePayload::ApplicationData(payload) => cx
                 .common
                 .take_received_plaintext(payload),
-            _ => {
-                return Err(inappropriate_message(&m, &[ContentType::ApplicationData]));
+            payload => {
+                return Err(inappropriate_message(
+                    &payload,
+                    &[ContentType::ApplicationData],
+                ));
             }
         }
         Ok(self)

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -303,8 +303,8 @@ impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
                 must_issue_new_ticket: self.must_issue_new_ticket,
             })
             .handle(cx, m),
-            ref payload => Err(inappropriate_handshake_message(
-                payload,
+            payload => Err(inappropriate_handshake_message(
+                &payload,
                 &[ContentType::Handshake],
                 &[
                     HandshakeType::ServerKeyExchange,
@@ -700,9 +700,9 @@ impl State<ClientConnectionData> for ExpectServerDone {
                 payload: HandshakePayload::ServerHelloDone,
                 ..
             }) => {}
-            ref payload => {
+            payload => {
                 return Err(inappropriate_handshake_message(
-                    payload,
+                    &payload,
                     &[ContentType::Handshake],
                     &[HandshakeType::ServerHelloDone],
                 ));
@@ -930,9 +930,9 @@ impl State<ClientConnectionData> for ExpectCcs {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ChangeCipherSpec(..) => {}
-            ref payload => {
+            payload => {
                 return Err(inappropriate_message(
-                    payload,
+                    &payload,
                     &[ContentType::ChangeCipherSpec],
                 ));
             }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1095,23 +1095,23 @@ impl State<ClientConnectionData> for ExpectTraffic {
             MessagePayload::ApplicationData(payload) => cx
                 .common
                 .take_received_plaintext(payload),
-            MessagePayload::Handshake(payload) => match payload.payload {
+            MessagePayload::Handshake(payload) => match &payload.payload {
                 HandshakePayload::NewSessionTicketTLS13(new_ticket) => {
-                    self.handle_new_ticket_tls13(cx, &new_ticket)?
+                    self.handle_new_ticket_tls13(cx, new_ticket)?
                 }
                 HandshakePayload::KeyUpdate(key_update) => {
-                    self.handle_key_update(cx.common, &key_update)?
+                    self.handle_key_update(cx.common, key_update)?
                 }
                 _ => {
                     return Err(inappropriate_handshake_message(
-                        &payload,
+                        &MessagePayload::Handshake(payload),
                         &[HandshakeType::NewSessionTicket, HandshakeType::KeyUpdate],
                     ));
                 }
             },
-            _ => {
+            payload => {
                 return Err(inappropriate_message(
-                    &m,
+                    &payload,
                     &[ContentType::ApplicationData, ContentType::Handshake],
                 ));
             }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -509,8 +509,8 @@ impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
                 may_send_sct_list: self.may_send_sct_list,
             })
             .handle(cx, m),
-            ref payload => Err(inappropriate_handshake_message(
-                payload,
+            payload => Err(inappropriate_handshake_message(
+                &payload,
                 &[ContentType::Handshake],
                 &[
                     HandshakeType::Certificate,
@@ -1108,9 +1108,9 @@ impl State<ClientConnectionData> for ExpectTraffic {
                 payload: HandshakePayload::KeyUpdate(ref key_update),
                 ..
             }) => self.handle_key_update(cx.common, key_update)?,
-            ref payload => {
+            payload => {
                 return Err(inappropriate_handshake_message(
-                    payload,
+                    &payload,
                     &[ContentType::ApplicationData, ContentType::Handshake],
                     &[HandshakeType::NewSessionTicket, HandshakeType::KeyUpdate],
                 ));

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -500,9 +500,9 @@ pub enum CertificateStatusRequest {
 
 impl Codec for CertificateStatusRequest {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        match *self {
+        match self {
             Self::OCSP(ref r) => r.encode(bytes),
-            Self::Unknown((typ, ref payload)) => {
+            Self::Unknown((typ, payload)) => {
                 typ.encode(bytes);
                 payload.encode(bytes);
             }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -6,7 +6,7 @@ use crate::log::{debug, trace};
 #[cfg(feature = "tls12")]
 use crate::msgs::enums::CipherSuite;
 use crate::msgs::enums::{AlertDescription, Compression, ExtensionType};
-use crate::msgs::enums::{ContentType, HandshakeType, ProtocolVersion, SignatureScheme};
+use crate::msgs::enums::{HandshakeType, ProtocolVersion, SignatureScheme};
 #[cfg(feature = "tls12")]
 use crate::msgs::handshake::SessionID;
 use crate::msgs::handshake::{ClientHelloPayload, Random, ServerExtension};

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -702,9 +702,9 @@ impl State<ServerConnectionData> for ExpectCcs {
     fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ChangeCipherSpec(..) => {}
-            ref payload => {
+            payload => {
                 return Err(inappropriate_message(
-                    payload,
+                    &payload,
                     &[ContentType::ChangeCipherSpec],
                 ))
             }
@@ -908,9 +908,9 @@ impl State<ServerConnectionData> for ExpectTraffic {
             MessagePayload::ApplicationData(payload) => cx
                 .common
                 .take_received_plaintext(payload),
-            ref payload => {
+            payload => {
                 return Err(inappropriate_message(
-                    payload,
+                    &payload,
                     &[ContentType::ApplicationData],
                 ));
             }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -900,8 +900,11 @@ impl State<ServerConnectionData> for ExpectTraffic {
             MessagePayload::ApplicationData(payload) => cx
                 .common
                 .take_received_plaintext(payload),
-            _ => {
-                return Err(inappropriate_message(&m, &[ContentType::ApplicationData]));
+            ref payload => {
+                return Err(inappropriate_message(
+                    payload,
+                    &[ContentType::ApplicationData],
+                ));
             }
         }
         Ok(self)

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1298,21 +1298,15 @@ impl State<ServerConnectionData> for ExpectTraffic {
             MessagePayload::ApplicationData(payload) => cx
                 .common
                 .take_received_plaintext(payload),
-            MessagePayload::Handshake(payload) => match payload.payload {
-                HandshakePayload::KeyUpdate(key_update) => {
-                    self.handle_key_update(cx.common, &key_update)?
-                }
-                _ => {
-                    return Err(inappropriate_handshake_message(
-                        &MessagePayload::Handshake(payload),
-                        &[HandshakeType::KeyUpdate],
-                    ));
-                }
-            },
-            payload => {
-                return Err(inappropriate_message(
-                    &payload,
+            MessagePayload::Handshake(HandshakeMessagePayload {
+                payload: HandshakePayload::KeyUpdate(key_update),
+                ..
+            }) => self.handle_key_update(cx.common, &key_update)?,
+            ref payload => {
+                return Err(inappropriate_handshake_message(
+                    payload,
                     &[ContentType::ApplicationData, ContentType::Handshake],
+                    &[HandshakeType::KeyUpdate],
                 ));
             }
         }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "quic")]
-use crate::check::check_message;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 #[cfg(feature = "quic")]
 use crate::conn::Protocol;
@@ -1349,8 +1347,7 @@ struct ExpectQuicTraffic {
 impl State<ServerConnectionData> for ExpectQuicTraffic {
     fn handle(self: Box<Self>, _cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         // reject all messages
-        check_message(&m, &[], &[])?;
-        unreachable!();
+        Err(inappropriate_message(&m.payload, &[]))
     }
 
     fn export_keying_material(

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1300,9 +1300,9 @@ impl State<ServerConnectionData> for ExpectTraffic {
                 payload: HandshakePayload::KeyUpdate(key_update),
                 ..
             }) => self.handle_key_update(cx.common, &key_update)?,
-            ref payload => {
+            payload => {
                 return Err(inappropriate_handshake_message(
-                    payload,
+                    &payload,
                     &[ContentType::ApplicationData, ContentType::Handshake],
                     &[HandshakeType::KeyUpdate],
                 ));

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1067,8 +1067,8 @@ impl State<ServerConnectionData> for ExpectEarlyData {
                     send_ticket: self.send_ticket,
                 }))
             }
-            _ => Err(inappropriate_message(
-                &m,
+            payload => Err(inappropriate_message(
+                &payload,
                 &[ContentType::ApplicationData, ContentType::Handshake],
             )),
         }
@@ -1304,14 +1304,14 @@ impl State<ServerConnectionData> for ExpectTraffic {
                 }
                 _ => {
                     return Err(inappropriate_handshake_message(
-                        &payload,
+                        &MessagePayload::Handshake(payload),
                         &[HandshakeType::KeyUpdate],
                     ));
                 }
             },
-            _ => {
+            payload => {
                 return Err(inappropriate_message(
-                    &m,
+                    &payload,
                     &[ContentType::ApplicationData, ContentType::Handshake],
                 ));
             }


### PR DESCRIPTION
* From inspection, `check_message(m, &[..., ContentType::Handshake], &[])` returns `Ok(())`, which doesn't make sense. It seems like we never do that, but that shouldn't even be a possibility. Remove the function.
* In some cases, `check_message()` is doing redundant work pessimistically with the `match` or `if ... else` immediately after it. Eliminate the redundant checks.
* The logic for returning `InappropriateHandshakeMessage` vs `InappropriateMessage` is duplicated in many different states. (Some of this duplication is hard to see because it's hidden in the `require_handshake_msg[_move]` macros. Minimize the amount of duplication.
* Make `require_handshake_msg[_move]` work like the rest of the code.

The removal of `check_message()` (and soon `is_handshake_type()`) is a step towards eliminating the need for `HandshakeMessagePayload::typ`; we may even be able to eliminate the need for `HandshakeMessagePayload` completely.