### PR TITLE
Deprecate RootCertStore::subjects()

### DIFF
--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -47,6 +47,18 @@ impl OwnedTrustAnchor {
             name_constraints: name_constraints.map(|x| x.into()),
         }
     }
+
+    /// Return the subject field.
+    ///
+    /// This can be decoded using [x509-parser's FromDer trait](https://docs.rs/x509-parser/latest/x509_parser/traits/trait.FromDer.html).
+    ///
+    /// ```ignore
+    /// use x509_parser::traits::FromDer;
+    /// println!("{}", x509_parser::x509::X509Name::from_der(anchor.subject())?.1);
+    /// ```
+    pub fn subject(&self) -> &[u8] {
+        &self.subject
+    }
 }
 
 /// A container for root certificates able to provide a root-of-trust

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -86,6 +86,7 @@ impl RootCertStore {
     }
 
     /// Return the Subject Names for certificates in the container.
+    #[deprecated(since = "0.20.7", note = "Use OwnedTrustAnchor::subject() instead")]
     pub fn subjects(&self) -> DistinguishedNames {
         let mut r = DistinguishedNames::new();
 

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -24,12 +24,18 @@ impl OwnedTrustAnchor {
 
     /// Constructs an `OwnedTrustAnchor` from its components.
     ///
-    /// `subject` is the subject field of the trust anchor.
+    /// All inputs are DER-encoded.
     ///
-    /// `spki` is the `subjectPublicKeyInfo` field of the trust anchor.
+    /// `subject` is the [Subject] field of the trust anchor.
     ///
-    /// `name_constraints` is the value of a DER-encoded name constraints to
+    /// `spki` is the [SubjectPublicKeyInfo] field of the trust anchor.
+    ///
+    /// `name_constraints` is the [Name Constraints] to
     /// apply for this trust anchor, if any.
+    ///
+    /// [Subject]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+    /// [SubjectPublicKeyInfo]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.7
+    /// [Name Constraints]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
     pub fn from_subject_spki_name_constraints(
         subject: impl Into<Vec<u8>>,
         spki: impl Into<Vec<u8>>,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1795,6 +1795,18 @@ impl HasServerExtensions for EncryptedExtensions {
 // -- CertificateRequest and sundries --
 declare_u8_vec!(ClientCertificateTypes, ClientCertificateType);
 pub type DistinguishedName = PayloadU16;
+/// DistinguishedNames is a `Vec<Vec<u8>>` wrapped in internal types. Each element contains the
+/// DER or BER encoded [`Subject` field from RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6)
+/// for a single certificate. The Subject field is
+/// [encoded as an RFC 5280 `Name`](https://datatracker.ietf.org/doc/html/rfc5280#page-116).
+/// It can be decoded using [x509-parser's FromDer trait](https://docs.rs/x509-parser/latest/x509_parser/traits/trait.FromDer.html).
+///
+/// ```ignore
+/// for name in distinguished_names {
+///     use x509_parser::traits::FromDer;
+///     println!("{}", x509_parser::x509::X509Name::from_der(&name.0)?.1);
+/// }
+/// ```
 pub type DistinguishedNames = VecU16OfPayloadU16;
 
 #[derive(Debug)]

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -508,6 +508,7 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
         true
     }
 
+    #[allow(deprecated)]
     fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
         Some(self.roots.subjects())
     }


### PR DESCRIPTION
In favor of a newly added `OwnedTrustAnchor::subject()` accessor. This eliminates one use of the type alias DistinguishedNames in the public, stable API, in favor of an accessor that returns a plain `&[u8]`.

Document DistinguishedNames and the new `OwnedTrustAnchor::subject()` with a description of how to decode them.

Add references to RFC 5280 in `OwnedTrustAnchor::new()`.

Part of #1061.