### PR TITLE
Lints: use Self and fix missing semicolons

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ quic = ["rustls/quic"]
 
 [dependencies]
 docopt = "~1.1"
-env_logger = "0.9.0"
+env_logger = "0.9.0" # 0.10 requires an MSRV bump to 1.60
 log = { version = "0.4.4", optional = true }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 rustls = { path = "../rustls" }

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -32,8 +32,8 @@ impl TlsClient {
         sock: TcpStream,
         server_name: rustls::ServerName,
         cfg: Arc<rustls::ClientConfig>,
-    ) -> TlsClient {
-        TlsClient {
+    ) -> Self {
+        Self {
             socket: sock,
             closing: false,
             clean_closure: false,

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -50,7 +50,7 @@ struct TlsServer {
 
 impl TlsServer {
     fn new(server: TcpListener, mode: ServerMode, cfg: Arc<rustls::ServerConfig>) -> Self {
-        TlsServer {
+        Self {
             server,
             connections: HashMap::new(),
             next_id: 2,
@@ -154,9 +154,9 @@ impl OpenConnection {
         token: mio::Token,
         mode: ServerMode,
         tls_conn: rustls::ServerConnection,
-    ) -> OpenConnection {
+    ) -> Self {
         let back = open_back(&mode);
-        OpenConnection {
+        Self {
             socket,
             token,
             closing: false,

--- a/examples/tests/common/mod.rs
+++ b/examples/tests/common/mod.rs
@@ -188,7 +188,7 @@ pub struct TlsClient {
 
 impl TlsClient {
     pub fn new(hostname: &str) -> Self {
-        TlsClient {
+        Self {
             hostname: hostname.to_string(),
             port: 443,
             http: true,
@@ -205,59 +205,59 @@ impl TlsClient {
         }
     }
 
-    pub fn cafile(&mut self, cafile: &Path) -> &mut TlsClient {
+    pub fn cafile(&mut self, cafile: &Path) -> &mut Self {
         self.cafile = Some(cafile.to_path_buf());
         self
     }
 
-    pub fn cache(&mut self, cache: &str) -> &mut TlsClient {
+    pub fn cache(&mut self, cache: &str) -> &mut Self {
         self.cache = Some(cache.to_string());
         self
     }
 
-    pub fn no_sni(&mut self) -> &mut TlsClient {
+    pub fn no_sni(&mut self) -> &mut Self {
         self.no_sni = true;
         self
     }
 
-    pub fn insecure(&mut self) -> &mut TlsClient {
+    pub fn insecure(&mut self) -> &mut Self {
         self.insecure = true;
         self
     }
 
-    pub fn verbose(&mut self) -> &mut TlsClient {
+    pub fn verbose(&mut self) -> &mut Self {
         self.verbose = true;
         self
     }
 
-    pub fn max_fragment_size(&mut self, max_fragment_size: usize) -> &mut TlsClient {
+    pub fn max_fragment_size(&mut self, max_fragment_size: usize) -> &mut Self {
         self.max_fragment_size = Some(max_fragment_size);
         self
     }
 
-    pub fn port(&mut self, port: u16) -> &mut TlsClient {
+    pub fn port(&mut self, port: u16) -> &mut Self {
         self.port = port;
         self
     }
 
-    pub fn expect(&mut self, expect: &str) -> &mut TlsClient {
+    pub fn expect(&mut self, expect: &str) -> &mut Self {
         self.expect_output
             .push(expect.to_string());
         self
     }
 
-    pub fn expect_log(&mut self, expect: &str) -> &mut TlsClient {
+    pub fn expect_log(&mut self, expect: &str) -> &mut Self {
         self.verbose = true;
         self.expect_log.push(expect.to_string());
         self
     }
 
-    pub fn suite(&mut self, suite: &str) -> &mut TlsClient {
+    pub fn suite(&mut self, suite: &str) -> &mut Self {
         self.suites.push(suite.to_string());
         self
     }
 
-    pub fn fails(&mut self) -> &mut TlsClient {
+    pub fn fails(&mut self) -> &mut Self {
         self.expect_fails = true;
         self
     }

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -136,9 +136,9 @@ enum Resumption {
 impl Resumption {
     fn label(&self) -> &'static str {
         match *self {
-            Resumption::No => "no-resume",
-            Resumption::SessionID => "sessionid",
-            Resumption::Tickets => "tickets",
+            Self::No => "no-resume",
+            Self::SessionID => "sessionid",
+            Self::Tickets => "tickets",
         }
     }
 }
@@ -162,8 +162,8 @@ impl BenchmarkParam {
         key_type: KeyType,
         ciphersuite: rustls::SupportedCipherSuite,
         version: &'static rustls::SupportedProtocolVersion,
-    ) -> BenchmarkParam {
-        BenchmarkParam {
+    ) -> Self {
+        Self {
             key_type,
             ciphersuite,
             version,
@@ -244,9 +244,9 @@ static ALL_BENCHMARKS: &[BenchmarkParam] = &[
 impl KeyType {
     fn path_for(&self, part: &str) -> String {
         match self {
-            KeyType::Rsa => format!("test-ca/rsa/{}", part),
-            KeyType::Ecdsa => format!("test-ca/ecdsa/{}", part),
-            KeyType::Ed25519 => format!("test-ca/eddsa/{}", part),
+            Self::Rsa => format!("test-ca/rsa/{}", part),
+            Self::Ecdsa => format!("test-ca/ecdsa/{}", part),
+            Self::Ed25519 => format!("test-ca/eddsa/{}", part),
         }
     }
 

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -120,7 +120,7 @@ impl RootCertStore {
         &mut self,
         trust_anchors: impl Iterator<Item = OwnedTrustAnchor>,
     ) {
-        self.roots.extend(trust_anchors)
+        self.roots.extend(trust_anchors);
     }
 
     /// Parse the given DER-encoded certificates and add all that can be parsed
@@ -141,7 +141,7 @@ impl RootCertStore {
                 Err(err) => {
                     trace!("invalid cert der {:?}", der_cert);
                     debug!("certificate parsing failed: {:?}", err);
-                    invalid_count += 1
+                    invalid_count += 1;
                 }
             }
         }

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -138,7 +138,7 @@ impl client::ClientSessionStore for ClientSessionMemoryCache {
                     data.tls13.pop_front();
                 }
                 data.tls13.push_back(value);
-            })
+            });
     }
 
     fn take_tls13_ticket(
@@ -224,7 +224,7 @@ mod test {
         c.set_tls12_session(
             &name,
             persist::Tls12ClientSessionValue::new(
-                &tls12_suite,
+                tls12_suite,
                 SessionID::empty(),
                 Vec::new(),
                 Vec::new(),
@@ -240,7 +240,7 @@ mod test {
         c.insert_tls13_ticket(
             &name,
             persist::Tls13ClientSessionValue::new(
-                &tls13_suite,
+                tls13_suite,
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -164,7 +164,7 @@ pub(super) fn hex<'a>(
     payload: impl IntoIterator<Item = &'a u8>,
 ) -> fmt::Result {
     for b in payload {
-        write!(f, "{:02x}", b)?
+        write!(f, "{:02x}", b)?;
     }
     Ok(())
 }

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -159,7 +159,7 @@ impl From<u24> for usize {
 impl Codec for u24 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         let be_bytes = u32::to_be_bytes(self.0);
-        bytes.extend_from_slice(&be_bytes[1..])
+        bytes.extend_from_slice(&be_bytes[1..]);
     }
 
     fn read(r: &mut Reader) -> Option<Self> {
@@ -173,7 +173,7 @@ pub fn decode_u32(bytes: &[u8]) -> Option<u32> {
 
 impl Codec for u32 {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        bytes.extend(Self::to_be_bytes(*self))
+        bytes.extend(Self::to_be_bytes(*self));
     }
 
     fn read(r: &mut Reader) -> Option<Self> {
@@ -183,7 +183,7 @@ impl Codec for u32 {
 
 pub fn put_u64(v: u64, bytes: &mut [u8]) {
     let bytes: &mut [u8; 8] = (&mut bytes[..8]).try_into().unwrap();
-    *bytes = u64::to_be_bytes(v)
+    *bytes = u64::to_be_bytes(v);
 }
 
 pub fn decode_u64(bytes: &[u8]) -> Option<u64> {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -122,7 +122,7 @@ impl PartialEq for SessionID {
 
         let mut diff = 0u8;
         for i in 0..self.len {
-            diff |= self.data[i] ^ other.data[i]
+            diff |= self.data[i] ^ other.data[i];
         }
 
         diff == 0u8
@@ -620,7 +620,7 @@ impl Codec for ClientExtension {
             Self::Cookie(ref r) => r.encode(&mut sub),
             Self::CertificateStatusRequest(ref r) => r.encode(&mut sub),
             Self::TransportParameters(ref r) | Self::TransportParametersDraft(ref r) => {
-                sub.extend_from_slice(r)
+                sub.extend_from_slice(r);
             }
             Self::Unknown(ref r) => r.encode(&mut sub),
         }
@@ -781,7 +781,7 @@ impl Codec for ServerExtension {
             Self::SignedCertificateTimestamp(ref r) => r.encode(&mut sub),
             Self::SupportedVersions(ref r) => r.encode(&mut sub),
             Self::TransportParameters(ref r) | Self::TransportParametersDraft(ref r) => {
-                sub.extend_from_slice(r)
+                sub.extend_from_slice(r);
             }
             Self::Unknown(ref r) => r.encode(&mut sub),
         }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -502,7 +502,7 @@ pub(super) fn process_client_hello<'a>(
         // Save the SNI into the session.
         // The SNI hostname is immutable once set.
         assert!(data.sni.is_none());
-        data.sni = Some(sni.clone())
+        data.sni = Some(sni.clone());
     } else if data.sni != sni {
         return Err(PeerMisbehaved::ServerNameDifferedOnRetry.into());
     }

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -383,7 +383,7 @@ impl ConnectionSecrets {
             &self.master_secret,
             label,
             &randoms,
-        )
+        );
     }
 
     #[cfg(feature = "secret_extraction")]

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -605,13 +605,13 @@ impl KeySchedule {
             .set_message_encrypter(Box::new(Tls13MessageEncrypter {
                 enc_key: aead::LessSafeKey::new(key),
                 iv,
-            }))
+            }));
     }
 
     fn set_decrypter(&self, secret: &hkdf::Prk, common: &mut CommonState) {
         common
             .record_layer
-            .set_message_decrypter(self.derive_decrypter(secret))
+            .set_message_decrypter(self.derive_decrypter(secret));
     }
 
     fn derive_decrypter(&self, secret: &hkdf::Prk) -> Box<dyn MessageDecrypter> {

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -59,10 +59,10 @@ impl fmt::Debug for EnabledVersions {
         let mut list = &mut f.debug_list();
         #[cfg(feature = "tls12")]
         if let Some(v) = self.tls12 {
-            list = list.entry(v)
+            list = list.entry(v);
         }
         if let Some(v) = self.tls13 {
-            list = list.entry(v)
+            list = list.entry(v);
         }
         list.finish()
     }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -8,8 +8,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use log;
-
 use rustls::client::ResolvesClientCert;
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
@@ -103,12 +101,12 @@ fn version_test(
     result: Option<ProtocolVersion>,
 ) {
     let client_versions = if client_versions.is_empty() {
-        &rustls::ALL_VERSIONS
+        rustls::ALL_VERSIONS
     } else {
         client_versions
     };
     let server_versions = if server_versions.is_empty() {
-        &rustls::ALL_VERSIONS
+        rustls::ALL_VERSIONS
     } else {
         server_versions
     };
@@ -893,7 +891,7 @@ struct ClientCheckCertResolve {
 
 impl ClientCheckCertResolve {
     fn new(expect_queries: usize) -> Self {
-        ClientCheckCertResolve {
+        Self {
             query_count: AtomicUsize::new(0),
             expect_queries,
         }
@@ -2254,7 +2252,7 @@ struct KeyLogToVec {
 
 impl KeyLogToVec {
     fn new(who: &'static str) -> Self {
-        KeyLogToVec {
+        Self {
             label: who,
             items: Mutex::new(vec![]),
         }
@@ -2618,7 +2616,7 @@ struct ServerStorage {
 
 impl ServerStorage {
     fn new() -> Self {
-        ServerStorage {
+        Self {
             storage: rustls::server::ServerSessionMemoryCache::new(1024),
             put_count: AtomicUsize::new(0),
             get_count: AtomicUsize::new(0),
@@ -2689,7 +2687,7 @@ struct ClientStorage {
 
 impl ClientStorage {
     fn new() -> Self {
-        ClientStorage {
+        Self {
             storage: rustls::client::ClientSessionMemoryCache::new(1024),
             ops: Mutex::new(Vec::new()),
         }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -188,9 +188,9 @@ pub static ALL_KEY_TYPES: [KeyType; 3] = [KeyType::Rsa, KeyType::Ecdsa, KeyType:
 impl KeyType {
     fn bytes_for(&self, part: &str) -> &'static [u8] {
         match self {
-            KeyType::Rsa => bytes_for("rsa", part),
-            KeyType::Ecdsa => bytes_for("ecdsa", part),
-            KeyType::Ed25519 => bytes_for("eddsa", part),
+            Self::Rsa => bytes_for("rsa", part),
+            Self::Ecdsa => bytes_for("ecdsa", part),
+            Self::Ed25519 => bytes_for("eddsa", part),
         }
     }
 
@@ -462,7 +462,7 @@ pub struct FailsReads {
 
 impl FailsReads {
     pub fn new(errkind: io::ErrorKind) -> Self {
-        FailsReads { errkind }
+        Self { errkind }
     }
 }
 


### PR DESCRIPTION
* fix [semicolon_if_nothing_returned](https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned) clippy lint
* fix [use_self](https://rust-lang.github.io/rust-clippy/master/index.html#use_self) clippy lint

This makes the code a bit cleaner, esp the self lint, when browsing the code in an IDE

Other minor fixes:
* remove non-needed `use log;`
* remove a few unneeded `&`
* copied comment explain why env_logger is pinned