### PR TITLE
doc: update {Client,Server}CertVerifier

### DIFF
--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -95,16 +95,18 @@ pub trait ServerCertVerifier: Send + Sync {
     /// Verify the end-entity certificate `end_entity` is valid for the
     /// hostname `dns_name` and chains to at least one trust anchor.
     ///
-    /// `intermediates` contains the intermediate certificates the client sent
-    /// along with the end-entity certificate; it is in the same order that the
-    /// peer sent them and may be empty.
+    /// `intermediates` contains all certificates other than `end_entity` that
+    /// were sent as part of the server's [Certificate] message. It is in the
+    /// same order that the server sent them and may be empty.
     ///
     /// Note that none of the certificates have been parsed yet, so it is the responsibility of
     /// the implementor to handle invalid data. It is recommended that the implementor returns
     /// [`Error::InvalidCertificateEncoding`] when these cases are encountered.
     ///
     /// `scts` contains the Signed Certificate Timestamps (SCTs) the server
-    /// sent with the certificate, if any.
+    /// sent with the end-entity certificate, if any.
+    ///
+    /// [Certificate]: https://datatracker.ietf.org/doc/html/rfc8446#section-4.4.2
     fn verify_server_cert(
         &self,
         end_entity: &Certificate,
@@ -121,10 +123,9 @@ pub trait ServerCertVerifier: Send + Sync {
     /// The signature and algorithm are within `dss`.  `cert` contains the
     /// public key to use.
     ///
-    /// `cert` is the same certificate that was previously validated by a
-    /// call to `verify_server_cert`.
+    /// `cert` has already been validated by [`ServerCertVerifier::verify_server_cert`].
     ///
-    /// If and only if the signature is valid, return HandshakeSignatureValid.
+    /// If and only if the signature is valid, return `Ok(HandshakeSignatureValid)`.
     /// Otherwise, return an error -- rustls will send an alert and abort the
     /// connection.
     ///
@@ -151,6 +152,12 @@ pub trait ServerCertVerifier: Send + Sync {
     /// tighter ECDSA SignatureScheme semantics -- e.g. `SignatureScheme::ECDSA_NISTP256_SHA256`
     /// must only validate signatures using public keys on the right curve --
     /// rustls does not enforce this requirement for you.
+    ///
+    /// `cert` has already been validated by [`ServerCertVerifier::verify_server_cert`].
+    ///
+    /// If and only if the signature is valid, return `Ok(HandshakeSignatureValid)`.
+    /// Otherwise, return an error -- rustls will send an alert and abort the
+    /// connection.
     ///
     /// This trait method has a default implementation that uses webpki to verify
     /// the signature.
@@ -217,15 +224,24 @@ pub trait ClientCertVerifier: Send + Sync {
         Some(self.offer_client_auth())
     }
 
-    /// Returns the subject names of the client authentication trust anchors to
+    /// Returns the [Subjects] of the client authentication trust anchors to
     /// share with the client when requesting client authentication.
     ///
+    /// These must be DER-encoded X.500 distinguished names, per RFC 5280.
+    /// They are sent in the [`certificate_authorities`] extension of a
+    /// [`CertificateRequest`] message.
+    ///
+    /// [Subjects]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+    /// [`CertificateRequest`]: https://datatracker.ietf.org/doc/html/rfc8446#section-4.3.2
+    /// [`certificate_authorities`]: https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.4
+    ///
     /// Return `None` to abort the connection. Return an empty `Vec` to continue
-    /// the handshake without passing a list of CA DNs.
+    /// the handshake without sending a CertificateRequest message.
     fn client_auth_root_subjects(&self) -> Option<DistinguishedNames>;
 
-    /// Verify the end-entity certificate `end_entity` is valid for the
-    /// and chains to at least one of the trust anchors in `roots`.
+    /// Verify the end-entity certificate `end_entity` is valid, acceptable,
+    /// and chains to at least one of the trust anchors trusted by
+    /// this verifier.
     ///
     /// `intermediates` contains the intermediate certificates the
     /// client sent along with the end-entity certificate; it is in the same
@@ -241,16 +257,15 @@ pub trait ClientCertVerifier: Send + Sync {
         now: SystemTime,
     ) -> Result<ClientCertVerified, Error>;
 
-    /// Verify a signature allegedly by the given server certificate.
+    /// Verify a signature allegedly by the given client certificate.
     ///
     /// `message` is not hashed, and needs hashing during the verification.
     /// The signature and algorithm are within `dss`.  `cert` contains the
     /// public key to use.
     ///
-    /// `cert` is the same certificate that was previously validated by a
-    /// call to `verify_server_cert`.
+    /// `cert` has already been validated by [`ClientCertVerifier::verify_client_cert`].
     ///
-    /// If and only if the signature is valid, return HandshakeSignatureValid.
+    /// If and only if the signature is valid, return `Ok(HandshakeSignatureValid)`.
     /// Otherwise, return an error -- rustls will send an alert and abort the
     /// connection.
     ///
@@ -269,12 +284,13 @@ pub trait ClientCertVerifier: Send + Sync {
         verify_signed_struct(message, cert, dss)
     }
 
-    /// Verify a signature allegedly by the given server certificate.
+    /// Verify a signature allegedly by the given client certificate.
     ///
     /// This method is only called for TLS1.3 handshakes.
     ///
-    /// This method is very similar to `verify_tls12_signature`: but note the
-    /// tighter ECDSA SignatureScheme semantics -- e.g. `SignatureScheme::ECDSA_NISTP256_SHA256`
+    /// This method is very similar to `verify_tls12_signature`, but note the
+    /// tighter ECDSA SignatureScheme semantics in TLS 1.3. For example,
+    /// `SignatureScheme::ECDSA_NISTP256_SHA256`
     /// must only validate signatures using public keys on the right curve --
     /// rustls does not enforce this requirement for you.
     ///


### PR DESCRIPTION
 - Fix some mixed-up client/server phrasing.
 - Fix a missing word ("valid for the and chains")
 - Remove a reference to `roots`, which is not part of the trait.
 - Add some RFC references.
 - Clarify that SCTs are provided only for the end entity certificate.
 - Copy some documentation from verify_tls12_signature to
   verify_tls13_signature.