### PR TITLE
Expose `to_trust_anchor` on OwnedTrustAnchor

### DIFF
--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -14,7 +14,7 @@ pub struct OwnedTrustAnchor {
 
 impl OwnedTrustAnchor {
     /// Get a `webpki::TrustAnchor` by borrowing the owned elements.
-    pub(crate) fn to_trust_anchor(&self) -> webpki::TrustAnchor {
+    pub fn to_trust_anchor(&self) -> webpki::TrustAnchor {
         webpki::TrustAnchor {
             subject: &self.subject,
             spki: &self.spki,


### PR DESCRIPTION
This would greatly help when implementing a custom verifier that needs access to the root cert held in `RootCertStore`.  The workaround for this is to avoid using `RootCertStore` and just hold the root cert as DER bytes, which is not very clean, in my opinion.

Example:

Suppose we have a custom verify with functions:
```
  fn verify_end_entity_certificate(
        &self,
        end_entity_certificate: &EndEntityCert,
        intermediate_certs: &[Certificate],
        now: DateTime<Utc>,
    ) -> Result<(), webpki::Error> {
        let trust_anchors = self.root_cert_store
            .roots
            .iter()
            .map(|cert| cert.to_trust_anchor()) // this used to be available but was made crate-public
            .collect();
        let time = Time::from_seconds_since_unix_epoch(now.timestamp() as u64);
        let intermediate_certs: Vec<&[u8]> = intermediate_certs
            .iter()
            .map(|cert| cert.0.as_slice())
            .collect();

        end_entity_certificate.verify_is_valid_tls_server_cert(
            SUPPORTED_SIG_ALGS,
            &TlsServerTrustAnchors(&trust_anchors),
            &intermediate_certs,
            time,
        )
    }
```

Here we cannot call `verify_is_valid_tls_server_cert` since we cannot map the roots in `RootCertStore` to `TrustAnchor`s to wrap into `TlsServerTrustAnchors`.