### PR TITLE
Remove DnsName wrapper & ServerName debug formatting

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -272,7 +272,7 @@ pub enum ServerName {
     /// The server is identified by a DNS name.  The name
     /// is sent in the TLS Server Name Indication (SNI)
     /// extension.
-    DnsName(verify::DnsName),
+    DnsName(webpki::DnsName),
 
     /// The server is identified by an IP address. SNI is not
     /// done.
@@ -285,7 +285,7 @@ impl ServerName {
     /// in the handshake.
     pub(crate) fn for_sni(&self) -> Option<webpki::DnsNameRef> {
         match self {
-            Self::DnsName(dns_name) => Some(dns_name.0.as_ref()),
+            Self::DnsName(dns_name) => Some(dns_name.as_ref()),
             Self::IpAddress(_) => None,
         }
     }
@@ -297,7 +297,7 @@ impl TryFrom<&str> for ServerName {
     type Error = InvalidDnsNameError;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match webpki::DnsNameRef::try_from_ascii_str(s) {
-            Ok(dns) => Ok(Self::DnsName(verify::DnsName(dns.into()))),
+            Ok(dns) => Ok(Self::DnsName(dns.to_owned())),
             Err(webpki::InvalidDnsNameError) => match s.parse() {
                 Ok(ip) => Ok(Self::IpAddress(ip)),
                 Err(_) => Err(InvalidDnsNameError),

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -267,7 +267,7 @@ impl ClientConfig {
 /// # let _: ServerName = x;
 /// ```
 #[non_exhaustive]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub enum ServerName {
     /// The server is identified by a DNS name.  The name
     /// is sent in the TLS Server Name Indication (SNI)
@@ -302,6 +302,21 @@ impl TryFrom<&str> for ServerName {
                 Ok(ip) => Ok(Self::IpAddress(ip)),
                 Err(_) => Err(InvalidDnsNameError),
             },
+        }
+    }
+}
+
+impl fmt::Debug for ServerName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self {
+            Self::DnsName(name) => f
+                .debug_tuple("ServerName::DnsName")
+                .field(&std::str::from_utf8(&name.as_ref().as_ref()).unwrap())
+                .finish(),
+            Self::IpAddress(ip) => f
+                .debug_tuple("ServerName::IpAddress")
+                .field(ip)
+                .finish(),
         }
     }
 }

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -201,17 +201,6 @@ impl fmt::Debug for dyn ServerCertVerifier {
     }
 }
 
-/// A type which encapsulates a string that is a syntactically valid DNS name.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
-pub struct DnsName(pub(crate) webpki::DnsName);
-
-impl AsRef<str> for DnsName {
-    fn as_ref(&self) -> &str {
-        AsRef::<str>::as_ref(&self.0)
-    }
-}
-
 /// Something that can verify a client certificate chain
 #[allow(unreachable_pub)]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
@@ -365,7 +354,7 @@ impl ServerCertVerifier for WebPkiVerifier {
 
         match server_name {
             ServerName::DnsName(dns_name) => {
-                let name = webpki::SubjectNameRef::DnsName(dns_name.0.as_ref());
+                let name = webpki::SubjectNameRef::DnsName(dns_name.as_ref());
                 cert.verify_is_valid_for_subject_name(name)
                     .map_err(pki_error)
                     .map(|_| ServerCertVerified::assertion())

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4611,3 +4611,22 @@ fn test_received_plaintext_backpressure() {
         24
     );
 }
+
+#[test]
+fn test_debug_server_name_from_ip() {
+    assert_eq!(
+        format!(
+            "{:?}",
+            rustls::ServerName::IpAddress("127.0.0.1".parse().unwrap())
+        ),
+        "IpAddress(127.0.0.1)"
+    )
+}
+
+#[test]
+fn test_debug_server_name_from_string() {
+    assert_eq!(
+        format!("{:?}", rustls::ServerName::try_from("a.com")),
+        "Ok(DnsName(DnsName(DnsName(\"a.com\"))))"
+    )
+}

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4627,6 +4627,6 @@ fn test_debug_server_name_from_ip() {
 fn test_debug_server_name_from_string() {
     assert_eq!(
         format!("{:?}", rustls::ServerName::try_from("a.com")),
-        "Ok(DnsName(DnsName(DnsName(\"a.com\"))))"
+        "Ok(DnsName(DnsName(\"a.com\")))"
     )
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4619,7 +4619,7 @@ fn test_debug_server_name_from_ip() {
             "{:?}",
             rustls::ServerName::IpAddress("127.0.0.1".parse().unwrap())
         ),
-        "IpAddress(127.0.0.1)"
+        "ServerName::IpAddress(127.0.0.1)"
     )
 }
 
@@ -4627,6 +4627,6 @@ fn test_debug_server_name_from_ip() {
 fn test_debug_server_name_from_string() {
     assert_eq!(
         format!("{:?}", rustls::ServerName::try_from("a.com")),
-        "Ok(DnsName(DnsName(\"a.com\")))"
+        "Ok(ServerName::DnsName(\"a.com\"))"
     )
 }


### PR DESCRIPTION
alternate solution to resolve #1177 - _potentially controversial_

removes an internal, private wrapper that was documented as "dangerous_configuration"

tests from PR #1192

result from `format!("{:?}", rustls::ServerName::try_from("a.com"))`

    ServerName::IpAddress(127.0.0.1)

result from `rustls::ServerName::IpAddress("127.0.0.1".parse().unwrap())`:

    Ok(ServerName::DnsName(\"a.com\"))