### PR TITLE
move `doc(cfg(feature = …))` to original definitions

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -320,6 +320,7 @@ pub(super) mod danger {
 
     /// Accessor for dangerous configuration options.
     #[derive(Debug)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
     pub struct DangerousClientConfig<'a> {
         /// The underlying ClientConfig
         pub cfg: &'a mut ClientConfig,
@@ -636,6 +637,7 @@ impl quic::QuicExt for ClientConnection {
 
 /// Methods specific to QUIC client sessions
 #[cfg(feature = "quic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "quic")))]
 pub trait ClientQuicExt {
     /// Make a new QUIC ClientConnection. This differs from `ClientConnection::new()`
     /// in that it takes an extra argument, `params`, which contains the

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -402,7 +402,6 @@ pub mod client {
 
     pub use builder::{WantsClientCert, WantsTransparencyPolicyOrClientCert};
     #[cfg(feature = "quic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "quic")))]
     pub use client_conn::ClientQuicExt;
     pub use client_conn::InvalidDnsNameError;
     pub use client_conn::ResolvesClientCert;
@@ -412,13 +411,11 @@ pub mod client {
     pub use handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 
     #[cfg(feature = "dangerous_configuration")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
     pub use crate::verify::{
         CertificateTransparencyPolicy, HandshakeSignatureValid, ServerCertVerified,
         ServerCertVerifier, WebPkiVerifier,
     };
     #[cfg(feature = "dangerous_configuration")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
     pub use client_conn::danger::DangerousClientConfig;
 }
 
@@ -442,7 +439,6 @@ pub mod server {
     pub use handy::ResolvesServerCertUsingSni;
     pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
     #[cfg(feature = "quic")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "quic")))]
     pub use server_conn::ServerQuicExt;
     pub use server_conn::StoresServerSessions;
     pub use server_conn::{
@@ -451,7 +447,6 @@ pub mod server {
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
 
     #[cfg(feature = "dangerous_configuration")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
     pub use crate::verify::{ClientCertVerified, ClientCertVerifier, DnsName};
 }
 
@@ -515,7 +510,6 @@ pub mod manual;
 pub type ResolvesServerCertUsingSNI = server::ResolvesServerCertUsingSni;
 #[allow(clippy::upper_case_acronyms)]
 #[cfg(feature = "dangerous_configuration")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 #[doc(hidden)]
 #[deprecated(since = "0.20.0", note = "Use client::WebPkiVerifier")]
 pub type WebPKIVerifier = client::WebPkiVerifier;

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -813,6 +813,7 @@ impl quic::QuicExt for ServerConnection {
 
 /// Methods specific to QUIC server sessions
 #[cfg(feature = "quic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "quic")))]
 pub trait ServerQuicExt {
     /// Make a new QUIC ServerConnection. This differs from `ServerConnection::new()`
     /// in that it takes an extra argument, `params`, which contains the

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -46,6 +46,7 @@ static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[
 
 /// Zero-sized marker type representing verification of a signature.
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct HandshakeSignatureValid(());
 
 impl HandshakeSignatureValid {
@@ -67,6 +68,7 @@ impl FinishedMessageVerified {
 /// Zero-sized marker type representing verification of a server cert chain.
 #[allow(unreachable_pub)]
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct ServerCertVerified(());
 
 #[allow(unreachable_pub)]
@@ -79,6 +81,7 @@ impl ServerCertVerified {
 
 /// Zero-sized marker type representing verification of a client cert chain.
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct ClientCertVerified(());
 
 impl ClientCertVerified {
@@ -91,6 +94,7 @@ impl ClientCertVerified {
 /// Something that can verify a server certificate chain, and verify
 /// signatures made by certificates.
 #[allow(unreachable_pub)]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub trait ServerCertVerifier: Send + Sync {
     /// Verify the end-entity certificate `end_entity` is valid for the
     /// hostname `dns_name` and chains to at least one trust anchor.
@@ -200,6 +204,7 @@ impl fmt::Debug for dyn ServerCertVerifier {
 
 /// A type which encapsulates a string that is a syntactically valid DNS name.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct DnsName(pub(crate) webpki::DnsName);
 
 impl AsRef<str> for DnsName {
@@ -210,6 +215,7 @@ impl AsRef<str> for DnsName {
 
 /// Something that can verify a client certificate chain
 #[allow(unreachable_pub)]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub trait ClientCertVerifier: Send + Sync {
     /// Returns `true` to enable the server to request a client certificate and
     /// `false` to skip requesting a client certificate. Defaults to `true`.
@@ -373,6 +379,7 @@ impl ServerCertVerifier for WebPkiVerifier {
 
 /// Default `ServerCertVerifier`, see the trait impl for more information.
 #[allow(unreachable_pub)]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct WebPkiVerifier {
     roots: RootCertStore,
     ct_policy: Option<CertificateTransparencyPolicy>,
@@ -416,6 +423,7 @@ impl WebPkiVerifier {
 /// certificates will no longer be validated, and a warning message will be logged. The deadline
 /// may vary depending on how often you deploy builds with updated dependencies.
 #[allow(unreachable_pub)]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct CertificateTransparencyPolicy {
     logs: &'static [&'static sct::Log<'static>],
     validation_deadline: SystemTime,


### PR DESCRIPTION
it seems like reexports don't pick those annotations up. closes #1155 