### PR TITLE
server: move filtering of signature schemes after config selection

### DIFF
--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -540,14 +540,9 @@ impl Acceptor {
             }
         };
 
-        // XXX(https://github.com/rustls/rustls/issues/973): We shouldn't be using
-        // `ALL_CIPHER_SUITES` here.
-        let supported_cipher_suites = &crate::ALL_CIPHER_SUITES;
-
         let (_, sig_schemes) = hs::process_client_hello(
             &message,
             false,
-            supported_cipher_suites,
             &mut connection.common_state,
             &mut connection.data,
         )?;


### PR DESCRIPTION
This avoids the need for using `ALL_CIPHER_SUITES` in the `Acceptor`,
at the cost of exposing more signature schemes in the `ClientHello`
emitted by the `Acceptor`.

Fixes #973.