### PR TITLE
DTLS re-use alterations

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1374,13 +1374,16 @@ impl CommonState {
     }
 }
 
-pub(crate) trait State<Data>: Send + Sync {
+/// The TLS state machine
+pub trait State<Data>: Send + Sync {
+    /// Handle a message from the state machine
     fn handle(
         self: Box<Self>,
         cx: &mut Context<'_, Data>,
         message: Message,
     ) -> Result<Box<dyn State<Data>>, Error>;
 
+    /// Export keying material to `output`, according to a `label`, together with a `context`
     fn export_keying_material(
         &self,
         _output: &mut [u8],
@@ -1395,10 +1398,12 @@ pub(crate) trait State<Data>: Send + Sync {
         Err(Error::HandshakeNotComplete)
     }
 
+    /// Used in TLS 1.3 to write key updates into the state
     fn perhaps_write_key_update(&mut self, _cx: &mut CommonState) {}
 }
 
-pub(crate) struct Context<'a, Data> {
+/// Context common to TLS state machines
+pub struct Context<'a, Data> {
     pub(crate) common: &'a mut CommonState,
     pub(crate) data: &'a mut Data,
 }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -355,6 +355,10 @@ pub mod internal {
     pub mod cipher {
         pub use crate::cipher::MessageDecrypter;
     }
+    /// Low-level TLS state machine types.
+    pub mod state {
+        pub use crate::conn::{Context, State};
+    }
 }
 
 // The public interface is:


### PR DESCRIPTION
Exposes more structures to allow for deduplication and re-use. 

This is required for [dustls](https://github.com/shadowjonathan/dustls) to be able to re-use internals from rustls.

Keeping WIP for now, while I work towards a PoC for DTLSv1.2

Suggestions of adoption within rustls have already been poked at in https://github.com/rustls/rustls/issues/40, with no clear result as i dropped the ball for about a year, though i'm still open for discussion.