### PR TITLE
Prepare 0.20.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,17 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 * Next release:
   - Planned: removal of unused signature verification schemes at link-time.
+* 0.20.6 (2022-05-18)
+  - 0.20.5 included a change to track more context for the `Error::CorruptMessage`
+    which made API-incompatible changes to the `Error` type. We yanked 0.20.5
+    and have reverted that change as part of 0.20.6.
 * 0.20.5 (2022-05-14)
   - Correct compatbility with servers which return no TLS extensions and take
     advantage of a special case encoding.
   - Remove spurious warn-level logging introduced in 0.20.3.
+  - Expose cipher suites in `ClientHello` type.
+  - Allow verification of IP addresses with `dangerous_config` enabled.
+  - Retry I/O operations in `ConnectionCommon::complete_io()` when interrupted.
   - Fix server::ResolvesServerCertUsingSni case sensitivity.
 * 0.20.4 (2022-02-19)
   - Correct regression in QUIC 0-RTT support.

--- a/rustls-mio/tests/badssl.rs
+++ b/rustls-mio/tests/badssl.rs
@@ -6,7 +6,6 @@ mod common;
 
 mod online {
     use super::common::TlsClient;
-    use super::common::DEBUG_LOCATION_REPLACEMENT;
 
     fn connect(hostname: &str) -> TlsClient {
         TlsClient::new(hostname)
@@ -106,7 +105,7 @@ mod online {
     fn too_many_sans() {
         connect("10000-sans.badssl.com")
             .fails()
-            .expect(&format!(r"TLS error: CorruptMessagePayload\(CorruptMessagePayload \{{ location: {}, kind: Handshake \}}\)", DEBUG_LOCATION_REPLACEMENT))
+            .expect(r"TLS error: CorruptMessagePayload\(Handshake\)")
             .go()
             .unwrap();
     }

--- a/rustls-mio/tests/common/mod.rs
+++ b/rustls-mio/tests/common/mod.rs
@@ -12,8 +12,6 @@ use std::time;
 use self::regex::Regex;
 use regex;
 
-pub const DEBUG_LOCATION_REPLACEMENT: &str = "TEST_PLACEHOLDER";
-
 use ring::rand::SecureRandom;
 
 pub struct DeleteFilesOnDrop {
@@ -328,12 +326,8 @@ impl TlsClient {
         let stdout_str = String::from_utf8_lossy(&output.stdout);
         let stderr_str = String::from_utf8_lossy(&output.stderr);
 
-        let location_regex = Regex::new(r"Location \{(.*?)\}").unwrap();
         for expect in &self.expect_output {
             let re = Regex::new(expect).unwrap();
-            // Replace the `Debug` form of `std::panic::Location` in errors with a constant to avoid
-            // code churn.
-            let stdout_str = location_regex.replace_all(&stdout_str, DEBUG_LOCATION_REPLACEMENT);
             if re.find(&stdout_str).is_none() {
                 println!("We expected to find '{}' in the following output:", expect);
                 println!("{:?}", output);

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,7 +2,6 @@
 name = "rustls"
 version = "0.20.6"
 edition = "2018"
-authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.20.5"
+version = "0.20.6"
 edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -595,16 +595,12 @@ fn handle_err(err: rustls::Error) -> ! {
         Error::AlertReceived(AlertDescription::InternalError) => {
             quit(":PEER_ALERT_INTERNAL_ERROR:")
         }
-        Error::CorruptMessagePayload(corrupt_payload) => match corrupt_payload.content_type() {
-            ContentType::ChangeCipherSpec => quit(":BAD_CHANGE_CIPHER_SPEC:"),
-            ContentType::Alert => quit(":BAD_ALERT:"),
-            ContentType::Handshake => quit(":BAD_HANDSHAKE_MSG:"),
-            ContentType::Unknown(42) => quit(":GARBAGE:"),
-            err => {
-                println_err!("unhandled corrupt message error: {:?}", err);
-                quit(":FIXME:")
-            }
-        },
+        Error::CorruptMessagePayload(ContentType::Alert) => quit(":BAD_ALERT:"),
+        Error::CorruptMessagePayload(ContentType::ChangeCipherSpec) => {
+            quit(":BAD_CHANGE_CIPHER_SPEC:")
+        }
+        Error::CorruptMessagePayload(ContentType::Handshake) => quit(":BAD_HANDSHAKE_MSG:"),
+        Error::CorruptMessagePayload(ContentType::Unknown(42)) => quit(":GARBAGE:"),
         Error::CorruptMessage => quit(":GARBAGE:"),
         Error::DecryptError => quit(":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"),
         Error::PeerIncompatibleError(_) => quit(":INCOMPATIBLE:"),
@@ -751,8 +747,7 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
             let mut one_byte = [0u8];
             let mut cursor = io::Cursor::new(&mut one_byte[..]);
             sess.write_tls(&mut cursor).unwrap();
-            conn.write_all(&one_byte)
-                .expect("IO error");
+            conn.write(&one_byte).expect("IO error");
 
             quench_writes = true;
         }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -405,7 +405,7 @@ impl State<ClientConnectionData> for ExpectServerKx {
             .ok_or_else(|| {
                 cx.common
                     .send_fatal_alert(AlertDescription::DecodeError);
-                Error::corrupt_message(ContentType::Handshake)
+                Error::CorruptMessagePayload(ContentType::Handshake)
             })?;
 
         // Save the signature and signed parameters for later verification.

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -561,7 +561,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             warn!("Server sent non-empty certreq context");
             cx.common
                 .send_fatal_alert(AlertDescription::DecodeError);
-            return Err(Error::corrupt_message(ContentType::Handshake));
+            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
         }
 
         let tls13_sign_schemes = sign::supported_sign_tls13();
@@ -629,7 +629,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
             warn!("certificate with non-empty context during handshake");
             cx.common
                 .send_fatal_alert(AlertDescription::DecodeError);
-            return Err(Error::corrupt_message(ContentType::Handshake));
+            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
         }
 
         if cert_chain.any_entry_has_duplicate_extension()
@@ -1076,7 +1076,7 @@ impl ExpectTraffic {
             }
             _ => {
                 common.send_fatal_alert(AlertDescription::IllegalParameter);
-                return Err(Error::corrupt_message(ContentType::Handshake));
+                return Err(Error::CorruptMessagePayload(ContentType::Handshake));
             }
         }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -533,7 +533,7 @@ impl<Data> ConnectionCommon<Data> {
 
         let msg = msg.into_plain_message();
         if !self.handshake_joiner.want_message(&msg) {
-            return Err(Error::corrupt_message(ContentType::Handshake));
+            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
         }
 
         if self
@@ -543,7 +543,7 @@ impl<Data> ConnectionCommon<Data> {
         {
             self.common_state
                 .send_fatal_alert(AlertDescription::DecodeError);
-            return Err(Error::corrupt_message(ContentType::Handshake));
+            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
         }
 
         self.common_state.aligned_handshake = self.handshake_joiner.is_empty();
@@ -616,7 +616,7 @@ impl<Data> ConnectionCommon<Data> {
                 .ok_or_else(|| {
                     self.common_state
                         .send_fatal_alert(AlertDescription::DecodeError);
-                    Error::corrupt_message(ContentType::Handshake)
+                    Error::CorruptMessagePayload(ContentType::Handshake)
                 })?;
             return self.process_new_handshake_messages(state);
         }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -365,7 +365,7 @@ pub use crate::builder::{
 pub use crate::conn::{
     CommonState, Connection, ConnectionCommon, IoState, Reader, SideData, Writer,
 };
-pub use crate::error::{CorruptMessagePayload, Error};
+pub use crate::error::Error;
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -57,7 +57,7 @@ impl MessagePayload {
             _ => None,
         };
 
-        parsed.ok_or_else(|| Error::corrupt_message(typ))
+        parsed.ok_or(Error::CorruptMessagePayload(typ))
     }
 
     pub fn content_type(&self) -> ContentType {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1281,7 +1281,7 @@ impl ExpectTraffic {
             }
             _ => {
                 common.send_fatal_alert(AlertDescription::IllegalParameter);
-                return Err(Error::corrupt_message(ContentType::Handshake));
+                return Err(Error::CorruptMessagePayload(ContentType::Handshake));
             }
         }
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -427,7 +427,7 @@ pub(crate) fn decode_ecdh_params<T: Codec>(
 ) -> Result<T, Error> {
     decode_ecdh_params_::<T>(kx_params).ok_or_else(|| {
         common.send_fatal_alert(AlertDescription::DecodeError);
-        Error::corrupt_message(ContentType::Handshake)
+        Error::CorruptMessagePayload(ContentType::Handshake)
     })
 }
 

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -88,13 +88,12 @@ fn client_verifier_no_schemes() {
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config.clone()), &server_config);
             let err = do_handshake_until_error(&mut client, &mut server);
-            match err {
-                Ok(()) => panic!("handshake did not error"),
-                Err(ErrorFromPeer::Client(Error::CorruptMessagePayload(c))) => {
-                    assert_eq!(c.content_type(), ContentType::Handshake)
-                }
-                Err(e) => panic!("unexpected error: {:?}", e),
-            }
+            assert_eq!(
+                err,
+                Err(ErrorFromPeer::Client(Error::CorruptMessagePayload(
+                    ContentType::Handshake
+                )))
+            );
         }
     }
 }


### PR DESCRIPTION
See discussion in #1041.

- [x] Changelog updated
- [x] Checked for outdated dependencies
- [x] Passed tests locally with `--all-features`
- [x] Bumped version number in `Cargo.toml`
- [x] Passed `cargo publish --dry-run`