### PR TITLE
doc: add links to the examples in the documentation

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -224,7 +224,9 @@
 //! ```
 //!
 //! # Examples
-//! `tlsserver` and `tlsclient` are full worked examples.  These both use mio.
+//! [`tlsserver`](https://github.com/rustls/rustls/blob/main/examples/src/bin/tlsserver-mio.rs)
+//! and [`tlsclient`](https://github.com/rustls/rustls/blob/main/examples/src/bin/tlsclient-mio.rs)
+//! are full worked examples.  These both use mio.
 //!
 //! # Crate features
 //! Here's a list of what features are exposed by the rustls crate and what


### PR DESCRIPTION
Hi,

I saw that the examples section of the [docs.rs](https://docs.rs/rustls/latest/rustls/) page were missing, so I added them in this commit.

Tristan