### PR TITLE
Rework client persistence interface for RFC8446 C.4 client tracking prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ Options:
                         SUITE instead.  May be used multiple times.
     --proto PROTOCOL    Send ALPN extension containing PROTOCOL.
                         May be used multiple times to offer several protocols.
-    --cache CACHE       Save session cache to file CACHE.
     --no-tickets        Disable session ticket support.
     --no-sni            Disable server name indication support.
     --insecure          Disable certificate verification.

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -1,9 +1,8 @@
 use std::process;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use mio::net::TcpStream;
 
-use std::collections;
 use std::fs;
 use std::io;
 use std::io::{BufReader, Read, Write};
@@ -188,98 +187,6 @@ impl io::Read for TlsClient {
     }
 }
 
-/// This is an example cache for client session data.
-/// It optionally dumps cached data to a file, but otherwise
-/// is just in-memory.
-///
-/// Note that the contents of such a file are extremely sensitive.
-/// Don't write this stuff to disk in production code.
-struct PersistCache {
-    cache: Mutex<collections::HashMap<Vec<u8>, Vec<u8>>>,
-    filename: Option<String>,
-}
-
-impl PersistCache {
-    /// Make a new cache.  If filename is Some, load the cache
-    /// from it and flush changes back to that file.
-    fn new(filename: &Option<String>) -> Self {
-        let cache = PersistCache {
-            cache: Mutex::new(collections::HashMap::new()),
-            filename: filename.clone(),
-        };
-        if cache.filename.is_some() {
-            cache.load();
-        }
-        cache
-    }
-
-    /// If we have a filename, save the cache contents to it.
-    fn save(&self) {
-        use rustls::internal::msgs::base::PayloadU16;
-        use rustls::internal::msgs::codec::Codec;
-
-        if self.filename.is_none() {
-            return;
-        }
-
-        let mut file =
-            fs::File::create(self.filename.as_ref().unwrap()).expect("cannot open cache file");
-
-        for (key, val) in self.cache.lock().unwrap().iter() {
-            let mut item = Vec::new();
-            let key_pl = PayloadU16::new(key.clone());
-            let val_pl = PayloadU16::new(val.clone());
-            key_pl.encode(&mut item);
-            val_pl.encode(&mut item);
-            file.write_all(&item).unwrap();
-        }
-    }
-
-    /// We have a filename, so replace the cache contents from it.
-    fn load(&self) {
-        use rustls::internal::msgs::base::PayloadU16;
-        use rustls::internal::msgs::codec::{Codec, Reader};
-
-        let mut file = match fs::File::open(self.filename.as_ref().unwrap()) {
-            Ok(f) => f,
-            Err(_) => return,
-        };
-        let mut data = Vec::new();
-        file.read_to_end(&mut data).unwrap();
-
-        let mut cache = self.cache.lock().unwrap();
-        cache.clear();
-        let mut rd = Reader::init(&data);
-
-        while rd.any_left() {
-            let key_pl = PayloadU16::read(&mut rd).unwrap();
-            let val_pl = PayloadU16::read(&mut rd).unwrap();
-            cache.insert(key_pl.0, val_pl.0);
-        }
-    }
-}
-
-impl rustls::client::StoresClientSessions for PersistCache {
-    /// put: insert into in-memory cache, and perhaps persist to disk.
-    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
-        self.cache
-            .lock()
-            .unwrap()
-            .insert(key, value);
-        self.save();
-        true
-    }
-
-    /// get: from in-memory cache
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.cache
-            .lock()
-            .unwrap()
-            .get(key)
-            .cloned()
-    }
-}
-
 const USAGE: &str = "
 Connects to the TLS server at hostname:PORT.  The default PORT
 is 443.  By default, this reads a request from stdin (to EOF)
@@ -307,7 +214,6 @@ Options:
                         SUITE instead.  May be used multiple times.
     --proto PROTOCOL    Send ALPN extension containing PROTOCOL.
                         May be used multiple times to offer several protocols.
-    --cache CACHE       Save session cache to file CACHE.
     --no-tickets        Disable session ticket support.
     --no-sni            Disable server name indication support.
     --insecure          Disable certificate verification.
