### PR TITLE
Update development dependencies, migrate to 2021 edition

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "rustls-examples"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 description = "Rustls example code and tests."
 publish = false
-resolver = "2"
 
 [features]
 default = ["logging"]

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -3,7 +3,6 @@
 /// observe using `nm` that the binary of this program does not contain any AES code.
 use std::sync::Arc;
 
-use std::convert::TryInto;
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use std::convert::TryInto;
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -9,7 +9,6 @@
 /// that is sensible outside of example code.
 use std::sync::Arc;
 
-use std::convert::TryInto;
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, Mutex};
 use mio::net::TcpStream;
 
 use std::collections;
-use std::convert::TryInto;
 use std::fs;
 use std::io;
 use std::io::{BufReader, Read, Write};

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "rustls-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
-resolver = "2"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -9,7 +9,6 @@ use rustls::{
     ClientConnection,
     RootCertStore
 };
-use std::convert::TryInto;
 use std::io;
 use std::sync::Arc;
 

--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -5,7 +5,6 @@ extern crate rustls;
 
 use rustls::internal::msgs::deframer;
 use rustls::internal::msgs::message::Message;
-use std::convert::TryFrom;
 use std::io;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -7,7 +7,6 @@ use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::fragmenter::MessageFragmenter;
 use rustls::internal::msgs::message::{Message, OpaqueMessage, PlainMessage};
