### PR TITLE
Output hex for Payload Debug impls

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -9,6 +9,7 @@ use crate::{sign, DistinguishedNames, SignatureScheme};
 
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub(super) struct ServerCertDetails {
     pub(super) cert_chain: CertificatePayload,
     pub(super) ocsp_response: Vec<u8>,

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -46,6 +46,12 @@ impl Codec for key::Certificate {
     }
 }
 
+impl fmt::Debug for Payload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex(f, &self.0)
+    }
+}
+
 /// An arbitrary, unknown-content, u24-length-prefixed payload
 #[derive(Clone, PartialEq)]
 pub struct PayloadU24(pub Vec<u8>);
@@ -67,6 +73,12 @@ impl Codec for PayloadU24 {
         let mut sub = r.sub(len)?;
         let body = sub.rest().to_vec();
         Some(Self(body))
+    }
+}
+
+impl fmt::Debug for PayloadU24 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex(f, &self.0)
     }
 }
 
@@ -102,6 +114,12 @@ impl Codec for PayloadU16 {
     }
 }
 
+impl fmt::Debug for PayloadU16 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex(f, &self.0)
+    }
+}
+
 /// An arbitrary, unknown-content, u8-length-prefixed payload
 #[derive(Clone, PartialEq)]
 pub struct PayloadU8(pub Vec<u8>);
@@ -120,41 +138,6 @@ impl PayloadU8 {
     }
 }
 
-// Format an iterator of u8 into a hex string
-pub(super) fn hex<'a>(
-    f: &mut fmt::Formatter<'_>,
-    payload: impl IntoIterator<Item = &'a u8>,
-) -> fmt::Result {
-    for b in payload {
-        write!(f, "{:02x}", b)?
-    }
-    Ok(())
-}
-
-impl fmt::Debug for Payload {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        hex(f, &self.0)
-    }
-}
-
-impl fmt::Debug for PayloadU8 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        hex(f, &self.0)
-    }
-}
-
-impl fmt::Debug for PayloadU16 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        hex(f, &self.0)
-    }
-}
-
-impl fmt::Debug for PayloadU24 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        hex(f, &self.0)
-    }
-}
-
 impl Codec for PayloadU8 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         (self.0.len() as u8).encode(bytes);
@@ -167,4 +150,21 @@ impl Codec for PayloadU8 {
         let body = sub.rest().to_vec();
         Some(Self(body))
     }
