### PR TITLE
Improve MessageDeframer mem usage

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -29,6 +29,7 @@ dangerous_configuration = []
 quic = []
 tls12 = []
 read_buf = ["rustversion"]
+shared_bufs = []
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -41,7 +41,8 @@ impl Default for MessageDeframer {
 }
 
 thread_local! {
-    static BUF: RefCell<Box<[u8; OpaqueMessage::MAX_WIRE_SIZE]>> =
+    /// A shared buffer, to be used in read().
+    static READ_BUF: RefCell<Box<[u8; OpaqueMessage::MAX_WIRE_SIZE]>> =
         RefCell::new(Box::new([0u8; OpaqueMessage::MAX_WIRE_SIZE]))
 }
 
@@ -57,7 +58,7 @@ impl MessageDeframer {
     /// Read some bytes from `rd` and combine them with the previously read ones.
     /// If this means the buffer now contains full messages, decode them all.
     pub fn read(&mut self, rd: &mut dyn io::Read) -> io::Result<usize> {
-        BUF.with(|buf| {
+        READ_BUF.with(|buf| {
             let buf = &mut buf.borrow_mut()[..];
             let mut used = 0;
 


### PR DESCRIPTION
Fixes #794

This PR removes `MessageDeframer::buf: Box<[u8; OpaqueMessage::MAX_WIRE_SIZE]>` and replaces it with:
* A thread-local shared buffer
* `MessageDeframer::partial_msg: Option<Box<[u8]>>` that keeps yet unparsed bytes between read attempts, if any

### CPU usage

~~According to `cargo run --release --example bench`, bulk transfer speed has decreased by a few percent.~~

~~On rustls/main:~~
<details>
  <summary><del>Click to expand</del></summary>
  
```
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:default	recv	1827.21	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:10000	recv	1904.42	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:default	recv	2038.66	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:10000	recv	1956.95	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:default	recv	2028.71	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:10000	recv	1978.17	MB/s
```
</details>

~~On this branch:~~
<details>
  <summary><del>Click to expand</del></summary>
  
```
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:default	recv	1780.28	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:10000	recv	1818.80	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:default	recv	2014.43	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:10000	recv	1851.29	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:default	recv	1956.25	MB/s
bulk	SupportedProtocolVersion { version: TLSv1_2, is_private: () }	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:10000	recv	1811.65	MB/s
```
</details>

**UPD**: The bulk transfer speed has been restored.

### MEM usage

Mem usage has massively improved for a chat-like server that handles a large number of long-running client connections that are mostly idle or send/receive short messages.

There have been three test runs: compiled with rustls/main, compiled with this branch, no TLS (just raw TCP). The C10k memory difference:
```
tls_main - no_tls = 262M
tls_this - no_tls = 45M
```

~~What bothers me is that the per-client difference of 21.7K (i.e. 26.2K - 4.5K) is larger than the optimised-out `OpaqueMessage::MAX_WIRE_SIZE` = 18K. I don't have an explanation for this yet.~~

**UPD**: The strangeness was due to jemalloc.
