### PR TITLE
Document verifier certificate content guarantees

### DIFF
--- a/rustls/src/key.rs
+++ b/rustls/src/key.rs
@@ -15,6 +15,11 @@ pub struct PrivateKey(pub Vec<u8>);
 /// The certificate must be DER-encoded X.509.
 ///
 /// The `rustls-pemfile` crate can be used to parse a PEM file.
+///
+/// ## Note
+///
+/// If you are receiving certificates from an untrusted client or server, the contents
+/// must be validated manually.
 #[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Certificate(pub Vec<u8>);
 

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -99,6 +99,10 @@ pub trait ServerCertVerifier: Send + Sync {
     /// along with the end-entity certificate; it is in the same order that the
     /// peer sent them and may be empty.
     ///
+    /// Note that none of the certificates have been parsed yet, so it is the responsibility of
+    /// the implementor to handle invalid data. It is recommended that the implementor returns
+    /// [`Error::InvalidCertificateEncoding`] when these cases are encountered.
+    ///
     /// `scts` contains the Signed Certificate Timestamps (SCTs) the server
     /// sent with the certificate, if any.
     fn verify_server_cert(
@@ -226,6 +230,10 @@ pub trait ClientCertVerifier: Send + Sync {
     /// `intermediates` contains the intermediate certificates the
     /// client sent along with the end-entity certificate; it is in the same
     /// order that the peer sent them and may be empty.
+    ///
+    /// Note that none of the certificates have been parsed yet, so it is the responsibility of
+    /// the implementor to handle invalid data. It is recommended that the implementor returns
+    /// [`Error::InvalidCertificateEncoding`] when these cases are encountered.
     fn verify_client_cert(
         &self,
         end_entity: &Certificate,


### PR DESCRIPTION
This PR clarifies what is inside the `Certificate` structures that are returned to certificate verifier implementations.

A better option than this, IMO, would be to create a `VerifiedCertificate` structure for the TLS signature verification methods to make this more clear. However, that would be a breaking change so I opted not to.

One open question: Should the documentation on `Certificate` be changed to be less strong? It notes that a certificate _must_ be DER, but `rustls` AFAIK constructs these with arbitrary bytes the other end of the connection provided.