+}
+
+impl fmt::Debug for PayloadU8 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex(f, &self.0)
+    }
+}
+
+// Format an iterator of u8 into a hex string
+pub(super) fn hex<'a>(
+    f: &mut fmt::Formatter<'_>,
+    payload: impl IntoIterator<Item = &'a u8>,
+) -> fmt::Result {
+    for b in payload {
+        write!(f, "{:02x}", b)?
+    }
+    Ok(())
 }

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -1,9 +1,11 @@
+use std::fmt;
+
 use crate::key;
 use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
 
 /// An externally length'd payload
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Payload(pub Vec<u8>);
 
 impl Codec for Payload {
@@ -45,7 +47,7 @@ impl Codec for key::Certificate {
 }
 
 /// An arbitrary, unknown-content, u24-length-prefixed payload
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct PayloadU24(pub Vec<u8>);
 
 impl PayloadU24 {
@@ -69,7 +71,7 @@ impl Codec for PayloadU24 {
 }
 
 /// An arbitrary, unknown-content, u16-length-prefixed payload
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct PayloadU16(pub Vec<u8>);
 
 impl PayloadU16 {
@@ -101,7 +103,7 @@ impl Codec for PayloadU16 {
 }
 
 /// An arbitrary, unknown-content, u8-length-prefixed payload
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct PayloadU8(pub Vec<u8>);
 
 impl PayloadU8 {
@@ -115,6 +117,41 @@ impl PayloadU8 {
 
     pub fn into_inner(self) -> Vec<u8> {
         self.0
+    }
+}
+
+// Format an iterator of u8 into a hex string
+pub(super) fn hex<'a>(
+    f: &mut fmt::Formatter<'_>,
+    payload: impl IntoIterator<Item = &'a u8>,
+) -> fmt::Result {
+    for b in payload {
+        write!(f, "{:02x}", b)?
+    }
+    Ok(())
+}
+
+impl fmt::Debug for Payload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex(f, &self.0)
+    }
+}
+
+impl fmt::Debug for PayloadU8 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex(f, &self.0)
+    }
+}
+
+impl fmt::Debug for PayloadU16 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex(f, &self.0)
+    }
+}
+
+impl fmt::Debug for PayloadU24 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex(f, &self.0)
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -52,8 +52,14 @@ macro_rules! declare_u16_vec(
 declare_u16_vec!(VecU16OfPayloadU8, PayloadU8);
 declare_u16_vec!(VecU16OfPayloadU16, PayloadU16);
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct Random(pub [u8; 32]);
+
+impl fmt::Debug for Random {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        super::base::hex(f, &self.0)
+    }
+}
 
 static HELLO_RETRY_REQUEST_RANDOM: Random = Random([
     0xcf, 0x21, 0xad, 0x74, 0xe5, 0x9a, 0x61, 0x11, 0xbe, 0x1d, 0x8c, 0x02, 0x1e, 0x65, 0xb8, 0x91,
@@ -103,10 +109,8 @@ pub struct SessionID {
 }
 
 impl fmt::Debug for SessionID {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("SessionID")
-            .field(&&self.data[..self.len]) // must be `Sized` to cast to `dyn Debug`
-            .finish()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        super::base::hex(f, &self.data[..self.len])
     }
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -23,6 +23,14 @@ fn reads_random() {
 }
 
 #[test]
+fn debug_random() {
+    assert_eq!(
+        "0101010101010101010101010101010101010101010101010101010101010101",
+        format!("{:?}", Random::from([1; 32]))
+    );
+}
+
+#[test]
 fn rejects_truncated_sessionid() {
     let bytes = [32; 32];
     let mut rd = Reader::init(&bytes);
@@ -65,6 +73,20 @@ fn accepts_empty_sessionid() {
     assert!(sess.is_empty());
     assert_eq!(sess.len(), 0);
     assert!(!rd.any_left());
+}
+
+#[test]
+fn debug_sessionid() {
+    let bytes = [
+        32, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1,
+    ];
+    let mut rd = Reader::init(&bytes);
+    let sess = SessionID::read(&mut rd).unwrap();
+    assert_eq!(
+        "0101010101010101010101010101010101010101010101010101010101010101",
+        format!("{:?}", sess)
+    );
 }
 
 #[test]

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -1,3 +1,6 @@
+use crate::msgs::base::{PayloadU16, PayloadU24, PayloadU8};
+
+use super::base::Payload;
 use super::codec::Reader;
 use super::enums::{AlertDescription, AlertLevel, HandshakeType};
 use super::message::{Message, OpaqueMessage, PlainMessage};
@@ -99,4 +102,12 @@ fn construct_all_types() {
         let m = Message::try_from(m.into_plain_message());
         println!("m' = {:?}", m);
     }
+}
+
+#[test]
+fn debug_payload() {
+    assert_eq!("01020304", format!("{:?}", Payload(vec![1, 2, 3, 4])));
+    assert_eq!("01020304", format!("{:?}", PayloadU8(vec![1, 2, 3, 4])));
+    assert_eq!("01020304", format!("{:?}", PayloadU16(vec![1, 2, 3, 4])));
+    assert_eq!("01020304", format!("{:?}", PayloadU24(vec![1, 2, 3, 4])));
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -439,6 +439,7 @@ fn test_config_builders_debug() {
     let b = b
         .with_protocol_versions(&[&rustls::version::TLS13])
         .unwrap();
+    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVerifier { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], versions: [TLSv1_3] } }", format!("{:?}", b));
 }
 
 /// Test that the server handles combination of `offer_client_auth()` returning true


### PR DESCRIPTION
Previously, these were output as long arrays of decimal numbers, which were noisy and hard to read. As hex numbers, it's a little easier to see the structure, and if necessary to translate them into binary or decode them independently.

<details>
<summary>
An example trace log line before:
</summary>

```
[2022-05-15T18:47:57Z TRACE rustls::client::hs] Sending ClientHello Message {
        version: TLSv1_0,
        payload: Handshake {
            parsed: HandshakeMessagePayload {
                typ: ClientHello,
                payload: ClientHello(
                    ClientHelloPayload {
                        client_version: TLSv1_2,
                        random: Random(
                            [
                                25,
                                13,
                                82,
                                239,
                                14,
                                222,
                                255,
                                7,
                                175,
                                194,
                                138,
                                56,
                                9,
                                29,
                                80,
                                12,
                                140,
                                190,
                                132,
                                98,
                                170,
                                240,
                                69,
                                233,
                                107,
                                178,
                                57,
                                146,
                                220,
                                115,
                                105,
                                115,
                            ],
                        ),
                        session_id: SessionID(
                            [
                                156,
                                181,
                                124,
                                152,
                                13,
                                160,
                                169,
                                37,
                                183,
                                43,
                                15,
                                185,
                                41,
                                224,
                                38,
                                120,
                                143,
                                146,
                                219,
                                217,
                                12,
                                153,
                                124,
                                178,
                                221,
                                35,
                                144,
                                59,
                                191,
                                11,
                                55,
                                17,
                            ],
                        ),
                        cipher_suites: [
                            TLS13_AES_256_GCM_SHA384,
                            TLS13_AES_128_GCM_SHA256,
                            TLS13_CHACHA20_POLY1305_SHA256,
                            TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
                            TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
                            TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
                            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
                            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
                            TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                            TLS_EMPTY_RENEGOTIATION_INFO_SCSV,
                        ],
                        compression_methods: [
                            Null,
                        ],
                        extensions: [
                            SupportedVersions(
                                [
                                    TLSv1_3,
                                    TLSv1_2,
                                ],
                            ),
                            ECPointFormats(
                                [
                                    Uncompressed,
                                ],
                            ),
                            NamedGroups(
                                [
                                    X25519,
                                    secp256r1,
                                    secp384r1,
                                ],
                            ),
                            SignatureAlgorithms(
                                [
                                    ECDSA_NISTP384_SHA384,
                                    ECDSA_NISTP256_SHA256,
                                    ED25519,
                                    RSA_PSS_SHA512,
                                    RSA_PSS_SHA384,
                                    RSA_PSS_SHA256,
                                    RSA_PKCS1_SHA512,
                                    RSA_PKCS1_SHA384,
                                    RSA_PKCS1_SHA256,
                                ],
                            ),
                            ExtendedMasterSecretRequest,
                            CertificateStatusRequest(
                                OCSP(
                                    OCSPCertificateStatusRequest {
                                        responder_ids: [],
                                        extensions: PayloadU16(
                                            [],
                                        ),
                                    },
                                ),
                            ),
                            ServerName(
                                [
                                    ServerName {
                                        typ: HostName,
                                        payload: HostName(
                                            (
                                                PayloadU16(
                                                    [
                                                        119,
                                                        119,
                                                        119,
                                                        46,
                                                        103,
                                                        111,
                                                        111,
                                                        103,
                                                        108,
                                                        101,
                                                        46,
                                                        99,
                                                        111,
                                                        109,
                                                    ],
                                                ),
                                                DnsName(
                                                    "www.google.com",
                                                ),
                                            ),
                                        ),
                                    },
                                ],
                            ),
                            SignedCertificateTimestampRequest,
                            KeyShare(
                                [
                                    KeyShareEntry {
                                        group: X25519,
                                        payload: PayloadU16(
                                            [
                                                132,
                                                211,
                                                117,
                                                34,
                                                172,
                                                132,
                                                132,
                                                50,
                                                61,
                                                50,
                                                203,
                                                239,
                                                84,
                                                60,
                                                49,
                                                235,
                                                172,
                                                193,
                                                72,
                                                168,
                                                107,
                                                225,
                                                222,
                                                121,
                                                146,
                                                148,
                                                72,
                                                141,
                                                182,
                                                97,
                                                140,
                                                52,
                                            ],
                                        ),
                                    },
                                ],
                            ),
                            PresharedKeyModes(
                                [
                                    PSK_DHE_KE,
                                ],
                            ),
                            SessionTicket(
                                Request,
                            ),
                        ],
                    },
                ),
            },
            encoded: Payload(
                [
                    1,
                    0,
                    0,
                    236,
                    3,
                    3,
                    25,
                    13,
                    82,
                    239,
                    14,
                    222,
                    255,
                    7,
                    175,
                    194,
                    138,
                    56,
                    9,
                    29,
                    80,
                    12,
                    140,
                    190,
                    132,
                    98,
                    170,
                    240,
                    69,
                    233,
                    107,
                    178,
                    57,
                    146,
                    220,
                    115,
                    105,
                    115,
                    32,
                    156,
                    181,
                    124,
                    152,
                    13,
                    160,
                    169,
                    37,
                    183,
                    43,
                    15,
                    185,
                    41,
                    224,
                    38,
                    120,
                    143,
                    146,
                    219,
                    217,
                    12,
                    153,
                    124,
                    178,
                    221,
                    35,
                    144,
                    59,
                    191,
                    11,
                    55,
                    17,
                    0,
                    20,
                    19,
                    2,
                    19,
                    1,
                    19,
                    3,
                    192,
                    44,
                    192,
                    43,
                    204,
                    169,
                    192,
                    48,
                    192,
                    47,
                    204,
                    168,
                    0,
                    255,
                    1,
                    0,
                    0,
                    143,
                    0,
                    43,
                    0,
                    5,
                    4,
                    3,
                    4,
                    3,
                    3,
                    0,
                    11,
                    0,
                    2,
                    1,
                    0,
                    0,
                    10,
                    0,
                    8,
                    0,
                    6,
                    0,
                    29,
                    0,
                    23,
                    0,
                    24,
                    0,
                    13,
                    0,
                    20,
                    0,
                    18,
                    5,
                    3,
                    4,
                    3,
                    8,
                    7,
                    8,
                    6,
                    8,
                    5,
                    8,
                    4,
                    6,
                    1,
                    5,
                    1,
                    4,
                    1,
                    0,
                    23,
                    0,
                    0,
                    0,
                    5,
                    0,
                    5,
                    1,
                    0,
                    0,
                    0,
                    0,
                    0,
                    0,
                    0,
                    19,
                    0,
                    17,
                    0,
                    0,
                    14,
                    119,
                    119,
                    119,
                    46,
                    103,
                    111,
                    111,
                    103,
                    108,
                    101,
                    46,
                    99,
                    111,
                    109,
                    0,
                    18,
                    0,
                    0,
                    0,
                    51,
                    0,
                    38,
                    0,
                    36,
                    0,
                    29,
                    0,
                    32,
                    132,
                    211,
                    117,
                    34,
                    172,
                    132,
                    132,
                    50,
                    61,
                    50,
                    203,
                    239,
                    84,
                    60,
                    49,
                    235,
                    172,
                    193,
                    72,
                    168,
                    107,
                    225,
                    222,
                    121,
                    146,
                    148,
                    72,
                    141,
                    182,
                    97,
                    140,
                    52,
                    0,
                    45,
                    0,
                    2,
                    1,
                    1,
                    0,
                    35,
                    0,
                    0,
                ],
            ),
        },
    }
[2022-05-15T18:47:57Z TRACE rustls::client::hs] We got ServerHello ServerHelloPayload {
        legacy_version: TLSv1_2,
        random: Random(
            [
                88,
                211,
                99,
                181,
                74,
                148,
                97,
                79,
                188,
                198,
                240,
                154,
                189,
                179,
                40,
                223,
                10,
                194,
                198,
                146,
                71,
                220,
                13,
                139,
                252,
                198,
                128,
                14,
                87,
                166,
                151,
                199,
            ],
        ),
        session_id: SessionID(
            [
                156,
                181,
                124,
                152,
                13,
                160,
                169,
                37,
                183,
                43,
                15,
                185,
                41,
                224,
                38,
                120,
                143,
                146,
                219,
                217,
                12,
                153,
                124,
                178,
                221,
                35,
                144,
                59,
                191,
                11,
                55,
                17,
            ],
        ),
        cipher_suite: TLS13_AES_256_GCM_SHA384,
        compression_method: Null,
        extensions: [
            KeyShare(
                KeyShareEntry {
                    group: X25519,
                    payload: PayloadU16(
                        [
                            8,
                            40,
                            59,
                            125,
                            42,
                            9,
                            77,
                            12,
                            107,
                            199,
                            237,
                            199,
                            60,
                            187,
                            111,
                            125,
                            36,
                            203,
                            3,
                            104,
                            106,
                            216,
                            254,
                            99,
                            144,
                            68,
                            249,
                            63,
                            136,
                            45,
                            56,
                            46,
                        ],
                    ),
                },
            ),
            SupportedVersions(
                TLSv1_3,
            ),
        ],
    }
```

</details>

<details>
<summary>
And after
</summary>

```
[2022-05-15T18:46:55Z TRACE rustls::client::hs] Sending ClientHello Message {
        version: TLSv1_0,
        payload: Handshake {
            parsed: HandshakeMessagePayload {
                typ: ClientHello,
                payload: ClientHello(
                    ClientHelloPayload {
                        client_version: TLSv1_2,
                        random: 8dd241871198a92ed2724e4800cb0c7d961411d6936786b8de3fe492d01e2ea1,
                        session_id: 4b3be1fe678db9a39d9073cc30ee4caf847190561aadf8e2523e45bc43e340b1,
                        cipher_suites: [
                            TLS13_AES_256_GCM_SHA384,
                            TLS13_AES_128_GCM_SHA256,
                            TLS13_CHACHA20_POLY1305_SHA256,
                            TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
                            TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
                            TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
                            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
                            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
                            TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
                            TLS_EMPTY_RENEGOTIATION_INFO_SCSV,
                        ],
                        compression_methods: [
                            Null,
                        ],
                        extensions: [
                            SupportedVersions(
                                [
                                    TLSv1_3,
                                    TLSv1_2,
                                ],
                            ),
                            ECPointFormats(
                                [
                                    Uncompressed,
                                ],
                            ),
                            NamedGroups(
                                [
                                    X25519,
                                    secp256r1,
                                    secp384r1,
                                ],
                            ),
                            SignatureAlgorithms(
                                [
                                    ECDSA_NISTP384_SHA384,
                                    ECDSA_NISTP256_SHA256,
                                    ED25519,
                                    RSA_PSS_SHA512,
                                    RSA_PSS_SHA384,
                                    RSA_PSS_SHA256,
                                    RSA_PKCS1_SHA512,
                                    RSA_PKCS1_SHA384,
                                    RSA_PKCS1_SHA256,
                                ],
                            ),
                            ExtendedMasterSecretRequest,
                            CertificateStatusRequest(
                                OCSP(
                                    OCSPCertificateStatusRequest {
                                        responder_ids: [],
                                        extensions: ,
                                    },
                                ),
                            ),
                            ServerName(
                                [
                                    ServerName {
                                        typ: HostName,
                                        payload: HostName(
                                            (
                                                7777772e676f6f676c652e636f6d,
                                                DnsName(
                                                    "www.google.com",
                                                ),
                                            ),
                                        ),
                                    },
                                ],
                            ),
                            SignedCertificateTimestampRequest,
                            KeyShare(
                                [
                                    KeyShareEntry {
                                        group: X25519,
                                        payload: 2c5e6b9146e9babf3b94ff3c721611323ed734d1968d37924b9c9424aee7db39,
                                    },
                                ],
                            ),
                            PresharedKeyModes(
                                [
                                    PSK_DHE_KE,
                                ],
                            ),
                            SessionTicket(
                                Request,
                            ),
                        ],
                    },
                ),
            },
            encoded: 010000ec03038dd241871198a92ed2724e4800cb0c7d961411d6936786b8de3fe492d01e2ea1204b3be1fe678db9a39d9073cc30ee4caf847190561aadf8e2523e45bc43e340b10014130213011303c02cc02bcca9c030c02fcca800ff0100008f002b00050403040303000b00020100000a00080006001d00170018000d001400120503040308070806080508040601050104010017000000050005010000000000000013001100000e7777772e676f6f676c652e636f6d00120000003300260024001d00202c5e6b9146e9babf3b94ff3c721611323ed734d1968d37924b9c9424aee7db39002d0002010100230000,
        },
    }
```

</details>