### PR TITLE
impl Default for Acceptor

### DIFF
--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -21,12 +21,11 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
 
-    let frg = fragmenter::MessageFragmenter::new(Some(32)).unwrap();
+    let mut frg = fragmenter::MessageFragmenter::default();
+    frg.set_max_fragment_size(Some(32))
+        .unwrap();
     let mut out = VecDeque::new();
-    frg.fragment(
-        message::PlainMessage::from(msg),
-        &mut out,
-    );
+    frg.fragment(message::PlainMessage::from(msg), &mut out);
 
     for msg in out {
         message::Message::try_from(msg).ok();

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -454,7 +454,8 @@ impl ClientConnection {
         extra_exts: Vec<ClientExtension>,
         proto: Protocol,
     ) -> Result<Self, Error> {
-        let mut common_state = CommonState::new(config.max_fragment_size, Side::Client)?;
+        let mut common_state = CommonState::new(Side::Client);
+        common_state.set_max_fragment_size(config.max_fragment_size)?;
         common_state.protocol = proto;
         let mut data = ClientConnectionData::new();
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -824,8 +824,8 @@ pub struct CommonState {
 }
 
 impl CommonState {
-    pub(crate) fn new(max_fragment_size: Option<usize>, side: Side) -> Result<Self, Error> {
-        Ok(Self {
+    pub(crate) fn new(side: Side) -> Self {
+        Self {
             negotiated_version: None,
             side,
             record_layer: record_layer::RecordLayer::new(),
@@ -840,8 +840,7 @@ impl CommonState {
             has_seen_eof: false,
             received_middlebox_ccs: 0,
             peer_certificates: None,
-            message_fragmenter: MessageFragmenter::new(max_fragment_size)
-                .map_err(|_| Error::BadMaxFragmentSize)?,
+            message_fragmenter: Default::default(),
             received_plaintext: ChunkVecBuffer::new(Some(0)),
             sendable_plaintext: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
             sendable_tls: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
@@ -849,7 +848,7 @@ impl CommonState {
             protocol: Protocol::Tcp,
             #[cfg(feature = "quic")]
             quic: Quic::new(),
-        })
+        }
     }
 
     /// Returns true if the caller should call [`CommonState::write_tls`] as soon

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -840,7 +840,7 @@ impl CommonState {
             has_seen_eof: false,
             received_middlebox_ccs: 0,
             peer_certificates: None,
-            message_fragmenter: Default::default(),
+            message_fragmenter: MessageFragmenter::default(),
             received_plaintext: ChunkVecBuffer::new(Some(0)),
             sendable_plaintext: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
             sendable_tls: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -8,9 +8,16 @@ pub const MAX_FRAGMENT_LEN: usize = 16384;
 pub const PACKET_OVERHEAD: usize = 1 + 2 + 2;
 pub const MAX_FRAGMENT_SIZE: usize = MAX_FRAGMENT_LEN + PACKET_OVERHEAD;
 
-#[derive(Default)]
 pub struct MessageFragmenter {
     max_frag: usize,
+}
+
+impl Default for MessageFragmenter {
+    fn default() -> Self {
+        Self {
+            max_frag: MAX_FRAGMENT_LEN,
+        }
+    }
 }
 
 impl MessageFragmenter {
@@ -53,11 +60,16 @@ impl MessageFragmenter {
         }
     }
 
-    /// `max_fragment_size` is the maximum fragment size that will be produced --
-    /// this includes overhead. A `max_fragment_size` of 10 will produce TLS fragments
-    /// up to 10 bytes.
-    pub fn set_max_fragment_size(&mut self, new: Option<usize>) -> Result<(), Error> {
-        self.max_frag = match new {
+    /// Set the maximum fragment size that will be produced.
+    ///
+    /// This includes overhead. A `max_fragment_size` of 10 will produce TLS fragments
+    /// up to 10 bytes long.
+    ///
+    /// A `max_fragment_size` of `None` sets the highest allowable fragment size.
+    ///
+    /// Returns BadMaxFragmentSize if the size is smaller than 32 or larger than 16389.
+    pub fn set_max_fragment_size(&mut self, max_fragment_size: Option<usize>) -> Result<(), Error> {
+        self.max_frag = match max_fragment_size {
             Some(sz @ 32..=MAX_FRAGMENT_SIZE) => sz - PACKET_OVERHEAD,
             None => MAX_FRAGMENT_LEN,
             _ => return Err(Error::BadMaxFragmentSize),

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -478,6 +478,10 @@ impl Default for Acceptor {
 
 impl Acceptor {
     /// Create a new `Acceptor`.
+    #[deprecated(
+        since = "0.20.7",
+        note = "Use Acceptor::default instead for an infallible constructor"
+    )]
     pub fn new() -> Result<Self, Error> {
         Ok(Self::default())
     }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -335,7 +335,8 @@ impl ServerConnection {
         config: Arc<ServerConfig>,
         extra_exts: Vec<ServerExtension>,
     ) -> Result<Self, Error> {
-        let common = CommonState::new(config.max_fragment_size, Side::Server)?;
+        let mut common = CommonState::new(Side::Server);
+        common.set_max_fragment_size(config.max_fragment_size)?;
         Ok(Self {
             inner: ConnectionCommon::new(
                 Box::new(hs::ExpectClientHello::new(config, extra_exts)),

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -464,14 +464,22 @@ pub struct Acceptor {
     inner: Option<ConnectionCommon<ServerConnectionData>>,
 }
 
+impl Default for Acceptor {
+    fn default() -> Self {
+        Self {
+            inner: Some(ConnectionCommon::new(
+                Box::new(Accepting),
+                ServerConnectionData::default(),
+                CommonState::new(Side::Server),
+            )),
+        }
+    }
+}
+
 impl Acceptor {
     /// Create a new `Acceptor`.
     pub fn new() -> Result<Self, Error> {
-        let common = CommonState::new(None, Side::Server)?;
-        let state = Box::new(Accepting);
-        Ok(Self {
-            inner: Some(ConnectionCommon::new(state, Default::default(), common)),
-        })
+        Ok(Self::default())
     }
 
     /// Returns true if the caller should call [`Connection::read_tls()`] as soon as possible.

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4040,7 +4040,7 @@ fn test_acceptor() {
     client.write_tls(&mut buf).unwrap();
 
     let server_config = Arc::new(make_server_config(KeyType::Ed25519));
-    let mut acceptor = Acceptor::new().unwrap();
+    let mut acceptor = Acceptor::default();
     assert!(acceptor.wants_read());
     acceptor
         .read_tls(&mut buf.as_slice())
@@ -4070,7 +4070,7 @@ fn test_acceptor() {
         ))
     );
 
-    let mut acceptor = Acceptor::new().unwrap();
+    let mut acceptor = Acceptor::default();
     assert!(acceptor.accept().unwrap().is_none());
     acceptor
         .read_tls(&mut &buf[..3])
@@ -4081,14 +4081,14 @@ fn test_acceptor() {
         .unwrap(); // invalid message (len = 32k bytes)
     assert!(acceptor.accept().is_err());
 
-    let mut acceptor = Acceptor::new().unwrap();
+    let mut acceptor = Acceptor::default();
     // Minimal valid 1-byte application data message is not a handshake message
     acceptor
         .read_tls(&mut [0x17, 0x03, 0x03, 0x00, 0x01, 0x00].as_ref())
         .unwrap();
     assert!(acceptor.accept().is_err());
 
-    let mut acceptor = Acceptor::new().unwrap();
+    let mut acceptor = Acceptor::default();
     // Minimal 1-byte ClientHello message is not a legal handshake message
     acceptor
         .read_tls(&mut [0x16, 0x03, 0x03, 0x00, 0x05, 0x01, 0x00, 0x00, 0x01, 0x00].as_ref())


### PR DESCRIPTION
`Acceptor::new()` returns an error only when `max_fragment_size` is invalid, which never happens. To avoid a breaking change, offer another way to construct an `Acceptor` via `Default`.

To make that possible, also implement `Default` for `MessageFragmenter`, replacing `MessageFragmenter::new()`. Previously there were two paths that would check that a max_fragment_size was in the acceptable range (new and set_max_fragment_size). Now there's just one path: calling set_max_fragment_size.

This provides a way to construct a MessageFragmenter with the default fragment size that is error-free.

Fixes #1044