### PR TITLE
[tls handshaked] fix:Interrupted system call (os error 4)

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -488,14 +488,14 @@ impl<Data> ConnectionCommon<Data> {
                         rdlen += n;
                         Some(n)
                     }
-                    Err(ref err) if err.kind() == io::ErrorKind::Interrupted => None,// nothing to do
+                    Err(ref err) if err.kind() == io::ErrorKind::Interrupted => None, // nothing to do
                     Err(err) => return Err(err),
                 };
                 if read_size.is_some() {
                     break;
                 }
             }
-            
+
             match self.process_new_packets() {
                 Ok(_) => {}
                 Err(e) => {

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -479,7 +479,7 @@ impl<Data> ConnectionCommon<Data> {
             }
 
             while !eof && self.wants_read() {
-                let readSize = match self.read_tls(io) {
+                let read_size = match self.read_tls(io) {
                     Ok(0) => {
                         eof = true;
                         Some(0)
@@ -491,7 +491,7 @@ impl<Data> ConnectionCommon<Data> {
                     Err(ref err) if err.kind() == io::ErrorKind::Interrupted => None,// nothing to do
                     Err(err) => return Err(err),
                 };
-                if readSize.is_some() {
+                if read_size.is_some() {
                     break;
                 }
             }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -479,7 +479,7 @@ impl<Data> ConnectionCommon<Data> {
             }
 
             while !eof && self.wants_read() {
-               let readSize = match self.read_tls(io) {
+                let readSize = match self.read_tls(io) {
                     Ok(0) => {
                         eof = true;
                         Some(0)
@@ -488,13 +488,8 @@ impl<Data> ConnectionCommon<Data> {
                         rdlen += n;
                         Some(n)
                     }
-                    Err(ref err) if err.kind() == io::ErrorKind::Interrupted => {
-                        // nothing to do
-                        None
-                    }
-                    Err(err) => {
-                        return Err(err);
-                    }
+                    Err(ref err) if err.kind() == io::ErrorKind::Interrupted => None,// nothing to do
+                    Err(err) => return Err(err),
                 };
                 if readSize.is_some() {
                     break;


### PR DESCRIPTION
Dynamically load the FFI Library using flutter in Android system.  `Connection Failed: tls connection init failed: Interrupted system call (os error 4)`(ureq error);