### PR TITLE
To have ClientCertVerifier to support sni_name_str

### DIFF
--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -251,7 +251,7 @@ impl ExpectClientHello {
     pub(super) fn new(config: Arc<ServerConfig>, extra_exts: Vec<ServerExtension>) -> Self {
         let mut transcript_buffer = HandshakeHashBuffer::new();
 
-        if config.verifier.offer_client_auth() {
+        if config.verifier.offer_client_auth(None) {
             transcript_buffer.set_client_auth_enabled();
         }
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -432,14 +432,14 @@ mod client_hello {
     ) -> Result<bool, Error> {
         let client_auth = &config.verifier;
 
-        if !client_auth.offer_client_auth() {
+        if !client_auth.offer_client_auth(cx.data.get_sni_str()) {
             return Ok(false);
         }
 
         let verify_schemes = client_auth.supported_verify_schemes();
 
         let names = client_auth
-            .client_auth_root_subjects()
+            .client_auth_root_subjects(cx.data.get_sni_str())
             .ok_or_else(|| {
                 debug!("could not determine root subjects based on SNI");
                 cx.common
@@ -509,7 +509,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         let mandatory = self
             .config
             .verifier
-            .client_auth_mandatory()
+            .client_auth_mandatory(cx.data.get_sni_str())
             .ok_or_else(|| {
                 debug!("could not determine if client auth is mandatory based on SNI");
                 cx.common

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -534,7 +534,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
                 let now = std::time::SystemTime::now();
                 self.config
                     .verifier
-                    .verify_client_cert(end_entity, intermediates, now)
+                    .verify_client_cert(cx.data.get_sni_str(), end_entity, intermediates, now)
                     .map_err(|err| {
                         hs::incompatible(cx.common, "certificate invalid");
                         err

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -958,7 +958,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         let now = std::time::SystemTime::now();
         self.config
             .verifier
-            .verify_client_cert(end_entity, intermediates, now)
+            .verify_client_cert(cx.data.get_sni_str(), end_entity, intermediates, now)
             .map_err(|err| {
                 hs::incompatible(cx.common, "certificate invalid");
                 err

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -703,7 +703,7 @@ mod client_hello {
         cx: &mut ServerContext<'_>,
         config: &ServerConfig,
     ) -> Result<bool, Error> {
-        if !config.verifier.offer_client_auth() {
+        if !config.verifier.offer_client_auth(cx.data.get_sni_str()) {
             return Ok(false);
         }
 
@@ -720,7 +720,7 @@ mod client_hello {
 
         let names = config
             .verifier
-            .client_auth_root_subjects()
+            .client_auth_root_subjects(cx.data.get_sni_str())
             .ok_or_else(|| {
                 debug!("could not determine root subjects based on SNI");
                 cx.common
@@ -926,7 +926,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         let mandatory = self
             .config
             .verifier
-            .client_auth_mandatory()
+            .client_auth_mandatory(cx.data.get_sni_str())
             .ok_or_else(|| {
                 debug!("could not determine if client auth is mandatory based on SNI");
                 cx.common

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -213,15 +213,15 @@ impl AsRef<str> for DnsName {
 pub trait ClientCertVerifier: Send + Sync {
     /// Returns `true` to enable the server to request a client certificate and
     /// `false` to skip requesting a client certificate. Defaults to `true`.
-    fn offer_client_auth(&self) -> bool {
+    fn offer_client_auth(&self, _sni_name_str: Option<&str>) -> bool {
         true
     }
 
     /// Return `Some(true)` to require a client certificate and `Some(false)` to make
     /// client authentication optional. Return `None` to abort the connection.
     /// Defaults to `Some(self.offer_client_auth())`.
-    fn client_auth_mandatory(&self) -> Option<bool> {
-        Some(self.offer_client_auth())
+    fn client_auth_mandatory(&self, sni_name_str: Option<&str>) -> Option<bool> {
+        Some(self.offer_client_auth(sni_name_str))
     }
 
     /// Returns the [Subjects] of the client authentication trust anchors to
@@ -237,7 +237,7 @@ pub trait ClientCertVerifier: Send + Sync {
     ///
     /// Return `None` to abort the connection. Return an empty `Vec` to continue
     /// the handshake without sending a CertificateRequest message.
-    fn client_auth_root_subjects(&self) -> Option<DistinguishedNames>;
+    fn client_auth_root_subjects(&self, sni_name_str: Option<&str>) -> Option<DistinguishedNames>;
 
     /// Verify the end-entity certificate `end_entity` is valid, acceptable,
     /// and chains to at least one of the trust anchors trusted by
@@ -529,12 +529,12 @@ impl AllowAnyAuthenticatedClient {
 }
 
 impl ClientCertVerifier for AllowAnyAuthenticatedClient {
-    fn offer_client_auth(&self) -> bool {
+    fn offer_client_auth(&self, _sni_name_str: Option<&str>) -> bool {
         true
     }
 
     #[allow(deprecated)]
-    fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
+    fn client_auth_root_subjects(&self, _sni_name_str: Option<&str>) -> Option<DistinguishedNames> {
         Some(self.roots.subjects())
     }
 
@@ -580,16 +580,16 @@ impl AllowAnyAnonymousOrAuthenticatedClient {
 }
 
 impl ClientCertVerifier for AllowAnyAnonymousOrAuthenticatedClient {
-    fn offer_client_auth(&self) -> bool {
-        self.inner.offer_client_auth()
+    fn offer_client_auth(&self, sni_name_str: Option<&str>) -> bool {
+        self.inner.offer_client_auth(sni_name_str)
     }
 
-    fn client_auth_mandatory(&self) -> Option<bool> {
+    fn client_auth_mandatory(&self, _sni_name_str: Option<&str>) -> Option<bool> {
         Some(false)
     }
 
-    fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
-        self.inner.client_auth_root_subjects()
+    fn client_auth_root_subjects(&self, sni_name_str: Option<&str>) -> Option<DistinguishedNames> {
+        self.inner.client_auth_root_subjects(sni_name_str)
     }
 
     fn verify_client_cert(
@@ -627,11 +627,11 @@ impl NoClientAuth {
 }
 
 impl ClientCertVerifier for NoClientAuth {
-    fn offer_client_auth(&self) -> bool {
+    fn offer_client_auth(&self, _sni_name_str: Option<&str>) -> bool {
         false
     }
 
-    fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
+    fn client_auth_root_subjects(&self, _sni_name_str: Option<&str>) -> Option<DistinguishedNames> {
         unimplemented!();
     }
 

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -252,6 +252,7 @@ pub trait ClientCertVerifier: Send + Sync {
     /// [`Error::InvalidCertificateEncoding`] when these cases are encountered.
     fn verify_client_cert(
         &self,
+        sni_name_str: Option<&str>,
         end_entity: &Certificate,
         intermediates: &[Certificate],
         now: SystemTime,
@@ -539,6 +540,7 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
 
     fn verify_client_cert(
         &self,
+        _sni_name_str: Option<&str>,
         end_entity: &Certificate,
         intermediates: &[Certificate],
         now: SystemTime,
@@ -592,12 +594,13 @@ impl ClientCertVerifier for AllowAnyAnonymousOrAuthenticatedClient {
 
     fn verify_client_cert(
         &self,
+        sni_name_str: Option<&str>,
         end_entity: &Certificate,
         intermediates: &[Certificate],
         now: SystemTime,
     ) -> Result<ClientCertVerified, Error> {
         self.inner
-            .verify_client_cert(end_entity, intermediates, now)
+            .verify_client_cert(sni_name_str, end_entity, intermediates, now)
     }
 }
 
@@ -634,6 +637,7 @@ impl ClientCertVerifier for NoClientAuth {
 
     fn verify_client_cert(
         &self,
+        _sni_name_str: Option<&str>,
         _end_entity: &Certificate,
         _intermediates: &[Certificate],
         _now: SystemTime,


### PR DESCRIPTION
Hi, experts

trying to modify ClientCertVerifier to support multiplexing certs according to DNSName, can you check is this doable in rustls project?

Br
Alex