### PR TITLE
Round out Debug impls for ConfigBuilder

### DIFF
--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -99,14 +99,15 @@ pub struct ConfigBuilder<Side: ConfigSide, State> {
     pub(crate) side: PhantomData<Side>,
 }
 
-impl<Side: ConfigSide, State> fmt::Debug for ConfigBuilder<Side, State> {
+impl<Side: ConfigSide, State: fmt::Debug> fmt::Debug for ConfigBuilder<Side, State> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ConfigBuilder")
-            .field("side", &format_args!("{}", &std::any::type_name::<Side>()))
-            .field(
-                "state",
-                &format_args!("{}", &std::any::type_name::<State>()),
-            )
+        let side_name = std::any::type_name::<Side>();
+        let side_name = side_name
+            .split("::")
+            .last()
+            .unwrap_or(side_name);
+        f.debug_struct(&format!("ConfigBuilder<{}, _>", side_name))
+            .field("state", &self.state)
             .finish()
     }
 }

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -114,7 +114,7 @@ impl<Side: ConfigSide, State> fmt::Debug for ConfigBuilder<Side, State> {
 /// Config builder state where the caller must supply cipher suites.
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WantsCipherSuites(pub(crate) ());
 
 impl<S: ConfigSide> ConfigBuilder<S, WantsCipherSuites> {
@@ -164,7 +164,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsCipherSuites> {
 /// Config builder state where the caller must supply key exchange groups.
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WantsKxGroups {
     cipher_suites: Vec<SupportedCipherSuite>,
 }
@@ -195,6 +195,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsKxGroups> {
 /// Config builder state where the caller must supply TLS protocol versions.
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
+#[derive(Clone, Debug)]
 pub struct WantsVersions {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
@@ -243,6 +244,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
 /// Config builder state where the caller must supply a verifier.
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
+#[derive(Clone, Debug)]
 pub struct WantsVerifier {
     pub(crate) cipher_suites: Vec<SupportedCipherSuite>,
     pub(crate) kx_groups: Vec<&'static SupportedKxGroup>,

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -10,7 +10,6 @@ use crate::verify::{self, CertificateTransparencyPolicy};
 use crate::versions;
 use crate::NoKeyLog;
 
-use std::fmt;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -138,22 +137,12 @@ impl ConfigBuilder<ClientConfig, WantsTransparencyPolicyOrClientCert> {
 /// certificate.
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WantsClientCert {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn verify::ServerCertVerifier>,
-}
-
-impl fmt::Debug for WantsClientCert {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("WantsClientCert")
-            .field("cipher_suites", &self.cipher_suites)
-            .field("kx_groups", &self.kx_groups)
-            .field("versions", &self.versions)
-            .finish()
-    }
 }
 
 impl ConfigBuilder<ClientConfig, WantsClientCert> {

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -56,6 +56,7 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
 /// invoke one of the methods related to client certificates (as in the [`WantsClientCert`] state).
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
+#[derive(Clone, Debug)]
 pub struct WantsTransparencyPolicyOrClientCert {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
@@ -136,6 +137,7 @@ impl ConfigBuilder<ClientConfig, WantsTransparencyPolicyOrClientCert> {
 /// certificate.
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
+#[derive(Clone)]
 pub struct WantsClientCert {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -10,6 +10,7 @@ use crate::verify::{self, CertificateTransparencyPolicy};
 use crate::versions;
 use crate::NoKeyLog;
 
+use std::fmt;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -143,6 +144,16 @@ pub struct WantsClientCert {
     kx_groups: Vec<&'static SupportedKxGroup>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn verify::ServerCertVerifier>,
+}
+
+impl fmt::Debug for WantsClientCert {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WantsClientCert")
+            .field("cipher_suites", &self.cipher_suites)
+            .field("kx_groups", &self.kx_groups)
+            .field("versions", &self.versions)
+            .finish()
+    }
 }
 
 impl ConfigBuilder<ClientConfig, WantsClientCert> {

--- a/rustls/src/kx.rs
+++ b/rustls/src/kx.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::error::Error;
 use crate::msgs::enums::NamedGroup;
 
@@ -62,13 +64,18 @@ impl KeyExchange {
 ///
 /// All possible instances of this class are provided by the library in
 /// the `ALL_KX_GROUPS` array.
-#[derive(Debug)]
 pub struct SupportedKxGroup {
     /// The IANA "TLS Supported Groups" name of the group
     pub name: NamedGroup,
 
     /// The corresponding ring agreement::Algorithm
     agreement_algorithm: &'static ring::agreement::Algorithm,
+}
+
+impl fmt::Debug for SupportedKxGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.name.fmt(f)
+    }
 }
 
 /// Ephemeral ECDH on curve25519 (see RFC7748)

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -39,6 +39,7 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
 /// the connecting peer.
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
+#[derive(Clone)]
 pub struct WantsServerCert {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -9,7 +9,6 @@ use crate::verify;
 use crate::versions;
 use crate::NoKeyLog;
 
-use std::fmt;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -40,22 +39,12 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
 /// the connecting peer.
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WantsServerCert {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn verify::ClientCertVerifier>,
-}
-
-impl fmt::Debug for WantsServerCert {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("WantsServerCert")
-            .field("cipher_suites", &self.cipher_suites)
-            .field("kx_groups", &self.kx_groups)
-            .field("versions", &self.versions)
-            .finish()
-    }
 }
 
 impl ConfigBuilder<ServerConfig, WantsServerCert> {

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -9,6 +9,7 @@ use crate::verify;
 use crate::versions;
 use crate::NoKeyLog;
 
+use std::fmt;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -45,6 +46,16 @@ pub struct WantsServerCert {
     kx_groups: Vec<&'static SupportedKxGroup>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn verify::ClientCertVerifier>,
+}
+
+impl fmt::Debug for WantsServerCert {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WantsServerCert")
+            .field("cipher_suites", &self.cipher_suites)
+            .field("kx_groups", &self.kx_groups)
+            .field("versions", &self.versions)
+            .finish()
+    }
 }
 
 impl ConfigBuilder<ServerConfig, WantsServerCert> {

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::msgs::enums::ProtocolVersion;
 use crate::msgs::enums::{CipherSuite, SignatureAlgorithm, SignatureScheme};
 use crate::msgs::handshake::DecomposedSignatureScheme;
@@ -50,13 +52,19 @@ pub struct CipherSuiteCommon {
 ///
 /// All possible instances of this type are provided by the library in
 /// the [`ALL_CIPHER_SUITES`] array.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum SupportedCipherSuite {
     /// A TLS 1.2 cipher suite
     #[cfg(feature = "tls12")]
     Tls12(&'static Tls12CipherSuite),
     /// A TLS 1.3 cipher suite
     Tls13(&'static Tls13CipherSuite),
+}
+
+impl fmt::Debug for SupportedCipherSuite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.suite().fmt(f)
+    }
 }
 
 impl SupportedCipherSuite {

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::anchors::{OwnedTrustAnchor, RootCertStore};
 use crate::client::ServerName;
 use crate::error::Error;
@@ -179,6 +181,12 @@ pub trait ServerCertVerifier: Send + Sync {
     }
 }
 
+impl fmt::Debug for dyn ServerCertVerifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "dyn ServerCertVerifier")
+    }
+}
+
 /// A type which encapsulates a string that is a syntactically valid DNS name.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DnsName(pub(crate) webpki::DnsName);
@@ -282,6 +290,12 @@ pub trait ClientCertVerifier: Send + Sync {
     /// supported by webpki.
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
         WebPkiVerifier::verification_schemes()
+    }
+}
+
+impl fmt::Debug for dyn ClientCertVerifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "dyn ClientCertVerifier")
     }
 }
 

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::msgs::enums::ProtocolVersion;
 
 /// A TLS protocol version supported by rustls.
@@ -5,11 +7,17 @@ use crate::msgs::enums::ProtocolVersion;
 /// All possible instances of this class are provided by the library in
 /// the [`ALL_VERSIONS`] array, as well as individually as [`TLS12`]
 /// and [`TLS13`].
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct SupportedProtocolVersion {
     /// The TLS enumeration naming this version.
     pub version: ProtocolVersion,
     is_private: (),
+}
+
+impl fmt::Debug for SupportedProtocolVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.version.fmt(f)
+    }
 }
 
 /// TLS1.2
@@ -39,11 +47,25 @@ pub static ALL_VERSIONS: &[&SupportedProtocolVersion] = &[
 /// versions.
 pub static DEFAULT_VERSIONS: &[&SupportedProtocolVersion] = ALL_VERSIONS;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct EnabledVersions {
     #[cfg(feature = "tls12")]
     tls12: Option<&'static SupportedProtocolVersion>,
     tls13: Option<&'static SupportedProtocolVersion>,
+}
+
+impl fmt::Debug for EnabledVersions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut list = &mut f.debug_list();
+        #[cfg(feature = "tls12")]
+        if let Some(v) = self.tls12 {
+            list = list.entry(v)
+        }
+        if let Some(v) = self.tls13 {
+            list = list.entry(v)
+        }
+        list.finish()
+    }
 }
 
 impl EnabledVersions {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -410,6 +410,24 @@ fn server_can_get_client_cert_after_resumption() {
     }
 }
 
