### PR TITLE
Server: Don't depend on `ALL_CIPHER_SUITES` when not using `Acceptor`.

### DIFF
--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -498,9 +498,14 @@ impl Acceptor {
             }
         };
 
+        // XXX(https://github.com/rustls/rustls/issues/973): We shouldn't be using
+        // `ALL_CIPHER_SUITES` here.
+        let supported_cipher_suites = &crate::ALL_CIPHER_SUITES;
+
         let (_, sig_schemes) = hs::process_client_hello(
             &message,
             false,
+            supported_cipher_suites,
             &mut connection.common_state,
             &mut connection.data,
         )?;


### PR DESCRIPTION
Reduce the chances that code for unwanted cipher suites will be linked
in, when not using the `Acceptor` API. This fixes a code size regression
from 0.20.0.

Doing the same for the case where `Acceptor` is used is tracked as
https://github.com/rustls/rustls/issues/973.