### PR TITLE
Expose cipher suites via `ClientHello`

### DIFF
--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -261,7 +261,7 @@ mod test {
     fn test_resolvesservercertusingsni_requires_sni() {
         let rscsni = ResolvesServerCertUsingSni::new();
         assert!(rscsni
-            .resolve(ClientHello::new(&None, &[], None))
+            .resolve(ClientHello::new(&None, &[], None, &[]))
             .is_none());
     }
 
@@ -272,7 +272,7 @@ mod test {
             .unwrap()
             .to_owned();
         assert!(rscsni
-            .resolve(ClientHello::new(&Some(name), &[], None))
+            .resolve(ClientHello::new(&Some(name), &[], None, &[]))
             .is_none());
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -321,6 +321,7 @@ impl ExpectClientHello {
                 &cx.data.sni,
                 &sig_schemes,
                 client_hello.get_alpn_extension(),
+                &client_hello.cipher_suites,
             );
 
             let certkey = self

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -162,10 +162,12 @@ impl<'a> ClientHello<'a> {
         })
     }
 
+    /// Get cipher suites.
     pub fn cipher_suites(&self) -> &[CipherSuite] {
         self.cipher_suites
     }
 
+    /// Get supported cipher suites
     pub fn supported_cipher_suites(&self) -> Vec<SupportedCipherSuite> {
         self.cipher_suites()
             .iter()

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -126,6 +126,7 @@ impl<'a> ClientHello<'a> {
         trace!("sni {:?}", server_name);
         trace!("sig schemes {:?}", signature_schemes);
         trace!("alpn protocols {:?}", alpn);
+        trace!("cipher suites {:?}", cipher_suites);
 
         ClientHello {
             server_name,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -167,19 +167,6 @@ impl<'a> ClientHello<'a> {
     pub fn cipher_suites(&self) -> &[CipherSuite] {
         self.cipher_suites
     }
-
-    /// Get supported cipher suites
-    pub fn supported_cipher_suites(&self) -> Vec<SupportedCipherSuite> {
-        self.cipher_suites()
-            .iter()
-            .filter_map(|cs| {
-                crate::ALL_CIPHER_SUITES
-                    .iter()
-                    .find(|scs| scs.suite() == *cs)
-                    .copied()
-            })
-            .collect()
-    }
 }
 
 /// Common configuration for a set of server sessions.

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -641,13 +641,11 @@ impl ResolvesServerCert for ServerCheckCertResolve {
         }
 
         if let Some(expected_sigalgs) = &self.expected_sigalgs {
-            if expected_sigalgs != client_hello.signature_schemes() {
-                panic!(
-                    "unexpected signature schemes (wanted {:?} got {:?})",
-                    self.expected_sigalgs,
-                    client_hello.signature_schemes()
-                );
-            }
+            assert_eq!(
+                expected_sigalgs,
+                client_hello.signature_schemes(),
+                "unexpected signature schemes"
+            );
         }
 
         if let Some(expected_alpn) = &self.expected_alpn {
@@ -663,13 +661,11 @@ impl ResolvesServerCert for ServerCheckCertResolve {
         }
 
         if let Some(expected_cipher_suites) = &self.expected_cipher_suites {
-            if expected_cipher_suites != client_hello.cipher_suites() {
-                panic!(
-                    "unexpected cipher_suites (wanted {:?} got {:?})",
-                    self.expected_cipher_suites,
-                    client_hello.cipher_suites()
-                );
-            }
+            assert_eq!(
+                expected_cipher_suites,
+                client_hello.cipher_suites(),
+                "unexpected cipher suites"
+            );
         }
 
         None


### PR DESCRIPTION
Fixes #1019 

Exposes the client hello's payload's cipher suites via `ClientHello`. I've created functions to access both "raw" cipher suites and "parsed" `SupportedCipherSuite`s. I'm not overly attached to the "raw" cipher suites, but I figured they might be useful and it doesn't cost anything to expose them.