### PR TITLE
Allow ignoring hostnames in server cert validation

### DIFF
--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -214,7 +214,7 @@ impl Context {
     }
 
     fn bench(&self, count: usize) {
-        let verifier = verify::WebPkiVerifier::new(self.roots.clone(), None);
+        let verifier = verify::WebPkiVerifier::new(self.roots.clone(), None, false);
         const SCTS: &[&[u8]] = &[];
         const OCSP_RESPONSE: &[u8] = &[];
         let mut times = Vec::new();


### PR DESCRIPTION
This may be useful for, e.g., peer-to-peer applications where peers
authenticate with each other using certificates but do not have stable
addresses or hostnames.

I'm guessing there may be objections to this API because it allows dangerous
configuration too easily. I'm mostly putting this up for discussion instead of
opening an issue, because at least this is something concrete to point at. :)

Perhaps a better API would be to simultaneously provide a single trusted
certificate _and_ ignore hostnames in one go — that way at least you _can't_
configure it to accept any certificate on the internet without meaning to.