### PR TITLE
Remove 1 second pause before running BadSSL tests.

### DIFF
--- a/rustls-mio/tests/badssl.rs
+++ b/rustls-mio/tests/badssl.rs
@@ -1,13 +1,11 @@
 // These tests use the various test servers run by Google
-// at badssl.com.  To be polite they sleep 1 second before
-// each test.
-//
+// at badssl.com.
 
 #[allow(dead_code)]
 mod common;
 
 mod online {
-    use super::common::{polite, TlsClient};
+    use super::common::TlsClient;
 
     fn connect(hostname: &str) -> TlsClient {
         TlsClient::new(hostname)
@@ -15,7 +13,6 @@ mod online {
 
     #[test]
     fn no_cbc() {
-        polite();
         connect("cbc.badssl.com")
             .fails()
             .expect(r"TLS error: AlertReceived\(HandshakeFailure\)")
@@ -25,7 +22,6 @@ mod online {
 
     #[test]
     fn no_rc4() {
-        polite();
         connect("rc4.badssl.com")
             .fails()
             .expect(r"TLS error: AlertReceived\(HandshakeFailure\)")
@@ -35,7 +31,6 @@ mod online {
 
     #[test]
     fn expired() {
-        polite();
         connect("expired.badssl.com")
             .fails()
             .expect(
@@ -47,7 +42,6 @@ mod online {
 
     #[test]
     fn wrong_host() {
-        polite();
         connect("wrong.host.badssl.com")
             .fails()
             .expect(r#"TLS error: InvalidCertificateData\("invalid peer certificate: CertNotValidForName"\)"#)
@@ -57,7 +51,6 @@ mod online {
 
     #[test]
     fn self_signed() {
-        polite();
         connect("self-signed.badssl.com")
             .fails()
             .expect(
@@ -69,7 +62,6 @@ mod online {
 
     #[test]
     fn no_dh() {
-        polite();
         connect("dh2048.badssl.com")
             .fails()
             .expect(r"TLS error: AlertReceived\(HandshakeFailure\)")
@@ -79,7 +71,6 @@ mod online {
 
     #[test]
     fn mozilla_old() {
-        polite();
         connect("mozilla-old.badssl.com")
             .expect("<title>mozilla-old.badssl.com</title>")
             .go()
@@ -88,7 +79,6 @@ mod online {
 
     #[test]
     fn mozilla_inter() {
-        polite();
         connect("mozilla-intermediate.badssl.com")
             .expect("<title>mozilla-intermediate.badssl.com</title>")
             .go()
@@ -97,7 +87,6 @@ mod online {
 
     #[test]
     fn mozilla_modern() {
-        polite();
         connect("mozilla-modern.badssl.com")
             .expect("<title>mozilla-modern.badssl.com</title>")
             .go()
@@ -106,7 +95,6 @@ mod online {
 
     #[test]
     fn sha256() {
-        polite();
         connect("sha256.badssl.com")
             .expect("<title>sha256.badssl.com</title>")
             .go()
@@ -115,7 +103,6 @@ mod online {
 
     #[test]
     fn too_many_sans() {
-        polite();
         connect("10000-sans.badssl.com")
             .fails()
             .expect(r"TLS error: CorruptMessagePayload\(Handshake\)")
@@ -125,7 +112,6 @@ mod online {
 
     #[test]
     fn rsa8192() {
-        polite();
         connect("rsa8192.badssl.com")
             .expect("<title>rsa8192.badssl.com</title>")
             .go()
@@ -134,7 +120,6 @@ mod online {
 
     #[test]
     fn sha1_2016() {
-        polite();
         connect("sha1-2016.badssl.com")
             .fails()
             .expect(
@@ -148,7 +133,6 @@ mod online {
     mod danger {
         #[test]
         fn self_signed() {
-            super::polite();
             super::connect("self-signed.badssl.com")
                 .insecure()
                 .expect("<title>self-signed.badssl.com</title>")

--- a/rustls-mio/tests/common/mod.rs
+++ b/rustls-mio/tests/common/mod.rs
@@ -136,11 +136,6 @@ embed_files! {
     (RSA_INTER_REQ, "rsa", "inter.req");
 }
 
-// For tests which connect to internet servers, don't go crazy.
-pub fn polite() {
-    thread::sleep(time::Duration::from_secs(1));
-}
-
 // Wait until we can connect to localhost:port.
 fn wait_for_port(port: u16) -> Option<()> {
     let mut count = 0;

--- a/rustls-mio/tests/topsites.rs
+++ b/rustls-mio/tests/topsites.rs
@@ -2,9 +2,6 @@
 // common hosts.
 //
 // Rules: only hosts that can really handle the traffic.
-// Because we don't go to the same host twice, polite()
-// is not needed.
-//
 
 #[allow(dead_code)]
 mod common;


### PR DESCRIPTION
The badssl tests attempt to do some rate limiting. But, it is assuming the tests
are executed serially. Actually, all the tests run concurrently, sleep
concurrently for 1 second, and then wake up and go at the same time. Thus, the
effect is basically just to slow down `cargo test` by 1 second.

I doubt the rate limiting would be useful if it worked, as badssl is probably
not getting a lot of traffic.