### PR TITLE
Lazily parse messages from the handshake joiner

### DIFF
--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -19,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
         let _ = jnr.take_message(msg);
     }
 
-    for msg in jnr.frames {
+    while let Some(msg) = jnr.pop() {
         message::Message::try_from(msg).unwrap();
     }
 });

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -15,8 +15,9 @@ fuzz_target!(|data: &[u8]| {
     };
 
     let mut jnr = hsjoiner::HandshakeJoiner::new();
-    if jnr.want_message(&msg) {
-        let _ = jnr.take_message(msg);
+    match jnr.push(msg) {
+        Ok(_) => {},
+        Err(_) => return,
     }
 
     while let Ok(Some(msg)) = jnr.pop() {

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -19,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
         let _ = jnr.take_message(msg);
     }
 
-    while let Some(msg) = jnr.pop() {
+    while let Ok(Some(msg)) = jnr.pop() {
         message::Message::try_from(msg).unwrap();
     }
 });

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -16,7 +16,7 @@ fuzz_target!(|data: &[u8]| {
 
     let mut jnr = hsjoiner::HandshakeJoiner::new();
     if jnr.want_message(&msg) {
-        jnr.take_message(msg);
+        let _ = jnr.take_message(msg);
     }
 
     for msg in jnr.frames {

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -551,7 +551,7 @@ impl<Data> ConnectionCommon<Data> {
         if self
             .handshake_joiner
             .take_message(msg)
-            .is_none()
+            .is_err()
         {
             self.common_state
                 .send_fatal_alert(AlertDescription::DecodeError);
@@ -625,7 +625,7 @@ impl<Data> ConnectionCommon<Data> {
 
             self.handshake_joiner
                 .take_message(msg)
-                .ok_or_else(|| {
+                .map_err(|_| {
                     self.common_state
                         .send_fatal_alert(AlertDescription::DecodeError);
                     Error::CorruptMessagePayload(ContentType::Handshake)
@@ -806,7 +806,7 @@ impl<Data> ConnectionCommon<Data> {
         if self
             .handshake_joiner
             .take_message(msg)
-            .is_none()
+            .is_err()
         {
             self.common_state.quic.alert = Some(AlertDescription::DecodeError);
             return Err(Error::CorruptMessage);

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -559,7 +559,7 @@ impl<Data> ConnectionCommon<Data> {
         }
 
         self.common_state.aligned_handshake = self.handshake_joiner.is_empty();
-        Ok(self.handshake_joiner.frames.pop_front())
+        Ok(self.handshake_joiner.pop())
     }
 
     pub(crate) fn replace_state(&mut self, new: Box<dyn State<Data>>) {
@@ -692,7 +692,7 @@ impl<Data> ConnectionCommon<Data> {
         mut state: Box<dyn State<Data>>,
     ) -> Result<Box<dyn State<Data>>, Error> {
         self.common_state.aligned_handshake = self.handshake_joiner.is_empty();
-        while let Some(msg) = self.handshake_joiner.frames.pop_front() {
+        while let Some(msg) = self.handshake_joiner.pop() {
             state = self
                 .common_state
                 .process_main_protocol(msg, state, &mut self.data)?;

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -26,12 +26,6 @@ pub struct HandshakeJoiner {
     buf: Vec<u8>,
 }
 
-impl Default for HandshakeJoiner {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl HandshakeJoiner {
     /// Make a new HandshakeJoiner.
     pub fn new() -> Self {

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -20,7 +20,7 @@ const MAX_HANDSHAKE_SIZE: u32 = 0xffff;
 /// one handshake payload.
 pub struct HandshakeJoiner {
     /// Completed handshake frames for output.
-    pub frames: VecDeque<Message>,
+    frames: VecDeque<Message>,
 
     /// The message payload we're currently accumulating.
     buf: Vec<u8>,
@@ -78,6 +78,10 @@ impl HandshakeJoiner {
         }
 
         Ok(())
+    }
+
+    pub fn pop(&mut self) -> Option<Message> {
+        self.frames.pop_front()
     }
 }
 


### PR DESCRIPTION
This will help borrowing data from the incoming buffers (and eventually a pass-through API). It removes more lines than it adds, while providing a more precisely typed API for the handshake joiner internally and externally.