### PR TITLE
Fix clippy: used `assert_eq!` with a literal bool

### DIFF
--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -107,7 +107,7 @@ mod test {
     #[test]
     fn test_noclientsessionstorage_drops_put() {
         let c = NoClientSessionStorage {};
-        assert_eq!(c.put(vec![0x01], vec![0x02]), false);
+        assert!(!c.put(vec![0x01], vec![0x02]));
     }
 
     #[test]
@@ -122,13 +122,13 @@ mod test {
     #[test]
     fn test_clientsessionmemorycache_accepts_put() {
         let c = ClientSessionMemoryCache::new(4);
-        assert_eq!(c.put(vec![0x01], vec![0x02]), true);
+        assert!(c.put(vec![0x01], vec![0x02]));
     }
 
     #[test]
     fn test_clientsessionmemorycache_persists_put() {
         let c = ClientSessionMemoryCache::new(4);
-        assert_eq!(c.put(vec![0x01], vec![0x02]), true);
+        assert!(c.put(vec![0x01], vec![0x02]));
         assert_eq!(c.get(&[0x01]), Some(vec![0x02]));
         assert_eq!(c.get(&[0x01]), Some(vec![0x02]));
     }
@@ -136,19 +136,19 @@ mod test {
     #[test]
     fn test_clientsessionmemorycache_overwrites_put() {
         let c = ClientSessionMemoryCache::new(4);
-        assert_eq!(c.put(vec![0x01], vec![0x02]), true);
-        assert_eq!(c.put(vec![0x01], vec![0x04]), true);
+        assert!(c.put(vec![0x01], vec![0x02]));
+        assert!(c.put(vec![0x01], vec![0x04]));
         assert_eq!(c.get(&[0x01]), Some(vec![0x04]));
     }
 
     #[test]
     fn test_clientsessionmemorycache_drops_to_maintain_size_invariant() {
         let c = ClientSessionMemoryCache::new(2);
-        assert_eq!(c.put(vec![0x01], vec![0x02]), true);
-        assert_eq!(c.put(vec![0x03], vec![0x04]), true);
-        assert_eq!(c.put(vec![0x05], vec![0x06]), true);
-        assert_eq!(c.put(vec![0x07], vec![0x08]), true);
-        assert_eq!(c.put(vec![0x09], vec![0x0a]), true);
+        assert!(c.put(vec![0x01], vec![0x02]));
+        assert!(c.put(vec![0x03], vec![0x04]));
+        assert!(c.put(vec![0x05], vec![0x06]));
+        assert!(c.put(vec![0x07], vec![0x08]));
+        assert!(c.put(vec![0x09], vec![0x0a]));
 
         let count = c.get(&[0x01]).iter().count()
             + c.get(&[0x03]).iter().count()

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2531,7 +2531,7 @@ fn vectored_write_for_server_handshake_no_half_rtt_with_client_auth() {
 #[test]
 fn vectored_write_for_server_handshake_no_half_rtt_by_default() {
     let server_config = make_server_config(KeyType::Rsa);
-    assert_eq!(server_config.send_half_rtt_data, false);
+    assert!(!server_config.send_half_rtt_data);
     check_half_rtt_does_not_work(server_config);
 }
 
@@ -2923,7 +2923,7 @@ fn early_data_can_be_rejected_by_server() {
     server.reject_early_data();
     do_handshake(&mut client, &mut server);
 
-    assert_eq!(client.is_early_data_accepted(), false);
+    assert!(!client.is_early_data_accepted());
 }
 
 #[cfg(feature = "quic")]


### PR DESCRIPTION
Change outdated use of `assert_eq!` in `handy.rs` and `api.rs`.

Because `#[warn(clippy::bool_assert_comparison)]` is on by default.

I've found some correct use of `assert!` in the codebase so I think it's preferable to include this Clippy fix.

For further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison