### PR TITLE
Automatically enable `read_buf` functionality on Rust Nightly (only)

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 resolver = "2"
 
 [build-dependencies]
-rustversion = { version = "1.0.6", optional = true }
+rustversion = { version = "1.0.6" }
 
 [dependencies]
 log = { version = "0.4.4", optional = true }
@@ -28,7 +28,6 @@ logging = ["log"]
 dangerous_configuration = []
 quic = []
 tls12 = []
-read_buf = ["rustversion"]
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/rustls/build.rs
+++ b/rustls/build.rs
@@ -3,10 +3,9 @@
 ///
 /// See the comment in lib.rs to understand why we need this.
 
-#[cfg_attr(feature = "read_buf", rustversion::not(nightly))]
+#[rustversion::not(nightly)]
 fn main() {}
 
-#[cfg(feature = "read_buf")]
 #[rustversion::nightly]
 fn main() {
     println!("cargo:rustc-cfg=read_buf");

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -251,10 +251,6 @@
 //!   is enabled by default, other crates in your dependency graph could re-enable
 //!   it for your application. If you want to disable TLS 1.2 for security reasons,
 //!   consider explicitly enabling TLS 1.3 only in the config builder API.
-//!
-//! - `read_buf`: When building with Rust Nightly, adds support for the unstable
-//!   `std::io::ReadBuf` and related APIs. This reduces costs from initializing
-//!   buffers. Will do nothing on non-Nightly releases.
 
 // Require docs for public APIs, deny unsafe code, etc.
 #![forbid(unsafe_code, unused_must_use)]


### PR DESCRIPTION
The functionality is now automatically enabled for Rust Nightly (only).
