### PR TITLE
expose more extensions in client hello server struct

### DIFF
--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -261,7 +261,16 @@ mod test {
     fn test_resolvesservercertusingsni_requires_sni() {
         let rscsni = ResolvesServerCertUsingSni::new();
         assert!(rscsni
-            .resolve(ClientHello::new(&None, &[], None, &[], None))
+            .resolve(ClientHello::new(
+                &None,
+                &[],
+                None,
+                &[],
+                None,
+                None,
+                None,
+                None
+            ))
             .is_none());
     }
 
@@ -272,7 +281,16 @@ mod test {
             .unwrap()
             .to_owned();
         assert!(rscsni
-            .resolve(ClientHello::new(&Some(name), &[], None, &[], None))
+            .resolve(ClientHello::new(
+                &Some(name),
+                &[],
+                None,
+                &[],
+                None,
+                None,
+                None,
+                None
+            ))
             .is_none());
     }
 }

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -261,7 +261,7 @@ mod test {
     fn test_resolvesservercertusingsni_requires_sni() {
         let rscsni = ResolvesServerCertUsingSni::new();
         assert!(rscsni
-            .resolve(ClientHello::new(&None, &[], None, &[]))
+            .resolve(ClientHello::new(&None, &[], None, &[], None))
             .is_none());
     }
 
@@ -272,7 +272,7 @@ mod test {
             .unwrap()
             .to_owned();
         assert!(rscsni
-            .resolve(ClientHello::new(&Some(name), &[], None, &[]))
+            .resolve(ClientHello::new(&Some(name), &[], None, &[], None))
             .is_none());
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -321,6 +321,7 @@ impl ExpectClientHello {
                 &sig_schemes,
                 client_hello.get_alpn_extension(),
                 &client_hello.cipher_suites,
+                maybe_versions_ext,
             );
 
             let certkey = self

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -322,6 +322,9 @@ impl ExpectClientHello {
                 client_hello.get_alpn_extension(),
                 &client_hello.cipher_suites,
                 maybe_versions_ext,
+                client_hello.get_psk_modes(),
+                client_hello.get_ecpoints_extension(),
+                client_hello.get_namedgroups_extension(),
             );
 
             let certkey = self

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -112,6 +112,7 @@ pub struct ClientHello<'a> {
     signature_schemes: &'a [SignatureScheme],
     alpn: Option<&'a Vec<PayloadU8>>,
     cipher_suites: &'a [CipherSuite],
+    supported_versions: Option<&'a Vec<ProtocolVersion>>,
 }
 
 impl<'a> ClientHello<'a> {
@@ -121,17 +122,20 @@ impl<'a> ClientHello<'a> {
         signature_schemes: &'a [SignatureScheme],
         alpn: Option<&'a Vec<PayloadU8>>,
         cipher_suites: &'a [CipherSuite],
+        supported_versions: Option<&'a Vec<ProtocolVersion>>,
     ) -> Self {
         trace!("sni {:?}", server_name);
         trace!("sig schemes {:?}", signature_schemes);
         trace!("alpn protocols {:?}", alpn);
         trace!("cipher suites {:?}", cipher_suites);
+        trace!("supported versions {:?}", supported_versions);
 
         ClientHello {
             server_name,
             signature_schemes,
             alpn,
             cipher_suites,
+            supported_versions,
         }
     }
 
@@ -165,6 +169,13 @@ impl<'a> ClientHello<'a> {
     /// Get cipher suites.
     pub fn cipher_suites(&self) -> &[CipherSuite] {
         self.cipher_suites
+    }
+
+    /// Get the supported TLS versions.
+    pub fn supported_versions(&self) -> Option<&[ProtocolVersion]> {
+        self.supported_versions
+            .as_ref()
+            .map(|v| &v[..])
     }
 }
 
@@ -579,6 +590,7 @@ impl Accepted {
             &self.sig_schemes,
             payload.get_alpn_extension(),
             &payload.cipher_suites,
+            payload.get_versions_extension(),
         )
     }
 


### PR DESCRIPTION
Closes #1055 and as discussed in that issue:

- careful with memory;
- added test cases;

Some of these extensions have enumerators defined,
but which aren't exposed as a public type. For now I exposed them as raw u8/u16 values.
Might perhaps be better to expose the types instead?

Something else I noticed is that the constructor to creating ClientHello is becoming lengthy, might be something we want to do something about as well.