### PR TITLE
Make `cargo {check,build,test} --all-features` work on Rust Stable (take 3).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,14 +39,7 @@ jobs:
       - name: cargo build (debug; default features)
         run: cargo build
 
-      - name: cargo test (debug; stable features)
-        if: ${{ matrix.rust != 'nightly' }}
-        run: cargo test --features=logging,dangerous_configuration,quic,tls12
-        env:
-          RUST_BACKTRACE: 1
-
       - name: cargo test (debug; all features)
-        if: ${{ matrix.rust == 'nightly' }}
         run: cargo test --all-features
         env:
           RUST_BACKTRACE: 1
@@ -85,19 +78,6 @@ jobs:
 
       - name: cargo test (release; no run)
         run: cargo test --release --no-run
-
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-
-      - name: cargo test (debug; all features)
-        run: cargo test --all-features
-        env:
-          RUST_BACKTRACE: 1
-          RUSTFLAGS: -D warnings
-
 
   bogo:
     name: BoGo test suite
@@ -288,7 +268,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -p rustls --features=logging,dangerous_configuration,quic,tls12 -- -D warnings
+          args: -p rustls --all-features -- -D warnings
 
   clippy-nightly:
     name: Clippy (Nightly)

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -10,7 +10,11 @@ homepage = "https://github.com/rustls/rustls"
 repository = "https://github.com/rustls/rustls"
 categories = ["network-programming", "cryptography"]
 autobenches = false
+build = "build.rs"
 resolver = "2"
+
+[build-dependencies]
+rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
 log = { version = "0.4.4", optional = true }
@@ -24,7 +28,7 @@ logging = ["log"]
 dangerous_configuration = []
 quic = []
 tls12 = []
-read_buf = []
+read_buf = ["rustversion"]
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/rustls/build.rs
+++ b/rustls/build.rs
@@ -1,0 +1,13 @@
+/// This build script allows us to enable the `read_buf` language feature only
+/// for Rust Nightly.
+///
+/// See the comment in lib.rs to understand why we need this.
+
+#[cfg_attr(feature = "read_buf", rustversion::not(nightly))]
+fn main() {}
+
+#[cfg(feature = "read_buf")]
+#[rustversion::nightly]
+fn main() {
+    println!("cargo:rustc-cfg=read_buf");
+}

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -263,7 +263,7 @@ impl<'a> io::Read for Reader<'a> {
     ///
     /// You may learn the number of bytes available at any time by inspecting
     /// the return of [`Connection::process_new_packets`].
-    #[cfg(feature = "read_buf")]
+    #[cfg(read_buf)]
     fn read_buf(&mut self, buf: &mut io::ReadBuf<'_>) -> io::Result<()> {
         let before = buf.filled_len();
         self.received_plaintext.read_buf(buf)?;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -252,13 +252,13 @@
 //!   it for your application. If you want to disable TLS 1.2 for security reasons,
 //!   consider explicitly enabling TLS 1.3 only in the config builder API.
 //!
-//! - `read_buf`: this nightly-only feature adds support for the unstable
+//! - `read_buf`: When building with Rust Nightly, adds support for the unstable
 //!   `std::io::ReadBuf` and related APIs. This reduces costs from initializing
-//!   buffers.
+//!   buffers. Will do nothing on non-Nightly releases.
 
 // Require docs for public APIs, deny unsafe code, etc.
 #![forbid(unsafe_code, unused_must_use)]
-#![cfg_attr(not(feature = "read_buf"), forbid(unstable_features))]
+#![cfg_attr(not(read_buf), forbid(unstable_features))]
 #![deny(
     clippy::clone_on_ref_ptr,
     clippy::use_self,
@@ -289,8 +289,15 @@
 )]
 // Enable documentation for all features on docs.rs
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Early testing of the read_buf nightly feature
-#![cfg_attr(feature = "read_buf", feature(read_buf))]
+// XXX: Because of https://github.com/rust-lang/rust/issues/54726, we cannot
+// write `#![rustversion::attr(nightly, feature(read_buf))]` here. Instead,
+// build.rs set `read_buf` for (only) Rust Nightly to get the same effect.
+//
+// All the other conditional logic in the crate could use
+// `#[rustversion::nightly]` instead of `#[cfg(read_buf)]`; `#[cfg(read_buf)]`
+// is used to avoid needing `rustversion` to be compiled twice during
+// cross-compiling.
+#![cfg_attr(read_buf, feature(read_buf))]
 
 // log for logging (optional).
 #[cfg(feature = "logging")]

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -280,7 +280,7 @@ impl<'a> std::io::Read for ReadEarlyData<'a> {
         self.early_data.read(buf)
     }
 
-    #[cfg(feature = "read_buf")]
+    #[cfg(read_buf)]
     fn read_buf(&mut self, buf: &mut io::ReadBuf<'_>) -> io::Result<()> {
         self.early_data.read_buf(buf)
     }
@@ -619,7 +619,7 @@ impl EarlyDataState {
         }
     }
 
-    #[cfg(feature = "read_buf")]
+    #[cfg(read_buf)]
     fn read_buf(&mut self, buf: &mut io::ReadBuf<'_>) -> io::Result<()> {
         match self {
             Self::Accepted(ref mut received) => received.read_buf(buf),
@@ -648,7 +648,7 @@ fn test_read_in_new_state() {
     );
 }
 
-#[cfg(feature = "read_buf")]
+#[cfg(read_buf)]
 #[test]
 fn test_read_buf_in_new_state() {
     assert_eq!(

--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -73,7 +73,7 @@ where
         self.conn.reader().read(buf)
     }
 
-    #[cfg(feature = "read_buf")]
+    #[cfg(read_buf)]
     fn read_buf(&mut self, buf: &mut std::io::ReadBuf<'_>) -> Result<()> {
         self.complete_prior_io()?;
 
@@ -209,7 +209,7 @@ where
         self.as_stream().read(buf)
     }
 
-    #[cfg(feature = "read_buf")]
+    #[cfg(read_buf)]
     fn read_buf(&mut self, buf: &mut std::io::ReadBuf<'_>) -> Result<()> {
         self.as_stream().read_buf(buf)
     }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -99,7 +99,7 @@ impl ChunkVecBuffer {
         Ok(offs)
     }
 
-    #[cfg(feature = "read_buf")]
+    #[cfg(read_buf)]
     /// Read data out of this object, writing it into `buf`.
     pub(crate) fn read_buf(&mut self, buf: &mut io::ReadBuf<'_>) -> io::Result<()> {
         while !self.is_empty() && buf.remaining() > 0 {
@@ -158,7 +158,7 @@ mod test {
         assert_eq!(buf.to_vec(), b"helloworldhe".to_vec());
     }
 
-    #[cfg(feature = "read_buf")]
+    #[cfg(read_buf)]
     #[test]
     fn read_buf() {
         use std::{io::ReadBuf, mem::MaybeUninit};


### PR DESCRIPTION
Make the `read_buf` feature do nothing on non-Nightly Rust.

This makes it easier for people not depending on that feature to
build/test Rustls, as demonstrated by the CI/CD changes here.

Use `rustversion` instead of `rustc_version`; `rustc_version` has more
dependencies.