### PR TITLE
Change nor to and in docs about compression support in TLS versions

### DIFF
--- a/rustls/src/manual/tlsvulns.rs
+++ b/rustls/src/manual/tlsvulns.rs
@@ -68,7 +68,7 @@ rustls does not support these ciphersuites.
 In 2002 [John Kelsey](https://www.iacr.org/cryptodb/archive/2002/FSE/3091/3091.pdf) discussed the length side channel
 as applied to compression of combined secret and attacker-chosen strings.
 
-Compression continued to be an option in TLSv1.1 (2006) nor in TLSv1.2 (2008).  Support in libraries was widespread.
+Compression continued to be an option in TLSv1.1 (2006) and in TLSv1.2 (2008).  Support in libraries was widespread.
 
 [CRIME](http://netifera.com/research/crime/CRIME_ekoparty2012.pdf) ([CVE-2012-4929](https://nvd.nist.gov/vuln/detail/CVE-2012-4929))
 was demonstrated in 2012, again by Thai Duong and Juliano Rizzo.  It attacked several protocols offering transparent


### PR DESCRIPTION
Updates the documentation on TLS vulnerabilities to specify that both
TLSv1.1 and TLSv1.2 offered support for compression.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Thanks for all of y'all's work on this project!