### PR TITLE
client: add support for sending unsupported cipher suites

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -187,6 +187,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             #[cfg(feature = "secret_extraction")]
             enable_secret_extraction: false,
             enable_early_data: false,
+            unsupported_suites: Vec::new(),
         }
     }
 }

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -92,6 +92,9 @@ pub enum Error {
     /// The `max_fragment_size` value supplied in configuration was too small,
     /// or too large.
     BadMaxFragmentSize,
+
+    /// The peer selected a unsupported cipher suite that we configured.
+    UnsupportedSuiteSelected,
 }
 
 #[non_exhaustive]
@@ -320,6 +323,9 @@ impl fmt::Display for Error {
             Self::FailedToGetRandomBytes => write!(f, "failed to get random bytes"),
             Self::BadMaxFragmentSize => {
                 write!(f, "the supplied max_fragment_size was too small or large")
+            }
+            Self::UnsupportedSuiteSelected => {
+                write!(f, "configured unsupported cipher suite selected")
             }
             Self::General(ref err) => write!(f, "unexpected error: {}", err),
         }


### PR DESCRIPTION
Fixes #1125. @ctz I know you said that you didn't want to support this, but I just wanted to sketch out for myself how much complexity it is to implement this given that there have been increasing requests for this (I don't like that this is necessary either, but I fear it might be a reality of competing with OpenSSL). IMO the resulting change is not too bad. If you're open to it, I'll add some tests.