### PR TITLE
Deprecate Acceptor::wants_read

### DIFF
--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -487,9 +487,10 @@ impl Acceptor {
 
     /// Returns true if the caller should call [`Connection::read_tls()`] as soon as possible.
     ///
-    /// For more details, refer to [`CommonState::wants_read()`].
+    /// Since the purpose of an Acceptor is to read and then parse TLS bytes, this always returns true.
     ///
     /// [`Connection::read_tls()`]: crate::Connection::read_tls
+    #[deprecated(since = "0.20.7", note = "Always returns true")]
     pub fn wants_read(&self) -> bool {
         self.inner
             .as_ref()

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4039,7 +4039,6 @@ fn test_acceptor() {
 
     let server_config = Arc::new(make_server_config(KeyType::Ed25519));
     let mut acceptor = Acceptor::default();
-    assert!(acceptor.wants_read());
     acceptor
         .read_tls(&mut buf.as_slice())
         .unwrap();


### PR DESCRIPTION
This method always returns true.

Fixes #1045 