### PR TITLE
Move benchmarks to benches directory

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -54,7 +54,7 @@ path = "examples/internal/bench.rs"
 
 [[bench]]
 name = "benchmarks"
-path = "tests/benchmarks.rs"
+path = "benches/benchmarks.rs"
 harness = false
 
 [package.metadata.docs.rs]

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -4,9 +4,9 @@ use criterion::criterion_main;
 /// performance go in examples/internal/bench.rs.
 use criterion::Criterion;
 
-#[allow(dead_code)]
-mod common;
-use crate::common::*;
+#[path = "../tests/common/mod.rs"]
+mod test_utils;
+use test_utils::*;
 
 use rustls::ServerConnection;
 


### PR DESCRIPTION
Hi! Here's a PR that fixes #694.

Previously, benchmarks were being built both as a test and as the benchmark target. By moving them out of the tests directory, we resolve this warning.

## Alternative approaches:
* split `rustls/rustls/tests/common/mod.rs` out into its own shared crate. This might be slightly preferred, but seems relatively high ceremony for a single test utility file.
* use a relative symlink to include that file in `rustls/rustls/benches`. I confirmed that this does resolve the warning, but it seems worse than the other two approaches