+#[test]
+fn test_debug() {
+    let b = ServerConfig::builder();
+    assert_eq!(
+        "ConfigBuilder<ServerConfig, _> { state: WantsCipherSuites(()) }",
+        format!("{:?}", b)
+    );
+    let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
+    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256] } }", format!("{:?}", b));
+    let b = b.with_kx_groups(&[&rustls::kx_group::X25519]);
+    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519] } }", format!("{:?}", b));
+    let b = b
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap();
+    let b = b.with_no_client_auth();
+    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsServerCert { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], versions: [TLSv1_3] } }", format!("{:?}", b));
+}
+
 /// Test that the server handles combination of `offer_client_auth()` returning true
 /// and `client_auth_mandatory` returning `Some(false)`. This exercises both the
 /// client's and server's ability to "recover" from the server asking for a client

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -411,7 +411,7 @@ fn server_can_get_client_cert_after_resumption() {
 }
 
 #[test]
-fn test_debug() {
+fn test_config_builders_debug() {
     let b = ServerConfig::builder();
     assert_eq!(
         "ConfigBuilder<ServerConfig, _> { state: WantsCipherSuites(()) }",
@@ -425,7 +425,20 @@ fn test_debug() {
         .with_protocol_versions(&[&rustls::version::TLS13])
         .unwrap();
     let b = b.with_no_client_auth();
-    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsServerCert { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], versions: [TLSv1_3] } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsServerCert { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], versions: [TLSv1_3], verifier: dyn ClientCertVerifier } }", format!("{:?}", b));
+
+    let b = ClientConfig::builder();
+    assert_eq!(
+        "ConfigBuilder<ClientConfig, _> { state: WantsCipherSuites(()) }",
+        format!("{:?}", b)
+    );
+    let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
+    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256] } }", format!("{:?}", b));
+    let b = b.with_kx_groups(&[&rustls::kx_group::X25519]);
+    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519] } }", format!("{:?}", b));
+    let b = b
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap();
 }
 
 /// Test that the server handles combination of `offer_client_auth()` returning true


### PR DESCRIPTION
The current Debug impl for `ConfigBuilder` doesn't give very much information, just the name of the side (Server or Client) and the name of the state. Change that to give the actual configuration built so far. As part of that, add `#[derive(Debug)]` to some config states that were missing it.

Also, improve the Debug impls for some wrapped enums that show up in ConfigBuilder. SupportedProtocolVersion, SupportedCipherSuite, and SupportedKxGroup now delegate their Debug impl to the underlying enum.

Also, `#[derive(Clone)]` for WantsVersions and WantsVerifier, to match the other states.