-use std::convert::TryFrom;
 
 fuzz_target!(|data: &[u8]| {
     let mut rdr = Reader::init(data);

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -2,7 +2,6 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;
 
-use std::convert::TryFrom;
 use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::hsjoiner;
 use rustls::internal::msgs::message;

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -5,7 +5,6 @@ extern crate rustls;
 
 use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, PlainMessage, OpaqueMessage};
-use std::convert::TryFrom;
 
 fuzz_target!(|data: &[u8]| {
     let mut rdr = Reader::init(data);

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustls"
 version = "0.20.8"
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 license = "Apache-2.0/ISC/MIT"
 readme = "../README.md"
@@ -11,7 +11,6 @@ repository = "https://github.com/rustls/rustls"
 categories = ["network-programming", "cryptography"]
 autobenches = false
 build = "build.rs"
-resolver = "2"
 
 [build-dependencies]
 rustversion = { version = "1.0.6", optional = true }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -32,12 +32,12 @@ tls12 = []
 read_buf = ["rustversion"]
 
 [dev-dependencies]
-env_logger = "0.9.0"
+env_logger = "0.9.0" # 0.10 requires an MSRV bump to 1.60
 log = "0.4.4"
 webpki-roots = "0.22.0"
-criterion = "0.3.0"
+criterion = "0.4.0"
 rustls-pemfile = "1.0.0"
-base64 = "0.13.0"
+base64 = "0.21"
 
 [[example]]
 name = "bogo_shim"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -31,10 +31,10 @@ tls12 = []
 read_buf = ["rustversion"]
 
 [dev-dependencies]
+bencher = "0.1.5"
 env_logger = "0.9.0" # 0.10 requires an MSRV bump to 1.60
 log = "0.4.4"
 webpki-roots = "0.22.0"
-criterion = "0.4.0"
 rustls-pemfile = "1.0.0"
 base64 = "0.21"
 

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -1,8 +1,4 @@
-use criterion::criterion_group;
-use criterion::criterion_main;
-/// Microbenchmarks go here.  Larger benchmarks of (e.g..) protocol
-/// performance go in examples/internal/bench.rs.
-use criterion::Criterion;
+use bencher::{benchmark_group, benchmark_main, Bencher};
 
 #[path = "../tests/common/mod.rs"]
 mod test_utils;
@@ -13,14 +9,12 @@ use rustls::ServerConnection;
 use std::io;
 use std::sync::Arc;
 
-fn bench_ewouldblock(c: &mut Criterion) {
+fn bench_ewouldblock(c: &mut Bencher) {
     let server_config = make_server_config(KeyType::Rsa);
     let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
     let mut read_ewouldblock = FailsReads::new(io::ErrorKind::WouldBlock);
-    c.bench_function("read_tls with EWOULDBLOCK", move |b| {
-        b.iter(|| server.read_tls(&mut read_ewouldblock))
-    });
+    c.iter(|| server.read_tls(&mut read_ewouldblock));
 }
 
-criterion_group!(benches, bench_ewouldblock);
-criterion_main!(benches);
+benchmark_group!(benches, bench_ewouldblock);
+benchmark_main!(benches);

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -3,7 +3,6 @@
 // Note: we don't use any of the standard 'cargo bench', 'test::Bencher',
 // etc. because it's unstable at the time of writing.
 
-use std::convert::TryInto;
 use std::env;
 use std::fs;
 use std::io::{self, Read, Write};

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -15,7 +15,6 @@ use rustls::server::ClientHello;
 use rustls::{CipherSuite, ProtocolVersion};
 use rustls::{ClientConnection, Connection, ServerConnection};
 
-use std::convert::TryInto;
 use std::env;
 use std::fs;
 use std::io;

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -4,7 +4,7 @@
 // https://boringssl.googlesource.com/boringssl/+/master/ssl/test
 //
 
-use base64;
+use base64::prelude::{Engine, BASE64_STANDARD};
 use env_logger;
 use rustls;
 
@@ -945,20 +945,20 @@ fn main() {
                 opts.export_keying_material_context_used = true;
             }
             "-quic-transport-params" => {
-                opts.quic_transport_params = base64::decode(args.remove(0).as_bytes())
+                opts.quic_transport_params = BASE64_STANDARD.decode(args.remove(0).as_bytes())
                     .expect("invalid base64");
             }
             "-expect-quic-transport-params" => {
-                opts.expect_quic_transport_params = base64::decode(args.remove(0).as_bytes())
+                opts.expect_quic_transport_params = BASE64_STANDARD.decode(args.remove(0).as_bytes())
                     .expect("invalid base64");
             }
 
             "-ocsp-response" => {
-                opts.server_ocsp_response = base64::decode(args.remove(0).as_bytes())
+                opts.server_ocsp_response = BASE64_STANDARD.decode(args.remove(0).as_bytes())
                     .expect("invalid base64");
             }
             "-signed-cert-timestamps" => {
-                opts.server_sct_list = base64::decode(args.remove(0).as_bytes())
+                opts.server_sct_list = BASE64_STANDARD.decode(args.remove(0).as_bytes())
                     .expect("invalid base64");
 
                 if opts.server_sct_list.len() == 2 &&

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -5,7 +5,6 @@
 //
 
 use rustls::{ClientConfig, ClientConnection, Error, OwnedTrustAnchor, RootCertStore};
-use std::convert::TryInto;
 use std::env;
 use std::error::Error as StdError;
 use std::fs::File;

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -20,7 +20,6 @@ use super::hs;
 #[cfg(feature = "quic")]
 use crate::quic;
 
-use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::marker::PhantomData;
 use std::net::IpAddr;
@@ -216,7 +215,6 @@ impl ClientConfig {
 /// so you can do:
 ///
 /// ```
-/// # use std::convert::{TryInto, TryFrom};
 /// # use rustls::ServerName;
 /// ServerName::try_from("example.com").expect("invalid DNS name");
 ///

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -26,7 +26,6 @@ use crate::vecbuf::ChunkVecBuffer;
 #[cfg(feature = "quic")]
 use std::collections::VecDeque;
 
-use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::io;
 use std::mem;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -133,7 +133,6 @@
 //! # use rustls;
 //! # use webpki;
 //! # use std::sync::Arc;
-//! # use std::convert::TryInto;
 //! # let mut root_store = rustls::RootCertStore::empty();
 //! # root_store.add_server_trust_anchors(
 //! #  webpki_roots::TLS_SERVER_ROOTS

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::fmt::Debug;
 
 /// Wrapper over a slice of bytes that allows reading chunks from

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -126,7 +126,6 @@ mod tests {
     use super::MessageDeframer;
     use crate::msgs::message::{Message, OpaqueMessage};
     use crate::{msgs, Error};
-    use std::convert::TryFrom;
     use std::io;
 
     const FIRST_MESSAGE: &[u8] = include_bytes!("../testdata/deframer-test.1.bin");

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -7,8 +7,6 @@ use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, AlertLevel, ContentType, HandshakeType};
 use crate::msgs::handshake::HandshakeMessagePayload;
 
-use std::convert::TryFrom;
-
 #[derive(Debug)]
 pub enum MessagePayload {
     Alert(AlertMessagePayload),

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -5,7 +5,6 @@ use super::codec::Reader;
 use super::enums::{AlertDescription, AlertLevel, HandshakeType};
 use super::message::{Message, OpaqueMessage, PlainMessage};
 
-use std::convert::TryFrom;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -30,8 +30,6 @@ mod message_test;
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryFrom;
-
     #[test]
     fn smoketest() {
         use super::codec::Reader;

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -6,8 +6,6 @@ use crate::key::Certificate;
 use crate::ticketer::TimeBase;
 use crate::tls13::TLS13_AES_128_GCM_SHA256;
 
-use std::convert::TryInto;
-
 #[test]
 fn clientsessionkey_is_debug() {
     let name = "hello".try_into().unwrap();

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -7,7 +7,6 @@ use crate::x509::{wrap_in_asn1_len, wrap_in_sequence};
 use ring::io::der;
 use ring::signature::{self, EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair};
 
-use std::convert::TryFrom;
 use std::error::Error as StdError;
 use std::fmt;
 use std::sync::Arc;

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -11,7 +11,6 @@ use crate::msgs::handshake::{DigitallySignedStruct, DistinguishedNames};
 
 use ring::digest::Digest;
 
-use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -4,7 +4,6 @@
 // Note: we don't use any of the standard 'cargo bench', 'test::Bencher',
 // etc. because it's unstable at the time of writing.
 
-use std::convert::TryInto;
 use std::time::{Duration, Instant, SystemTime};
 
 use crate::key;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1,8 +1,5 @@
 //! Assorted public API tests.
 use std::cell::RefCell;
-use std::convert::TryFrom;
-#[cfg(feature = "tls12")]
-use std::convert::TryInto;
 use std::fmt;
 use std::io::{self, IoSlice, Read, Write};
 use std::mem;

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use std::convert::{TryFrom, TryInto};
 use std::io;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;


### PR DESCRIPTION
Since our MSRV is 1.56+ anyway, might as well update to the new edition.