### PR TITLE
Harmonize certificate verifiers construction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
   - The number of tickets sent by a TLS1.3 server is now configurable via
     `ServerConfig::send_tls13_tickets`.  Previously one ticket was sent, now
     the default is four.
+  - *Breaking change*: `AllowAnyAuthenticatedClient` and `AllowAnyAnonymousOrAuthenticatedClient`
+    `new` functions now return `Self`. A `boxed` function was added to both types to easily acquire
+    an `Arc<dyn ClientCertVerifier>`.
+  - *Breaking change*: `NoClientAuth::new` was renamed to `boxed`.
 * 0.20.8 (2023-01-12)
   - Yield an error from `ConnectionCommon::read_tls()` if buffers are full.
     Both a full deframer buffer and a full incoming plaintext buffer will

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -559,12 +559,12 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
             client_auth_roots.add(&root).unwrap();
         }
         if args.flag_require_auth {
-            AllowAnyAuthenticatedClient::new(client_auth_roots).coerce()
+            AllowAnyAuthenticatedClient::new(client_auth_roots).boxed()
         } else {
-            AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots).coerce()
+            AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots).boxed()
         }
     } else {
-        NoClientAuth::new_coerced()
+        NoClientAuth::boxed()
     };
 
     let suites = if !args.flag_suite.is_empty() {

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -559,12 +559,12 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
             client_auth_roots.add(&root).unwrap();
         }
         if args.flag_require_auth {
-            AllowAnyAuthenticatedClient::new(client_auth_roots)
+            AllowAnyAuthenticatedClient::new(client_auth_roots).coerce()
         } else {
-            AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots)
+            AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots).coerce()
         }
     } else {
-        NoClientAuth::new()
+        NoClientAuth::new_coerced()
     };
 
     let suites = if !args.flag_suite.is_empty() {

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -304,9 +304,9 @@ fn make_server_config(
             for root in roots {
                 client_auth_roots.add(&root).unwrap();
             }
-            AllowAnyAuthenticatedClient::new(client_auth_roots).coerce()
+            Arc::new(AllowAnyAuthenticatedClient::new(client_auth_roots))
         }
-        ClientAuth::No => NoClientAuth::new_coerced(),
+        ClientAuth::No => NoClientAuth::boxed(),
     };
 
     let mut cfg = ServerConfig::builder()

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -304,9 +304,9 @@ fn make_server_config(
             for root in roots {
                 client_auth_roots.add(&root).unwrap();
             }
-            AllowAnyAuthenticatedClient::new(client_auth_roots)
+            AllowAnyAuthenticatedClient::new(client_auth_roots).coerce()
         }
