### PR TITLE
improve & test ServerName debug output - workaround

### DIFF
--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -202,13 +202,22 @@ impl fmt::Debug for dyn ServerCertVerifier {
 }
 
 /// A type which encapsulates a string that is a syntactically valid DNS name.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct DnsName(pub(crate) webpki::DnsName);
 
 impl AsRef<str> for DnsName {
     fn as_ref(&self) -> &str {
         AsRef::<str>::as_ref(&self.0)
+    }
+}
+
+impl fmt::Debug for DnsName {
+    // Workaround solution for ServerName debug formatting:
+    // Just show the string contents here, as verify::DnsName is only
+    // used in ServerName which has some more verbose debug output
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", &self.as_ref())
     }
 }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4611,3 +4611,22 @@ fn test_received_plaintext_backpressure() {
         24
     );
 }
+
+#[test]
+fn test_debug_server_name_from_ip() {
+    assert_eq!(
+        format!(
+            "{:?}",
+            rustls::ServerName::IpAddress("127.0.0.1".parse().unwrap())
+        ),
+        "IpAddress(127.0.0.1)"
+    )
+}
+
+#[test]
+fn test_debug_server_name_from_string() {
+    assert_eq!(
+        format!("{:?}", rustls::ServerName::try_from("a.com").unwrap()),
+        "DnsName(\"a.com\")"
+    )
+}


### PR DESCRIPTION
**hopefully** resolves #1177

**before:**

result from `format!("{:?}", rustls::ServerName::try_from("a.com"))`:

    Ok(DnsName(DnsName(DnsName(\"a.com\"))))

**after:**

result from `format!("{:?}", rustls::ServerName::try_from("a.com"))`:

    Ok(DnsName(\"a.com\"))

**also tested:**

`rustls::ServerName::IpAddress("127.0.0.1".parse().unwrap())` formats as:

    IpAddress(127.0.0.1)

As I said in 3a3e203d51f08463719513f0bd6cb5f7716631cb, I think the root cause lies in the difference between the standard debug formatting of tuples vs enums in Rust.

Quick disclaimer that I just started learning Rust after many years of programming and this is actually my first ever contribution in this language. I made a simple workaround solution for now but think it would be ideal to consider further improvement in the future. Please feel free to leave **candid** feedback or even rework before merging if needed.

I would personally favor merging this one in a squash commit and would be happy to squash the changes myself if needed.