### PR TITLE
Require 0.5RTT server data to be explicitly enabled

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -434,6 +434,7 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
     if opts.enable_early_data {
         // see kMaxEarlyDataAccepted in boringssl, which bogo validates
         cfg.max_early_data_size = 14336;
+        cfg.send_half_rtt_data = true;
     }
 
     Arc::new(cfg)

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -107,6 +107,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             versions: self.state.versions,
             key_log: Arc::new(NoKeyLog {}),
             max_early_data_size: 0,
+            send_half_rtt_data: false,
         }
     }
 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -234,6 +234,27 @@ pub struct ServerConfig {
     /// this value to account for the unknown amount of ciphertext
     /// expansion in the latter case.
     pub max_early_data_size: u32,
+
+    /// Whether the server should send "0.5RTT" data.  This means the server
+    /// sends data after its first flight of handshake messages, without
+    /// waiting for the client to complete the handshake.
+    ///
+    /// This can improve TTFB latency for either server-speaks-first protocols,
+    /// or client-speaks-first protocols when paired with "0RTT" data.  This
+    /// comes at the cost of a subtle weakening of the normal handshake
+    /// integrity guarantees that TLS provides.  Note that the initial
+    /// `ClientHello` is indirectly authenticated because it is included
+    /// in the transcript used to derive the keys used to encrypt the data.
+    ///
+    /// This only applies to TLS1.3 connections.  TLS1.2 connections cannot
+    /// do this optimisation and this setting is ignored for them.  It is
+    /// also ignored for TLS1.3 connections that even attempt client
+    /// authentication.
+    ///
+    /// This defaults to false.  This means the first application data
+    /// sent by the server comes after receiving and validating the client's
+    /// handshake up to the `Finished` message.  This is the safest option.
+    pub send_half_rtt_data: bool,
 }
 
 impl ServerConfig {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -407,7 +407,7 @@ mod client_hello {
                 &self.config,
             );
 
-            if !doing_client_auth {
+            if !doing_client_auth && self.config.send_half_rtt_data {
                 // Application data can be sent immediately after Finished, in one
                 // flight.  However, if client auth is enabled, we don't want to send
                 // application data to an unauthenticated peer.


### PR DESCRIPTION
Aims to resolve #944