### PR TITLE
Minor cleanup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-Rustls is a modern TLS library written in Rust.  It uses <a href = "https://github.com/briansmith/ring"><em>ring</em></a> for cryptography and <a href = "https://github.com/briansmith/webpki">libwebpki</a> for certificate
+Rustls is a modern TLS library written in Rust.  It uses <a href = "https://github.com/briansmith/ring">[`ring`]</a> for cryptography and <a href = "https://github.com/briansmith/webpki">[`webpki`]</a> for certificate
 verification.
 </p>
 
@@ -17,9 +17,9 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 [![Coverage Status (codecov.io)](https://codecov.io/gh/rustls/rustls/branch/main/graph/badge.svg)](https://codecov.io/gh/rustls/rustls/)
 [![Documentation](https://docs.rs/rustls/badge.svg)](https://docs.rs/rustls/)
 
-## Release history:
+## Release history
 
-* Next release:
+* Next Release
   - Planned: removal of unused signature verification schemes at link-time.
   - Expose AlertDescription, ContentType, and HandshakeType,
     SignatureAlgorithm, and NamedGroup as part of the stable API. Previously they

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-Rustls is a modern TLS library written in Rust.  It uses <a href = "https://github.com/briansmith/ring">[`ring`]</a> for cryptography and <a href = "https://github.com/briansmith/webpki">[`webpki`]</a> for certificate
+Rustls is a modern TLS library written in Rust.  It uses <a href = "https://github.com/briansmith/ring">ring</a> for cryptography and <a href = "https://github.com/briansmith/webpki">webpki</a> for certificate
 verification.
 </p>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-Rustls is a modern TLS library written in Rust.  It uses <a href = "https://github.com/briansmith/ring">ring</a> for cryptography and <a href = "https://github.com/briansmith/webpki">webpki</a> for certificate
+Rustls is a modern TLS library written in Rust.  It uses <a href = "https://github.com/briansmith/ring"><em>ring</em></a> for cryptography and <a href = "https://github.com/briansmith/webpki">webpki</a> for certificate
 verification.
 </p>
 
@@ -19,7 +19,7 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Release history
 
-* Next Release
+* Next release
   - Planned: removal of unused signature verification schemes at link-time.
   - Expose AlertDescription, ContentType, and HandshakeType,
     SignatureAlgorithm, and NamedGroup as part of the stable API. Previously they


### PR DESCRIPTION
- Gets rid of extraneous em around first mention of ring
- Don't prefix webpki with "lib"
- Get rid of a couple of extraneous ":" characters not used in other headers or list items