### PR TITLE
Split ring into a single crate

### DIFF
--- a/rustls-backend/Cargo.toml
+++ b/rustls-backend/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rustls-backend"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+ring = "0.16.20"

--- a/rustls-backend/src/lib.rs
+++ b/rustls-backend/src/lib.rs
@@ -1,0 +1,1 @@
+pub use ring::*;

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -17,7 +17,7 @@ rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
 log = { version = "0.4.4", optional = true }
-ring = "0.16.20"
+rustls-backend = { path = "../rustls-backend" }
 sct = "0.7.0"
 webpki = { package = "rustls-webpki", version = "0.100.0-alpha.2", features = ["alloc", "std"] }
 

--- a/rustls/src/cipher.rs
+++ b/rustls/src/cipher.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use crate::msgs::codec;
 use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 
-use ring::{aead, hkdf};
+use rustls_backend::{aead, hkdf};
 
 /// Objects with this trait can decrypt TLS messages.
 pub trait MessageDecrypter: Send + Sync {
@@ -30,17 +30,17 @@ impl dyn MessageDecrypter {
 
 /// A write or read IV.
 #[derive(Default)]
-pub(crate) struct Iv(pub(crate) [u8; ring::aead::NONCE_LEN]);
+pub(crate) struct Iv(pub(crate) [u8; rustls_backend::aead::NONCE_LEN]);
 
 impl Iv {
     #[cfg(feature = "tls12")]
-    fn new(value: [u8; ring::aead::NONCE_LEN]) -> Self {
+    fn new(value: [u8; rustls_backend::aead::NONCE_LEN]) -> Self {
         Self(value)
     }
 
     #[cfg(feature = "tls12")]
     pub(crate) fn copy(value: &[u8]) -> Self {
-        debug_assert_eq!(value.len(), ring::aead::NONCE_LEN);
+        debug_assert_eq!(value.len(), rustls_backend::aead::NONCE_LEN);
         let mut iv = Self::new(Default::default());
         iv.0.copy_from_slice(value);
         iv
@@ -68,8 +68,8 @@ impl From<hkdf::Okm<'_, IvLen>> for Iv {
     }
 }
 
-pub(crate) fn make_nonce(iv: &Iv, seq: u64) -> ring::aead::Nonce {
-    let mut nonce = [0u8; ring::aead::NONCE_LEN];
+pub(crate) fn make_nonce(iv: &Iv, seq: u64) -> rustls_backend::aead::Nonce {
+    let mut nonce = [0u8; rustls_backend::aead::NONCE_LEN];
     codec::put_u64(seq, &mut nonce[4..]);
 
     nonce

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -30,8 +30,8 @@ use crate::client::common::ClientAuthDetails;
 use crate::client::common::ServerCertDetails;
 use crate::client::{hs, ClientConfig, ServerName};
 
-use ring::agreement::PublicKey;
-use ring::constant_time;
+use rustls_backend::agreement::PublicKey;
+use rustls_backend::constant_time;
 
 use std::sync::Arc;
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -41,7 +41,7 @@ use crate::client::common::{ClientAuthDetails, ClientHelloDetails};
 use crate::client::{hs, ClientConfig, ClientSessionStore, ServerName};
 
 use crate::ticketer::TimeBase;
-use ring::constant_time;
+use rustls_backend::constant_time;
 
 use crate::sign::{CertifiedKey, Signer};
 use std::sync::Arc;
@@ -758,7 +758,7 @@ fn emit_certverify_tls13(
 
 fn emit_finished_tls13(
     transcript: &mut HandshakeHash,
-    verify_data: ring::hmac::Tag,
+    verify_data: rustls_backend::hmac::Tag,
     common: &mut CommonState,
 ) {
     let verify_data_payload = Payload::new(verify_data.as_ref());

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1353,7 +1353,7 @@ pub(crate) struct Quic {
     pub(crate) params: Option<Vec<u8>>,
     pub(crate) alert: Option<AlertDescription>,
     pub(crate) hs_queue: VecDeque<(bool, Vec<u8>)>,
-    pub(crate) early_secret: Option<ring::hkdf::Prk>,
+    pub(crate) early_secret: Option<rustls_backend::hkdf::Prk>,
     pub(crate) hs_secrets: Option<quic::Secrets>,
     pub(crate) traffic_secrets: Option<quic::Secrets>,
     /// Whether keys derived from traffic_secrets have been passed to the QUIC implementation

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -1,7 +1,7 @@
 use crate::msgs::codec::Codec;
 use crate::msgs::handshake::HandshakeMessagePayload;
 use crate::msgs::message::{Message, MessagePayload};
-use ring::digest;
+use rustls_backend::digest;
 use std::mem;
 
 /// Early stage buffering of handshake payloads.
@@ -164,7 +164,7 @@ impl HandshakeHash {
 #[cfg(test)]
 mod test {
     use super::HandshakeHashBuffer;
-    use ring::digest;
+    use rustls_backend::digest;
 
     #[test]
     fn hashes_correctly() {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -10,7 +10,7 @@ use crate::tls13::key_schedule::hkdf_expand;
 use crate::tls13::{Tls13CipherSuite, TLS13_AES_128_GCM_SHA256_INTERNAL};
 use std::fmt::Debug;
 
-use ring::{aead, hkdf};
+use rustls_backend::{aead, hkdf};
 
 /// Secrets used to encrypt/decrypt traffic
 #[derive(Clone, Debug)]
@@ -459,7 +459,7 @@ pub enum KeyChange {
 }
 
 /// Compute the nonce to use for encrypting or decrypting `packet_number`
-fn nonce_for(packet_number: u64, iv: &Iv) -> ring::aead::Nonce {
+fn nonce_for(packet_number: u64, iv: &Iv) -> rustls_backend::aead::Nonce {
     let mut out = [0; aead::NONCE_LEN];
     out[4..].copy_from_slice(&packet_number.to_be_bytes());
     for (out, inp) in out.iter_mut().zip(iv.0.iter()) {

--- a/rustls/src/rand.rs
+++ b/rustls/src/rand.rs
@@ -2,7 +2,7 @@ use crate::msgs::codec;
 /// The single place where we generate random material
 /// for our own use.  These functions never fail,
 /// they panic on error.
-use ring::rand::{SecureRandom, SystemRandom};
+use rustls_backend::rand::{SecureRandom, SystemRandom};
 
 /// Fill the whole slice with random material.
 pub(crate) fn fill_random(bytes: &mut [u8]) -> Result<(), GetRandomFailed> {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -23,7 +23,7 @@ use super::common::ActiveCertifiedKey;
 use super::hs::{self, ServerContext};
 use super::server_conn::{ProducesTickets, ServerConfig, ServerConnectionData};
 
-use ring::constant_time;
+use rustls_backend::constant_time;
 
 use std::sync::Arc;
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -32,7 +32,7 @@ use super::server_conn::ServerConnectionData;
 
 use std::sync::Arc;
 
-use ring::constant_time;
+use rustls_backend::constant_time;
 
 pub(super) use client_hello::CompleteClientHelloHandling;
 

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -4,8 +4,8 @@ use crate::key;
 use crate::msgs::enums::SignatureAlgorithm;
 use crate::x509::{wrap_in_asn1_len, wrap_in_sequence};
 
-use ring::io::der;
-use ring::signature::{self, EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair};
+use rustls_backend::io::der;
+use rustls_backend::signature::{self, EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair};
 
 use std::error::Error as StdError;
 use std::fmt;
@@ -246,7 +246,7 @@ impl Signer for RsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error> {
         let mut sig = vec![0; self.key.public_modulus_len()];
 
-        let rng = ring::rand::SystemRandom::new();
+        let rng = rustls_backend::rand::SystemRandom::new();
         self.key
             .sign(self.encoding, &rng, message, &mut sig)
             .map(|_| sig)
@@ -366,7 +366,7 @@ struct EcdsaSigner {
 
 impl Signer for EcdsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error> {
-        let rng = ring::rand::SystemRandom::new();
+        let rng = rustls_backend::rand::SystemRandom::new();
         self.key
             .sign(&rng, message)
             .map_err(|_| Error::General("signing failed".into()))

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -46,7 +46,7 @@ pub struct CipherSuiteCommon {
     /// How to do bulk encryption.
     pub bulk: BulkAlgorithm,
 
-    pub(crate) aead_algorithm: &'static ring::aead::Algorithm,
+    pub(crate) aead_algorithm: &'static rustls_backend::aead::Algorithm,
 }
 
 /// A cipher suite supported by rustls.
@@ -70,7 +70,7 @@ impl fmt::Debug for SupportedCipherSuite {
 
 impl SupportedCipherSuite {
     /// Which hash function to use with this suite.
-    pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
+    pub fn hash_algorithm(&self) -> &'static rustls_backend::digest::Algorithm {
         match self {
             #[cfg(feature = "tls12")]
             Self::Tls12(inner) => inner.hash_algorithm(),

--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -2,7 +2,7 @@ use crate::rand;
 use crate::server::ProducesTickets;
 use crate::Error;
 
-use ring::aead;
+use rustls_backend::aead;
 use std::mem;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time;
@@ -68,8 +68,8 @@ impl ProducesTickets for AeadTicketer {
         // Random nonce, because a counter is a privacy leak.
         let mut nonce_buf = [0u8; 12];
         rand::fill_random(&mut nonce_buf).ok()?;
-        let nonce = ring::aead::Nonce::assume_unique_for_key(nonce_buf);
-        let aad = ring::aead::Aad::empty();
+        let nonce = rustls_backend::aead::Nonce::assume_unique_for_key(nonce_buf);
+        let aad = rustls_backend::aead::Aad::empty();
 
         let mut ciphertext =
             Vec::with_capacity(nonce_buf.len() + message.len() + self.key.algorithm().tag_len());
@@ -91,7 +91,7 @@ impl ProducesTickets for AeadTicketer {
         let ciphertext = ciphertext.get(nonce.len()..)?;
 
         // This won't fail since `nonce` has the required length.
-        let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce).ok()?;
+        let nonce = rustls_backend::aead::Nonce::try_assume_unique_for_key(nonce).ok()?;
 
         let mut out = Vec::from(ciphertext);
 

--- a/rustls/src/tls12/cipher.rs
+++ b/rustls/src/tls12/cipher.rs
@@ -7,7 +7,7 @@ use crate::msgs::enums::ContentType;
 use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
 use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 
-use ring::aead;
+use rustls_backend::aead;
 
 const TLS12_AAD_SIZE: usize = 8 + 1 + 2 + 2;
 
@@ -16,13 +16,13 @@ fn make_tls12_aad(
     typ: ContentType,
     vers: ProtocolVersion,
     len: usize,
-) -> ring::aead::Aad<[u8; TLS12_AAD_SIZE]> {
+) -> rustls_backend::aead::Aad<[u8; TLS12_AAD_SIZE]> {
     let mut out = [0; TLS12_AAD_SIZE];
     codec::put_u64(seq, &mut out[0..]);
     out[8] = typ.get_u8();
     codec::put_u16(vers.get_u16(), &mut out[9..]);
     codec::put_u16(len as u16, &mut out[11..]);
-    ring::aead::Aad::from(out)
+    rustls_backend::aead::Aad::from(out)
 }
 
 pub(crate) struct AesGcm;

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -10,8 +10,8 @@ use crate::suites::{BulkAlgorithm, CipherSuiteCommon, SupportedCipherSuite};
 use crate::suites::{ConnectionTrafficSecrets, PartiallyExtractedSecrets};
 use crate::Error;
 
-use ring::aead;
-use ring::digest::Digest;
+use rustls_backend::aead;
+use rustls_backend::digest::Digest;
 
 use std::fmt;
 
@@ -26,14 +26,14 @@ pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
             bulk: BulkAlgorithm::Chacha20Poly1305,
-            aead_algorithm: &ring::aead::CHACHA20_POLY1305,
+            aead_algorithm: &rustls_backend::aead::CHACHA20_POLY1305,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
         fixed_iv_len: 12,
         explicit_nonce_len: 0,
         aead_alg: &ChaCha20Poly1305,
-        hmac_algorithm: ring::hmac::HMAC_SHA256,
+        hmac_algorithm: rustls_backend::hmac::HMAC_SHA256,
     });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
@@ -42,14 +42,14 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
             bulk: BulkAlgorithm::Chacha20Poly1305,
-            aead_algorithm: &ring::aead::CHACHA20_POLY1305,
+            aead_algorithm: &rustls_backend::aead::CHACHA20_POLY1305,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
         fixed_iv_len: 12,
         explicit_nonce_len: 0,
         aead_alg: &ChaCha20Poly1305,
-        hmac_algorithm: ring::hmac::HMAC_SHA256,
+        hmac_algorithm: rustls_backend::hmac::HMAC_SHA256,
     });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
@@ -58,14 +58,14 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
             bulk: BulkAlgorithm::Aes128Gcm,
-            aead_algorithm: &ring::aead::AES_128_GCM,
+            aead_algorithm: &rustls_backend::aead::AES_128_GCM,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
         fixed_iv_len: 4,
         explicit_nonce_len: 8,
         aead_alg: &AesGcm,
-        hmac_algorithm: ring::hmac::HMAC_SHA256,
+        hmac_algorithm: rustls_backend::hmac::HMAC_SHA256,
     });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -74,14 +74,14 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             bulk: BulkAlgorithm::Aes256Gcm,
-            aead_algorithm: &ring::aead::AES_256_GCM,
+            aead_algorithm: &rustls_backend::aead::AES_256_GCM,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
         fixed_iv_len: 4,
         explicit_nonce_len: 8,
         aead_alg: &AesGcm,
-        hmac_algorithm: ring::hmac::HMAC_SHA384,
+        hmac_algorithm: rustls_backend::hmac::HMAC_SHA384,
     });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
@@ -90,14 +90,14 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
             bulk: BulkAlgorithm::Aes128Gcm,
-            aead_algorithm: &ring::aead::AES_128_GCM,
+            aead_algorithm: &rustls_backend::aead::AES_128_GCM,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
         fixed_iv_len: 4,
         explicit_nonce_len: 8,
         aead_alg: &AesGcm,
-        hmac_algorithm: ring::hmac::HMAC_SHA256,
+        hmac_algorithm: rustls_backend::hmac::HMAC_SHA256,
     });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
@@ -106,14 +106,14 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
             bulk: BulkAlgorithm::Aes256Gcm,
-            aead_algorithm: &ring::aead::AES_256_GCM,
+            aead_algorithm: &rustls_backend::aead::AES_256_GCM,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
         fixed_iv_len: 4,
         explicit_nonce_len: 8,
         aead_alg: &AesGcm,
-        hmac_algorithm: ring::hmac::HMAC_SHA384,
+        hmac_algorithm: rustls_backend::hmac::HMAC_SHA384,
     });
 
 static TLS12_ECDSA_SCHEMES: &[SignatureScheme] = &[
@@ -136,7 +136,7 @@ static TLS12_RSA_SCHEMES: &[SignatureScheme] = &[
 pub struct Tls12CipherSuite {
     /// Common cipher suite fields.
     pub common: CipherSuiteCommon,
-    pub(crate) hmac_algorithm: ring::hmac::Algorithm,
+    pub(crate) hmac_algorithm: rustls_backend::hmac::Algorithm,
     /// How to exchange/agree keys.
     pub kx: KeyExchangeAlgorithm,
 
@@ -171,7 +171,7 @@ impl Tls12CipherSuite {
     }
 
     /// Which hash function to use with this suite.
-    pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
+    pub fn hash_algorithm(&self) -> &'static rustls_backend::digest::Algorithm {
         self.hmac_algorithm.digest_algorithm()
     }
 }
@@ -414,7 +414,7 @@ impl ConnectionSecrets {
             iv: server_iv,
         };
 
-        let (client_secrets, server_secrets) = if algo == &ring::aead::AES_128_GCM {
+        let (client_secrets, server_secrets) = if algo == &rustls_backend::aead::AES_128_GCM {
             let extract = |pair: Pair| -> ConnectionTrafficSecrets {
                 let mut key = [0u8; 16];
                 key.copy_from_slice(pair.key);
@@ -429,7 +429,7 @@ impl ConnectionSecrets {
             };
 
             (extract(client_pair), extract(server_pair))
-        } else if algo == &ring::aead::AES_256_GCM {
+        } else if algo == &rustls_backend::aead::AES_256_GCM {
             let extract = |pair: Pair| -> ConnectionTrafficSecrets {
                 let mut key = [0u8; 32];
                 key.copy_from_slice(pair.key);
@@ -444,7 +444,7 @@ impl ConnectionSecrets {
             };
 
             (extract(client_pair), extract(server_pair))
-        } else if algo == &ring::aead::CHACHA20_POLY1305 {
+        } else if algo == &rustls_backend::aead::CHACHA20_POLY1305 {
             let extract = |pair: Pair| -> ConnectionTrafficSecrets {
                 let mut key = [0u8; 32];
                 key.copy_from_slice(pair.key);

--- a/rustls/src/tls12/prf.rs
+++ b/rustls/src/tls12/prf.rs
@@ -1,4 +1,4 @@
-use ring::hmac;
+use rustls_backend::hmac;
 
 fn concat_sign(key: &hmac::Key, a: &[u8], b: &[u8]) -> hmac::Tag {
     let mut ctx = hmac::Context::with_key(key);
@@ -37,7 +37,7 @@ pub(crate) fn prf(out: &mut [u8], alg: hmac::Algorithm, secret: &[u8], label: &[
 
 #[cfg(test)]
 mod tests {
-    use ring::hmac::{HMAC_SHA256, HMAC_SHA512};
+    use rustls_backend::hmac::{HMAC_SHA256, HMAC_SHA512};
 
     #[test]
     fn check_sha256() {

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -10,7 +10,7 @@ use crate::suites::{ConnectionTrafficSecrets, PartiallyExtractedSecrets};
 use crate::{KeyLog, Tls13CipherSuite};
 
 /// Key schedule maintenance for TLS1.3
-use ring::{
+use rustls_backend::{
     aead,
     digest::{self, Digest},
     hkdf::{self, KeyType as _},
@@ -532,8 +532,7 @@ impl KeyScheduleTraffic {
         let client_secrets;
         let server_secrets;
 
-        let algo = self.ks.suite.common.aead_algorithm;
-        if algo == &ring::aead::AES_128_GCM {
+        if algo == &rustls_backend::aead::AES_128_GCM {
             let extract = |secret: &hkdf::Prk| -> Result<ConnectionTrafficSecrets, Error> {
                 let (key, iv_in) = expand::<16, 12>(secret)?;
 
@@ -548,7 +547,7 @@ impl KeyScheduleTraffic {
 
             client_secrets = extract(&self.current_client_traffic_secret)?;
             server_secrets = extract(&self.current_server_traffic_secret)?;
-        } else if algo == &ring::aead::AES_256_GCM {
+        } else if algo == &rustls_backend::aead::AES_256_GCM {
             let extract = |secret: &hkdf::Prk| -> Result<ConnectionTrafficSecrets, Error> {
                 let (key, iv_in) = expand::<32, 12>(secret)?;
 
@@ -563,7 +562,7 @@ impl KeyScheduleTraffic {
 
             client_secrets = extract(&self.current_client_traffic_secret)?;
             server_secrets = extract(&self.current_server_traffic_secret)?;
-        } else if algo == &ring::aead::CHACHA20_POLY1305 {
+        } else if algo == &rustls_backend::aead::CHACHA20_POLY1305 {
             let extract = |secret: &hkdf::Prk| -> Result<ConnectionTrafficSecrets, Error> {
                 let (key, iv) = expand::<32, 12>(secret)?;
                 Ok(ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv })
@@ -832,7 +831,7 @@ mod test {
     use super::{derive_traffic_iv, derive_traffic_key, KeySchedule, SecretKind};
     use crate::tls13::TLS13_CHACHA20_POLY1305_SHA256_INTERNAL;
     use crate::KeyLog;
-    use ring::aead;
+    use rustls_backend::aead;
 
     #[test]
     fn test_vectors() {

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -8,7 +8,7 @@ use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
 use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 use crate::suites::{BulkAlgorithm, CipherSuiteCommon, SupportedCipherSuite};
 
-use ring::aead;
+use rustls_backend::aead;
 
 use std::fmt;
 
@@ -22,9 +22,9 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
         bulk: BulkAlgorithm::Chacha20Poly1305,
-        aead_algorithm: &ring::aead::CHACHA20_POLY1305,
+        aead_algorithm: &rustls_backend::aead::CHACHA20_POLY1305,
     },
-    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
+    hkdf_algorithm: rustls_backend::hkdf::HKDF_SHA256,
     #[cfg(feature = "quic")]
     confidentiality_limit: u64::MAX,
     #[cfg(feature = "quic")]
@@ -37,9 +37,9 @@ pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
             bulk: BulkAlgorithm::Aes256Gcm,
-            aead_algorithm: &ring::aead::AES_256_GCM,
+            aead_algorithm: &rustls_backend::aead::AES_256_GCM,
         },
-        hkdf_algorithm: ring::hkdf::HKDF_SHA384,
+        hkdf_algorithm: rustls_backend::hkdf::HKDF_SHA384,
         #[cfg(feature = "quic")]
         confidentiality_limit: 1 << 23,
         #[cfg(feature = "quic")]
@@ -54,9 +54,9 @@ pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13C
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
         bulk: BulkAlgorithm::Aes128Gcm,
-        aead_algorithm: &ring::aead::AES_128_GCM,
+        aead_algorithm: &rustls_backend::aead::AES_128_GCM,
     },
-    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
+    hkdf_algorithm: rustls_backend::hkdf::HKDF_SHA256,
     #[cfg(feature = "quic")]
     confidentiality_limit: 1 << 23,
     #[cfg(feature = "quic")]
@@ -67,7 +67,7 @@ pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13C
 pub struct Tls13CipherSuite {
     /// Common cipher suite fields.
     pub common: CipherSuiteCommon,
-    pub(crate) hkdf_algorithm: ring::hkdf::Algorithm,
+    pub(crate) hkdf_algorithm: rustls_backend::hkdf::Algorithm,
     #[cfg(feature = "quic")]
     pub(crate) confidentiality_limit: u64,
     #[cfg(feature = "quic")]
@@ -76,7 +76,7 @@ pub struct Tls13CipherSuite {
 
 impl Tls13CipherSuite {
     /// Which hash function to use with this suite.
-    pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
+    pub fn hash_algorithm(&self) -> &'static rustls_backend::digest::Algorithm {
         self.hkdf_algorithm
             .hmac_algorithm()
             .digest_algorithm()
@@ -129,8 +129,8 @@ fn unpad_tls13(v: &mut Vec<u8>) -> ContentType {
     }
 }
 
-fn make_tls13_aad(len: usize) -> ring::aead::Aad<[u8; TLS13_AAD_SIZE]> {
-    ring::aead::Aad::from([
+fn make_tls13_aad(len: usize) -> rustls_backend::aead::Aad<[u8; TLS13_AAD_SIZE]> {
+    rustls_backend::aead::Aad::from([
         0x17, // ContentType::ApplicationData
         0x3,  // ProtocolVersion (major)
         0x3,  // ProtocolVersion (minor)

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -9,7 +9,7 @@ use crate::key::Certificate;
 use crate::log::{debug, trace, warn};
 use crate::msgs::handshake::{DigitallySignedStruct, DistinguishedNames};
 
-use ring::digest::Digest;
+use rustls_backend::digest::Digest;
 
 use std::sync::Arc;
 use std::time::SystemTime;

--- a/rustls/src/x509.rs
+++ b/rustls/src/x509.rs
@@ -1,6 +1,6 @@
 // Additional x509/asn1 functions to those provided in webpki/ring.
 
-use ring::io::der;
+use rustls_backend::io::der;
 
 pub(crate) fn wrap_in_asn1_len(bytes: &mut Vec<u8>) {
     let len = bytes.len();

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3352,7 +3352,6 @@ mod test_quic {
             ServerConnection::new_quic(server_config, quic::Version::V1, b"server params".to_vec())
                 .unwrap();
 
-        use ring::rand::SecureRandom;
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, HandshakeType, NamedGroup};
         use rustls::internal::msgs::handshake::{
@@ -3360,16 +3359,20 @@ mod test_quic {
         };
         use rustls::internal::msgs::message::PlainMessage;
         use rustls::{CipherSuite, SignatureScheme};
+        use rustls_backend::rand::SecureRandom;
 
-        let rng = ring::rand::SystemRandom::new();
+        let rng = rustls_backend::rand::SystemRandom::new();
         let mut random = [0; 32];
         rng.fill(&mut random).unwrap();
         let random = Random::from(random);
 
-        let kx = ring::agreement::EphemeralPrivateKey::generate(&ring::agreement::X25519, &rng)
-            .unwrap()
-            .compute_public_key()
-            .unwrap();
+        let kx = rustls_backend::agreement::EphemeralPrivateKey::generate(
+            &rustls_backend::agreement::X25519,
+            &rng,
+        )
+        .unwrap()
+        .compute_public_key()
+        .unwrap();
 
         let client_hello = Message {
             version: ProtocolVersion::TLSv1_3,
@@ -3415,7 +3418,6 @@ mod test_quic {
         server_config.alpn_protocols = vec!["foo".into()];
         let server_config = Arc::new(server_config);
 
-        use ring::rand::SecureRandom;
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, HandshakeType, NamedGroup};
         use rustls::internal::msgs::handshake::{
@@ -3423,16 +3425,20 @@ mod test_quic {
         };
         use rustls::internal::msgs::message::PlainMessage;
         use rustls::{CipherSuite, SignatureScheme};
+        use rustls_backend::rand::SecureRandom;
 
-        let rng = ring::rand::SystemRandom::new();
+        let rng = rustls_backend::rand::SystemRandom::new();
         let mut random = [0; 32];
         rng.fill(&mut random).unwrap();
         let random = Random::from(random);
 
-        let kx = ring::agreement::EphemeralPrivateKey::generate(&ring::agreement::X25519, &rng)
-            .unwrap()
-            .compute_public_key()
-            .unwrap();
+        let kx = rustls_backend::agreement::EphemeralPrivateKey::generate(
+            &rustls_backend::agreement::X25519,
+            &rng,
+        )
+        .unwrap()
+        .compute_public_key()
+        .unwrap();
 
         let mut server =
             ServerConnection::new_quic(server_config, quic::Version::V1, b"server params".to_vec())


### PR DESCRIPTION
https://github.com/rustls/rustls/issues/521
>There has not been any further discussion. If you or your community wants to work on this, I'd be open to reviewing a potential design. I think essentially it would have to be a high-level set of traits that essentially mimic the current ring API to cover the rustls crypto requirements that are not currently covered by traits.

Rustls and ring coupled together, and the workload of trying to separate it in a PR will be huge, I wish it can split into many steps.

1. Change the direct dependency on ring to indirect dependency (a new crate: rustls-backend in this pr). And then we can perform further abstraction in this new crate.
2. Design trait in rustls-backend. We can replace indirect dependence on ring to abstraction of trait in to many step(e.g. hash/hmac/...) since their underylying implementations is same. 
3. After the design `cover the rustls crypto requirements that are not currently covered by traits`, we can stable them and support users to register different implementation. By default the underlying implementation should be ring. The rustls-backend trait should only expose to those want to use custom backend


This is an attempt, please correct me if there is anything wrong.
