### PR TITLE
Attach location context to corrupt message errors

### DIFF
--- a/rustls-mio/tests/badssl.rs
+++ b/rustls-mio/tests/badssl.rs
@@ -6,6 +6,7 @@ mod common;
 
 mod online {
     use super::common::TlsClient;
+    use super::common::DEBUG_LOCATION_REPLACEMENT;
 
     fn connect(hostname: &str) -> TlsClient {
         TlsClient::new(hostname)
@@ -105,7 +106,7 @@ mod online {
     fn too_many_sans() {
         connect("10000-sans.badssl.com")
             .fails()
-            .expect(r"TLS error: CorruptMessagePayload\(Handshake\)")
+            .expect(&format!(r"TLS error: CorruptMessagePayload\(CorruptMessagePayload \{{ location: {}, kind: Handshake \}}\)", DEBUG_LOCATION_REPLACEMENT))
             .go()
             .unwrap();
     }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -405,7 +405,7 @@ impl State<ClientConnectionData> for ExpectServerKx {
             .ok_or_else(|| {
                 cx.common
                     .send_fatal_alert(AlertDescription::DecodeError);
-                Error::CorruptMessagePayload(ContentType::Handshake)
+                Error::corrupt_message(ContentType::Handshake)
             })?;
 
         // Save the signature and signed parameters for later verification.

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -561,7 +561,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             warn!("Server sent non-empty certreq context");
             cx.common
                 .send_fatal_alert(AlertDescription::DecodeError);
-            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
+            return Err(Error::corrupt_message(ContentType::Handshake));
         }
 
         let tls13_sign_schemes = sign::supported_sign_tls13();
@@ -629,7 +629,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
             warn!("certificate with non-empty context during handshake");
             cx.common
                 .send_fatal_alert(AlertDescription::DecodeError);
-            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
+            return Err(Error::corrupt_message(ContentType::Handshake));
         }
 
         if cert_chain.any_entry_has_duplicate_extension()
@@ -1076,7 +1076,7 @@ impl ExpectTraffic {
             }
             _ => {
                 common.send_fatal_alert(AlertDescription::IllegalParameter);
-                return Err(Error::CorruptMessagePayload(ContentType::Handshake));
+                return Err(Error::corrupt_message(ContentType::Handshake));
             }
         }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -533,7 +533,7 @@ impl<Data> ConnectionCommon<Data> {
 
         let msg = msg.into_plain_message();
         if !self.handshake_joiner.want_message(&msg) {
-            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
+            return Err(Error::corrupt_message(ContentType::Handshake));
         }
 
         if self
@@ -543,7 +543,7 @@ impl<Data> ConnectionCommon<Data> {
         {
             self.common_state
                 .send_fatal_alert(AlertDescription::DecodeError);
-            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
+            return Err(Error::corrupt_message(ContentType::Handshake));
         }
 
         self.common_state.aligned_handshake = self.handshake_joiner.is_empty();
@@ -616,7 +616,7 @@ impl<Data> ConnectionCommon<Data> {
                 .ok_or_else(|| {
                     self.common_state
                         .send_fatal_alert(AlertDescription::DecodeError);
-                    Error::CorruptMessagePayload(ContentType::Handshake)
+                    Error::corrupt_message(ContentType::Handshake)
                 })?;
             return self.process_new_handshake_messages(state);
         }

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -5,6 +5,21 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::time::SystemTimeError;
 
+/// Context around a corrupt TLS message payload that resulted in
+/// an error.
+#[derive(Debug, PartialEq, Clone)]
+pub struct CorruptMessagePayload {
+    location: &'static core::panic::Location<'static>,
+    kind: ContentType,
+}
+
+impl CorruptMessagePayload {
+    /// Returns the type of content we expected but found as corrupt.
+    pub fn content_type(&self) -> ContentType {
+        self.kind
+    }
+}
+
 /// rustls reports protocol errors using this type.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Error {
@@ -34,7 +49,7 @@ pub enum Error {
     CorruptMessage,
 
     /// The peer sent us a TLS message with invalid contents.
-    CorruptMessagePayload(ContentType),
+    CorruptMessagePayload(CorruptMessagePayload),
 
     /// The peer didn't give us any certificates.
     NoCertificatesPresented,
@@ -97,6 +112,16 @@ pub enum Error {
     /// The `max_fragment_size` value supplied in configuration was too small,
     /// or too large.
     BadMaxFragmentSize,
+}
+
+impl Error {
+    #[track_caller]
+    pub(crate) fn corrupt_message(kind: ContentType) -> Self {
+        Self::CorruptMessagePayload(CorruptMessagePayload {
+            location: core::panic::Location::caller(),
+            kind,
+        })
+    }
 }
 
 fn join<T: fmt::Debug>(items: &[T]) -> String {
@@ -182,7 +207,7 @@ impl From<rand::GetRandomFailed> for Error {
 
 #[cfg(test)]
 mod tests {
-    use super::Error;
+    use super::{CorruptMessagePayload, Error};
 
     #[test]
     fn smoke() {
@@ -199,7 +224,10 @@ mod tests {
                 got_type: HandshakeType::ServerHello,
             },
             Error::CorruptMessage,
-            Error::CorruptMessagePayload(ContentType::Alert),
+            Error::CorruptMessagePayload(CorruptMessagePayload {
+                location: core::panic::Location::caller(),
+                kind: ContentType::Alert,
+            }),
             Error::NoCertificatesPresented,
             Error::DecryptError,
             Error::PeerIncompatibleError("no tls1.2".to_string()),

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -365,7 +365,7 @@ pub use crate::builder::{
 pub use crate::conn::{
     CommonState, Connection, ConnectionCommon, IoState, Reader, SideData, Writer,
 };
-pub use crate::error::Error;
+pub use crate::error::{CorruptMessagePayload, Error};
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -57,7 +57,7 @@ impl MessagePayload {
             _ => None,
         };
 
-        parsed.ok_or(Error::CorruptMessagePayload(typ))
+        parsed.ok_or_else(|| Error::corrupt_message(typ))
     }
 
     pub fn content_type(&self) -> ContentType {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1281,7 +1281,7 @@ impl ExpectTraffic {
             }
             _ => {
                 common.send_fatal_alert(AlertDescription::IllegalParameter);
-                return Err(Error::CorruptMessagePayload(ContentType::Handshake));
+                return Err(Error::corrupt_message(ContentType::Handshake));
             }
         }
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -427,7 +427,7 @@ pub(crate) fn decode_ecdh_params<T: Codec>(
 ) -> Result<T, Error> {
     decode_ecdh_params_::<T>(kx_params).ok_or_else(|| {
         common.send_fatal_alert(AlertDescription::DecodeError);
-        Error::CorruptMessagePayload(ContentType::Handshake)
+        Error::corrupt_message(ContentType::Handshake)
     })
 }
 

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -88,12 +88,13 @@ fn client_verifier_no_schemes() {
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config.clone()), &server_config);
             let err = do_handshake_until_error(&mut client, &mut server);
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Client(Error::CorruptMessagePayload(
-                    ContentType::Handshake
-                )))
-            );
+            match err {
+                Ok(()) => panic!("handshake did not error"),
+                Err(ErrorFromPeer::Client(Error::CorruptMessagePayload(c))) => {
+                    assert_eq!(c.content_type(), ContentType::Handshake)
+                }
+                Err(e) => panic!("unexpected error: {:?}", e),
+            }
         }
     }
 }


### PR DESCRIPTION
Originally from #1016, reverted in #1042 due to API compatibility
issues reported in #1041.