### PR TITLE
quic: remove unnecessary parentheses

### DIFF
--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -217,7 +217,7 @@ impl HeaderProtectionKey {
 
         let first_plain = match masked {
             // When unmasking, use the packet length bits after unmasking
-            true => (*first ^ (first_mask & bits)),
+            true => *first ^ (first_mask & bits),
             // When masking, use the packet length bits before masking
             false => *first,
         };


### PR DESCRIPTION
This cleans up a CI failure ostensibly from `cargo doc --all-features --no-deps --workspace` (that I was unable to reproduce locally).