### PR TITLE
TLS 1.3: update record layer directly from key schedule

### DIFF
--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1098,9 +1098,8 @@ impl State<ClientConnectionData> for ExpectTraffic {
     fn perhaps_write_key_update(&mut self, common: &mut CommonState) {
         if self.want_write_key_update {
             self.want_write_key_update = false;
-            common.send_msg_encrypt(Message::build_key_update_notify().into());
             self.key_schedule
-                .update_encrypter(common);
+                .update_encrypter_and_notify(common);
         }
     }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1,5 +1,7 @@
 use crate::check::inappropriate_handshake_message;
-use crate::conn::{CommonState, ConnectionRandoms, Side, State};
+#[cfg(feature = "secret_extraction")]
+use crate::conn::Side;
+use crate::conn::{CommonState, ConnectionRandoms, State};
 use crate::enums::{ProtocolVersion, SignatureScheme};
 use crate::error::Error;
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
@@ -1093,16 +1095,8 @@ impl ExpectTraffic {
         }
 
         // Update our read-side keys.
-        let new_read_key = self
-            .key_schedule
-            .next_application_traffic_secret(Side::Server);
-        common
-            .record_layer
-            .set_message_decrypter(
-                self.suite
-                    .derive_decrypter(&new_read_key),
-            );
-
+        self.key_schedule
+            .update_decrypter(common);
         Ok(())
     }
 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1155,13 +1155,8 @@ impl State<ClientConnectionData> for ExpectTraffic {
         if self.want_write_key_update {
             self.want_write_key_update = false;
             common.send_msg_encrypt(Message::build_key_update_notify().into());
-
-            let write_key = self
-                .key_schedule
-                .next_application_traffic_secret(Side::Client);
-            common
-                .record_layer
-                .set_message_encrypter(self.suite.derive_encrypter(&write_key));
+            self.key_schedule
+                .update_encrypter(common);
         }
     }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1461,6 +1461,15 @@ pub enum Side {
     Server,
 }
 
