### PR TITLE
Expose some enums as part of the stable API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 * Next release:
   - Planned: removal of unused signature verification schemes at link-time.
+  - Expose AlertDescription, ContentType, and HandshakeType,
+    SignatureAlgorithm, and NamedGroup as part of the stable API. Previously they
+    were part of the unstable internals API, but were referenced by parts of the
+    stable API.
 * 0.20.6 (2022-05-18)
   - 0.20.5 included a change to track more context for the `Error::CorruptMessage`
     which made API-incompatible changes to the `Error` type. We yanked 0.20.5

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -371,6 +371,9 @@ pub use crate::key::{Certificate, PrivateKey};
 pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;
 pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
+pub use crate::msgs::enums::{
+    AlertDescription, ContentType, HandshakeType, NamedGroup, SignatureAlgorithm,
+};
 pub use crate::msgs::handshake::DistinguishedNames;
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{


### PR DESCRIPTION
Expose AlertDescription, ContentType, and HandshakeType, SignatureAlgorithm, and NamedGroup as part of the stable API. Previously they were part of the unstable internals API, but were referenced by parts of the stable API.

`AlertDescription`, `ContentType`, and `HandshakeType` are fields of [`Error`](https://docs.rs/rustls/latest/rustls/enum.Error.html) variants.

`SignatureAlgorithm` is returned by the [`SigningKey`](https://docs.rs/rustls/latest/rustls/sign/trait.SigningKey.html#tymethod.algorithm) trait.

`NamedGroup` is the type of a public field of [SupportedKxGroup](https://docs.rs/rustls/0.20.6/rustls/struct.SupportedKxGroup.html).

Related to #1036.