### PR TITLE
examples: use inline variable names in format strings

### DIFF
--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -10,15 +10,14 @@ fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
         .try_into()
         .expect("invalid DNS name");
     let mut conn = rustls::ClientConnection::new(Arc::clone(config), server_name).unwrap();
-    let mut sock = TcpStream::connect(format!("{}:443", domain_name)).unwrap();
+    let mut sock = TcpStream::connect(format!("{domain_name}:443")).unwrap();
     sock.set_nodelay(true).unwrap();
     let request = format!(
         "GET / HTTP/1.1\r\n\
-         Host: {}\r\n\
+         Host: {domain_name}\r\n\
          Connection: close\r\n\
          Accept-Encoding: identity\r\n\
          \r\n",
-        domain_name
     );
 
     // If early data is available with this server, then early_data()

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -101,7 +101,7 @@ impl TlsClient {
         let io_state = match self.tls_conn.process_new_packets() {
             Ok(io_state) => io_state,
             Err(err) => {
-                println!("TLS error: {:?}", err);
+                println!("TLS error: {err:?}");
                 self.closing = true;
                 return;
             }
@@ -373,7 +373,7 @@ fn lookup_suites(suites: &[String]) -> Vec<rustls::SupportedCipherSuite> {
         let scs = find_suite(csname);
         match scs {
             Some(s) => out.push(s),
-            None => panic!("cannot look up ciphersuite '{}'", csname),
+            None => panic!("cannot look up ciphersuite '{csname}'"),
         }
     }
 
@@ -388,10 +388,7 @@ fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtoco
         let version = match vname.as_ref() {
             "1.2" => &rustls::version::TLS12,
             "1.3" => &rustls::version::TLS13,
-            _ => panic!(
-                "cannot look up version '{}', valid are '1.2' and '1.3'",
-                vname
-            ),
+            _ => panic!("cannot look up version '{vname}', valid are '1.2' and '1.3'",),
         };
         out.push(version);
     }
@@ -423,10 +420,7 @@ fn load_private_key(filename: &str) -> rustls::PrivateKey {
         }
     }
 
-    panic!(
-        "no keys found in {:?} (encrypted keys not supported)",
-        filename
-    );
+    panic!("no keys found in {filename:?} (encrypted keys not supported)",);
 }
 
 #[cfg(feature = "dangerous_configuration")]

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -79,10 +79,7 @@ impl TlsServer {
                 }
                 Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(()),
                 Err(err) => {
-                    println!(
-                        "encountered error while accepting connection; err={:?}",
-                        err
-                    );
+                    println!("encountered error while accepting connection; err={err:?}",);
                     return Err(err);
                 }
             }
@@ -497,10 +494,7 @@ fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtoco
         let version = match vname.as_ref() {
             "1.2" => &rustls::version::TLS12,
             "1.3" => &rustls::version::TLS13,
-            _ => panic!(
-                "cannot look up version '{}', valid are '1.2' and '1.3'",
-                vname
-            ),
+            _ => panic!("cannot look up version '{vname}', valid are '1.2' and '1.3'",),
         };
         out.push(version);
     }


### PR DESCRIPTION
As suggested by nightly clippy.