### PR TITLE
Add support for EC private keys

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -16,7 +16,6 @@ log = { version = "0.4.4", optional = true }
 ring = "0.16.20"
 sct = "0.7.0"
 webpki = { version = "0.22.0", features = ["alloc", "std"] }
-sec1 = "0.2.1"
 
 [features]
 default = ["logging", "tls12"]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -16,6 +16,7 @@ log = { version = "0.4.4", optional = true }
 ring = "0.16.20"
 sct = "0.7.0"
 webpki = { version = "0.22.0", features = ["alloc", "std"] }
+sec1 = "0.2.1"
 
 [features]
 default = ["logging", "tls12"]

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -3,8 +3,6 @@ use crate::key;
 use crate::msgs::enums::{SignatureAlgorithm, SignatureScheme};
 
 use ring::signature::{self, EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair};
-use sec1::der::Decodable;
-use sec1::EcPrivateKey;
 
 use std::convert::TryFrom;
 use std::error::Error as StdError;
@@ -276,24 +274,10 @@ impl EcdsaSigningKey {
         sigalg: &'static signature::EcdsaSigningAlgorithm,
     ) -> Result<Self, ()> {
         EcdsaKeyPair::from_pkcs8(sigalg, &der.0)
+            .or_else(|_| EcdsaKeyPair::from_der(sigalg, &der.0))
             .map(|kp| Self {
                 key: Arc::new(kp),
                 scheme,
-            })
-            .or_else(|_| match EcPrivateKey::from_der(&der.0) {
-                Ok(EcPrivateKey {
-                    private_key,
-                    public_key: Some(public_key),
-                    ..
-                }) => {
-                    EcdsaKeyPair::from_private_key_and_public_key(sigalg, private_key, public_key)
-                        .map(|kp| Self {
-                            key: Arc::new(kp),
-                            scheme,
-                        })
-                        .map_err(|_| ())
-                }
-                _ => Err(()),
             })
             .map_err(|_| ())
     }


### PR DESCRIPTION
This adds support for [EC PRIVATE KEY](https://datatracker.ietf.org/doc/html/rfc5915).

Arguably this should be within ring but frankly I'm afraid to touch it as I couldn't even find the github tag for the current version. I suggest the support lands in rustls first so that its clients (e.g. kube-rs) can move on with the required support and then I'll see if this could go into ring.