### PR TITLE
update github actions msrv to 1.57 so that base64 will build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.56 # MSRV
+          - 1.57 # MSRV
         os: [ubuntu-20.04]
         # but only stable on macos/windows (slower platforms)
         include:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
     Both a full deframer buffer and a full incoming plaintext buffer will
     now cause an error to be returned. Callers should call `process_new_packets()`
     and read out the `writer()` after each successful call to `read_tls()`.
+  - The minimum supported Rust version is now 1.57.0 due to some dependencies
+    requiring it.
 * 0.20.7 (2022-10-18)
   - Expose secret extraction API under the `secret_extraction` cargo feature.
     This is designed to enable switching from rustls to kTLS (kernel TLS

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls"
 version = "0.20.7"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 license = "Apache-2.0/ISC/MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."


### PR DESCRIPTION
#1148 made CI red on main. This is the minimum change from #1140 that is required to make CI green