### PR TITLE
Improve client/server fuzzer drivers

### DIFF
--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -23,4 +23,5 @@ fuzz_target!(|data: &[u8]| {
     let example_com = "example.com".try_into().unwrap();
     let mut client = ClientConnection::new(config, example_com).unwrap();
     let _ = client.read_tls(&mut io::Cursor::new(data));
+    let _ = client.process_new_packets();
 });

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -29,4 +29,5 @@ fuzz_target!(|data: &[u8]| {
     );
     let mut server = ServerConnection::new(config).unwrap();
     let _ = server.read_tls(&mut io::Cursor::new(data));
+    let _ = server.process_new_packets();
 });

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1226,6 +1226,7 @@ impl CommonState {
         // Reject unknown AlertLevels.
         if let AlertLevel::Unknown(_) = alert.level {
             self.send_fatal_alert(AlertDescription::IllegalParameter);
+            return Err(Error::AlertReceived(alert.description));
         }
 
         // If we get a CloseNotify, make a note to declare EOF to our


### PR DESCRIPTION
Noticed that these just read in messages, and don't call `process_new_packets`. The second commit fixes a reachable debug assert failure.