-        ClientAuth::No => NoClientAuth::new(),
+        ClientAuth::No => NoClientAuth::new_coerced(),
     };
 
     let mut cfg = ServerConfig::builder()

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -400,7 +400,7 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
                 mandatory: opts.require_any_client_cert,
             })
         } else {
-            rustls::server::NoClientAuth::new_coerced()
+            rustls::server::NoClientAuth::boxed()
         };
 
     let cert = load_cert(&opts.cert_file);

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -400,7 +400,7 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
                 mandatory: opts.require_any_client_cert,
             })
         } else {
-            rustls::server::NoClientAuth::new()
+            rustls::server::NoClientAuth::new_coerced()
         };
 
     let cert = load_cert(&opts.cert_file);

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -31,7 +31,7 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
 
     /// Disable client authentication.
     pub fn with_no_client_auth(self) -> ConfigBuilder<ServerConfig, WantsServerCert> {
-        self.with_client_cert_verifier(verify::NoClientAuth::new_coerced())
+        self.with_client_cert_verifier(verify::NoClientAuth::boxed())
     }
 }
 

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -31,7 +31,7 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
 
     /// Disable client authentication.
     pub fn with_no_client_auth(self) -> ConfigBuilder<ServerConfig, WantsServerCert> {
-        self.with_client_cert_verifier(verify::NoClientAuth::new())
+        self.with_client_cert_verifier(verify::NoClientAuth::new_coerced())
     }
 }
 

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -535,8 +535,16 @@ impl AllowAnyAuthenticatedClient {
     /// Construct a new `AllowAnyAuthenticatedClient`.
     ///
     /// `roots` is the list of trust anchors to use for certificate validation.
-    pub fn new(roots: RootCertStore) -> Arc<dyn ClientCertVerifier> {
-        Arc::new(Self { roots })
+    pub fn new(roots: RootCertStore) -> Self {
+        Self { roots }
+    }
+
+    /// Wrap this verifier in an [`Arc`] and coerce it to `dyn ClientCertVerifier`
+    #[inline(always)]
+    pub fn coerce(self) -> Arc<dyn ClientCertVerifier> {
+        // This function is needed because `ClientCertVerifier` is only reachable if the
+        // `dangerous_configuration` feature is enabled, which makes coercing hard to outside users
+        Arc::new(self)
     }
 }
 
@@ -583,10 +591,18 @@ impl AllowAnyAnonymousOrAuthenticatedClient {
     /// Construct a new `AllowAnyAnonymousOrAuthenticatedClient`.
     ///
     /// `roots` is the list of trust anchors to use for certificate validation.
-    pub fn new(roots: RootCertStore) -> Arc<dyn ClientCertVerifier> {
-        Arc::new(Self {
+    pub fn new(roots: RootCertStore) -> Self {
+        Self {
             inner: AllowAnyAuthenticatedClient { roots },
-        })
+        }
+    }
+
+    /// Wrap this verifier in an [`Arc`] and coerce it to `dyn ClientCertVerifier`
+    #[inline(always)]
+    pub fn coerce(self) -> Arc<dyn ClientCertVerifier> {
+        // This function is needed because `ClientCertVerifier` is only reachable if the
+        // `dangerous_configuration` feature is enabled, which makes coercing hard to outside users
+        Arc::new(self)
     }
 }
 
@@ -634,8 +650,12 @@ fn pki_error(error: webpki::Error) -> Error {
 pub struct NoClientAuth;
 
 impl NoClientAuth {
-    /// Constructs a `NoClientAuth` and wraps it in an `Arc`.
-    pub fn new() -> Arc<dyn ClientCertVerifier> {
+    /// Constructs a [`NoClientAuth`], wraps it in an [`Arc`] and coerces it to
+    /// `dyn ClientCertVerifier`.
+    #[inline(always)]
+    pub fn new_coerced() -> Arc<dyn ClientCertVerifier> {
+        // This function is needed because `ClientCertVerifier` is only reachable if the
+        // `dangerous_configuration` feature is enabled, which makes coercing hard to outside users
         Arc::new(Self)
     }
 }

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -650,7 +650,7 @@ fn pki_error(error: webpki::Error) -> Error {
 pub struct NoClientAuth;
 
 impl NoClientAuth {
-    /// Constructs a [`NoClientAuth`], wraps it in an [`Arc`] and coerces it to
+    /// Construct a [`NoClientAuth`], wrap it in an [`Arc`] and coerce it to
     /// `dyn ClientCertVerifier`.
     #[inline(always)]
     pub fn boxed() -> Arc<dyn ClientCertVerifier> {

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -541,7 +541,7 @@ impl AllowAnyAuthenticatedClient {
 
     /// Wrap this verifier in an [`Arc`] and coerce it to `dyn ClientCertVerifier`
     #[inline(always)]
-    pub fn coerce(self) -> Arc<dyn ClientCertVerifier> {
+    pub fn boxed(self) -> Arc<dyn ClientCertVerifier> {
         // This function is needed because `ClientCertVerifier` is only reachable if the
         // `dangerous_configuration` feature is enabled, which makes coercing hard to outside users
         Arc::new(self)
@@ -599,7 +599,7 @@ impl AllowAnyAnonymousOrAuthenticatedClient {
 
     /// Wrap this verifier in an [`Arc`] and coerce it to `dyn ClientCertVerifier`
     #[inline(always)]
-    pub fn coerce(self) -> Arc<dyn ClientCertVerifier> {
+    pub fn boxed(self) -> Arc<dyn ClientCertVerifier> {
         // This function is needed because `ClientCertVerifier` is only reachable if the
         // `dangerous_configuration` feature is enabled, which makes coercing hard to outside users
         Arc::new(self)
@@ -653,7 +653,7 @@ impl NoClientAuth {
     /// Constructs a [`NoClientAuth`], wraps it in an [`Arc`] and coerces it to
     /// `dyn ClientCertVerifier`.
     #[inline(always)]
-    pub fn new_coerced() -> Arc<dyn ClientCertVerifier> {
+    pub fn boxed() -> Arc<dyn ClientCertVerifier> {
         // This function is needed because `ClientCertVerifier` is only reachable if the
         // `dangerous_configuration` feature is enabled, which makes coercing hard to outside users
         Arc::new(Self)

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -454,11 +454,11 @@ fn server_allow_any_anonymous_or_authenticated_client() {
     let kt = KeyType::Rsa;
     for client_cert_chain in [None, Some(kt.get_client_chain())].iter() {
         let client_auth_roots = get_client_root_store(kt);
-        let client_auth = AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots).coerce();
+        let client_auth = AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots);
 
         let server_config = ServerConfig::builder()
             .with_safe_defaults()
-            .with_client_cert_verifier(client_auth)
+            .with_client_cert_verifier(Arc::new(client_auth))
             .with_single_cert(kt.get_chain(), kt.get_key())
             .unwrap();
         let server_config = Arc::new(server_config);

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -454,7 +454,7 @@ fn server_allow_any_anonymous_or_authenticated_client() {
     let kt = KeyType::Rsa;
     for client_cert_chain in [None, Some(kt.get_client_chain())].iter() {
         let client_auth_roots = get_client_root_store(kt);
-        let client_auth = AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots);
+        let client_auth = AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots).coerce();
 
         let server_config = ServerConfig::builder()
             .with_safe_defaults()

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -282,11 +282,11 @@ pub fn get_client_root_store(kt: KeyType) -> RootCertStore {
 pub fn make_server_config_with_mandatory_client_auth(kt: KeyType) -> ServerConfig {
     let client_auth_roots = get_client_root_store(kt);
 
-    let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots).coerce();
+    let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots);
 
     ServerConfig::builder()
         .with_safe_defaults()
-        .with_client_cert_verifier(client_auth)
+        .with_client_cert_verifier(Arc::new(client_auth))
         .with_single_cert(kt.get_chain(), kt.get_key())
         .unwrap()
 }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -282,7 +282,7 @@ pub fn get_client_root_store(kt: KeyType) -> RootCertStore {
 pub fn make_server_config_with_mandatory_client_auth(kt: KeyType) -> ServerConfig {
     let client_auth_roots = get_client_root_store(kt);
 
-    let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots);
+    let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots).coerce();
 
     ServerConfig::builder()
         .with_safe_defaults()


### PR DESCRIPTION
Closes #1106

This turned out less elegant than first expected. The issue is that `ClientCertVerifier` is only reachable with the `dangerous_configuration` feature enabled.

Usually, the compiler is smart enough to do the coercion automatically. However, there are a few cases where you might need to coerce it in advance, I actually hit one such case in `tlsserver-mio`, where the compiler would delay the coercion on a nested if/else and cause a compilation error.

For the motivation, please see the issue and/or commit message.

Should I also add the changes description directly to the README ?