### PR TITLE
Improve error reporting for corrupt messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
   - The minimum supported Rust version is now 1.56.0 due to several dependencies
     requiring it.
 * 0.20.6 (2022-05-18)
-  - 0.20.5 included a change to track more context for the `Error::CorruptMessage`
+  - 0.20.5 included a change to track more context for the `Error::InvalidMessage`
     which made API-incompatible changes to the `Error` type. We yanked 0.20.5
     and have reverted that change as part of 0.20.6.
 * 0.20.5 (2022-05-14)

--- a/examples/tests/badssl.rs
+++ b/examples/tests/badssl.rs
@@ -101,7 +101,7 @@ mod online {
     fn too_many_sans() {
         connect("10000-sans.badssl.com")
             .fails()
-            .expect(r"TLS error: CorruptMessagePayload\(Handshake\)")
+            .expect(r"TLS error: InvalidMessage\(HandshakePayloadTooLarge\)")
             .go()
             .unwrap();
     }

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -9,6 +9,7 @@ use env_logger;
 use rustls;
 
 use rustls::internal::msgs::codec::Codec;
+use rustls::internal::msgs::enums::KeyUpdateRequest;
 use rustls::internal::msgs::persist;
 use rustls::quic::{self, ClientQuicExt, QuicExt, ServerQuicExt};
 use rustls::server::ClientHello;
@@ -592,7 +593,7 @@ fn quit_err(why: &str) -> ! {
 
 fn handle_err(err: rustls::Error) -> ! {
     use rustls::{AlertDescription, ContentType};
-    use rustls::{Error, PeerMisbehaved};
+    use rustls::{Error, InvalidMessage, PeerMisbehaved};
     use std::{thread, time};
 
     println!("TLS error: {:?}", err);
@@ -610,13 +611,22 @@ fn handle_err(err: rustls::Error) -> ! {
         Error::AlertReceived(AlertDescription::InternalError) => {
             quit(":PEER_ALERT_INTERNAL_ERROR:")
         }
-        Error::CorruptMessagePayload(ContentType::Alert) => quit(":BAD_ALERT:"),
-        Error::CorruptMessagePayload(ContentType::ChangeCipherSpec) => {
+        Error::InvalidMessage(InvalidMessage::MissingPayload(ContentType::Alert)) => {
+            quit(":BAD_ALERT:")
+        }
+        Error::InvalidMessage(InvalidMessage::MissingPayload(ContentType::ChangeCipherSpec)) => {
             quit(":BAD_CHANGE_CIPHER_SPEC:")
         }
-        Error::CorruptMessagePayload(ContentType::Handshake) => quit(":BAD_HANDSHAKE_MSG:"),
-        Error::CorruptMessagePayload(ContentType::Unknown(42)) => quit(":GARBAGE:"),
-        Error::CorruptMessage => quit(":GARBAGE:"),
+        Error::InvalidMessage(InvalidMessage::MissingPayload(ContentType::Handshake)) => {
+            quit(":BAD_HANDSHAKE_MSG:")
+        }
+        Error::InvalidMessage(InvalidMessage::InvalidKeyUpdate(KeyUpdateRequest::Unknown(42))) => {
+            quit(":BAD_HANDSHAKE_MSG:")
+        }
+        Error::InvalidMessage(InvalidMessage::InvalidCertRequest)
+        | Error::InvalidMessage(InvalidMessage::InvalidDhParams)
+        | Error::InvalidMessage(InvalidMessage::MissingKeyExchange) => quit(":BAD_HANDSHAKE_MSG:"),
+        Error::InvalidMessage(_) => quit(":GARBAGE:"),
         Error::DecryptError => quit(":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"),
         Error::PeerIncompatible(_) => quit(":INCOMPATIBLE:"),
         Error::PeerMisbehaved(PeerMisbehaved::TooMuchEarlyDataReceived) => {
@@ -764,7 +774,8 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
             let mut one_byte = [0u8];
             let mut cursor = io::Cursor::new(&mut one_byte[..]);
             sess.write_tls(&mut cursor).unwrap();
-            conn.write(&one_byte).expect("IO error");
+            conn.write_all(&one_byte)
+                .expect("IO error");
 
             quench_writes = true;
         }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,8 +1,9 @@
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::conn::{CommonState, ConnectionRandoms, Side, State};
 use crate::enums::ProtocolVersion;
-use crate::error::{Error, PeerMisbehaved};
+use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
+use crate::kx;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::{Payload, PayloadU8};
@@ -22,7 +23,7 @@ use crate::suites::PartiallyExtractedSecrets;
 use crate::suites::SupportedCipherSuite;
 use crate::ticketer::TimeBase;
 use crate::tls12::{self, ConnectionSecrets, Tls12CipherSuite};
-use crate::{kx, verify};
+use crate::verify;
 
 use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;
@@ -405,7 +406,7 @@ impl State<ClientConnectionData> for ExpectServerKx {
             .ok_or_else(|| {
                 cx.common
                     .send_fatal_alert(AlertDescription::DecodeError);
-                Error::CorruptMessagePayload(ContentType::Handshake)
+                InvalidMessage::MissingKeyExchange
             })?;
 
         // Save the signature and signed parameters for later verification.

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -5,7 +5,7 @@ use crate::conn::Protocol;
 use crate::conn::Side;
 use crate::conn::{CommonState, ConnectionRandoms, State};
 use crate::enums::{ProtocolVersion, SignatureScheme};
-use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
+use crate::error::{Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
 use crate::kx;
 #[cfg(feature = "logging")]
@@ -522,7 +522,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             warn!("Server sent non-empty certreq context");
             cx.common
                 .send_fatal_alert(AlertDescription::DecodeError);
-            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
+            return Err(InvalidMessage::InvalidCertRequest.into());
         }
 
         let tls13_sign_schemes = sign::supported_sign_tls13();
@@ -588,7 +588,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
             warn!("certificate with non-empty context during handshake");
             cx.common
                 .send_fatal_alert(AlertDescription::DecodeError);
-            return Err(Error::CorruptMessagePayload(ContentType::Handshake));
+            return Err(InvalidMessage::InvalidCertRequest.into());
         }
 
         if cert_chain.any_entry_has_duplicate_extension()

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -371,7 +371,7 @@ pub use crate::conn::{
     CommonState, Connection, ConnectionCommon, IoState, Reader, Side, SideData, Writer,
 };
 pub use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
-pub use crate::error::{CertificateError, Error, PeerIncompatible, PeerMisbehaved};
+pub use crate::error::{CertificateError, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -16,10 +16,10 @@ use crate::{InvalidMessage, ProtocolVersion};
 /// QUIC connections will call `push()` to append handshake payload data directly.
 #[derive(Default)]
 pub struct MessageDeframer {
-    /// Set to true if the peer is not talking TLS, but some other
+    /// Set if the peer is not talking TLS, but some other
     /// protocol.  The caller should abort the connection, because
     /// the deframer cannot recover.
-    desynced: bool,
+    last_error: Option<Error>,
 
     /// Buffer of data read from the socket, in the process of being parsed into messages.
     ///
@@ -40,8 +40,8 @@ impl MessageDeframer {
     /// failed, `Ok(None)` if no full message is buffered or if trial decryption failed, and
     /// `Ok(Some(_))` if a valid message was found and decrypted successfully.
     pub fn pop(&mut self, record_layer: &mut RecordLayer) -> Result<Option<Deframed>, Error> {
-        if self.desynced {
-            return Err(InvalidMessage::IncorrectFrame.into());
+        if let Some(last_err) = self.last_error.clone() {
+            return Err(last_err);
         } else if self.used == 0 {
             return Ok(None);
         }
@@ -75,17 +75,15 @@ impl MessageDeframer {
                         MessageError::TooShortForHeader | MessageError::TooShortForLength => {
                             return Ok(None)
                         }
-                        MessageError::EmptyDataForDisallowedRecord => {
-                            InvalidMessage::InvalidEmptyPayload
-                        }
+                        MessageError::InvalidEmptyPayload => InvalidMessage::InvalidEmptyPayload,
                         MessageError::MessageTooLarge => InvalidMessage::MessageTooLarge,
                         MessageError::InvalidContentType => InvalidMessage::InvalidContentType,
                         MessageError::UnknownProtocolVersion => {
                             InvalidMessage::UnknownProtocolVersion
                         }
                     };
-                    self.desynced = true;
-                    return Err(Error::InvalidMessage(err_kind));
+
+                    return Err(self.set_err(err_kind));
                 }
             };
 
@@ -116,10 +114,9 @@ impl MessageDeframer {
                 // This was rejected early data, discard it. If we currently have a handshake
                 // payload in progress, this counts as interleaved, so we error out.
                 Ok(None) if self.joining_hs.is_some() => {
-                    self.desynced = true;
-                    return Err(
-                        PeerMisbehaved::RejectedEarlyDataInterleavedWithHandshakeMessage.into(),
-                    );
+                    return Err(self.set_err(
+                        PeerMisbehaved::RejectedEarlyDataInterleavedWithHandshakeMessage,
+                    ));
                 }
                 Ok(None) => {
                     self.discard(end);
@@ -133,8 +130,7 @@ impl MessageDeframer {
                 // types.  That is, if a handshake message is split over two or more
                 // records, there MUST NOT be any other records between them."
                 // https://www.rfc-editor.org/rfc/rfc8446#section-5.1
-                self.desynced = true;
-                return Err(PeerMisbehaved::MessageInterleavedWithHandshakeMessage.into());
+                return Err(self.set_err(PeerMisbehaved::MessageInterleavedWithHandshakeMessage));
             }
 
             // If it's not a handshake message, just return it -- no joining necessary.
@@ -187,6 +183,15 @@ impl MessageDeframer {
             trial_decryption_finished: true,
             message,
         }))
+    }
+
+    /// Fuses this deframer's error and returns the set value.
+    ///
+    /// Any future calls to `pop` will return `err` again.
+    fn set_err(&mut self, err: impl Into<Error>) -> Error {
+        let err = err.into();
+        self.last_error = Some(err.clone());
+        err
     }
 
     /// Allow pushing handshake messages directly into the buffer.
@@ -530,7 +535,7 @@ mod tests {
         let mut rl = RecordLayer::new();
         pop_first(&mut d, &mut rl);
         assert!(!d.has_pending());
-        assert!(!d.desynced);
+        assert!(d.last_error.is_none());
     }
 
     #[test]
@@ -547,7 +552,7 @@ mod tests {
         assert!(d.has_pending());
         pop_second(&mut d, &mut rl);
         assert!(!d.has_pending());
-        assert!(!d.desynced);
+        assert!(d.last_error.is_none());
     }
 
     #[test]
@@ -560,7 +565,7 @@ mod tests {
         let mut rl = RecordLayer::new();
         pop_first(&mut d, &mut rl);
         assert!(!d.has_pending());
-        assert!(!d.desynced);
+        assert!(d.last_error.is_none());
     }
 
     #[test]
@@ -574,7 +579,7 @@ mod tests {
         pop_first(&mut d, &mut rl);
         pop_second(&mut d, &mut rl);
         assert!(!d.has_pending());
-        assert!(!d.desynced);
+        assert!(d.last_error.is_none());
     }
 
     #[test]
@@ -590,7 +595,7 @@ mod tests {
         pop_first(&mut d, &mut rl);
         pop_second(&mut d, &mut rl);
         assert!(!d.has_pending());
-        assert!(!d.desynced);
+        assert!(d.last_error.is_none());
     }
 
     #[test]
@@ -606,7 +611,7 @@ mod tests {
         pop_second(&mut d, &mut rl);
         pop_first(&mut d, &mut rl);
         assert!(!d.has_pending());
-        assert!(!d.desynced);
+        assert!(d.last_error.is_none());
     }
 
     #[test]
@@ -622,7 +627,7 @@ mod tests {
         let mut rl = RecordLayer::new();
         pop_first(&mut d, &mut rl);
         assert!(!d.has_pending());
-        assert!(!d.desynced);
+        assert!(d.last_error.is_none());
     }
 
     #[test]
@@ -683,7 +688,7 @@ mod tests {
         assert_eq!(m.typ, ContentType::ApplicationData);
         assert_eq!(m.payload.0.len(), 0);
         assert!(!d.has_pending());
-        assert!(!d.desynced);
+        assert!(d.last_error.is_none());
     }
 
     #[test]
@@ -699,10 +704,11 @@ mod tests {
             d.pop(&mut rl).unwrap_err(),
             Error::InvalidMessage(InvalidMessage::InvalidEmptyPayload)
         ));
-        // CorruptMessage has been fused
+        // CorruptMessage has been fused, and returns the same error upon every read
+        // afterwards.
         assert!(matches!(
             d.pop(&mut rl).unwrap_err(),
-            Error::InvalidMessage(InvalidMessage::IncorrectFrame)
+            Error::InvalidMessage(InvalidMessage::InvalidEmptyPayload)
         ));
     }
 

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -92,7 +92,7 @@ impl OpaqueMessage {
         //  implemented per section 5.1 of RFC8446 (TLSv1.3)
         //              per section 6.2.1 of RFC5246 (TLSv1.2)
         if typ != ContentType::ApplicationData && len == 0 {
-            return Err(MessageError::EmptyDataForDisallowedRecord);
+            return Err(MessageError::InvalidEmptyPayload);
         }
 
         // Reject oversize messages
@@ -285,7 +285,7 @@ impl<'a> BorrowedPlainMessage<'a> {
 pub enum MessageError {
     TooShortForHeader,
     TooShortForLength,
-    EmptyDataForDisallowedRecord,
+    InvalidEmptyPayload,
     MessageTooLarge,
     InvalidContentType,
     UnknownProtocolVersion,

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -1,14 +1,14 @@
 use crate::cipher::{MessageDecrypter, MessageEncrypter};
 use crate::conn::{CommonState, ConnectionRandoms, Side};
 use crate::enums::{CipherSuite, SignatureScheme};
-use crate::kx;
 use crate::msgs::codec::{Codec, Reader};
-use crate::msgs::enums::{AlertDescription, ContentType};
+use crate::msgs::enums::AlertDescription;
 use crate::msgs::handshake::KeyExchangeAlgorithm;
 use crate::suites::{BulkAlgorithm, CipherSuiteCommon, SupportedCipherSuite};
 #[cfg(feature = "secret_extraction")]
 use crate::suites::{ConnectionTrafficSecrets, PartiallyExtractedSecrets};
 use crate::Error;
+use crate::{kx, InvalidMessage};
 
 use ring::aead;
 use ring::digest::Digest;
@@ -500,7 +500,7 @@ pub(crate) fn decode_ecdh_params<T: Codec>(
 ) -> Result<T, Error> {
     decode_ecdh_params_::<T>(kx_params).ok_or_else(|| {
         common.send_fatal_alert(AlertDescription::DecodeError);
-        Error::CorruptMessagePayload(ContentType::Handshake)
+        Error::InvalidMessage(InvalidMessage::InvalidDhParams)
     })
 }
 

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -13,11 +13,9 @@ use crate::common::{
 use rustls::client::WebPkiVerifier;
 use rustls::internal::msgs::base::PayloadU16;
 use rustls::server::{ClientCertVerified, ClientCertVerifier};
-use rustls::AlertDescription;
-use rustls::ContentType;
 use rustls::{
-    Certificate, ClientConnection, DistinguishedNames, Error, ServerConfig, ServerConnection,
-    SignatureScheme,
+    AlertDescription, Certificate, ClientConnection, ContentType, DistinguishedNames, Error,
+    InvalidMessage, ServerConfig, ServerConnection, SignatureScheme,
 };
 use std::sync::Arc;
 
@@ -104,8 +102,8 @@ fn client_verifier_no_schemes() {
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_debug_eq(
                 err,
-                Err(ErrorFromPeer::Client(Error::CorruptMessagePayload(
-                    ContentType::Handshake,
+                Err(ErrorFromPeer::Client(Error::InvalidMessage(
+                    InvalidMessage::MissingPayload(ContentType::Handshake),
                 ))),
             );
         }

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -11,8 +11,7 @@ use rustls::client::{
     HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, WebPkiVerifier,
 };
 use rustls::internal::msgs::handshake::DigitallySignedStruct;
-use rustls::AlertDescription;
-use rustls::{Certificate, Error, SignatureScheme};
+use rustls::{AlertDescription, Certificate, Error, InvalidMessage, SignatureScheme};
 use std::sync::Arc;
 
 #[test]
@@ -39,7 +38,7 @@ fn client_can_override_certificate_verification() {
 fn client_can_override_certificate_verification_and_reject_certificate() {
     for kt in ALL_KEY_TYPES.iter() {
         let verifier = Arc::new(MockServerVerifier::rejects_certificate(
-            Error::CorruptMessage,
+            Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
         ));
 
         let server_config = Arc::new(make_server_config(*kt));
@@ -56,7 +55,9 @@ fn client_can_override_certificate_verification_and_reject_certificate() {
             assert_debug_eq(
                 errs,
                 Err(vec![
-                    ErrorFromPeer::Client(Error::CorruptMessage),
+                    ErrorFromPeer::Client(Error::InvalidMessage(
+                        InvalidMessage::HandshakePayloadTooLarge,
+                    )),
                     ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::BadCertificate)),
                 ]),
             );
@@ -70,7 +71,7 @@ fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
     for kt in ALL_KEY_TYPES.iter() {
         let mut client_config = make_client_config_with_versions(*kt, &[&rustls::version::TLS12]);
         let verifier = Arc::new(MockServerVerifier::rejects_tls12_signatures(
-            Error::CorruptMessage,
+            Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
         ));
 
         client_config
@@ -85,7 +86,9 @@ fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
         assert_debug_eq(
             errs,
             Err(vec![
-                ErrorFromPeer::Client(Error::CorruptMessage),
+                ErrorFromPeer::Client(Error::InvalidMessage(
+                    InvalidMessage::HandshakePayloadTooLarge,
+                )),
                 ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::BadCertificate)),
             ]),
         );
@@ -97,7 +100,7 @@ fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
     for kt in ALL_KEY_TYPES.iter() {
         let mut client_config = make_client_config_with_versions(*kt, &[&rustls::version::TLS13]);
         let verifier = Arc::new(MockServerVerifier::rejects_tls13_signatures(
-            Error::CorruptMessage,
+            Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
         ));
 
         client_config
@@ -112,7 +115,9 @@ fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
         assert_debug_eq(
             errs,
             Err(vec![
-                ErrorFromPeer::Client(Error::CorruptMessage),
+                ErrorFromPeer::Client(Error::InvalidMessage(
+                    InvalidMessage::HandshakePayloadTooLarge,
+                )),
                 ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::BadCertificate)),
             ]),
         );


### PR DESCRIPTION
Re-introduction and rebasing of https://github.com/rustls/rustls/pull/1016 now that the API is open for breaking changes again.

Closes https://github.com/rustls/rustls/pull/1043