### PR TITLE
quic: initial salt for version draft-23

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -603,6 +603,11 @@ pub trait ClientQuicExt {
         let ext = match quic_version {
             quic::Version::V1Draft => ClientExtension::TransportParametersDraft(params),
             quic::Version::V1 => ClientExtension::TransportParameters(params),
+            _ => {
+                return Err(Error::General(
+                    "QUIC unsupported version".into(),
+                ));
+            }
         };
 
         ClientConnection::new_inner(config, name, vec![ext], Protocol::Quic)

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -474,6 +474,8 @@ fn nonce_for(packet_number: u64, iv: &Iv) -> ring::aead::Nonce {
 #[non_exhaustive]
 #[derive(Clone, Copy)]
 pub enum Version {
+    /// Draft versions 23 till 28 and 0xfaceb002
+    V1Draft23,
     /// Draft versions 29, 30, 31 and 32
     V1Draft,
     /// First stable RFC
@@ -483,6 +485,11 @@ pub enum Version {
 impl Version {
     fn initial_salt(self) -> &'static [u8; 20] {
         match self {
+            Self::V1Draft23 => &[
+                // https://datatracker.ietf.org/doc/html/draft-ietf-quic-tls-23#section-5.2
+                0xc3, 0xee, 0xf7, 0x12, 0xc7, 0x2e, 0xbb, 0x5a, 0x11, 0xa7, 0xd2, 0x43, 0x2b, 0xb4,
+                0x63, 0x65, 0xbe, 0xf9, 0xf5, 0x02,
+            ],
             Self::V1Draft => &[
                 // https://datatracker.ietf.org/doc/html/draft-ietf-quic-tls-32#section-5.2
                 0xaf, 0xbf, 0xec, 0x28, 0x99, 0x93, 0xd2, 0x4c, 0x9e, 0x97, 0x86, 0xf1, 0x9c, 0x61,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -778,6 +778,11 @@ pub trait ServerQuicExt {
         let ext = match quic_version {
             quic::Version::V1Draft => ServerExtension::TransportParametersDraft(params),
             quic::Version::V1 => ServerExtension::TransportParameters(params),
+            _ => {
+                return Err(Error::General(
+                    "QUIC unsupported version".into(),
+                ));
+            }
         };
         let mut new = ServerConnection::from_config(config, vec![ext])?;
         new.inner.common_state.protocol = Protocol::Quic;


### PR DESCRIPTION
We would like to use rustls in Suricata to "decrypt" quic initial packets

And we would like to support more versions like 0xfaceb002

cf https://github.com/OISF/suricata/pull/7174

Is there another way to define ourselves the salt (than calling `rustls::quic::Keys::initial`) ?