### PR TITLE
Increase MSRV to 1.56.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.52.1 # MSRV as recommend by https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html
+          - 1.56 # MSRV
         os: [ubuntu-18.04]
         # but only stable on macos/windows (slower platforms)
         include:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ cryptography in TLS. As a result, rustls only runs on platforms
 [supported by `ring`](https://github.com/briansmith/ring#online-automated-testing).
 At the time of writing this means x86, x86-64, armv7, and aarch64.
 
+Rustls requires Rust 1.56 or later.
+
 # Example code
 There are two example programs which use
 [mio](https://github.com/carllerche/mio) to do asynchronous IO.

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustls"
 version = "0.20.6"
 edition = "2018"
+rust-version = "1.56"
 license = "Apache-2.0/ISC/MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."


### PR DESCRIPTION
One of our dev-dependencies has started requiring it, and more dependencies will likely start requiring it soon too. 1.56.0 is the first release supporting edition = 2021.