### PR TITLE
Add support for IP addresses for dangerous clients only

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -270,7 +270,6 @@ impl ServerName {
 impl TryFrom<&str> for ServerName {
     type Error = InvalidDnsNameError;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        trace!("in try_from: {s}");
         match webpki::DnsNameRef::try_from_ascii_str(s) {
             Ok(dns) => Ok(Self::DnsName(verify::DnsName(dns.into()))),
             Err(webpki::InvalidDnsNameError) => match s.parse() {

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -302,7 +302,12 @@ impl ServerCertVerifier for WebPkiVerifier {
         let (cert, chain, trustroots) = prepare(end_entity, intermediates, &self.roots)?;
         let webpki_now = webpki::Time::try_from(now).map_err(|_| Error::FailedToGetCurrentTime)?;
 
-        let ServerName::DnsName(dns_name) = server_name;
+        let dns_name = match server_name {
+            ServerName::DnsName(dns_name) => dns_name,
+            ServerName::IpAddress(_) => {
+                return Err(Error::UnsupportedNameType);
+            }
+        };
 
         let cert = cert
             .verify_is_valid_tls_server_cert(


### PR DESCRIPTION
This is an attempt to partially address #184 in some circumstances only: It would only apply to clients that also use the `dangerous_configuration` feature.

Currently, `rustls` doesn't support IP addresses because `webpki` does not support IP addresses. However, `webpki` is only relevant in the certificate verification phase, so if certificate verification can be suppressed or modified (as it can through the `dangerous_configuration` feature), it makes sense that IP addresses should be allowed if an alternative certificate verification system is used (including `NoVerifier`).

This code allows parsing IP addresses. For code that uses the default certificate verification, IP addresses simply fail further along in the pipeline in certificate validation. However, for other code, it simply works.

I have tested this with `reqwest` using its `danger_accept_invalid_certs` method, and connecting to a raw IP address now works in that context.