### PR TITLE
Fixing TLS version typo 1_2 -> 1_3

### DIFF
--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -181,7 +181,7 @@ impl MessageEncrypter for Tls13MessageEncrypter {
 
         Ok(OpaqueMessage {
             typ: ContentType::ApplicationData,
-            version: ProtocolVersion::TLSv1_2,
+            version: ProtocolVersion::TLSv1_3,
             payload: Payload::new(payload),
         })
     }


### PR DESCRIPTION
I do not understand enough of the code to be absolutely sure, but this looks an awful lot like a typo to me. If it is, it would be nice to have some test that would have detected it earlier. If it aint it would be really nice to have a comment at this line explaining the choice.
Thanks a lot for your time, to whoever is reading this! :)