### PR TITLE
Use Side enum in QUIC APIs (including public API)

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -13,7 +13,7 @@ use rustls::internal::msgs::persist;
 use rustls::quic::{self, ClientQuicExt, QuicExt, ServerQuicExt};
 use rustls::server::ClientHello;
 use rustls::{CipherSuite, ProtocolVersion};
-use rustls::{ClientConnection, Connection, ServerConnection};
+use rustls::{ClientConnection, Connection, ServerConnection, Side};
 
 use std::env;
 use std::fs;
@@ -36,7 +36,7 @@ macro_rules! println_err(
 #[derive(Debug)]
 struct Options {
     port: u16,
-    server: bool,
+    side: Side,
     max_fragment: Option<usize>,
     resumes: usize,
     verify_peer: bool,
@@ -83,7 +83,7 @@ impl Options {
     fn new() -> Self {
         Options {
             port: 0,
-            server: false,
+            side: Side::Client,
             max_fragment: None,
             resumes: 0,
             verify_peer: false,
@@ -694,7 +694,7 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
             }
         }
 
-        if opts.server && opts.enable_early_data {
+        if opts.side == Side::Server && opts.enable_early_data {
             if let Some(ref mut ed) = server(&mut sess).early_data() {
                 let mut data = Vec::new();
                 let data_len = ed
@@ -751,7 +751,11 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
             quench_writes = true;
         }
 
-        if opts.enable_early_data && !opts.server && !sess.is_handshaking() && count > 0 {
+        if opts.enable_early_data
+            && opts.side == Side::Client
+            && !sess.is_handshaking()
+            && count > 0
+        {
             if opts.expect_accept_early_data && !client(&mut sess).is_early_data_accepted() {
                 quit_err("Early data was not accepted, but we expect the opposite");
             } else if opts.expect_reject_early_data && client(&mut sess).is_early_data_accepted() {
@@ -841,7 +845,7 @@ fn main() {
                 opts.port = args.remove(0).parse::<u16>().unwrap();
             }
             "-server" => {
-                opts.server = true;
+                opts.side = Side::Server;
             }
             "-key-file" => {
                 opts.key_file = args.remove(0);
@@ -1131,15 +1135,9 @@ fn main() {
 
     println!("opts {:?}", opts);
 
-    let mut server_cfg = if opts.server {
-        Some(make_server_cfg(&opts))
-    } else {
-        None
-    };
-    let client_cfg = if !opts.server {
-        Some(make_client_cfg(&opts))
-    } else {
-        None
+    let (client_cfg, mut server_cfg) = match opts.side {
+        Side::Client => (Some(make_client_cfg(&opts)), None),
+        Side::Server => (None, Some(make_server_cfg(&opts))),
     };
 
     fn make_session(
@@ -1147,7 +1145,7 @@ fn main() {
         scfg: &Option<Arc<rustls::ServerConfig>>,
         ccfg: &Option<Arc<rustls::ClientConfig>>,
     ) -> Connection {
-        if opts.server {
+        if opts.side == Side::Server {
             let scfg = Arc::clone(scfg.as_ref().unwrap());
             let s = if opts.quic_transport_params.is_empty() {
                 rustls::ServerConnection::new(scfg).unwrap()

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -168,7 +168,12 @@ pub(super) fn handle_server_hello(
 
     #[cfg(feature = "quic")]
     if cx.common.is_quic() {
-        cx.common.quic.hs_secrets = Some(quic::Secrets::new(client_key, server_key, suite, true));
+        cx.common.quic.hs_secrets = Some(quic::Secrets::new(
+            client_key,
+            server_key,
+            suite,
+            cx.common.side,
+        ));
     }
 
     emit_fake_ccs(&mut sent_tls13_fake_ccs, cx.common);
@@ -953,8 +958,12 @@ impl State<ClientConnectionData> for ExpectFinished {
         #[cfg(feature = "quic")]
         {
             if cx.common.protocol == Protocol::Quic {
-                cx.common.quic.traffic_secrets =
-                    Some(quic::Secrets::new(client_key, server_key, st.suite, true));
+                cx.common.quic.traffic_secrets = Some(quic::Secrets::new(
+                    client_key,
+                    server_key,
+                    st.suite,
+                    cx.common.side,
+                ));
                 return Ok(Box::new(ExpectQuicTraffic(st)));
             }
         }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1452,9 +1452,12 @@ impl Quic {
     }
 }
 
+/// Side of the connection.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) enum Side {
+pub enum Side {
+    /// A client initiates the connection.
     Client,
+    /// A server waits for a client to connect.
     Server,
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -364,7 +364,7 @@ pub use crate::builder::{
     ConfigBuilder, ConfigSide, WantsCipherSuites, WantsKxGroups, WantsVerifier, WantsVersions,
 };
 pub use crate::conn::{
-    CommonState, Connection, ConnectionCommon, IoState, Reader, SideData, Writer,
+    CommonState, Connection, ConnectionCommon, IoState, Reader, Side, SideData, Writer,
 };
 pub use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 pub use crate::error::Error;

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -373,7 +373,7 @@ pub struct Keys {
 
 impl Keys {
     /// Construct keys for use with initial packets
-    pub fn initial(version: Version, client_dst_connection_id: &[u8], is_client: bool) -> Self {
+    pub fn initial(version: Version, client_dst_connection_id: &[u8], side: Side) -> Self {
         const CLIENT_LABEL: &[u8] = b"client in";
         const SERVER_LABEL: &[u8] = b"server in";
         let salt = version.initial_salt();
@@ -383,10 +383,7 @@ impl Keys {
             client: hkdf_expand(&hs_secret, hkdf::HKDF_SHA256, CLIENT_LABEL, &[]),
             server: hkdf_expand(&hs_secret, hkdf::HKDF_SHA256, SERVER_LABEL, &[]),
             suite: TLS13_AES_128_GCM_SHA256_INTERNAL,
-            side: match is_client {
-                true => Side::Client,
-                false => Side::Server,
-            },
+            side,
         };
         Self::new(&secrets)
     }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -547,8 +547,12 @@ mod client_hello {
             // If 0-RTT should be rejected, this will be clobbered by ExtensionProcessing
             // before the application can see.
             cx.common.quic.early_secret = early_data_client_key;
-            cx.common.quic.hs_secrets =
-                Some(quic::Secrets::new(_client_key, server_key, suite, false));
+            cx.common.quic.hs_secrets = Some(quic::Secrets::new(
+                _client_key,
+                server_key,
+                suite,
+                cx.common.side,
+            ));
         }
 
         Ok(key_schedule)
@@ -868,8 +872,12 @@ mod client_hello {
 
         #[cfg(feature = "quic")]
         {
-            cx.common.quic.traffic_secrets =
-                Some(quic::Secrets::new(_client_key, server_key, suite, false));
+            cx.common.quic.traffic_secrets = Some(quic::Secrets::new(
+                _client_key,
+                server_key,
+                suite,
+                cx.common.side,
+            ));
         }
 
         key_schedule_traffic

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3396,6 +3396,7 @@ mod test_quic {
     #[test]
     fn packet_key_api() {
         use rustls::quic::{Keys, Version};
+        use rustls::Side;
 
         // Test vectors: https://www.rfc-editor.org/rfc/rfc9001.html#name-client-initial
         const CONNECTION_ID: &[u8] = &[0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08];
@@ -3426,7 +3427,7 @@ mod test_quic {
             0x08, 0x06, 0x04, 0x80, 0x00, 0xff, 0xff,
         ];
 
-        let client_keys = Keys::initial(Version::V1, &CONNECTION_ID, true);
+        let client_keys = Keys::initial(Version::V1, &CONNECTION_ID, Side::Client);
         assert_eq!(
             client_keys
                 .local
@@ -3562,7 +3563,7 @@ mod test_quic {
         let (first, rest) = header.split_at_mut(1);
         let sample = &payload[..sample_len];
 
-        let server_keys = Keys::initial(Version::V1, &CONNECTION_ID, false);
+        let server_keys = Keys::initial(Version::V1, &CONNECTION_ID, Side::Server);
         server_keys
             .remote
             .header


### PR DESCRIPTION
While working on #1167, I got confused for a while after I missed a `false`/`true` difference. Now that we have the enum, might as well use it everywhere.