### PR TITLE
bogo: Remove redundant specification of features for bogo_shim.

### DIFF
--- a/bogo/runme
+++ b/bogo/runme
@@ -6,7 +6,7 @@
 set -xe
 
 if [ "x$USE_EXISTING_BOGO_SHIM" = "x" ] ; then
-  cargo build --example bogo_shim --features dangerous_configuration,quic
+  cargo build --example bogo_shim
 fi
 
 if [ ! -e bogo/ssl/test/runner/runner.test ] ; then


### PR DESCRIPTION
The features will be enabled automatically since bogo_shim lists them as
required features in Cargo.toml.