### PR TITLE
server: further improve documentation for ClientHello::alpn()

### DIFF
--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -151,9 +151,9 @@ impl<'a> ClientHello<'a> {
         self.signature_schemes
     }
 
-    /// Get the alpn.
+    /// Get the ALPN protocol identifiers submitted by the client.
     ///
-    /// Returns `None` if the client did not include an ALPN extension
+    /// Returns `None` if the client did not include an ALPN extension.
     ///
     /// Application Layer Protocol Negotiation (ALPN) is a TLS extension that lets a client
     /// submit a set of identifiers that each a represent an application-layer protocol.
@@ -162,17 +162,12 @@ impl<'a> ClientHello<'a> {
     /// See the official RFC-7301 specifications at <https://datatracker.ietf.org/doc/html/rfc7301>
     /// for more information on ALPN.
     ///
-    /// Common examples of ALPN identifiers given by web clients are "http/1.1" and "h2".
-    /// These indicate that the web client supports each of these HTTP protocols,
-    /// and it is the server that will respond with one of these two as the chosen HTTP protocol.
-    ///
-    /// On the server side you can configure the ALPN protocols supported by your server
-    /// using `ServerConfig::alpn_protocols`. And it are the protocols that it has in common with the ones
-    /// defined in the `ClientHello` message which will be sent back to the client as part of the handshake phase.
-    ///
-    /// You can find a list of many other possible identifier values at
+    /// For example, a HTTP client might specify "http/1.1" and/or "h2". Other well-known values
+    /// are listed in the at IANA registry at
     /// <https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids>.
-    /// Please keep in mind that this is not an exhaustive list.
+    ///
+    /// The server can specify supported ALPN protocols by setting [`ServerConfig::alpn_protocols`].
+    /// During the handshake, the server will select the first protocol configured that the client supports.
     pub fn alpn(&self) -> Option<impl Iterator<Item = &'a [u8]>> {
         self.alpn.map(|protocols| {
             protocols


### PR DESCRIPTION
Follow-up to fix language and clarify concepts from #1070.