### PR TITLE
Reworked export_keying_material interface to be safer for the end user

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -730,22 +730,39 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
         }
 
         if !sess.is_handshaking() && opts.export_keying_material > 0 && !sent_exporter {
-            let mut export = Vec::new();
-            export.resize(opts.export_keying_material, 0u8);
-            sess.export_keying_material(
-                &mut export,
-                opts.export_keying_material_label
-                    .as_bytes(),
-                if opts.export_keying_material_context_used {
-                    Some(
-                        opts.export_keying_material_context
+            let export = match opts.export_keying_material {
+                1 => sess
+                    .export_keying_material::<1>(
+                        opts.export_keying_material_label
                             .as_bytes(),
+                        if opts.export_keying_material_context_used {
+                            Some(
+                                opts.export_keying_material_context
+                                    .as_bytes(),
+                            )
+                        } else {
+                            None
+                        },
                     )
-                } else {
-                    None
-                },
-            )
-            .unwrap();
+                    .unwrap()
+                    .to_vec(),
+                1024 => sess
+                    .export_keying_material::<1024>(
+                        opts.export_keying_material_label
+                            .as_bytes(),
+                        if opts.export_keying_material_context_used {
+                            Some(
+                                opts.export_keying_material_context
+                                    .as_bytes(),
+                            )
+                        } else {
+                            None
+                        },
+                    )
+                    .unwrap()
+                    .to_vec(),
+                _ => panic!("Unsupported export length {}", opts.export_keying_material),
+            };
             sess.writer()
                 .write_all(&export)
                 .unwrap();

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2016,40 +2016,34 @@ fn sni_resolver_rejects_bad_certs() {
 }
 
 fn do_exporter_test(client_config: ClientConfig, server_config: ServerConfig) {
-    let mut client_secret = [0u8; 64];
-    let mut server_secret = [0u8; 64];
-
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
     assert_debug_eq(
-        client.export_keying_material(&mut client_secret, b"label", Some(b"context")),
+        client.export_keying_material::<64>(b"label", Some(b"context")),
         Err(Error::HandshakeNotComplete),
     );
     assert_debug_eq(
-        server.export_keying_material(&mut server_secret, b"label", Some(b"context")),
+        server.export_keying_material::<64>(b"label", Some(b"context")),
         Err(Error::HandshakeNotComplete),
     );
     do_handshake(&mut client, &mut server);
 
-    assert_debug_eq(
-        client.export_keying_material(&mut client_secret, b"label", Some(b"context")),
-        Ok(()),
-    );
-    assert_debug_eq(
-        server.export_keying_material(&mut server_secret, b"label", Some(b"context")),
-        Ok(()),
-    );
+    let client_secret = client
+        .export_keying_material::<64>(b"label", Some(b"context"))
+        .unwrap();
+    let server_secret = server
+        .export_keying_material::<64>(b"label", Some(b"context"))
+        .unwrap();
     assert_eq!(client_secret.to_vec(), server_secret.to_vec());
 
-    assert_debug_eq(
-        client.export_keying_material(&mut client_secret, b"label", None),
-        Ok(()),
-    );
+    let client_secret = client
+        .export_keying_material::<64>(b"label", None)
+        .unwrap();
     assert_ne!(client_secret.to_vec(), server_secret.to_vec());
-    assert_debug_eq(
-        server.export_keying_material(&mut server_secret, b"label", None),
-        Ok(()),
-    );
+
+    let server_secret = server
+        .export_keying_material::<64>(b"label", None)
+        .unwrap();
     assert_eq!(client_secret.to_vec(), server_secret.to_vec());
 }
 


### PR DESCRIPTION
This changes the export_keying_material in such that ownership of the key buffer can pass through the export_keying_material function. Doing this ensures that the key buffer is dropped on error and cannot accidentally be used when export_keying_material fails.

The disadvantage is that this requires the two exported variants of export_keying_material to be generic, incurring a small compile duration penalty.

Also note that this is an incompatible change to the public api of rustls.