### PR TITLE
Auto-shrink `MessageDeframer::buf` while at rest

### DIFF
--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -293,10 +293,12 @@ impl MessageDeframer {
         // If we can and need to increase the buffer size to allow a 4k read, do so. After
         // dealing with a large handshake message (exceeding `OpaqueMessage::MAX_WIRE_SIZE`),
         // make sure to reduce the buffer size again (large messages should be rare).
+        // Also, reduce the buffer size if there are neither full nor partial messages in it,
+        // which usually means that the other side suspended sending data.
         let need_capacity = Ord::min(allow_max, self.used + READ_SIZE);
         if need_capacity > self.buf.len() {
             self.buf.resize(need_capacity, 0);
-        } else if self.buf.len() > allow_max {
+        } else if self.used == 0 || self.buf.len() > allow_max {
             self.buf.resize(need_capacity, 0);
             self.buf.shrink_to(need_capacity);
         }


### PR DESCRIPTION
Relates #794

This PR addresses https://github.com/rustls/rustls/pull/1171#discussion_r1070984963 by reducing the `MessageDeframer::buf` while it does not contain partial or full messages, which usually means that we've read everything the sender has sent so far.

The change does not affect the result of `cargo run --release --example bench`, i.e. neither handshake no bulk transfer speed is affected.