### PR TITLE
Improve clippy usability with Cargo alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+clippy-rustls = "clippy --all-features"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,8 +266,8 @@ jobs:
           components: clippy
       - uses: actions-rs/cargo@v1
         with:
-          command: clippy
-          args: -p rustls --all-features -- -D warnings
+          command: clippy-rustls
+          args: -- -D warnings
 
   clippy-nightly:
     name: Clippy (Nightly)
@@ -286,5 +286,4 @@ jobs:
           components: clippy
       - uses: actions-rs/cargo@v1
         with:
-          command: clippy
-          args: -p rustls --all-features
+          command: clippy-rustls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Some ideas and guidelines for contributions:
 - Try to keep code formatting commits separate from functional commits.
 - See [`.github/workflows/build.yml`](.github/workflows/build.yml) for
   how to run the various test suites, and how to make coverage measurements.
+  - `cargo clippy-rustls` can be used to perform most of the same checks CI will also do.
 - I run `cargo outdated` prior to major releases; but PRs to update specific
   dependencies are welcome.
 

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -56,7 +56,7 @@ impl TlsClient {
 
         if self.is_closed() {
             println!("Connection closed");
-            process::exit(if self.clean_closure { 0 } else { 1 });
+            process::exit(i32::from(!self.clean_closure));
         }
     }
 


### PR DESCRIPTION
This PR allows local developers and CI to more easily share testing configurations. Now, developers can double check their code will pass CI by easily keeping the "right command and flags" synced automatically. `cargo clipppy-rustls` and `cargo test` are now the two commands "most" contributors need to remember.

Both the [Neon project](https://github.com/neon-bindings/neon/blob/main/.cargo/config.toml#L1) and internally at 1P make use of this pattern to improve the developer experience. Its especially helpful if `rustls` ever decides to make some code stricter (banning `as` casting, for example).

Additionally, this moves Clippy to run on the whole workspace instead of just `rustls`. The one remaining Clippy lint in the workspace was fixed in order to pass with the new command.