### PR TITLE
DRY in TLS 1.2 and TLS 1.3 handshakes

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,5 +1,5 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
-use crate::conn::{CommonState, ConnectionCommon, Protocol, Side};
+use crate::conn::{CommonState, ConnectionCommon, Protocol};
 use crate::error::Error;
 use crate::kx::SupportedKxGroup;
 #[cfg(feature = "logging")]
@@ -431,7 +431,7 @@ impl ClientConnection {
         extra_exts: Vec<ClientExtension>,
         proto: Protocol,
     ) -> Result<Self, Error> {
-        let mut common_state = CommonState::new(config.max_fragment_size, Side::Client)?;
+        let mut common_state = CommonState::new(config.max_fragment_size)?;
         common_state.protocol = proto;
         let mut data = ClientConnectionData::new();
 

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -1,10 +1,11 @@
+use super::ResolvesClientCert;
 #[cfg(feature = "logging")]
-use crate::log::trace;
+use crate::log::{debug, trace};
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::handshake::CertificatePayload;
 use crate::msgs::handshake::SCTList;
 use crate::msgs::handshake::ServerExtension;
-use crate::sign;
+use crate::{sign, DistinguishedNames, SignatureScheme};
 
 use std::sync::Arc;
 
@@ -70,18 +71,43 @@ impl ClientHelloDetails {
     }
 }
 