+impl Side {
+    pub(crate) fn peer(&self) -> Self {
+        match self {
+            Self::Client => Self::Server,
+            Self::Server => Self::Client,
+        }
+    }
+}
+
 /// Data specific to the peer's side (client or server).
 pub trait SideData {}
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -117,7 +117,7 @@ mod client_hello {
                 .transcript
                 .get_hash_given(&binder_plaintext);
 
-            let key_schedule = KeyScheduleEarly::new(suite.hkdf_algorithm, psk);
+            let key_schedule = KeyScheduleEarly::new(suite, psk);
             let real_binder =
                 key_schedule.resumption_psk_binder_key_and_sign_verify_data(&handshake_hash);
 
@@ -502,7 +502,7 @@ mod client_hello {
 
         // Start key schedule
         let (key_schedule_pre_handshake, early_data_client_key) = if let Some(psk) = resuming_psk {
-            let early_key_schedule = KeyScheduleEarly::new(suite.hkdf_algorithm, psk);
+            let early_key_schedule = KeyScheduleEarly::new(suite, psk);
             let client_early_traffic_secret = early_key_schedule.client_early_traffic_secret(
                 &client_hello_hash,
                 &*config.key_log,
@@ -514,7 +514,7 @@ mod client_hello {
                 Some(client_early_traffic_secret),
             )
         } else {
-            (KeySchedulePreHandshake::new(suite.hkdf_algorithm), None)
+            (KeySchedulePreHandshake::new(suite), None)
         };
 
         // Do key exchange
@@ -1365,7 +1365,7 @@ impl State<ServerConnectionData> for ExpectTraffic {
     #[cfg(feature = "secret_extraction")]
     fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
         self.key_schedule
-            .extract_secrets(self.suite.common.aead_algorithm, Side::Server)
+            .extract_secrets(Side::Server)
     }
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1352,13 +1352,8 @@ impl State<ServerConnectionData> for ExpectTraffic {
         if self.want_write_key_update {
             self.want_write_key_update = false;
             common.send_msg_encrypt(Message::build_key_update_notify().into());
-
-            let write_key = self
-                .key_schedule
-                .next_application_traffic_secret(Side::Server);
-            common
-                .record_layer
-                .set_message_encrypter(self.suite.derive_encrypter(&write_key));
+            self.key_schedule
+                .update_encrypter(common);
         }
     }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1,5 +1,7 @@
 use crate::check::inappropriate_handshake_message;
-use crate::conn::{CommonState, ConnectionRandoms, Side, State};
+#[cfg(feature = "secret_extraction")]
+use crate::conn::Side;
+use crate::conn::{CommonState, ConnectionRandoms, State};
 use crate::enums::ProtocolVersion;
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
@@ -1252,7 +1254,6 @@ impl State<ServerConnectionData> for ExpectFinished {
         }
 
         Ok(Box::new(ExpectTraffic {
-            suite: self.suite,
             key_schedule: key_schedule_traffic,
             want_write_key_update: false,
             _fin_verified: fin,
@@ -1262,7 +1263,6 @@ impl State<ServerConnectionData> for ExpectFinished {
 
 // --- Process traffic ---
 struct ExpectTraffic {
-    suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTraffic,
     want_write_key_update: bool,
     _fin_verified: verify::FinishedMessageVerified,
@@ -1298,16 +1298,8 @@ impl ExpectTraffic {
         }
 
         // Update our read-side keys.
-        let new_read_key = self
-            .key_schedule
-            .next_application_traffic_secret(Side::Client);
-        common
-            .record_layer
-            .set_message_decrypter(
-                self.suite
-                    .derive_decrypter(&new_read_key),
-            );
-
+        self.key_schedule
+            .update_decrypter(common);
         Ok(())
     }
 }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1019,7 +1019,7 @@ impl State<ServerConnectionData> for ExpectEarlyData {
                 ..
             } => {
                 self.key_schedule
-                    .update_decrypter(&mut cx.common);
+                    .update_decrypter(cx.common);
                 self.transcript.add_message(&m);
                 Ok(Box::new(ExpectFinished {
                     config: self.config,
@@ -1278,9 +1278,8 @@ impl State<ServerConnectionData> for ExpectTraffic {
     fn perhaps_write_key_update(&mut self, common: &mut CommonState) {
         if self.want_write_key_update {
             self.want_write_key_update = false;
-            common.send_msg_encrypt(Message::build_key_update_notify().into());
             self.key_schedule
-                .update_encrypter(common);
+                .update_encrypter_and_notify(common);
         }
     }
 

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -2,6 +2,7 @@ use crate::cipher::{Iv, IvLen, MessageDecrypter};
 use crate::conn::{CommonState, Side};
 use crate::error::Error;
 use crate::msgs::base::PayloadU8;
+use crate::msgs::message::Message;
 #[cfg(feature = "quic")]
 use crate::quic;
 #[cfg(feature = "secret_extraction")]
@@ -461,8 +462,9 @@ impl KeyScheduleTraffic {
         }
     }
 
-    pub(crate) fn update_encrypter(&mut self, common: &mut CommonState) {
+    pub(crate) fn update_encrypter_and_notify(&mut self, common: &mut CommonState) {
         let secret = self.next_application_traffic_secret(common.side);
+        common.send_msg_encrypt(Message::build_key_update_notify().into());
         self.ks.set_encrypter(&secret, common);
     }
 

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -1,5 +1,5 @@
 use crate::cipher::{Iv, IvLen};
-use crate::conn::Side;
+use crate::conn::{CommonState, Side};
 use crate::error::Error;
 use crate::msgs::base::PayloadU8;
 #[cfg(feature = "secret_extraction")]
@@ -296,6 +296,13 @@ impl KeyScheduleTraffic {
             current_server_traffic_secret,
             current_exporter_secret,
         }
+    }
+
+    pub(crate) fn update_encrypter(&mut self, common: &mut CommonState) {
+        let secret = self.next_application_traffic_secret(common.side);
+        common
+            .record_layer
+            .set_message_encrypter(self.ks.suite.derive_encrypter(&secret));
     }
 
     pub(crate) fn next_application_traffic_secret(&mut self, side: Side) -> hkdf::Prk {

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -305,6 +305,13 @@ impl KeyScheduleTraffic {
             .set_message_encrypter(self.ks.suite.derive_encrypter(&secret));
     }
 
+    pub(crate) fn update_decrypter(&mut self, common: &mut CommonState) {
+        let secret = self.next_application_traffic_secret(common.side.peer());
+        common
+            .record_layer
+            .set_message_decrypter(self.ks.suite.derive_decrypter(&secret));
+    }
+
     pub(crate) fn next_application_traffic_secret(&mut self, side: Side) -> hkdf::Prk {
         let current = match side {
             Side::Client => &mut self.current_client_traffic_secret,

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -8,12 +8,11 @@ use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
 use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 use crate::suites::{BulkAlgorithm, CipherSuiteCommon, SupportedCipherSuite};
 
-use ring::{aead, hkdf};
+use ring::aead;
 
 use std::fmt;
 
 pub(crate) mod key_schedule;
-use key_schedule::{derive_traffic_iv, derive_traffic_key};
 
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256
 pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
@@ -76,28 +75,6 @@ pub struct Tls13CipherSuite {
 }
 
 impl Tls13CipherSuite {
-    pub(crate) fn derive_encrypter(&self, secret: &hkdf::Prk) -> Box<dyn MessageEncrypter> {
-        let key = derive_traffic_key(secret, self.common.aead_algorithm);
-        let iv = derive_traffic_iv(secret);
-
-        Box::new(Tls13MessageEncrypter {
-            enc_key: aead::LessSafeKey::new(key),
-            iv,
-        })
-    }
-
-    /// Derive a `MessageDecrypter` object from the concerned TLS 1.3
-    /// cipher suite.
-    pub fn derive_decrypter(&self, secret: &hkdf::Prk) -> Box<dyn MessageDecrypter> {
-        let key = derive_traffic_key(secret, self.common.aead_algorithm);
-        let iv = derive_traffic_iv(secret);
-
-        Box::new(Tls13MessageDecrypter {
-            dec_key: aead::LessSafeKey::new(key),
-            iv,
-        })
-    }
-
     /// Which hash function to use with this suite.
     pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
         self.hkdf_algorithm


### PR DESCRIPTION
Lets key schedule types provide a higher-level API that handles the updating of record layer encrypters/decrypters, moving complexity from the handshake states into the key schedule. Prevents secrets from being passed around outside of the `key_schedule` module, and avoids several secret clones.

cc @jbr