### PR TITLE
Export DigitallySignedStruct in stable API

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -374,7 +374,7 @@ pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
 pub use crate::msgs::enums::{
     AlertDescription, ContentType, HandshakeType, NamedGroup, SignatureAlgorithm,
 };
-pub use crate::msgs::handshake::DistinguishedNames;
+pub use crate::msgs::handshake::{DigitallySignedStruct, DistinguishedNames};
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     BulkAlgorithm, SupportedCipherSuite, ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1595,19 +1595,26 @@ impl Codec for ECParameters {
 #[derive(Debug, Clone)]
 pub struct DigitallySignedStruct {
     pub scheme: SignatureScheme,
+    #[deprecated(since = "0.20.7", note = "Use sig() accessor")]
     pub sig: PayloadU16,
 }
 
 impl DigitallySignedStruct {
+    #![allow(deprecated)]
     pub fn new(scheme: SignatureScheme, sig: Vec<u8>) -> Self {
         Self {
             scheme,
             sig: PayloadU16::new(sig),
         }
     }
+
+    pub fn signature(&self) -> &[u8] {
+        &self.sig.0
+    }
 }
 
 impl Codec for DigitallySignedStruct {
+    #![allow(deprecated)]
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.scheme.encode(bytes);
         self.sig.encode(bytes);

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -867,10 +867,7 @@ fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
             },
             public: PayloadU8(vec![1, 2, 3]),
         },
-        dss: DigitallySignedStruct {
-            scheme: SignatureScheme::RSA_PSS_SHA256,
-            sig: PayloadU16(vec![1, 2, 3]),
-        },
+        dss: DigitallySignedStruct::new(SignatureScheme::RSA_PSS_SHA256, vec![1, 2, 3]),
     })
 }
 

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -689,7 +689,7 @@ fn verify_signed_struct(
     let possible_algs = convert_scheme(dss.scheme)?;
     let cert = webpki::EndEntityCert::try_from(cert.0.as_ref()).map_err(pki_error)?;
 
-    verify_sig_using_any_alg(&cert, possible_algs, message, &dss.sig.0)
+    verify_sig_using_any_alg(&cert, possible_algs, message, dss.signature())
         .map_err(pki_error)
         .map(|_| HandshakeSignatureValid::assertion())
 }
@@ -743,7 +743,7 @@ fn verify_tls13(
 
     let cert = webpki::EndEntityCert::try_from(cert.0.as_ref()).map_err(pki_error)?;
 
-    cert.verify_signature(alg, msg, &dss.sig.0)
+    cert.verify_signature(alg, msg, dss.signature())
         .map_err(pki_error)
         .map(|_| HandshakeSignatureValid::assertion())
 }


### PR DESCRIPTION
This was exposed as part of the public API via ServerCertVerifier,
ClientCertVerifier, and structs that implement those two traits.

Transitively, this should expose PayloadU16 as part of the stable API, since
DigitallySignedStruct's `sig` field has type PayloadU16. However, PayloadU16
exposes unnecessary implementation details (specifically, that a given field is
encoded with 16-bit length). Instead, deprecate the `sig` field for public
access and provide a `sig() -> &[u8]` accessor instead.

Fixes #1061