### PR TITLE
Use LLVM 14 for code coverage.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,11 +179,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install LLVM12
+      # Install a version of clang that (more or less) has the same coverage
+      # instrumentation format.
+      - name: Install LLVM
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository -y 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-13 main'
-          sudo apt-get install -y clang-13
+          sudo apt-add-repository -y 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-14 main'
+          sudo apt-get install -y clang-14
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1

--- a/admin/coverage
+++ b/admin/coverage
@@ -62,7 +62,7 @@ def rustc_llvm_version():
     ln = [ln for ln in lines if ln.split(':', 1)[0] == 'LLVM version'][0]
     return int(ln.split(':')[1].split('.')[0].strip())
 
-LLVM_VERSION = 13
+LLVM_VERSION = 14
 llvm_version = rustc_llvm_version()
 if llvm_version != LLVM_VERSION:
     print('expected rustc to use LLVM {}, found {}'.format(LLVM_VERSION, llvm_version))

--- a/admin/llvm-gcov
+++ b/admin/llvm-gcov
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-llvm-cov-13 gcov $*
+llvm-cov-14 gcov $*


### PR DESCRIPTION
Rust Nightly recently upgraded to LLVM 14, and coverage jobs in CI
are currently broken. Fix them by upgrading to LLVM 14.