@@ -327,7 +233,6 @@ struct Args {
     flag_proto: Vec<String>,
     flag_max_frag_size: Option<usize>,
     flag_cafile: Option<String>,
-    flag_cache: Option<String>,
     flag_no_tickets: bool,
     flag_no_sni: bool,
     flag_insecure: bool,
@@ -530,8 +435,6 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     if args.flag_no_sni {
         config.enable_sni = false;
     }
-
-    config.session_storage = Arc::new(PersistCache::new(&args.flag_cache));
 
     config.alpn_protocols = args
         .flag_proto

--- a/fuzz/fuzzers/persist.rs
+++ b/fuzz/fuzzers/persist.rs
@@ -10,22 +10,6 @@ fn try_type<T>(data: &[u8]) where T: Codec {
     T::read(&mut rdr);
 }
 
-fn try_tls12clientsession(data: &[u8]) {
-    let mut rdr = Reader::init(data);
-    persist::ClientSessionValue::read(&mut rdr,
-                                      rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-                                      &rustls::ALL_CIPHER_SUITES);
-}
-
-fn try_tls13clientsession(data: &[u8]) {
-    let mut rdr = Reader::init(data);
-    persist::ClientSessionValue::read(&mut rdr,
-                                      rustls::CipherSuite::TLS13_AES_256_GCM_SHA384,
-                                      &rustls::ALL_CIPHER_SUITES);
-}
-
 fuzz_target!(|data: &[u8]| {
-    try_tls12clientsession(data);
-    try_tls13clientsession(data);
     try_type::<persist::ServerSessionValue>(data);
 });

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -502,6 +502,11 @@ impl rustls::client::StoresClientSessions for ClientCacheWithoutKxHints {
             .get_tls12_session(server_name)
     }
 
+    fn forget_tls12_session(&self, server_name: &rustls::ServerName) {
+        self.storage
+            .forget_tls12_session(server_name);
+    }
+
     fn add_tls13_ticket(
         &self,
         server_name: &rustls::ServerName,

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -431,6 +431,7 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
 
     cfg.session_storage = ServerCacheWithResumptionDelay::new(opts.resumption_delay);
     cfg.max_fragment_size = opts.max_fragment;
+    cfg.send_tls13_tickets = 1;
 
     if opts.use_signing_scheme > 0 {
         let scheme = lookup_scheme(opts.use_signing_scheme);

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -479,42 +479,41 @@ impl ClientCacheWithoutKxHints {
 }
 
 impl rustls::client::ClientSessionStore for ClientCacheWithoutKxHints {
-    fn put_kx_hint(&self, _: &rustls::ServerName, _: rustls::NamedGroup) {}
-    fn get_kx_hint(&self, _: &rustls::ServerName) -> Option<rustls::NamedGroup> {
+    fn set_kx_hint(&self, _: &rustls::ServerName, _: rustls::NamedGroup) {}
+    fn kx_hint(&self, _: &rustls::ServerName) -> Option<rustls::NamedGroup> {
         None
     }
 
-    fn put_tls12_session(
+    fn set_tls12_session(
         &self,
         server_name: &rustls::ServerName,
         mut value: rustls::client::Tls12ClientSessionValue,
     ) {
         value.common.rewind_epoch(self.delay);
         self.storage
-            .put_tls12_session(server_name, value);
+            .set_tls12_session(server_name, value);
     }
 
-    fn get_tls12_session(
+    fn tls12_session(
         &self,
         server_name: &rustls::ServerName,
     ) -> Option<rustls::client::Tls12ClientSessionValue> {
-        self.storage
-            .get_tls12_session(server_name)
+        self.storage.tls12_session(server_name)
     }
 
-    fn forget_tls12_session(&self, server_name: &rustls::ServerName) {
+    fn remove_tls12_session(&self, server_name: &rustls::ServerName) {
         self.storage
-            .forget_tls12_session(server_name);
+            .remove_tls12_session(server_name);
     }
 
-    fn add_tls13_ticket(
+    fn insert_tls13_ticket(
         &self,
         server_name: &rustls::ServerName,
         mut value: rustls::client::Tls13ClientSessionValue,
     ) {
         value.common.rewind_epoch(self.delay);
         self.storage
-            .add_tls13_ticket(server_name, value);
+            .insert_tls13_ticket(server_name, value);
     }
 
     fn take_tls13_ticket(

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -478,7 +478,7 @@ impl ClientCacheWithoutKxHints {
     }
 }
 
-impl rustls::client::StoresClientSessions for ClientCacheWithoutKxHints {
+impl rustls::client::ClientSessionStore for ClientCacheWithoutKxHints {
     fn put_kx_hint(&self, _: &rustls::ServerName, _: rustls::NamedGroup) {}
     fn get_kx_hint(&self, _: &rustls::ServerName) -> Option<rustls::NamedGroup> {
         None

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -8,11 +8,11 @@ use base64::prelude::{Engine, BASE64_STANDARD};
 use env_logger;
 use rustls;
 
-use rustls::internal::msgs::codec::{Codec, Reader};
+use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::persist;
 use rustls::quic::{self, ClientQuicExt, QuicExt, ServerQuicExt};
 use rustls::server::ClientHello;
-use rustls::{CipherSuite, ProtocolVersion};
+use rustls::ProtocolVersion;
 use rustls::{ClientConnection, Connection, ServerConnection, Side};
 
 use std::env;
@@ -478,34 +478,45 @@ impl ClientCacheWithoutKxHints {
 }
 
 impl rustls::client::StoresClientSessions for ClientCacheWithoutKxHints {
-    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
-        if key.len() > 2 && key[0] == b'k' && key[1] == b'x' {
-            return true;
-        }
-
-        let mut reader = Reader::init(&value[2..]);
-        let csv = CipherSuite::read_bytes(&value[..2])
-            .and_then(|suite| {
-                persist::ClientSessionValue::read(&mut reader, suite, &rustls::ALL_CIPHER_SUITES)
-            })
-            .unwrap();
-
-        let value = match csv {
-            persist::ClientSessionValue::Tls13(mut tls13) => {
-                tls13.common.rewind_epoch(self.delay);
-                tls13.get_encoding()
-            }
-            persist::ClientSessionValue::Tls12(mut tls12) => {
-                tls12.common.rewind_epoch(self.delay);
-                tls12.get_encoding()
-            }
-        };
-
-        self.storage.put(key, value)
+    fn put_kx_hint(&self, _: &rustls::ServerName, _: rustls::NamedGroup) {}
+    fn get_kx_hint(&self, _: &rustls::ServerName) -> Option<rustls::NamedGroup> {
+        None
     }
 
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.storage.get(key)
+    fn put_tls12_session(
+        &self,
+        server_name: &rustls::ServerName,
+        mut value: rustls::client::Tls12ClientSessionValue,
+    ) {
+        value.common.rewind_epoch(self.delay);
+        self.storage
+            .put_tls12_session(server_name, value);
+    }
+
+    fn get_tls12_session(
+        &self,
+        server_name: &rustls::ServerName,
+    ) -> Option<rustls::client::Tls12ClientSessionValue> {
+        self.storage
+            .get_tls12_session(server_name)
+    }
+
+    fn add_tls13_ticket(
+        &self,
+        server_name: &rustls::ServerName,
+        mut value: rustls::client::Tls13ClientSessionValue,
+    ) {
+        value.common.rewind_epoch(self.delay);
+        self.storage
+            .add_tls13_ticket(server_name, value);
+    }
+
+    fn take_tls13_ticket(
+        &self,
+        server_name: &rustls::ServerName,
+    ) -> Option<rustls::client::Tls13ClientSessionValue> {
+        self.storage
+            .take_tls13_ticket(server_name)
     }
 }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -37,7 +37,7 @@ use std::{fmt, io, mem};
 /// **highly sensitive data**, containing enough key material
 /// to break all security of the corresponding session.
 ///
-/// `put_`, `add_` and `take_` operations are mutating; this isn't
+/// `put_`, `add_`, `forget_` and `take_` operations are mutating; this isn't
 /// expressed in the type system to allow implementations freedom in
 /// how to achieve interior mutability.  `Mutex` is a common choice.
 pub trait StoresClientSessions: Send + Sync {
@@ -61,6 +61,9 @@ pub trait StoresClientSessions: Send + Sync {
         &self,
         server_name: &ServerName,
     ) -> Option<persist::Tls12ClientSessionValue>;
+
+    /// Forget any saved TLS1.2 session for `server_name`.
+    fn forget_tls12_session(&self, server_name: &ServerName);
 
     /// Remember a TLS1.3 ticket that might be retrieved later from `take_tls13_ticket`, allowing
     /// resumption of this session.  This can be called multiple times for a given session, allowing

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -30,17 +30,17 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::{fmt, io, mem};
 
-/// A trait for the ability to store client session data, so that future
-/// sessions can be resumed.
+/// A trait for the ability to store client session data, so that sessions
+/// can be resumed in future connections.
 ///
-/// Both the keys and values should be treated as
-/// **highly sensitive data**, containing enough key material
-/// to break all security of the corresponding session.
+/// Generally all data in this interface should be treated as
+/// **highly sensitive**, containing enough key material to break all security
+/// of the corresponding session.
 ///
 /// `put_`, `add_`, `forget_` and `take_` operations are mutating; this isn't
 /// expressed in the type system to allow implementations freedom in
 /// how to achieve interior mutability.  `Mutex` is a common choice.
-pub trait StoresClientSessions: Send + Sync {
+pub trait ClientSessionStore: Send + Sync {
     /// Remember what `NamedGroup` the given server chose.
     fn put_kx_hint(&self, server_name: &ServerName, group: NamedGroup);
 
@@ -143,7 +143,7 @@ pub struct ClientConfig {
     pub alpn_protocols: Vec<Vec<u8>>,
 
     /// How we store session data or tickets.
-    pub session_storage: Arc<dyn StoresClientSessions>,
+    pub session_storage: Arc<dyn ClientSessionStore>,
 
     /// The maximum size of TLS message we'll emit.  If None, we don't limit TLS
     /// message lengths except to the 2**16 limit specified in the standard.

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -54,16 +54,23 @@ pub trait StoresClientSessions: Send + Sync {
 
     /// Remember a TLS1.2 session. At most one of these can be remembered at a time, per
     /// `server_name`.
+    #[cfg(feature = "tls12")]
     fn put_tls12_session(&self, server_name: &ServerName, value: persist::Tls12ClientSessionValue);
 
     /// Get the most recently saved TLS1.2 session for `server_name` provided to `put_tls12_session`.
+    #[cfg(feature = "tls12")]
     fn get_tls12_session(
         &self,
         server_name: &ServerName,
     ) -> Option<persist::Tls12ClientSessionValue>;
 
     /// Forget any saved TLS1.2 session for `server_name`.
+    #[cfg(feature = "tls12")]
     fn forget_tls12_session(&self, server_name: &ServerName);
+
+    /// Forget any saved TLS1.2 session for `server_name`.
+    #[cfg(not(feature = "tls12"))]
+    fn forget_tls12_session(&self, _: &ServerName) {}
 
     /// Remember a TLS1.3 ticket that might be retrieved later from `take_tls13_ticket`, allowing
     /// resumption of this session.  This can be called multiple times for a given session, allowing

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -11,10 +11,10 @@ use crate::ServerName;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-/// An implementer of `StoresClientSessions` which does nothing.
+/// An implementer of `ClientSessionStore` which does nothing.
 pub struct NoClientSessionStorage {}
 
-impl client::StoresClientSessions for NoClientSessionStorage {
+impl client::ClientSessionStore for NoClientSessionStorage {
     fn put_kx_hint(&self, _: &ServerName, _: NamedGroup) {}
 
     fn get_kx_hint(&self, _: &ServerName) -> Option<NamedGroup> {
@@ -63,9 +63,10 @@ impl Default for ServerData {
     }
 }
 
-/// An implementer of `StoresClientSessions` that stores everything
-/// in memory.  It enforces a limit on the number of entries
-/// to bound memory usage.
+/// An implementer of `ClientSessionStore` that stores everything
+/// in memory.
+///
+/// It enforces a limit on the number of entries to bound memory usage.
 pub struct ClientSessionMemoryCache {
     servers: Mutex<limited_cache::LimitedCache<ServerName, ServerData>>,
 }
@@ -82,7 +83,7 @@ impl ClientSessionMemoryCache {
     }
 }
 
-impl client::StoresClientSessions for ClientSessionMemoryCache {
+impl client::ClientSessionStore for ClientSessionMemoryCache {
     fn put_kx_hint(&self, server_name: &ServerName, group: NamedGroup) {
         self.servers
             .lock()

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -27,6 +27,8 @@ impl client::StoresClientSessions for NoClientSessionStorage {
         None
     }
 
+    fn forget_tls12_session(&self, _: &ServerName) {}
+
     fn add_tls13_ticket(&self, _: &ServerName, _: persist::Tls13ClientSessionValue) {}
 
     fn take_tls13_ticket(&self, _: &ServerName) -> Option<persist::Tls13ClientSessionValue> {
@@ -107,6 +109,14 @@ impl client::StoresClientSessions for ClientSessionMemoryCache {
             .unwrap()
             .get(server_name)
             .and_then(|sd| sd.tls12.as_ref().cloned())
+    }
+
+    fn forget_tls12_session(&self, server_name: &ServerName) {
+        self.servers
+            .lock()
+            .unwrap()
+            .get_mut(server_name)
+            .and_then(|data| data.tls12.take());
     }
 
     fn add_tls13_ticket(&self, server_name: &ServerName, value: persist::Tls13ClientSessionValue) {

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -15,24 +15,24 @@ use std::sync::{Arc, Mutex};
 pub struct NoClientSessionStorage {}
 
 impl client::ClientSessionStore for NoClientSessionStorage {
-    fn put_kx_hint(&self, _: &ServerName, _: NamedGroup) {}
+    fn set_kx_hint(&self, _: &ServerName, _: NamedGroup) {}
 
-    fn get_kx_hint(&self, _: &ServerName) -> Option<NamedGroup> {
+    fn kx_hint(&self, _: &ServerName) -> Option<NamedGroup> {
         None
     }
 
     #[cfg(feature = "tls12")]
-    fn put_tls12_session(&self, _: &ServerName, _: persist::Tls12ClientSessionValue) {}
+    fn set_tls12_session(&self, _: &ServerName, _: persist::Tls12ClientSessionValue) {}
 
     #[cfg(feature = "tls12")]
-    fn get_tls12_session(&self, _: &ServerName) -> Option<persist::Tls12ClientSessionValue> {
+    fn tls12_session(&self, _: &ServerName) -> Option<persist::Tls12ClientSessionValue> {
         None
     }
 
     #[cfg(feature = "tls12")]
-    fn forget_tls12_session(&self, _: &ServerName) {}
+    fn remove_tls12_session(&self, _: &ServerName) {}
 
-    fn add_tls13_ticket(&self, _: &ServerName, _: persist::Tls13ClientSessionValue) {}
+    fn insert_tls13_ticket(&self, _: &ServerName, _: persist::Tls13ClientSessionValue) {}
 
     fn take_tls13_ticket(&self, _: &ServerName) -> Option<persist::Tls13ClientSessionValue> {
         None
@@ -84,14 +84,14 @@ impl ClientSessionMemoryCache {
 }
 
 impl client::ClientSessionStore for ClientSessionMemoryCache {
-    fn put_kx_hint(&self, server_name: &ServerName, group: NamedGroup) {
+    fn set_kx_hint(&self, server_name: &ServerName, group: NamedGroup) {
         self.servers
             .lock()
             .unwrap()
             .get_or_insert_default_and_edit(server_name.clone(), |data| data.kx_hint = Some(group));
     }
 
-    fn get_kx_hint(&self, server_name: &ServerName) -> Option<NamedGroup> {
+    fn kx_hint(&self, server_name: &ServerName) -> Option<NamedGroup> {
         self.servers
             .lock()
             .unwrap()
@@ -100,7 +100,7 @@ impl client::ClientSessionStore for ClientSessionMemoryCache {
     }
 
     #[cfg(feature = "tls12")]
-    fn put_tls12_session(&self, server_name: &ServerName, value: persist::Tls12ClientSessionValue) {
+    fn set_tls12_session(&self, server_name: &ServerName, value: persist::Tls12ClientSessionValue) {
         self.servers
             .lock()
             .unwrap()
@@ -108,10 +108,7 @@ impl client::ClientSessionStore for ClientSessionMemoryCache {
     }
 
     #[cfg(feature = "tls12")]
-    fn get_tls12_session(
-        &self,
-        server_name: &ServerName,
-    ) -> Option<persist::Tls12ClientSessionValue> {
+    fn tls12_session(&self, server_name: &ServerName) -> Option<persist::Tls12ClientSessionValue> {
         self.servers
             .lock()
             .unwrap()
@@ -120,7 +117,7 @@ impl client::ClientSessionStore for ClientSessionMemoryCache {
     }
 
     #[cfg(feature = "tls12")]
-    fn forget_tls12_session(&self, server_name: &ServerName) {
+    fn remove_tls12_session(&self, server_name: &ServerName) {
         self.servers
             .lock()
             .unwrap()
@@ -128,7 +125,11 @@ impl client::ClientSessionStore for ClientSessionMemoryCache {
             .and_then(|data| data.tls12.take());
     }
 
-    fn add_tls13_ticket(&self, server_name: &ServerName, value: persist::Tls13ClientSessionValue) {
+    fn insert_tls13_ticket(
+        &self,
+        server_name: &ServerName,
+        value: persist::Tls13ClientSessionValue,
+    ) {
         self.servers
             .lock()
             .unwrap()

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -21,12 +21,15 @@ impl client::StoresClientSessions for NoClientSessionStorage {
         None
     }
 
+    #[cfg(feature = "tls12")]
     fn put_tls12_session(&self, _: &ServerName, _: persist::Tls12ClientSessionValue) {}
 
+    #[cfg(feature = "tls12")]
     fn get_tls12_session(&self, _: &ServerName) -> Option<persist::Tls12ClientSessionValue> {
         None
     }
 
+    #[cfg(feature = "tls12")]
     fn forget_tls12_session(&self, _: &ServerName) {}
 
     fn add_tls13_ticket(&self, _: &ServerName, _: persist::Tls13ClientSessionValue) {}
@@ -42,6 +45,7 @@ struct ServerData {
     kx_hint: Option<NamedGroup>,
 
     // Zero or one TLS1.2 sessions.
+    #[cfg(feature = "tls12")]
     tls12: Option<persist::Tls12ClientSessionValue>,
 
     // Up to MAX_TLS13_TICKETS_PER_SERVER TLS1.3 tickets, oldest first.
@@ -52,6 +56,7 @@ impl Default for ServerData {
     fn default() -> Self {
         Self {
             kx_hint: None,
+            #[cfg(feature = "tls12")]
             tls12: None,
             tls13: VecDeque::with_capacity(MAX_TLS13_TICKETS_PER_SERVER),
         }
@@ -93,6 +98,7 @@ impl client::StoresClientSessions for ClientSessionMemoryCache {
             .and_then(|sd| sd.kx_hint)
     }
 
+    #[cfg(feature = "tls12")]
     fn put_tls12_session(&self, server_name: &ServerName, value: persist::Tls12ClientSessionValue) {
         self.servers
             .lock()
@@ -100,6 +106,7 @@ impl client::StoresClientSessions for ClientSessionMemoryCache {
             .get_or_insert_default_and_edit(server_name.clone(), |data| data.tls12 = Some(value));
     }
 
+    #[cfg(feature = "tls12")]
     fn get_tls12_session(
         &self,
         server_name: &ServerName,
@@ -111,6 +118,7 @@ impl client::StoresClientSessions for ClientSessionMemoryCache {
             .and_then(|sd| sd.tls12.as_ref().cloned())
     }
 
+    #[cfg(feature = "tls12")]
     fn forget_tls12_session(&self, server_name: &ServerName) {
         self.servers
             .lock()

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -3,20 +3,56 @@ use crate::enums::SignatureScheme;
 use crate::error::Error;
 use crate::key;
 use crate::limited_cache;
+use crate::msgs::persist;
 use crate::sign;
+use crate::NamedGroup;
+use crate::ServerName;
 
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 /// An implementer of `StoresClientSessions` which does nothing.
 pub struct NoClientSessionStorage {}
 
 impl client::StoresClientSessions for NoClientSessionStorage {
-    fn put(&self, _key: Vec<u8>, _value: Vec<u8>) -> bool {
-        false
+    fn put_kx_hint(&self, _: &ServerName, _: NamedGroup) {}
+
+    fn get_kx_hint(&self, _: &ServerName) -> Option<NamedGroup> {
+        None
     }
 
-    fn get(&self, _key: &[u8]) -> Option<Vec<u8>> {
+    fn put_tls12_session(&self, _: &ServerName, _: persist::Tls12ClientSessionValue) {}
+
+    fn get_tls12_session(&self, _: &ServerName) -> Option<persist::Tls12ClientSessionValue> {
         None
+    }
+
+    fn add_tls13_ticket(&self, _: &ServerName, _: persist::Tls13ClientSessionValue) {}
+
+    fn take_tls13_ticket(&self, _: &ServerName) -> Option<persist::Tls13ClientSessionValue> {
+        None
+    }
+}
+
+const MAX_TLS13_TICKETS_PER_SERVER: usize = 8;
+
+struct ServerData {
+    kx_hint: Option<NamedGroup>,
+
+    // Zero or one TLS1.2 sessions.
+    tls12: Option<persist::Tls12ClientSessionValue>,
+
+    // Up to MAX_TLS13_TICKETS_PER_SERVER TLS1.3 tickets, oldest first.
+    tls13: VecDeque<persist::Tls13ClientSessionValue>,
+}
+
+impl Default for ServerData {
+    fn default() -> Self {
+        Self {
+            kx_hint: None,
+            tls12: None,
+            tls13: VecDeque::with_capacity(MAX_TLS13_TICKETS_PER_SERVER),
+        }
     }
 }
 
@@ -24,35 +60,76 @@ impl client::StoresClientSessions for NoClientSessionStorage {
 /// in memory.  It enforces a limit on the number of entries
 /// to bound memory usage.
 pub struct ClientSessionMemoryCache {
-    cache: Mutex<limited_cache::LimitedCache<Vec<u8>, Vec<u8>>>,
+    servers: Mutex<limited_cache::LimitedCache<ServerName, ServerData>>,
 }
 
 impl ClientSessionMemoryCache {
     /// Make a new ClientSessionMemoryCache.  `size` is the
     /// maximum number of stored sessions.
     pub fn new(size: usize) -> Arc<Self> {
-        debug_assert!(size > 0);
+        let max_servers =
+            size.saturating_add(MAX_TLS13_TICKETS_PER_SERVER - 1) / MAX_TLS13_TICKETS_PER_SERVER;
         Arc::new(Self {
-            cache: Mutex::new(limited_cache::LimitedCache::new(size)),
+            servers: Mutex::new(limited_cache::LimitedCache::new(max_servers)),
         })
     }
 }
 
 impl client::StoresClientSessions for ClientSessionMemoryCache {
-    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
-        self.cache
+    fn put_kx_hint(&self, server_name: &ServerName, group: NamedGroup) {
+        self.servers
             .lock()
             .unwrap()
-            .insert(key, value);
-        true
+            .get_or_insert_default_and_edit(server_name.clone(), |data| data.kx_hint = Some(group));
     }
 
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.cache
+    fn get_kx_hint(&self, server_name: &ServerName) -> Option<NamedGroup> {
+        self.servers
             .lock()
             .unwrap()
-            .get(key)
-            .cloned()
+            .get(server_name)
+            .and_then(|sd| sd.kx_hint)
+    }
+
+    fn put_tls12_session(&self, server_name: &ServerName, value: persist::Tls12ClientSessionValue) {
+        self.servers
+            .lock()
+            .unwrap()
+            .get_or_insert_default_and_edit(server_name.clone(), |data| data.tls12 = Some(value));
+    }
+
+    fn get_tls12_session(
+        &self,
+        server_name: &ServerName,
+    ) -> Option<persist::Tls12ClientSessionValue> {
+        self.servers
+            .lock()
+            .unwrap()
+            .get(server_name)
+            .and_then(|sd| sd.tls12.as_ref().cloned())
+    }
+
+    fn add_tls13_ticket(&self, server_name: &ServerName, value: persist::Tls13ClientSessionValue) {
+        self.servers
+            .lock()
+            .unwrap()
+            .get_or_insert_default_and_edit(server_name.clone(), |data| {
+                if data.tls13.len() == data.tls13.capacity() {
+                    data.tls13.pop_front();
+                }
+                data.tls13.push_back(value);
+            })
+    }
+
+    fn take_tls13_ticket(
+        &self,
+        server_name: &ServerName,
+    ) -> Option<persist::Tls13ClientSessionValue> {
+        self.servers
+            .lock()
+            .unwrap()
+            .get_mut(server_name)
+            .and_then(|data| data.tls13.pop_front())
     }
 }
 
@@ -102,60 +179,57 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::client::StoresClientSessions;
+    use crate::client::ClientSessionStore;
+    use crate::internal::msgs::handshake::SessionID;
+    use std::convert::TryInto;
 
+    #[cfg(feature = "tls12")]
     #[test]
-    fn test_noclientsessionstorage_drops_put() {
+    fn test_noclientsessionstorage_does_nothing() {
         let c = NoClientSessionStorage {};
-        assert!(!c.put(vec![0x01], vec![0x02]));
-    }
+        let name = "example.com".try_into().unwrap();
+        let tls12_suite = match crate::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 {
+            crate::suites::SupportedCipherSuite::Tls12(inner) => inner,
+            _ => unreachable!(),
+        };
+        let tls13_suite = match crate::cipher_suite::TLS13_AES_256_GCM_SHA384 {
+            crate::suites::SupportedCipherSuite::Tls13(inner) => inner,
+            _ => unreachable!(),
+        };
+        let now = crate::ticketer::TimeBase::now().unwrap();
 
-    #[test]
-    fn test_noclientsessionstorage_denies_gets() {
-        let c = NoClientSessionStorage {};
-        c.put(vec![0x01], vec![0x02]);
-        assert_eq!(c.get(&[]), None);
-        assert_eq!(c.get(&[0x01]), None);
-        assert_eq!(c.get(&[0x02]), None);
-    }
+        c.set_kx_hint(&name, NamedGroup::X25519);
+        assert_eq!(None, c.kx_hint(&name));
 
-    #[test]
-    fn test_clientsessionmemorycache_accepts_put() {
-        let c = ClientSessionMemoryCache::new(4);
-        assert!(c.put(vec![0x01], vec![0x02]));
-    }
+        c.set_tls12_session(
+            &name,
+            persist::Tls12ClientSessionValue::new(
+                &tls12_suite,
+                SessionID::empty(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                now,
+                0,
+                true,
+            ),
+        );
+        assert!(c.tls12_session(&name).is_none());
+        c.remove_tls12_session(&name);
 
-    #[test]
-    fn test_clientsessionmemorycache_persists_put() {
-        let c = ClientSessionMemoryCache::new(4);
-        assert!(c.put(vec![0x01], vec![0x02]));
-        assert_eq!(c.get(&[0x01]), Some(vec![0x02]));
-        assert_eq!(c.get(&[0x01]), Some(vec![0x02]));
-    }
-
-    #[test]
-    fn test_clientsessionmemorycache_overwrites_put() {
-        let c = ClientSessionMemoryCache::new(4);
-        assert!(c.put(vec![0x01], vec![0x02]));
-        assert!(c.put(vec![0x01], vec![0x04]));
-        assert_eq!(c.get(&[0x01]), Some(vec![0x04]));
-    }
-
-    #[test]
-    fn test_clientsessionmemorycache_drops_to_maintain_size_invariant() {
-        let c = ClientSessionMemoryCache::new(2);
-        assert!(c.put(vec![0x01], vec![0x02]));
-        assert!(c.put(vec![0x03], vec![0x04]));
-        assert!(c.put(vec![0x05], vec![0x06]));
-        assert!(c.put(vec![0x07], vec![0x08]));
-        assert!(c.put(vec![0x09], vec![0x0a]));
-
-        let count = c.get(&[0x01]).iter().count()
-            + c.get(&[0x03]).iter().count()
-            + c.get(&[0x05]).iter().count()
-            + c.get(&[0x07]).iter().count()
-            + c.get(&[0x09]).iter().count();
-
-        assert!(count < 5);
+        c.insert_tls13_ticket(
+            &name,
+            persist::Tls13ClientSessionValue::new(
+                &tls13_suite,
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                now,
+                0,
+                0,
+                0,
+            ),
+        );
+        assert!(c.take_tls13_ticket(&name).is_none());
     }
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -48,10 +48,16 @@ fn find_session(
         .take_tls13_ticket(server_name)
         .map(persist::ClientSessionValue::from)
         .or_else(|| {
-            config
-                .session_storage
-                .get_tls12_session(server_name)
-                .map(persist::ClientSessionValue::from)
+            #[cfg(feature = "tls12")]
+            {
+                config
+                    .session_storage
+                    .get_tls12_session(server_name)
+                    .map(persist::ClientSessionValue::from)
+            }
+
+            #[cfg(not(feature = "tls12"))]
+            None
         })
         .and_then(|resuming| {
             let retrieved = persist::Retrieved::new(resuming, TimeBase::now().ok()?);

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -52,7 +52,7 @@ fn find_session(
             {
                 config
                     .session_storage
-                    .get_tls12_session(server_name)
+                    .tls12_session(server_name)
                     .map(persist::ClientSessionValue::from)
             }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -9,8 +9,6 @@ use crate::kx;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
-#[cfg(feature = "quic")]
-use crate::msgs::base::PayloadU16;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, Compression, ContentType};
 use crate::msgs::enums::{ECPointFormat, PSKKeyExchangeMode};
@@ -73,8 +71,9 @@ fn find_session(
         .and_then(|resuming| {
             #[cfg(feature = "quic")]
             if cx.common.is_quic() {
-                let params = PayloadU16::read(&mut reader)?;
-                cx.common.quic.params = Some(params.0);
+                cx.common.quic.params = resuming
+                    .tls13()
+                    .map(|v| v.quic_params());
             }
             Some(resuming)
         })

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -997,7 +997,7 @@ impl ExpectFinished {
             }
         };
 
-        let stored_value = persist::Tls12ClientSessionValue::new(
+        let session_value = persist::Tls12ClientSessionValue::new(
             self.secrets.suite(),
             self.session_id,
             ticket,
@@ -1013,7 +1013,7 @@ impl ExpectFinished {
 
         self.config
             .session_storage
-            .put_tls12_session(&self.server_name, stored_value);
+            .set_tls12_session(&self.server_name, session_value);
     }
 }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -997,8 +997,7 @@ impl ExpectFinished {
             }
         };
 
-        let key = persist::ClientSessionKey::session_for_server_name(&self.server_name);
-        let value = persist::Tls12ClientSessionValue::new(
+        let stored_value = persist::Tls12ClientSessionValue::new(
             self.secrets.suite(),
             self.session_id,
             ticket,
@@ -1012,16 +1011,9 @@ impl ExpectFinished {
             self.using_ems,
         );
 
-        let worked = self
-            .config
+        self.config
             .session_storage
-            .put(key.get_encoding(), value.get_encoding());
-
-        if worked {
-            debug!("Session saved");
-        } else {
-            debug!("Session not saved");
-        }
+            .put_tls12_session(&self.server_name, &stored_value);
     }
 }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1013,7 +1013,7 @@ impl ExpectFinished {
 
         self.config
             .session_storage
-            .put_tls12_session(&self.server_name, &stored_value);
+            .put_tls12_session(&self.server_name, stored_value);
     }
 }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -141,7 +141,7 @@ pub(super) fn handle_server_hello(
     // Remember what KX group the server liked for next time.
     config
         .session_storage
-        .put_kx_hint(&server_name, their_key_share.group);
+        .set_kx_hint(&server_name, their_key_share.group);
 
     // If we change keying when a subsequent handshake message is being joined,
     // the two halves will have different record layer protections.  Disallow this.
@@ -191,7 +191,7 @@ pub(super) fn initial_key_share(
 ) -> Result<kx::KeyExchange, Error> {
     let group = config
         .session_storage
-        .get_kx_hint(server_name)
+        .kx_hint(server_name)
         .and_then(|group| kx::KeyExchange::choose(group, &config.kx_groups))
         .unwrap_or_else(|| {
             config
@@ -876,7 +876,7 @@ impl State<ClientConnectionData> for ExpectFinished {
          * when connecting to it again, we definitely don't want to attempt a TLS1.2 resumption. */
         st.config
             .session_storage
-            .forget_tls12_session(&st.server_name);
+            .remove_tls12_session(&st.server_name);
 
         /* Now move to our application traffic keys. */
         cx.common.check_aligned_handshake()?;
@@ -976,7 +976,7 @@ impl ExpectTraffic {
         }
 
         self.session_storage
-            .add_tls13_ticket(&self.server_name, value);
+            .insert_tls13_ticket(&self.server_name, value);
         Ok(())
     }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -12,7 +12,6 @@ use crate::kx;
 use crate::log::{debug, trace, warn};
 use crate::msgs::base::{Payload, PayloadU8};
 use crate::msgs::ccs::ChangeCipherSpecPayload;
-use crate::msgs::codec::Codec;
 use crate::msgs::enums::AlertDescription;
 use crate::msgs::enums::KeyUpdateRequest;
 use crate::msgs::enums::{ContentType, ExtensionType, HandshakeType};
@@ -970,18 +969,8 @@ impl ExpectTraffic {
             }
         }
 
-        let key = persist::ClientSessionKey::session_for_server_name(&self.server_name);
-        let ticket = value.get_encoding();
-
-        let worked = self
-            .session_storage
-            .put(key.get_encoding(), ticket);
-
-        if worked {
-            debug!("Ticket saved");
-        } else {
-            debug!("Ticket not saved");
-        }
+        self.session_storage
+            .add_tls13_ticket(&self.server_name, &value);
         Ok(())
     }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -872,6 +872,12 @@ impl State<ClientConnectionData> for ExpectFinished {
 
         emit_finished_tls13(&mut st.transcript, verify_data, cx.common);
 
+        /* We're now sure this server supports TLS1.3.  But if we run out of TLS1.3 tickets
+         * when connecting to it again, we definitely don't want to attempt a TLS1.2 resumption. */
+        st.config
+            .session_storage
+            .forget_tls12_session(&st.server_name);
+
         /* Now move to our application traffic keys. */
         cx.common.check_aligned_handshake()?;
         let key_schedule_traffic = key_schedule_pre_finished.into_traffic(cx.common);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -38,7 +38,7 @@ use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;
 use crate::client::common::ServerCertDetails;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails};
-use crate::client::{hs, ClientConfig, ServerName, StoresClientSessions};
+use crate::client::{hs, ClientConfig, ClientSessionStore, ServerName};
 
 use crate::ticketer::TimeBase;
 use ring::constant_time;
@@ -908,7 +908,7 @@ impl State<ClientConnectionData> for ExpectFinished {
 // In this state we can be sent tickets, key updates,
 // and application data.
 struct ExpectTraffic {
-    session_storage: Arc<dyn StoresClientSessions>,
+    session_storage: Arc<dyn ClientSessionStore>,
     server_name: ServerName,
     suite: &'static Tls13CipherSuite,
     transcript: HandshakeHash,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -141,7 +141,7 @@ pub(super) fn handle_server_hello(
     // Remember what KX group the server liked for next time.
     config
         .session_storage
-        .put_kx_hint_for_server(&server_name, their_key_share.group);
+        .put_kx_hint(&server_name, their_key_share.group);
 
     // If we change keying when a subsequent handshake message is being joined,
     // the two halves will have different record layer protections.  Disallow this.
@@ -191,7 +191,7 @@ pub(super) fn initial_key_share(
 ) -> Result<kx::KeyExchange, Error> {
     let group = config
         .session_storage
-        .get_kx_hint_for_server(server_name)
+        .get_kx_hint(server_name)
         .and_then(|group| kx::KeyExchange::choose(group, &config.kx_groups))
         .unwrap_or_else(|| {
             config
@@ -970,7 +970,7 @@ impl ExpectTraffic {
         }
 
         self.session_storage
-            .add_tls13_ticket(&self.server_name, &value);
+            .add_tls13_ticket(&self.server_name, value);
         Ok(())
     }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -420,6 +420,8 @@ pub mod client {
     };
     #[cfg(feature = "dangerous_configuration")]
     pub use client_conn::danger::DangerousClientConfig;
+
+    pub use crate::msgs::persist::{Tls12ClientSessionValue, Tls13ClientSessionValue};
 }
 
 pub use client::{ClientConfig, ClientConnection, ServerName};

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -406,10 +406,10 @@ pub mod client {
     pub use builder::{WantsClientCert, WantsTransparencyPolicyOrClientCert};
     #[cfg(feature = "quic")]
     pub use client_conn::ClientQuicExt;
+    pub use client_conn::ClientSessionStore;
     pub use client_conn::InvalidDnsNameError;
     pub use client_conn::ResolvesClientCert;
     pub use client_conn::ServerName;
-    pub use client_conn::StoresClientSessions;
     pub use client_conn::{ClientConfig, ClientConnection, ClientConnectionData, WriteEarlyData};
     pub use handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -421,7 +421,9 @@ pub mod client {
     #[cfg(feature = "dangerous_configuration")]
     pub use client_conn::danger::DangerousClientConfig;
 
-    pub use crate::msgs::persist::{Tls12ClientSessionValue, Tls13ClientSessionValue};
+    #[cfg(feature = "tls12")]
+    pub use crate::msgs::persist::Tls12ClientSessionValue;
+    pub use crate::msgs::persist::Tls13ClientSessionValue;
 }
 
 pub use client::{ClientConfig, ClientConnection, ServerName};

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -161,6 +161,8 @@ pub struct Tls13ClientSessionValue {
     age_add: u32,
     max_early_data_size: u32,
     pub common: ClientSessionCommon,
+    #[cfg(feature = "quic")]
+    quic_params: PayloadU16,
 }
 
 impl Tls13ClientSessionValue {
@@ -185,6 +187,8 @@ impl Tls13ClientSessionValue {
                 lifetime_secs,
                 server_cert_chain,
             ),
+            #[cfg(feature = "quic")]
+            quic_params: PayloadU16(Vec::new()),
         }
     }
 
@@ -198,6 +202,8 @@ impl Tls13ClientSessionValue {
             age_add: u32::read(r)?,
             max_early_data_size: u32::read(r)?,
             common: ClientSessionCommon::read(r)?,
+            #[cfg(feature = "quic")]
+            quic_params: PayloadU16::read(r)?,
         })
     }
 
@@ -214,6 +220,8 @@ impl Tls13ClientSessionValue {
         self.max_early_data_size
             .encode(&mut bytes);
         self.common.encode(&mut bytes);
+        #[cfg(feature = "quic")]
+        self.quic_params.encode(&mut bytes);
         bytes
     }
 
@@ -223,6 +231,16 @@ impl Tls13ClientSessionValue {
 
     pub fn suite(&self) -> &'static Tls13CipherSuite {
         self.suite
+    }
+
+    #[cfg(feature = "quic")]
+    pub fn set_quic_params(&mut self, quic_params: &[u8]) {
+        self.quic_params = PayloadU16(quic_params.to_vec());
+    }
+
+    #[cfg(feature = "quic")]
+    pub fn quic_params(&self) -> Vec<u8> {
+        self.quic_params.0.clone()
     }
 }
 

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -7,20 +7,6 @@ use crate::ticketer::TimeBase;
 use crate::tls13::TLS13_AES_128_GCM_SHA256;
 
 #[test]
-fn clientsessionkey_is_debug() {
-    let name = "hello".try_into().unwrap();
-    let csk = ClientSessionKey::session_for_server_name(&name);
-    println!("{:?}", csk);
-}
-
-#[test]
-fn clientsessionkey_cannot_be_read() {
-    let bytes = [0; 1];
-    let mut rd = Reader::init(&bytes);
-    assert!(ClientSessionKey::read(&mut rd).is_none());
-}
-
-#[test]
 fn clientsessionvalue_is_debug() {
     let csv = ClientSessionValue::from(Tls13ClientSessionValue::new(
         TLS13_AES_128_GCM_SHA256

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -111,6 +111,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             enable_secret_extraction: false,
             max_early_data_size: 0,
             send_half_rtt_data: false,
+            send_tls13_tickets: 4,
         }
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -242,7 +242,7 @@ pub(super) struct ExpectClientHello {
     #[cfg(feature = "tls12")]
     pub(super) using_ems: bool,
     pub(super) done_retry: bool,
-    pub(super) send_ticket: bool,
+    pub(super) send_tickets: usize,
 }
 
 impl ExpectClientHello {
@@ -262,7 +262,7 @@ impl ExpectClientHello {
             #[cfg(feature = "tls12")]
             using_ems: false,
             done_retry: false,
-            send_ticket: false,
+            send_tickets: 0,
         }
     }
 
@@ -404,7 +404,7 @@ impl ExpectClientHello {
                 suite,
                 randoms,
                 done_retry: self.done_retry,
-                send_ticket: self.send_ticket,
+                send_tickets: self.send_tickets,
                 extra_exts: self.extra_exts,
             }
             .handle_client_hello(cx, certkey, m, client_hello, sig_schemes),
@@ -416,7 +416,7 @@ impl ExpectClientHello {
                 suite,
                 using_ems: self.using_ems,
                 randoms,
-                send_ticket: self.send_ticket,
+                send_ticket: self.send_tickets > 0,
                 extra_exts: self.extra_exts,
             }
             .handle_client_hello(

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -197,6 +197,7 @@ impl<'a> ClientHello<'a> {
 /// * [`ServerConfig::session_storage`]: the default stores 256 sessions in memory.
 /// * [`ServerConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ServerConfig::key_log`]: key material is not logged.
+/// * [`ServerConfig::send_tls13_tickets`]: 4 tickets are sent.
 #[derive(Clone)]
 pub struct ServerConfig {
     /// List of ciphersuites, in preference order.
@@ -284,6 +285,18 @@ pub struct ServerConfig {
     /// sent by the server comes after receiving and validating the client's
     /// handshake up to the `Finished` message.  This is the safest option.
     pub send_half_rtt_data: bool,
+
+    /// How many TLS1.3 tickets to send immediately after a successful
+    /// handshake.
+    ///
+    /// Because TLS1.3 tickets are single-use, this allows
+    /// a client to perform multiple resumptions.
+    ///
+    /// The default is 4.
+    ///
+    /// If this is 0, no tickets are sent and clients will not be able to
+    /// do any resumption.
+    pub send_tls13_tickets: usize,
 }
 
 impl fmt::Debug for ServerConfig {
@@ -294,6 +307,7 @@ impl fmt::Debug for ServerConfig {
             .field("alpn_protocols", &self.alpn_protocols)
             .field("max_early_data_size", &self.max_early_data_size)
             .field("send_half_rtt_data", &self.send_half_rtt_data)
+            .field("send_tls13_tickets", &self.send_tls13_tickets)
             .finish_non_exhaustive()
     }
 }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -79,7 +79,7 @@ mod client_hello {
         pub(in crate::server) suite: &'static Tls13CipherSuite,
         pub(in crate::server) randoms: ConnectionRandoms,
         pub(in crate::server) done_retry: bool,
-        pub(in crate::server) send_ticket: bool,
+        pub(in crate::server) send_tickets: usize,
         pub(in crate::server) extra_exts: Vec<ServerExtension>,
     }
 
@@ -235,7 +235,7 @@ mod client_hello {
                             #[cfg(feature = "tls12")]
                             using_ems: false,
                             done_retry: true,
-                            send_ticket: self.send_ticket,
+                            send_tickets: self.send_tickets,
                             extra_exts: self.extra_exts,
                         });
 
@@ -312,11 +312,11 @@ mod client_hello {
 
             if !client_hello.psk_mode_offered(PSKKeyExchangeMode::PSK_DHE_KE) {
                 debug!("Client unwilling to resume, DHE_KE not offered");
-                self.send_ticket = false;
+                self.send_tickets = 0;
                 chosen_psk_index = None;
                 resumedata = None;
             } else {
-                self.send_ticket = true;
+                self.send_tickets = self.config.send_tls13_tickets;
             }
 
             if let Some(ref resume) = resumedata {
@@ -422,7 +422,7 @@ mod client_hello {
                     transcript: self.transcript,
                     suite: self.suite,
                     key_schedule: key_schedule_traffic,
-                    send_ticket: self.send_ticket,
+                    send_tickets: self.send_tickets,
                 }))
             } else if doing_early_data == EarlyDataDecision::Accepted && !cx.common.is_quic() {
                 // Not used for QUIC: RFC 9001 §8.3: Clients MUST NOT send the EndOfEarlyData
@@ -433,7 +433,7 @@ mod client_hello {
                     transcript: self.transcript,
                     suite: self.suite,
                     key_schedule: key_schedule_traffic,
-                    send_ticket: self.send_ticket,
+                    send_tickets: self.send_tickets,
                 }))
             } else {
                 Ok(Box::new(ExpectFinished {
@@ -441,7 +441,7 @@ mod client_hello {
                     transcript: self.transcript,
                     suite: self.suite,
                     key_schedule: key_schedule_traffic,
-                    send_ticket: self.send_ticket,
+                    send_tickets: self.send_tickets,
                 }))
             }
         }
@@ -866,7 +866,7 @@ struct ExpectCertificate {
     transcript: HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
-    send_ticket: bool,
+    send_tickets: usize,
 }
 
 impl State<ServerConnectionData> for ExpectCertificate {
@@ -907,7 +907,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
                         suite: self.suite,
                         key_schedule: self.key_schedule,
                         transcript: self.transcript,
-                        send_ticket: self.send_ticket,
+                        send_tickets: self.send_tickets,
                     }));
                 }
 
@@ -934,7 +934,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
             transcript: self.transcript,
             key_schedule: self.key_schedule,
             client_cert,
-            send_ticket: self.send_ticket,
+            send_tickets: self.send_tickets,
         }))
     }
 }
@@ -945,7 +945,7 @@ struct ExpectCertificateVerify {
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
     client_cert: Vec<Certificate>,
-    send_ticket: bool,
+    send_tickets: usize,
 }
 
 impl State<ServerConnectionData> for ExpectCertificateVerify {
@@ -981,7 +981,7 @@ impl State<ServerConnectionData> for ExpectCertificateVerify {
             suite: self.suite,
             key_schedule: self.key_schedule,
             transcript: self.transcript,
-            send_ticket: self.send_ticket,
+            send_tickets: self.send_tickets,
         }))
     }
 }
@@ -994,7 +994,7 @@ struct ExpectEarlyData {
     transcript: HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
-    send_ticket: bool,
+    send_tickets: usize,
 }
 
 impl State<ServerConnectionData> for ExpectEarlyData {
@@ -1030,7 +1030,7 @@ impl State<ServerConnectionData> for ExpectEarlyData {
                     suite: self.suite,
                     key_schedule: self.key_schedule,
                     transcript: self.transcript,
-                    send_ticket: self.send_ticket,
+                    send_tickets: self.send_tickets,
                 }))
             }
             payload => Err(inappropriate_handshake_message(
@@ -1044,7 +1044,7 @@ impl State<ServerConnectionData> for ExpectEarlyData {
 
 // --- Process client's Finished ---
 fn get_server_session_value(
-    transcript: &mut HandshakeHash,
+    transcript: &HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: &KeyScheduleTraffic,
     cx: &ServerContext<'_>,
@@ -1076,12 +1076,12 @@ struct ExpectFinished {
     transcript: HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
-    send_ticket: bool,
+    send_tickets: usize,
 }
 
 impl ExpectFinished {
     fn emit_ticket(
-        transcript: &mut HandshakeHash,
+        transcript: &HandshakeHash,
         suite: &'static Tls13CipherSuite,
         cx: &mut ServerContext<'_>,
         key_schedule: &KeyScheduleTraffic,
@@ -1139,7 +1139,6 @@ impl ExpectFinished {
         };
 
         trace!("sending new ticket {:?} (stateless: {})", m, stateless);
-        transcript.add_message(&m);
         cx.common.send_msg(m, true);
         Ok(())
     }
@@ -1169,9 +1168,10 @@ impl State<ServerConnectionData> for ExpectFinished {
         self.transcript.add_message(&m);
 
         cx.common.check_aligned_handshake()?;
-        if self.send_ticket {
+
+        for _ in 0..self.send_tickets {
             Self::emit_ticket(
-                &mut self.transcript,
+                &self.transcript,
                 self.suite,
                 cx,
                 &key_schedule_traffic,

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2718,6 +2718,7 @@ impl rustls::client::StoresClientSessions for ClientStorage {
         rc
     }
 
+    #[cfg(feature = "tls12")]
     fn put_tls12_session(
         &self,
         server_name: &rustls::ServerName,
@@ -2731,6 +2732,7 @@ impl rustls::client::StoresClientSessions for ClientStorage {
             .put_tls12_session(server_name, value)
     }
 
+    #[cfg(feature = "tls12")]
     fn get_tls12_session(
         &self,
         server_name: &rustls::ServerName,
@@ -2748,6 +2750,7 @@ impl rustls::client::StoresClientSessions for ClientStorage {
         rc
     }
 
+    #[cfg(feature = "tls12")]
     fn forget_tls12_session(&self, server_name: &rustls::ServerName) {
         self.ops
             .lock()
@@ -3726,6 +3729,7 @@ fn test_client_config_keyshare_mismatch() {
     assert!(do_handshake_until_error(&mut client, &mut server).is_err());
 }
 
+#[cfg(feature = "tls12")]
 #[test]
 fn test_client_sends_helloretryrequest() {
     // client sends a secp384r1 key share

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2676,7 +2676,7 @@ enum ClientStorageOp {
 }
 
 struct ClientStorage {
-    storage: Arc<dyn rustls::client::StoresClientSessions>,
+    storage: Arc<dyn rustls::client::ClientSessionStore>,
     ops: Mutex<Vec<ClientStorageOp>>,
 }
 
@@ -2699,7 +2699,7 @@ impl fmt::Debug for ClientStorage {
     }
 }
 
-impl rustls::client::StoresClientSessions for ClientStorage {
+impl rustls::client::ClientSessionStore for ClientStorage {
     fn put_kx_hint(&self, server_name: &rustls::ServerName, group: rustls::NamedGroup) {
         self.ops
             .lock()

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3705,8 +3705,8 @@ fn test_client_sends_helloretryrequest() {
 
     do_handshake_until_error(&mut client, &mut server).unwrap();
 
-    // client only did two storage queries: one for a session, another for a kx type
-    assert_eq!(storage.gets(), 2);
+    // client only did three storage queries: two for sessions, another for a kx type
+    assert_eq!(storage.gets(), 3);
     assert_eq!(storage.puts(), 2);
 }
 
@@ -4026,7 +4026,7 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
         ClientConnection::new(client_config, "localhost".try_into().unwrap()).unwrap();
     let mut server_2 = ServerConnection::new(Arc::new(server_config_2)).unwrap();
     common::do_handshake(&mut client_2, &mut server_2);
-    assert_eq!(client_storage.puts(), 2);
+    assert_eq!(client_storage.puts(), 3);
 }
 
 #[test]


### PR DESCRIPTION
This is for #466 

Todo:
- [x] review coverage
- [x] reinstate unit tests in client/handy.rs
- [x] add tests for overall TLS1.3 repeated resumption behaviour