### PR TITLE
Delete unused dev-deps `ct-logs` in rustls-mio

### DIFF
--- a/rustls-mio/Cargo.toml
+++ b/rustls-mio/Cargo.toml
@@ -21,7 +21,6 @@ rustls-pemfile = "1.0.0"
 sct = "0.7"
 
 [dev-dependencies]
-ct-logs = "0.9"
 docopt = "~1.1"
 env_logger = "0.9.0"
 mio = { version = "0.8", features = ["net", "os-poll"] }


### PR DESCRIPTION
Fixed https://github.com/rustls/rustls/issues/1073

Searched on git logs and it turns out never used in this codebase.