### PR TITLE
AllowAnyAuthenticatedClient: Remove redundant function.

### DIFF
--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -489,10 +489,6 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
         true
     }
 
-    fn client_auth_mandatory(&self) -> Option<bool> {
-        Some(true)
-    }
-
     fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
         Some(self.roots.subjects())
     }


### PR DESCRIPTION
The implementation of `client_auth_mandatory()` is redundant with the
default implementation. By removing this redundant implementation, we
add test coverage of the default implementation, which is currently
uncovered.