-pub(super) struct ClientAuthDetails {
-    pub(super) certkey: Option<Arc<sign::CertifiedKey>>,
-    pub(super) signer: Option<Box<dyn sign::Signer>>,
-    pub(super) auth_context: Option<Vec<u8>>,
+pub(super) enum ClientAuthDetails {
+    /// Send an empty `Certificate` and no `CertificateVerify`.
+    Empty { auth_context_tls13: Option<Vec<u8>> },
+    /// Send a non-empty `Certificate` and a `CertificateVerify`.
+    Verify {
+        certkey: Arc<sign::CertifiedKey>,
+        signer: Box<dyn sign::Signer>,
+        auth_context_tls13: Option<Vec<u8>>,
+    },
 }
 
 impl ClientAuthDetails {
-    pub(super) fn new() -> Self {
-        Self {
-            certkey: None,
-            signer: None,
-            auth_context: None,
+    pub(super) fn resolve(
+        resolver: &dyn ResolvesClientCert,
+        canames: Option<&DistinguishedNames>,
+        sigschemes: &[SignatureScheme],
+        auth_context_tls13: Option<Vec<u8>>,
+    ) -> Self {
+        let acceptable_issuers = canames
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .map(|p| p.0.as_slice())
+            .collect::<Vec<&[u8]>>();
+
+        if let Some(certkey) = resolver.resolve(&acceptable_issuers, sigschemes) {
+            if let Some(signer) = certkey.key.choose_scheme(sigschemes) {
+                debug!("Attempting client auth");
+                return Self::Verify {
+                    certkey,
+                    signer,
+                    auth_context_tls13,
+                };
+            }
         }
+
+        debug!("Client auth requested but no cert/sigscheme available");
+        Self::Empty { auth_context_tls13 }
     }
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -746,10 +746,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
             emit_certverify(&mut transcript, signer.as_ref(), cx.common)?;
         }
 
-        // 5d.
-        cx.common.send_ccs();
-
-        // 5e. Now commit secrets.
+        // 5e (Intentionally before 5d). Now commit secrets
         let secrets = ConnectionSecrets::from_key_exchange(
             kx,
             &ecdh_params.public.0,
@@ -765,6 +762,8 @@ impl State<ClientConnectionData> for ExpectServerDone {
         );
         cx.common
             .start_encryption_tls12(&secrets, Side::Client);
+        // 5d.
+        cx.common.send_ccs();
         cx.common
             .record_layer
             .start_encrypting();

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1065,26 +1065,9 @@ struct ExpectTraffic {
 
 impl State<ClientConnectionData> for ExpectTraffic {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
-        match m.payload {
-            MessagePayload::ApplicationData(payload) => cx
-                .common
-                .take_received_plaintext(payload),
-            MessagePayload::Handshake(HandshakeMessagePayload {
-                payload: HandshakePayload::HelloRequest,
-                ..
-            }) => {
-                // XXX(https://github.com/rustls/rustls/issues/952): DoS potential.
-                cx.common
-                    .send_no_renegotiation_warning_alert();
-            }
-            payload => {
-                return Err(inappropriate_handshake_message(
-                    &payload,
-                    &[ContentType::ApplicationData, ContentType::Handshake],
-                    &[HandshakeType::HelloRequest],
-                ));
-            }
-        }
+        tls12::hs::handle_traffic(cx.common, m, |hsp| {
+            matches!(hsp, HandshakePayload::HelloRequest)
+        })?;
         Ok(self)
     }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -760,13 +760,10 @@ impl State<ClientConnectionData> for ExpectServerDone {
             &secrets.randoms.client,
             &secrets.master_secret,
         );
+        // 5d.
         cx.common
             .start_encryption_tls12(&secrets, Side::Client);
-        // 5d.
-        cx.common.send_ccs();
-        cx.common
-            .record_layer
-            .start_encrypting();
+        tls12::hs::emit_ccs_and_start_encrypting(cx.common);
 
         // 6.
         emit_finished(&secrets, &mut transcript, cx.common);
@@ -985,10 +982,7 @@ impl State<ClientConnectionData> for ExpectFinished {
         st.save_session(cx);
 
         if st.resuming {
-            cx.common.send_ccs();
-            cx.common
-                .record_layer
-                .start_encrypting();
+            tls12::hs::emit_ccs_and_start_encrypting(cx.common);
             emit_finished(&st.secrets, &mut st.transcript, cx.common);
         }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -6,7 +6,6 @@ use crate::kx;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
 use crate::msgs::base::{Payload, PayloadU8};
-use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
 use crate::msgs::enums::KeyUpdateRequest;
 use crate::msgs::enums::{AlertDescription, NamedGroup, ProtocolVersion};
@@ -333,11 +332,7 @@ pub(super) fn emit_fake_ccs(sent_tls13_fake_ccs: &mut bool, common: &mut CommonS
         return;
     }
 
-    let m = Message {
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
-    };
-    common.send_msg(m, false);
+    common.send_ccs();
 }
 
 fn validate_encrypted_extensions(

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -4,6 +4,7 @@ use crate::key;
 use crate::log::{debug, error, trace, warn};
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
+use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::deframer::MessageDeframer;
 use crate::msgs::enums::{AlertDescription, AlertLevel, ContentType, ProtocolVersion};
 use crate::msgs::fragmenter::MessageFragmenter;
@@ -1204,6 +1205,15 @@ impl CommonState {
             .prepare_message_encrypter(enc);
         self.record_layer
             .prepare_message_decrypter(dec);
+    }
+
+    pub(crate) fn send_ccs(&mut self) {
+        let ccs = Message {
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
+        };
+
+        self.send_msg(ccs, false);
     }
 
     #[cfg(feature = "quic")]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -312,18 +312,30 @@ mod log {
     macro_rules! error    ( ($($tt:tt)*) => {{}} );
 }
 
+#[macro_use]
+mod check;
+
 #[allow(missing_docs)]
 #[macro_use]
 mod msgs;
+
 mod anchors;
+mod bs_debug;
+mod builder;
 mod cipher;
 mod conn;
 mod error;
 mod hash_hs;
+mod key;
+mod key_log;
+mod key_log_file;
+mod kx;
 mod limited_cache;
 mod rand;
 mod record_layer;
 mod stream;
+mod suites;
+mod ticketer;
 #[cfg(feature = "tls12")]
 mod tls12;
 mod tls13;
@@ -331,18 +343,8 @@ mod vecbuf;
 mod verify;
 #[cfg(test)]
 mod verifybench;
-mod x509;
-#[macro_use]
-mod check;
-mod bs_debug;
-mod builder;
-mod key;
-mod key_log;
-mod key_log_file;
-mod kx;
-mod suites;
-mod ticketer;
 mod versions;
+mod x509;
 
 /// Internal classes which may be useful outside the library.
 /// The contents of this section DO NOT form part of the stable interface.

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1474,9 +1474,9 @@ impl Codec for CertificatePayloadTLS13 {
 }
 
 impl CertificatePayloadTLS13 {
-    pub fn new(entries: Vec<CertificateEntry>) -> Self {
+    pub fn new(context: Option<Vec<u8>>, entries: Vec<CertificateEntry>) -> Self {
         Self {
-            context: PayloadU8::empty(),
+            context: PayloadU8::new(context.unwrap_or_default()),
             entries,
         }
     }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,5 +1,5 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
-use crate::conn::{CommonState, ConnectionCommon, Side, State};
+use crate::conn::{CommonState, ConnectionCommon, State};
 use crate::error::Error;
 use crate::kx::SupportedKxGroup;
 #[cfg(feature = "logging")]
@@ -305,7 +305,7 @@ impl ServerConnection {
         config: Arc<ServerConfig>,
         extra_exts: Vec<ServerExtension>,
     ) -> Result<Self, Error> {
-        let common = CommonState::new(config.max_fragment_size, Side::Server)?;
+        let common = CommonState::new(config.max_fragment_size)?;
         Ok(Self {
             inner: ConnectionCommon::new(
                 Box::new(hs::ExpectClientHello::new(config, extra_exts)),
@@ -436,7 +436,7 @@ pub struct Acceptor {
 impl Acceptor {
     /// Create a new `Acceptor`.
     pub fn new() -> Result<Self, Error> {
-        let common = CommonState::new(None, Side::Server)?;
+        let common = CommonState::new(None)?;
         let state = Box::new(Accepting);
         Ok(Self {
             inner: Some(ConnectionCommon::new(state, Default::default(), common)),

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -282,10 +282,7 @@ mod client_hello {
                     &*self.config.ticketer,
                 )?;
             }
-            cx.common.send_ccs();
-            cx.common
-                .record_layer
-                .start_encrypting();
+            tls12::hs::emit_ccs_and_start_encrypting(cx.common);
             emit_finished(&secrets, &mut self.transcript, cx.common);
 
             Ok(Box::new(ExpectCcs {
@@ -828,10 +825,7 @@ impl State<ServerConnectionData> for ExpectFinished {
                 )?;
             }
 
-            cx.common.send_ccs();
-            cx.common
-                .record_layer
-                .start_encrypting();
+            tls12::hs::emit_ccs_and_start_encrypting(cx.common);
             emit_finished(&self.secrets, &mut self.transcript, cx.common);
         }
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -827,6 +827,7 @@ impl State<ServerConnectionData> for ExpectFinished {
                     &*self.config.ticketer,
                 )?;
             }
+
             cx.common.send_ccs();
             cx.common
                 .record_layer

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,4 +1,4 @@
-use crate::check::{inappropriate_handshake_message, inappropriate_message};
+use crate::check::inappropriate_message;
 use crate::conn::{CommonState, ConnectionRandoms, Side, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
@@ -904,26 +904,9 @@ impl ExpectTraffic {}
 
 impl State<ServerConnectionData> for ExpectTraffic {
     fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
-        match m.payload {
-            MessagePayload::ApplicationData(payload) => cx
-                .common
-                .take_received_plaintext(payload),
-            MessagePayload::Handshake(HandshakeMessagePayload {
-                payload: HandshakePayload::ClientHello(..),
-                ..
-            }) => {
-                // TODO(https://github.com/rustls/rustls/issues/952): DoS potential.
-                cx.common
-                    .send_no_renegotiation_warning_alert();
-            }
-            payload => {
-                return Err(inappropriate_handshake_message(
-                    &payload,
-                    &[ContentType::ApplicationData, ContentType::Handshake],
-                    &[HandshakeType::ClientHello],
-                ));
-            }
-        }
+        tls12::hs::handle_traffic(cx.common, m, |hsp| {
+            matches!(hsp, HandshakePayload::ClientHello(..))
+        })?;
         Ok(self)
     }
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -5,7 +5,6 @@ use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
-use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
 use crate::msgs::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::msgs::handshake::{ClientECDHParams, HandshakeMessagePayload, HandshakePayload};
@@ -283,7 +282,7 @@ mod client_hello {
                     &*self.config.ticketer,
                 )?;
             }
-            emit_ccs(cx.common);
+            cx.common.send_ccs();
             cx.common
                 .record_layer
                 .start_encrypting();
@@ -771,15 +770,6 @@ fn emit_ticket(
     Ok(())
 }
 
-fn emit_ccs(common: &mut CommonState) {
-    let m = Message {
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
-    };
-
-    common.send_msg(m, false);
-}
-
 fn emit_finished(
     secrets: &ConnectionSecrets,
     transcript: &mut HandshakeHash,
@@ -837,7 +827,7 @@ impl State<ServerConnectionData> for ExpectFinished {
                     &*self.config.ticketer,
                 )?;
             }
-            emit_ccs(cx.common);
+            cx.common.send_ccs();
             cx.common
                 .record_layer
                 .start_encrypting();

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -188,7 +188,7 @@ mod client_hello {
                 &self.randoms,
                 self.extra_exts,
             )?;
-            emit_certificate(&mut self.transcript, cx.common, server_key.get_cert());
+            tls12::hs::emit_certificate(&mut self.transcript, cx.common, server_key.get_cert());
             if let Some(ocsp_response) = ocsp_response {
                 emit_cert_status(&mut self.transcript, cx.common, ocsp_response);
             }
@@ -346,23 +346,6 @@ mod client_hello {
         transcript.add_message(&sh);
         cx.common.send_msg(sh, false);
         Ok(ep.send_ticket)
-    }
-
-    fn emit_certificate(
-        transcript: &mut HandshakeHash,
-        common: &mut CommonState,
-        cert_chain: &[Certificate],
-    ) {
-        let c = Message {
-            version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::Handshake(HandshakeMessagePayload {
-                typ: HandshakeType::Certificate,
-                payload: HandshakePayload::Certificate(cert_chain.to_owned()),
-            }),
-        };
-
-        transcript.add_message(&c);
-        common.send_msg(c, false);
     }
 
     fn emit_cert_status(transcript: &mut HandshakeHash, common: &mut CommonState, ocsp: &[u8]) {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -34,7 +34,6 @@ pub(super) use client_hello::CompleteClientHelloHandling;
 mod client_hello {
     use crate::kx;
     use crate::msgs::base::{Payload, PayloadU8};
-    use crate::msgs::ccs::ChangeCipherSpecPayload;
     use crate::msgs::enums::{Compression, PSKKeyExchangeMode};
     use crate::msgs::enums::{NamedGroup, SignatureScheme};
     use crate::msgs::handshake::CertReqExtension;
@@ -549,11 +548,7 @@ mod client_hello {
         if common.is_quic() {
             return;
         }
-        let m = Message {
-            version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
-        };
-        common.send_msg(m, false);
+        common.send_ccs();
     }
 
     fn emit_hello_retry_request(

--- a/rustls/src/tls12/hs.rs
+++ b/rustls/src/tls12/hs.rs
@@ -1,0 +1,32 @@
+//! Shared logic for TLS 1.2 client and server handshakes.
+//!
+use crate::check::inappropriate_handshake_message;
+use crate::msgs::enums::{ContentType, HandshakeType};
+use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
+use crate::msgs::message::{Message, MessagePayload};
+use crate::{CommonState, Error};
+
+pub(crate) fn handle_traffic(
+    common_state: &mut CommonState,
+    m: Message,
+    is_valid_renegotiation_request: fn(&HandshakePayload) -> bool,
+) -> Result<(), Error> {
+    match m.payload {
+        MessagePayload::ApplicationData(payload) => {
+            common_state.take_received_plaintext(payload);
+            Ok(())
+        }
+        MessagePayload::Handshake(HandshakeMessagePayload { payload, .. })
+            if is_valid_renegotiation_request(&payload) =>
+        {
+            // XXX(https://github.com/rustls/rustls/issues/952): DoS potential.
+            common_state.send_no_renegotiation_warning_alert();
+            Ok(())
+        }
+        payload => Err(inappropriate_handshake_message(
+            &payload,
+            &[ContentType::ApplicationData, ContentType::Handshake],
+            &[HandshakeType::HelloRequest],
+        )),
+    }
+}

--- a/rustls/src/tls12/hs.rs
+++ b/rustls/src/tls12/hs.rs
@@ -27,6 +27,11 @@ pub(crate) fn emit_certificate(
     common.send_msg(cert, false);
 }
 
+pub(crate) fn emit_ccs_and_start_encrypting(common: &mut CommonState) {
+    common.send_ccs();
+    common.record_layer.start_encrypting();
+}
+
 pub(crate) fn emit_finished(
     secrets: &ConnectionSecrets,
     transcript: &mut HandshakeHash,

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -367,14 +367,6 @@ impl ConnectionSecrets {
         out
     }
 
-    pub(crate) fn client_verify_data(&self, handshake_hash: &Digest) -> Vec<u8> {
-        self.make_verify_data(handshake_hash, CLIENT_FINISHED)
-    }
-
-    pub(crate) fn server_verify_data(&self, handshake_hash: &Digest) -> Vec<u8> {
-        self.make_verify_data(handshake_hash, SERVER_FINISHED)
-    }
-
     pub(crate) fn export_keying_material(
         &self,
         output: &mut [u8],

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -16,6 +16,8 @@ use std::fmt;
 mod cipher;
 pub(crate) use cipher::{AesGcm, ChaCha20Poly1305, Tls12AeadAlgorithm};
 
+pub(crate) mod hs;
+
 mod prf;
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256.

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -353,7 +353,7 @@ impl ConnectionSecrets {
         ret
     }
 
-    fn make_verify_data(&self, handshake_hash: &Digest, label: &[u8]) -> Vec<u8> {
+    fn make_verify_data(&self, handshake_hash: &Digest, label: FinishedLabel) -> Vec<u8> {
         let mut out = Vec::new();
         out.resize(12, 0u8);
 
@@ -361,18 +361,18 @@ impl ConnectionSecrets {
             &mut out,
             self.suite.hmac_algorithm,
             &self.master_secret,
-            label,
+            label.0,
             handshake_hash.as_ref(),
         );
         out
     }
 
     pub(crate) fn client_verify_data(&self, handshake_hash: &Digest) -> Vec<u8> {
-        self.make_verify_data(handshake_hash, b"client finished")
+        self.make_verify_data(handshake_hash, CLIENT_FINISHED)
     }
 
     pub(crate) fn server_verify_data(&self, handshake_hash: &Digest) -> Vec<u8> {
-        self.make_verify_data(handshake_hash, b"server finished")
+        self.make_verify_data(handshake_hash, SERVER_FINISHED)
     }
 
     pub(crate) fn export_keying_material(
@@ -399,6 +399,10 @@ impl ConnectionSecrets {
         )
     }
 }
+
+pub(crate) struct FinishedLabel(&'static [u8]);
+pub(crate) const CLIENT_FINISHED: FinishedLabel = FinishedLabel(b"client finished");
+pub(crate) const SERVER_FINISHED: FinishedLabel = FinishedLabel(b"server finished");
 
 enum Seed {
     Ems(Digest),

--- a/rustls/src/tls13/hs.rs
+++ b/rustls/src/tls13/hs.rs
@@ -1,13 +1,16 @@
+//! Shared logic for TLS 1.3 client and server handshakes.
+
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::msgs::enums::HandshakeType;
 use crate::msgs::handshake::{
     CertificateEntry, CertificateExtension, CertificatePayloadTLS13, CertificateStatus,
-    HandshakeMessagePayload, HandshakePayload,
+    DigitallySignedStruct, HandshakeMessagePayload, HandshakePayload,
 };
 use crate::msgs::message::{Message, MessagePayload};
-use crate::{Certificate, CommonState, ProtocolVersion};
+use crate::sign::Signer;
+use crate::{verify, Certificate, CommonState, Error, ProtocolVersion};
 
 pub(crate) fn emit_certificate(
     transcript: &mut HandshakeHash,
@@ -55,4 +58,32 @@ pub(crate) fn emit_certificate(
     trace!("sending certificate {:?}", c);
     transcript.add_message(&c);
     common.send_msg(c, true);
+}
+
+pub(crate) fn emit_certificate_verify(
+    transcript: &mut HandshakeHash,
+    common: &mut CommonState,
+    signer: &dyn Signer,
+    context_string_with_0: verify::ContextString,
+) -> Result<(), Error> {
+    let message = verify::construct_tls13_verify_message(
+        &transcript.get_current_hash(),
+        context_string_with_0,
+    );
+
+    let scheme = signer.scheme();
+    let sig = signer.sign(&message)?;
+    let dss = DigitallySignedStruct::new(scheme, sig);
+
+    let m = Message {
+        version: ProtocolVersion::TLSv1_3,
+        payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            typ: HandshakeType::CertificateVerify,
+            payload: HandshakePayload::CertificateVerify(dss),
+        }),
+    };
+
+    transcript.add_message(&m);
+    common.send_msg(m, true);
+    Ok(())
 }

--- a/rustls/src/tls13/hs.rs
+++ b/rustls/src/tls13/hs.rs
@@ -1,0 +1,58 @@
+use crate::hash_hs::HandshakeHash;
+#[cfg(feature = "logging")]
+use crate::log::trace;
+use crate::msgs::enums::HandshakeType;
+use crate::msgs::handshake::{
+    CertificateEntry, CertificateExtension, CertificatePayloadTLS13, CertificateStatus,
+    HandshakeMessagePayload, HandshakePayload,
+};
+use crate::msgs::message::{Message, MessagePayload};
+use crate::{Certificate, CommonState, ProtocolVersion};
+
+pub(crate) fn emit_certificate(
+    transcript: &mut HandshakeHash,
+    common: &mut CommonState,
+    context: Option<Vec<u8>>,
+    cert_chain: Vec<Certificate>,
+    ocsp_response: Option<&[u8]>,
+    sct_list: Option<&[u8]>,
+) {
+    let mut cert_entries = cert_chain
+        .into_iter()
+        .map(|cert| CertificateEntry {
+            cert,
+            exts: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+
+    if let Some(end_entity_cert) = cert_entries.first_mut() {
+        // Apply OCSP response to first certificate (we don't support OCSP
+        // except for leaf certs).
+        if let Some(ocsp) = ocsp_response {
+            let cst = CertificateStatus::new(ocsp.to_owned());
+            end_entity_cert
+                .exts
+                .push(CertificateExtension::CertificateStatus(cst));
+        }
+
+        // Likewise, SCT
+        if let Some(sct_list) = sct_list {
+            end_entity_cert
+                .exts
+                .push(CertificateExtension::make_sct(sct_list.to_owned()));
+        }
+    }
+
+    let cert_body = CertificatePayloadTLS13::new(context, cert_entries);
+    let c = Message {
+        version: ProtocolVersion::TLSv1_3,
+        payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            typ: HandshakeType::Certificate,
+            payload: HandshakePayload::CertificateTLS13(cert_body),
+        }),
+    };
+
+    trace!("sending certificate {:?}", c);
+    transcript.add_message(&c);
+    common.send_msg(c, true);
+}

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -14,6 +14,8 @@ use std::fmt;
 pub(crate) mod key_schedule;
 use key_schedule::{derive_traffic_iv, derive_traffic_key};
 
+pub(crate) mod hs;
+
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256
 pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
     SupportedCipherSuite::Tls13(TLS13_CHACHA20_POLY1305_SHA256_INTERNAL);

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -692,17 +692,24 @@ fn convert_alg_tls13(
 
 /// Constructs the signature message specified in section 4.4.3 of RFC8446.
 pub(crate) fn construct_tls13_client_verify_message(handshake_hash: &Digest) -> Vec<u8> {
-    construct_tls13_verify_message(handshake_hash, b"TLS 1.3, client CertificateVerify\x00")
+    construct_tls13_verify_message(handshake_hash, CLIENT_VERIFY_CONTEXT_STRING)
 }
 
 /// Constructs the signature message specified in section 4.4.3 of RFC8446.
 pub(crate) fn construct_tls13_server_verify_message(handshake_hash: &Digest) -> Vec<u8> {
-    construct_tls13_verify_message(handshake_hash, b"TLS 1.3, server CertificateVerify\x00")
+    construct_tls13_verify_message(handshake_hash, SERVER_VERIFY_CONTEXT_STRING)
 }
 
-fn construct_tls13_verify_message(
+#[derive(Clone, Copy)]
+pub(crate) struct ContextString(&'static [u8]);
+pub(crate) const CLIENT_VERIFY_CONTEXT_STRING: ContextString =
+    ContextString(b"TLS 1.3, client CertificateVerify\x00");
+pub(crate) const SERVER_VERIFY_CONTEXT_STRING: ContextString =
+    ContextString(b"TLS 1.3, server CertificateVerify\x00");
+
+pub(crate) fn construct_tls13_verify_message(
     handshake_hash: &Digest,
-    context_string_with_0: &[u8],
+    ContextString(context_string_with_0): ContextString,
 ) -> Vec<u8> {
     let mut msg = Vec::new();
     msg.resize(64, 0x20u8);


### PR DESCRIPTION
In each place where we emit a particular kind of message (e.g. `Certificate`, `CertificateVerify`) for a protocol version, for both client and server, factor out that commonality into a shared function.

In each place where we verify a particular kind of message (e.g. `Finished`), factor out that common verification logic into a shared function.

This will make it easier to audit and test the code.