### PR TITLE
Use original handshake encoding for transcript hash

### DIFF
--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -11,10 +11,10 @@ use crate::msgs::message::MessagePayload;
 macro_rules! require_handshake_msg(
   ( $m:expr, $handshake_type:path, $payload_type:path ) => (
     match &$m.payload {
-        MessagePayload::Handshake($crate::msgs::handshake::HandshakeMessagePayload {
+        MessagePayload::Handshake { parsed: $crate::msgs::handshake::HandshakeMessagePayload {
             payload: $payload_type(hm),
             ..
-        }) => Ok(hm),
+        }, .. } => Ok(hm),
         payload => Err($crate::check::inappropriate_handshake_message(
             payload,
             &[$crate::msgs::enums::ContentType::Handshake],
@@ -28,10 +28,10 @@ macro_rules! require_handshake_msg(
 macro_rules! require_handshake_msg_move(
   ( $m:expr, $handshake_type:path, $payload_type:path ) => (
     match $m.payload {
-        MessagePayload::Handshake($crate::msgs::handshake::HandshakeMessagePayload {
+        MessagePayload::Handshake { parsed: $crate::msgs::handshake::HandshakeMessagePayload {
             payload: $payload_type(hm),
             ..
-        }) => Ok(hm),
+        }, .. } => Ok(hm),
         payload =>
             Err($crate::check::inappropriate_handshake_message(
                 &payload,
@@ -62,14 +62,14 @@ pub(crate) fn inappropriate_handshake_message(
     handshake_types: &[HandshakeType],
 ) -> Error {
     match payload {
-        MessagePayload::Handshake(hsp) => {
+        MessagePayload::Handshake { parsed, .. } => {
             warn!(
                 "Received a {:?} handshake message while expecting {:?}",
-                hsp.typ, handshake_types
+                parsed.typ, handshake_types
             );
             Error::InappropriateHandshakeMessage {
                 expect_types: handshake_types.to_vec(),
-                got_type: hsp.typ,
+                got_type: parsed.typ,
             }
         }
         payload => inappropriate_message(payload, content_types),

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -366,7 +366,7 @@ fn emit_client_hello_for_retry(
         } else {
             ProtocolVersion::TLSv1_0
         },
-        payload: MessagePayload::Handshake(chp),
+        payload: MessagePayload::handshake(chp),
     };
 
     if retryreq.is_some() {
@@ -792,16 +792,24 @@ impl ExpectServerHelloOrHelloRetryRequest {
 impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> NextStateOrError {
         match m.payload {
-            MessagePayload::Handshake(HandshakeMessagePayload {
-                payload: HandshakePayload::ServerHello(..),
+            MessagePayload::Handshake {
+                parsed:
+                    HandshakeMessagePayload {
+                        payload: HandshakePayload::ServerHello(..),
+                        ..
+                    },
                 ..
-            }) => self
+            } => self
                 .into_expect_server_hello()
                 .handle(cx, m),
-            MessagePayload::Handshake(HandshakeMessagePayload {
-                payload: HandshakePayload::HelloRetryRequest(..),
+            MessagePayload::Handshake {
+                parsed:
+                    HandshakeMessagePayload {
+                        payload: HandshakePayload::HelloRetryRequest(..),
+                        ..
+                    },
                 ..
-            }) => self.handle_hello_retry_request(cx, m),
+            } => self.handle_hello_retry_request(cx, m),
             payload => Err(inappropriate_handshake_message(
                 &payload,
                 &[ContentType::Handshake],

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1194,7 +1194,7 @@ impl CommonState {
                     self.quic.alert = Some(alert.description);
                 } else {
                     debug_assert!(
-                        matches!(m.payload, MessagePayload::Handshake(_)),
+                        matches!(m.payload, MessagePayload::Handshake { .. }),
                         "QUIC uses TLS for the cryptographic handshake only"
                     );
                     let mut bytes = Vec::new();

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -30,9 +30,9 @@ impl HandshakeHashBuffer {
 
     /// Hash/buffer a handshake message.
     pub(crate) fn add_message(&mut self, m: &Message) {
-        if let MessagePayload::Handshake(hs) = &m.payload {
+        if let MessagePayload::Handshake { encoded, .. } = &m.payload {
             self.buffer
-                .extend_from_slice(&hs.get_encoding());
+                .extend_from_slice(&encoded.0);
         }
     }
 
@@ -92,9 +92,8 @@ impl HandshakeHash {
 
     /// Hash/buffer a handshake message.
     pub(crate) fn add_message(&mut self, m: &Message) -> &mut Self {
-        if let MessagePayload::Handshake(hs) = &m.payload {
-            let buf = hs.get_encoding();
-            self.update_raw(&buf);
+        if let MessagePayload::Handshake { encoded, .. } = &m.payload {
+            self.update_raw(&encoded.0);
         }
         self
     }

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -1,6 +1,7 @@
 use crate::key;
 use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
+
 /// An externally length'd payload
 #[derive(Debug, Clone, PartialEq)]
 pub struct Payload(pub Vec<u8>);

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -599,7 +599,8 @@ impl Accepted {
 
     fn client_hello_payload(message: &Message) -> &ClientHelloPayload {
         match &message.payload {
-            crate::msgs::message::MessagePayload::Handshake(inner) => match &inner.payload {
+            crate::msgs::message::MessagePayload::Handshake { parsed, .. } => match &parsed.payload
+            {
                 crate::msgs::handshake::HandshakePayload::ClientHello(ch) => ch,
                 _ => unreachable!(),
             },

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -332,7 +332,7 @@ mod client_hello {
 
         let sh = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::ServerHello,
                 payload: HandshakePayload::ServerHello(ServerHelloPayload {
                     legacy_version: ProtocolVersion::TLSv1_2,
@@ -358,7 +358,7 @@ mod client_hello {
     ) {
         let c = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::Certificate,
                 payload: HandshakePayload::Certificate(cert_chain.to_owned()),
             }),
@@ -373,7 +373,7 @@ mod client_hello {
 
         let c = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::CertificateStatus,
                 payload: HandshakePayload::CertificateStatus(st),
             }),
@@ -412,7 +412,7 @@ mod client_hello {
 
         let m = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::ServerKeyExchange,
                 payload: HandshakePayload::ServerKeyExchange(skx),
             }),
@@ -456,7 +456,7 @@ mod client_hello {
 
         let m = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::CertificateRequest,
                 payload: HandshakePayload::CertificateRequest(cr),
             }),
@@ -471,7 +471,7 @@ mod client_hello {
     fn emit_server_hello_done(transcript: &mut HandshakeHash, common: &mut CommonState) {
         let m = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::ServerHelloDone,
                 payload: HandshakePayload::ServerHelloDone,
             }),
@@ -777,7 +777,7 @@ fn emit_ticket(
 
     let m = Message {
         version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
+        payload: MessagePayload::handshake(HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
             payload: HandshakePayload::NewSessionTicket(NewSessionTicketPayload::new(
                 ticket_lifetime,
@@ -811,7 +811,7 @@ fn emit_finished(
 
     let f = Message {
         version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
+        payload: MessagePayload::handshake(HandshakeMessagePayload {
             typ: HandshakeType::Finished,
             payload: HandshakePayload::Finished(verify_data_payload),
         }),


### PR DESCRIPTION
Stores the parsed data for a handshake message payload alongside
the encoded version to avoid having to re-encode the message when
updating the transcript hash. Also avoids encoding outgoing handshake
message payloads twice.

Fixes #603 and helps simplify #1028.