### PR TITLE
TLS 1.3: Immediately update keys when requested

### DIFF
--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -2,7 +2,6 @@ use crate::cipher::{Iv, IvLen, MessageDecrypter};
 use crate::conn::{CommonState, Side};
 use crate::error::Error;
 use crate::msgs::base::PayloadU8;
-use crate::msgs::message::Message;
 #[cfg(feature = "quic")]
 use crate::quic;
 #[cfg(feature = "secret_extraction")]
@@ -464,7 +463,7 @@ impl KeyScheduleTraffic {
 
     pub(crate) fn update_encrypter_and_notify(&mut self, common: &mut CommonState) {
         let secret = self.next_application_traffic_secret(common.side);
-        common.send_msg_encrypt(Message::build_key_update_notify().into());
+        common.enqueue_key_update_notification();
         self.ks.set_encrypter(&secret, common);
     }
 


### PR DESCRIPTION
Hopefully will close #938 after expected review iterations.

Notes:

* Is the existing behavior tested anywhere? I couldn't figure out how to get a failing test
* I attempted to follow the suggested approach closely, but opted for an `Option<Vec<u8>>` instead of a possibly-zero-length `Vec<u8>`
* I was not at all sure if `common.sendable_tls.append(message)` is the appropriate way to send a pre-encrypted message, but it seemed like a reasonable choice.

Still outstanding, but possible candidates for subsequent PR:
* Dropping write key when a close_notify or error is sent
* Dropping read key when close_notify is received