### PR TITLE
msgs: yield Result instead of Option from Reader/Codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
   - The minimum supported Rust version is now 1.56.0 due to several dependencies
     requiring it.
 * 0.20.6 (2022-05-18)
-  - 0.20.5 included a change to track more context for the `Error::InvalidMessage`
+  - 0.20.5 included a change to track more context for the `Error::CorruptMessage`
     which made API-incompatible changes to the `Error` type. We yanked 0.20.5
     and have reverted that change as part of 0.20.6.
 * 0.20.5 (2022-05-14)

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -401,7 +401,7 @@ impl State<ClientConnectionData> for ExpectServerKx {
         self.transcript.add_message(&m);
 
         let ecdhe = opaque_kx
-            .unwrap_given_kxa(&self.suite.kx)
+            .unwrap_given_kxa(self.suite.kx)
             .ok_or_else(|| {
                 cx.common
                     .send_fatal_alert(AlertDescription::DecodeError);

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -3,7 +3,6 @@ use crate::conn::{CommonState, ConnectionRandoms, Side, State};
 use crate::enums::ProtocolVersion;
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
-use crate::kx;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::{Payload, PayloadU8};
@@ -23,7 +22,7 @@ use crate::suites::PartiallyExtractedSecrets;
 use crate::suites::SupportedCipherSuite;
 use crate::ticketer::TimeBase;
 use crate::tls12::{self, ConnectionSecrets, Tls12CipherSuite};
-use crate::verify;
+use crate::{kx, verify};
 
 use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1,5 +1,6 @@
 use crate::enums::ProtocolVersion;
-use crate::error::{Error, PeerMisbehaved};
+use crate::error::{Error, InvalidMessage, PeerMisbehaved};
+use crate::key;
 #[cfg(feature = "logging")]
 use crate::log::{debug, error, trace, warn};
 use crate::msgs::alert::AlertMessagePayload;
@@ -21,7 +22,6 @@ use crate::suites::{ExtractedSecrets, PartiallyExtractedSecrets};
 #[cfg(feature = "tls12")]
 use crate::tls12::ConnectionSecrets;
 use crate::vecbuf::ChunkVecBuffer;
-use crate::{key, InvalidMessage};
 #[cfg(feature = "quic")]
 use std::collections::VecDeque;
 

--- a/rustls/src/msgs/alert.rs
+++ b/rustls/src/msgs/alert.rs
@@ -1,3 +1,4 @@
+use crate::error::InvalidMessage;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, AlertLevel};
 
@@ -13,10 +14,10 @@ impl Codec for AlertMessagePayload {
         self.description.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let level = AlertLevel::read(r)?;
         let description = AlertDescription::read(r)?;
-
-        Some(Self { level, description })
+        r.expect_empty("AlertMessagePayload")
+            .map(|_| Self { level, description })
     }
 }

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::error::InvalidMessage;
 use crate::key;
 use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
@@ -13,8 +14,8 @@ impl Codec for Payload {
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        Some(Self::read(r))
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        Ok(Self::read(r))
     }
 }
 
@@ -38,11 +39,11 @@ impl Codec for key::Certificate {
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let len = codec::u24::read(r)?.0 as usize;
         let mut sub = r.sub(len)?;
         let body = sub.rest().to_vec();
-        Some(Self(body))
+        Ok(Self(body))
     }
 }
 
@@ -68,11 +69,11 @@ impl Codec for PayloadU24 {
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let len = codec::u24::read(r)?.0 as usize;
         let mut sub = r.sub(len)?;
         let body = sub.rest().to_vec();
-        Some(Self(body))
+        Ok(Self(body))
     }
 }
 
@@ -106,11 +107,11 @@ impl Codec for PayloadU16 {
         Self::encode_slice(&self.0, bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let len = u16::read(r)? as usize;
         let mut sub = r.sub(len)?;
         let body = sub.rest().to_vec();
-        Some(Self(body))
+        Ok(Self(body))
     }
 }
 
@@ -144,11 +145,11 @@ impl Codec for PayloadU8 {
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let len = u8::read(r)? as usize;
         let mut sub = r.sub(len)?;
         let body = sub.rest().to_vec();
-        Some(Self(body))
+        Ok(Self(body))
     }
 }
 

--- a/rustls/src/msgs/ccs.rs
+++ b/rustls/src/msgs/ccs.rs
@@ -1,3 +1,4 @@
+use crate::error::InvalidMessage;
 use crate::msgs::codec::{Codec, Reader};
 
 #[derive(Debug)]
@@ -8,13 +9,13 @@ impl Codec for ChangeCipherSpecPayload {
         1u8.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = u8::read(r)?;
-
-        if typ == 1 && !r.any_left() {
-            Some(Self {})
-        } else {
-            None
+        if typ != 1 {
+            return Err(InvalidMessage::InvalidCcs);
         }
+
+        r.expect_empty("ChangeCipherSpecPayload")
+            .map(|_| Self {})
     }
 }

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use crate::error::InvalidMessage;
+
 /// Wrapper over a slice of bytes that allows reading chunks from
 /// with the current position state held using a cursor.
 ///
@@ -26,8 +28,11 @@ impl<'a> Reader<'a> {
     /// Attempts to create a new Reader on a sub section of this
     /// readers bytes by taking a slice of the provided `length`
     /// will return None if there is not enough bytes
-    pub fn sub(&mut self, length: usize) -> Option<Reader> {
-        self.take(length).map(Reader::init)
+    pub fn sub(&mut self, length: usize) -> Result<Reader, InvalidMessage> {
+        match self.take(length) {
+            Some(bytes) => Ok(Reader::init(bytes)),
+            None => Err(InvalidMessage::MessageTooShort),
+        }
     }
 
     /// Borrows a slice of all the remaining bytes
@@ -59,6 +64,13 @@ impl<'a> Reader<'a> {
         self.cursor < self.buffer.len()
     }
 
+    pub fn expect_empty(&self, name: &'static str) -> Result<(), InvalidMessage> {
+        match self.any_left() {
+            true => Err(InvalidMessage::TrailingData(name)),
+            false => Ok(()),
+        }
+    }
+
     /// Returns the cursor position which is also the number
     /// of bytes that have been read from the buffer.
     pub fn used(&self) -> usize {
@@ -82,7 +94,7 @@ pub trait Codec: Debug + Sized {
     /// Function for decoding itself from the provided reader
     /// will return Some if the decoding was successful or
     /// None if it was not.
-    fn read(_: &mut Reader) -> Option<Self>;
+    fn read(_: &mut Reader) -> Result<Self, InvalidMessage>;
 
     /// Convenience function for encoding the implementation
     /// into a vec and returning it
@@ -94,15 +106,10 @@ pub trait Codec: Debug + Sized {
 
     /// Function for wrapping a call to the read function in
     /// a Reader for the slice of bytes provided
-    fn read_bytes(bytes: &[u8]) -> Option<Self> {
+    fn read_bytes(bytes: &[u8]) -> Result<Self, InvalidMessage> {
         let mut reader = Reader::init(bytes);
         Self::read(&mut reader)
     }
-}
-
-fn decode_u8(bytes: &[u8]) -> Option<u8> {
-    let [value]: [u8; 1] = bytes.try_into().ok()?;
-    Some(value)
 }
 
 impl Codec for u8 {
@@ -110,18 +117,17 @@ impl Codec for u8 {
         bytes.push(*self);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        r.take(1).and_then(decode_u8)
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        match r.take(1) {
+            Some(&[byte]) => Ok(byte),
+            _ => Err(InvalidMessage::MissingData("u8")),
+        }
     }
 }
 
 pub fn put_u16(v: u16, out: &mut [u8]) {
     let out: &mut [u8; 2] = (&mut out[..2]).try_into().unwrap();
     *out = u16::to_be_bytes(v);
-}
-
-pub fn decode_u16(bytes: &[u8]) -> Option<u16> {
-    Some(u16::from_be_bytes(bytes.try_into().ok()?))
 }
 
 impl Codec for u16 {
@@ -131,8 +137,11 @@ impl Codec for u16 {
         bytes.extend_from_slice(&b16);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        r.take(2).and_then(decode_u16)
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        match r.take(2) {
+            Some(&[b1, b2]) => Ok(Self::from_be_bytes([b1, b2])),
+            _ => Err(InvalidMessage::MissingData("u8")),
+        }
     }
 }
 
@@ -140,13 +149,6 @@ impl Codec for u16 {
 #[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone)]
 pub struct u24(pub u32);
-
-impl u24 {
-    pub fn decode(bytes: &[u8]) -> Option<Self> {
-        let [a, b, c]: [u8; 3] = bytes.try_into().ok()?;
-        Some(Self(u32::from_be_bytes([0, a, b, c])))
-    }
-}
 
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl From<u24> for usize {
@@ -162,13 +164,12 @@ impl Codec for u24 {
         bytes.extend_from_slice(&be_bytes[1..]);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        r.take(3).and_then(Self::decode)
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        match r.take(3) {
+            Some(&[a, b, c]) => Ok(Self(u32::from_be_bytes([0, a, b, c]))),
+            _ => Err(InvalidMessage::MissingData("u24")),
+        }
     }
-}
-
-pub fn decode_u32(bytes: &[u8]) -> Option<u32> {
-    Some(u32::from_be_bytes(bytes.try_into().ok()?))
 }
 
 impl Codec for u32 {
@@ -176,18 +177,17 @@ impl Codec for u32 {
         bytes.extend(Self::to_be_bytes(*self));
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        r.take(4).and_then(decode_u32)
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        match r.take(4) {
+            Some(&[a, b, c, d]) => Ok(Self::from_be_bytes([a, b, c, d])),
+            _ => Err(InvalidMessage::MissingData("u32")),
+        }
     }
 }
 
 pub fn put_u64(v: u64, bytes: &mut [u8]) {
     let bytes: &mut [u8; 8] = (&mut bytes[..8]).try_into().unwrap();
     *bytes = u64::to_be_bytes(v);
-}
-
-pub fn decode_u64(bytes: &[u8]) -> Option<u64> {
-    Some(u64::from_be_bytes(bytes.try_into().ok()?))
 }
 
 impl Codec for u64 {
@@ -197,8 +197,11 @@ impl Codec for u64 {
         bytes.extend_from_slice(&b64);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        r.take(8).and_then(decode_u64)
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        match r.take(8) {
+            Some(&[a, b, c, d, e, f, g, h]) => Ok(Self::from_be_bytes([a, b, c, d, e, f, g, h])),
+            _ => Err(InvalidMessage::MissingData("u64")),
+        }
     }
 }
 
@@ -248,7 +251,7 @@ pub fn encode_vec_u24<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
     out.copy_from_slice(&len_bytes[1..]);
 }
 
-pub fn read_vec_u8<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
+pub fn read_vec_u8<T: Codec>(r: &mut Reader) -> Result<Vec<T>, InvalidMessage> {
     let mut ret: Vec<T> = Vec::new();
     let len = usize::from(u8::read(r)?);
     let mut sub = r.sub(len)?;
@@ -257,10 +260,10 @@ pub fn read_vec_u8<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
         ret.push(T::read(&mut sub)?);
     }
 
-    Some(ret)
+    Ok(ret)
 }
 
-pub fn read_vec_u16<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
+pub fn read_vec_u16<T: Codec>(r: &mut Reader) -> Result<Vec<T>, InvalidMessage> {
     let mut ret: Vec<T> = Vec::new();
     let len = usize::from(u16::read(r)?);
     let mut sub = r.sub(len)?;
@@ -269,14 +272,17 @@ pub fn read_vec_u16<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
         ret.push(T::read(&mut sub)?);
     }
 
-    Some(ret)
+    Ok(ret)
 }
 
-pub fn read_vec_u24_limited<T: Codec>(r: &mut Reader, max_bytes: usize) -> Option<Vec<T>> {
+pub fn read_vec_u24_limited<T: Codec>(
+    r: &mut Reader,
+    max_bytes: usize,
+) -> Result<Vec<T>, InvalidMessage> {
     let mut ret: Vec<T> = Vec::new();
     let len = u24::read(r)?.0 as usize;
     if len > max_bytes {
-        return None;
+        return Err(InvalidMessage::MessageTooLarge);
     }
 
     let mut sub = r.sub(len)?;
@@ -285,5 +291,5 @@ pub fn read_vec_u24_limited<T: Codec>(r: &mut Reader, max_bytes: usize) -> Optio
         ret.push(T::read(&mut sub)?);
     }
 
-    Some(ret)
+    Ok(ret)
 }

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::ops::Range;
 
 use super::base::Payload;
+use super::codec::Codec;
 use super::enums::ContentType;
 use super::message::PlainMessage;
 use crate::enums::ProtocolVersion;
@@ -396,11 +397,11 @@ fn payload_size(buf: &[u8]) -> Result<Option<usize>, Error> {
     }
 
     let (header, _) = buf.split_at(HEADER_SIZE);
-    match codec::u24::decode(&header[1..]) {
-        Some(len) if len.0 > MAX_HANDSHAKE_SIZE => {
-            Err(InvalidMessage::HandshakePayloadTooLarge.into())
-        }
-        Some(len) => Ok(Some(HEADER_SIZE + usize::from(len))),
+    match codec::u24::read_bytes(&header[1..]) {
+        Ok(len) if len.0 > MAX_HANDSHAKE_SIZE => Err(Error::InvalidMessage(
+            InvalidMessage::HandshakePayloadTooLarge,
+        )),
+        Ok(len) => Ok(Some(HEADER_SIZE + usize::from(len))),
         _ => Ok(None),
     }
 }

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -4,11 +4,11 @@ use std::ops::Range;
 use super::base::Payload;
 use super::enums::ContentType;
 use super::message::PlainMessage;
-use crate::error::{Error, PeerMisbehaved};
+use crate::enums::ProtocolVersion;
+use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::msgs::codec;
 use crate::msgs::message::{MessageError, OpaqueMessage};
 use crate::record_layer::{Decrypted, RecordLayer};
-use crate::{InvalidMessage, ProtocolVersion};
 
 /// This deframer works to reconstruct TLS messages from a stream of arbitrary-sized reads.
 ///

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
+use crate::error::InvalidMessage;
 use crate::key;
 use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
 use crate::msgs::codec;
@@ -26,7 +27,7 @@ macro_rules! declare_u8_vec(
         codec::encode_vec_u8(bytes, self);
       }
 
-      fn read(r: &mut Reader) -> Option<Self> {
+      fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         codec::read_vec_u8::<$itemtype>(r)
       }
     }
@@ -42,7 +43,7 @@ macro_rules! declare_u16_vec(
         codec::encode_vec_u16(bytes, self);
       }
 
-      fn read(r: &mut Reader) -> Option<Self> {
+      fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         codec::read_vec_u16::<$itemtype>(r)
       }
     }
@@ -73,12 +74,15 @@ impl Codec for Random {
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        let bytes = r.take(32)?;
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        let bytes = match r.take(32) {
+            Some(bytes) => bytes,
+            None => return Err(InvalidMessage::MissingData("Random")),
+        };
+
         let mut opaque = [0; 32];
         opaque.clone_from_slice(bytes);
-
-        Some(Self(opaque))
+        Ok(Self(opaque))
     }
 }
 
@@ -136,17 +140,20 @@ impl Codec for SessionID {
         bytes.extend_from_slice(&self.data[..self.len]);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let len = u8::read(r)? as usize;
         if len > 32 {
-            return None;
+            return Err(InvalidMessage::TrailingData("SessionID"));
         }
 
-        let bytes = r.take(len)?;
+        let bytes = match r.take(len) {
+            Some(bytes) => bytes,
+            None => return Err(InvalidMessage::MissingData("SessionID")),
+        };
+
         let mut out = [0u8; 32];
         out[..len].clone_from_slice(&bytes[..len]);
-
-        Some(Self { data: out, len })
+        Ok(Self { data: out, len })
     }
 }
 
@@ -261,19 +268,19 @@ impl ServerNamePayload {
         Self::HostName((raw, hostname))
     }
 
-    fn read_hostname(r: &mut Reader) -> Option<Self> {
+    fn read_hostname(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let raw = PayloadU16::read(r)?;
-
         let dns_name = {
             match webpki::DnsNameRef::try_from_ascii(&raw.0) {
                 Ok(dns_name) => dns_name.into(),
                 Err(_) => {
                     warn!("Illegal SNI hostname received {:?}", raw.0);
-                    return None;
+                    return Err(InvalidMessage::InvalidServerName);
                 }
             }
         };
-        Some(Self::HostName((raw, dns_name)))
+
+        Ok(Self::HostName((raw, dns_name)))
     }
 
     fn encode(&self, bytes: &mut Vec<u8>) {
@@ -296,7 +303,7 @@ impl Codec for ServerName {
         self.payload.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = ServerNameType::read(r)?;
 
         let payload = match typ {
@@ -304,7 +311,7 @@ impl Codec for ServerName {
             _ => ServerNamePayload::Unknown(Payload::read(r)),
         };
 
-        Some(Self { typ, payload })
+        Ok(Self { typ, payload })
     }
 }
 
@@ -400,11 +407,11 @@ impl Codec for KeyShareEntry {
         self.payload.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let group = NamedGroup::read(r)?;
         let payload = PayloadU16::read(r)?;
 
-        Some(Self { group, payload })
+        Ok(Self { group, payload })
     }
 }
 
@@ -430,8 +437,8 @@ impl Codec for PresharedKeyIdentity {
         self.obfuscated_ticket_age.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        Some(Self {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        Ok(Self {
             identity: PayloadU16::read(r)?,
             obfuscated_ticket_age: u32::read(r)?,
         })
@@ -464,8 +471,8 @@ impl Codec for PresharedKeyOffer {
         self.binders.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        Some(Self {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        Ok(Self {
             identities: PresharedKeyIdentities::read(r)?,
             binders: PresharedKeyBinders::read(r)?,
         })
@@ -488,8 +495,8 @@ impl Codec for OCSPCertificateStatusRequest {
         self.extensions.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        Some(Self {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        Ok(Self {
             responder_ids: ResponderIDs::read(r)?,
             extensions: PayloadU16::read(r)?,
         })
@@ -513,17 +520,17 @@ impl Codec for CertificateStatusRequest {
         }
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = CertificateStatusType::read(r)?;
 
         match typ {
             CertificateStatusType::OCSP => {
                 let ocsp_req = OCSPCertificateStatusRequest::read(r)?;
-                Some(Self::OCSP(ocsp_req))
+                Ok(Self::OCSP(ocsp_req))
             }
             _ => {
                 let data = Payload::read(r);
-                Some(Self::Unknown((typ, data)))
+                Ok(Self::Unknown((typ, data)))
             }
         }
     }
@@ -629,7 +636,7 @@ impl Codec for ClientExtension {
         bytes.append(&mut sub);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = ExtensionType::read(r)?;
         let len = u16::read(r)? as usize;
         let mut sub = r.sub(len)?;
@@ -680,11 +687,8 @@ impl Codec for ClientExtension {
             _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
         };
 
-        if sub.any_left() {
-            None
-        } else {
-            Some(ext)
-        }
+        sub.expect_empty("ClientExtension")
+            .map(|_| ext)
     }
 }
 
@@ -790,7 +794,7 @@ impl Codec for ServerExtension {
         bytes.append(&mut sub);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = ExtensionType::read(r)?;
         let len = u16::read(r)? as usize;
         let mut sub = r.sub(len)?;
@@ -824,11 +828,8 @@ impl Codec for ServerExtension {
             _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
         };
 
-        if sub.any_left() {
-            None
-        } else {
-            Some(ext)
-        }
+        sub.expect_empty("ServerExtension")
+            .map(|_| ext)
     }
 }
 
@@ -871,7 +872,7 @@ impl Codec for ClientHelloPayload {
         }
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let mut ret = Self {
             client_version: ProtocolVersion::read(r)?,
             random: Random::read(r)?,
@@ -885,10 +886,10 @@ impl Codec for ClientHelloPayload {
             ret.extensions = codec::read_vec_u16::<ClientExtension>(r)?;
         }
 
-        if r.any_left() || ret.extensions.is_empty() {
-            None
-        } else {
-            Some(ret)
+        match (r.any_left(), ret.extensions.is_empty()) {
+            (true, _) => Err(InvalidMessage::TrailingData("ClientHelloPayload")),
+            (_, true) => Err(InvalidMessage::MissingData("ClientHelloPayload")),
+            _ => Ok(ret),
         }
     }
 }
@@ -1085,7 +1086,7 @@ impl Codec for HelloRetryExtension {
         bytes.append(&mut sub);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = ExtensionType::read(r)?;
         let len = u16::read(r)? as usize;
         let mut sub = r.sub(len)?;
@@ -1099,11 +1100,8 @@ impl Codec for HelloRetryExtension {
             _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
         };
 
-        if sub.any_left() {
-            None
-        } else {
-            Some(ext)
-        }
+        sub.expect_empty("HelloRetryExtension")
+            .map(|_| ext)
     }
 }
 
@@ -1125,16 +1123,16 @@ impl Codec for HelloRetryRequest {
         codec::encode_vec_u16(bytes, &self.extensions);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let session_id = SessionID::read(r)?;
         let cipher_suite = CipherSuite::read(r)?;
         let compression = Compression::read(r)?;
 
         if compression != Compression::Null {
-            return None;
+            return Err(InvalidMessage::UnsupportedCompression);
         }
 
-        Some(Self {
+        Ok(Self {
             legacy_version: ProtocolVersion::Unknown(0),
             session_id,
             cipher_suite,
@@ -1225,7 +1223,7 @@ impl Codec for ServerHelloPayload {
     }
 
     // minus version and random, which have already been read.
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let session_id = SessionID::read(r)?;
         let suite = CipherSuite::read(r)?;
         let compression = Compression::read(r)?;
@@ -1249,11 +1247,8 @@ impl Codec for ServerHelloPayload {
             extensions,
         };
 
-        if r.any_left() {
-            None
-        } else {
-            Some(ret)
-        }
+        r.expect_empty("ServerHelloPayload")
+            .map(|_| ret)
     }
 }
 
@@ -1317,7 +1312,7 @@ impl Codec for CertificatePayload {
         codec::encode_vec_u24(bytes, self);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         // 64KB of certificates is plenty, 16MB is obviously silly
         codec::read_vec_u24_limited(r, 0x10000)
     }
@@ -1378,7 +1373,7 @@ impl Codec for CertificateExtension {
         bytes.append(&mut sub);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = ExtensionType::read(r)?;
         let len = u16::read(r)? as usize;
         let mut sub = r.sub(len)?;
@@ -1395,11 +1390,8 @@ impl Codec for CertificateExtension {
             _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
         };
 
-        if sub.any_left() {
-            None
-        } else {
-            Some(ext)
-        }
+        sub.expect_empty("CertificateExtension")
+            .map(|_| ext)
     }
 }
 
@@ -1417,8 +1409,8 @@ impl Codec for CertificateEntry {
         self.exts.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        Some(Self {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        Ok(Self {
             cert: key::Certificate::read(r)?,
             exts: CertificateExtensions::read(r)?,
         })
@@ -1481,8 +1473,8 @@ impl Codec for CertificatePayloadTLS13 {
         codec::encode_vec_u24(bytes, &self.entries);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
-        Some(Self {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        Ok(Self {
             context: PayloadU8::read(r)?,
             entries: codec::read_vec_u24_limited::<CertificateEntry>(r, 0x10000)?,
         })
@@ -1551,7 +1543,7 @@ impl CertificatePayloadTLS13 {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum KeyExchangeAlgorithm {
     BulkOnly,
     DH,
@@ -1576,16 +1568,15 @@ impl Codec for ECParameters {
         self.named_group.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let ct = ECCurveType::read(r)?;
-
         if ct != ECCurveType::NamedCurve {
-            return None;
+            return Err(InvalidMessage::UnsupportedCurve(ct));
         }
 
         let grp = NamedGroup::read(r)?;
 
-        Some(Self {
+        Ok(Self {
             curve_type: ct,
             named_group: grp,
         })
@@ -1620,11 +1611,11 @@ impl Codec for DigitallySignedStruct {
         self.sig.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let scheme = SignatureScheme::read(r)?;
         let sig = PayloadU16::read(r)?;
 
-        Some(Self { scheme, sig })
+        Ok(Self { scheme, sig })
     }
 }
 
@@ -1638,9 +1629,9 @@ impl Codec for ClientECDHParams {
         self.public.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let pb = PayloadU8::read(r)?;
-        Some(Self { public: pb })
+        Ok(Self { public: pb })
     }
 }
 
@@ -1668,11 +1659,11 @@ impl Codec for ServerECDHParams {
         self.public.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let cp = ECParameters::read(r)?;
         let pb = PayloadU8::read(r)?;
 
-        Some(Self {
+        Ok(Self {
             curve_params: cp,
             public: pb,
         })
@@ -1691,11 +1682,11 @@ impl Codec for ECDHEServerKeyExchange {
         self.dss.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let params = ServerECDHParams::read(r)?;
         let dss = DigitallySignedStruct::read(r)?;
 
-        Some(Self { params, dss })
+        Ok(Self { params, dss })
     }
 }
 
@@ -1713,25 +1704,25 @@ impl Codec for ServerKeyExchangePayload {
         }
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         // read as Unknown, fully parse when we know the
         // KeyExchangeAlgorithm
-        Some(Self::Unknown(Payload::read(r)))
+        Ok(Self::Unknown(Payload::read(r)))
     }
 }
 
 impl ServerKeyExchangePayload {
-    pub fn unwrap_given_kxa(&self, kxa: &KeyExchangeAlgorithm) -> Option<ECDHEServerKeyExchange> {
+    pub fn unwrap_given_kxa(&self, kxa: KeyExchangeAlgorithm) -> Option<ECDHEServerKeyExchange> {
         if let Self::Unknown(ref unk) = *self {
             let mut rd = Reader::init(&unk.0);
 
-            let result = match *kxa {
+            let result = match kxa {
                 KeyExchangeAlgorithm::ECDHE => ECDHEServerKeyExchange::read(&mut rd),
-                _ => None,
+                _ => return None,
             };
 
             if !rd.any_left() {
-                return result;
+                return result.ok();
             };
         }
 
@@ -1830,16 +1821,16 @@ impl Codec for CertificateRequestPayload {
         self.canames.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let certtypes = ClientCertificateTypes::read(r)?;
         let sigschemes = SupportedSignatureSchemes::read(r)?;
         let canames = DistinguishedNames::read(r)?;
 
         if sigschemes.is_empty() {
             warn!("meaningless CertificateRequest message");
-            None
+            Err(InvalidMessage::NoSignatureSchemes)
         } else {
-            Some(Self {
+            Ok(Self {
                 certtypes,
                 sigschemes,
                 canames,
@@ -1880,7 +1871,7 @@ impl Codec for CertReqExtension {
         bytes.append(&mut sub);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = ExtensionType::read(r)?;
         let len = u16::read(r)? as usize;
         let mut sub = r.sub(len)?;
@@ -1889,7 +1880,7 @@ impl Codec for CertReqExtension {
             ExtensionType::SignatureAlgorithms => {
                 let schemes = SupportedSignatureSchemes::read(&mut sub)?;
                 if schemes.is_empty() {
-                    return None;
+                    return Err(InvalidMessage::NoSignatureSchemes);
                 }
                 Self::SignatureAlgorithms(schemes)
             }
@@ -1900,11 +1891,8 @@ impl Codec for CertReqExtension {
             _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
         };
 
-        if sub.any_left() {
-            None
-        } else {
-            Some(ext)
-        }
+        sub.expect_empty("CertReqExtension")
+            .map(|_| ext)
     }
 }
 
@@ -1922,11 +1910,11 @@ impl Codec for CertificateRequestPayloadTLS13 {
         self.extensions.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let context = PayloadU8::read(r)?;
         let extensions = CertReqExtensions::read(r)?;
 
-        Some(Self {
+        Ok(Self {
             context,
             extensions,
         })
@@ -1979,11 +1967,11 @@ impl Codec for NewSessionTicketPayload {
         self.ticket.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let lifetime = u32::read(r)?;
         let ticket = PayloadU16::read(r)?;
 
-        Some(Self {
+        Ok(Self {
             lifetime_hint: lifetime,
             ticket,
         })
@@ -2020,7 +2008,7 @@ impl Codec for NewSessionTicketExtension {
         bytes.append(&mut sub);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = ExtensionType::read(r)?;
         let len = u16::read(r)? as usize;
         let mut sub = r.sub(len)?;
@@ -2030,11 +2018,8 @@ impl Codec for NewSessionTicketExtension {
             _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
         };
 
-        if sub.any_left() {
-            None
-        } else {
-            Some(ext)
-        }
+        sub.expect_empty("NewSessionTicketExtension")
+            .map(|_| ext)
     }
 }
 
@@ -2099,14 +2084,14 @@ impl Codec for NewSessionTicketPayloadTLS13 {
         self.exts.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let lifetime = u32::read(r)?;
         let age_add = u32::read(r)?;
         let nonce = PayloadU8::read(r)?;
         let ticket = PayloadU16::read(r)?;
         let exts = NewSessionTicketExtensions::read(r)?;
 
-        Some(Self {
+        Ok(Self {
             lifetime,
             age_add,
             nonce,
@@ -2130,14 +2115,14 @@ impl Codec for CertificateStatus {
         self.ocsp_response.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let typ = CertificateStatusType::read(r)?;
 
         match typ {
-            CertificateStatusType::OCSP => Some(Self {
+            CertificateStatusType::OCSP => Ok(Self {
                 ocsp_response: PayloadU24::read(r)?,
             }),
-            _ => None,
+            _ => Err(InvalidMessage::InvalidCertificateStatusType(typ)),
         }
     }
 }
@@ -2228,13 +2213,13 @@ impl Codec for HandshakeMessagePayload {
         bytes.append(&mut sub);
     }
 
-    fn read(r: &mut Reader) -> Option<Self> {
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         Self::read_version(r, ProtocolVersion::TLSv1_2)
     }
 }
 
 impl HandshakeMessagePayload {
-    pub fn read_version(r: &mut Reader, vers: ProtocolVersion) -> Option<Self> {
+    pub fn read_version(r: &mut Reader, vers: ProtocolVersion) -> Result<Self, InvalidMessage> {
         let mut typ = HandshakeType::read(r)?;
         let len = codec::u24::read(r)?.0 as usize;
         let mut sub = r.sub(len)?;
@@ -2272,9 +2257,7 @@ impl HandshakeMessagePayload {
                 HandshakePayload::ServerKeyExchange(p)
             }
             HandshakeType::ServerHelloDone => {
-                if sub.any_left() {
-                    return None;
-                }
+                sub.expect_empty("ServerHelloDone")?;
                 HandshakePayload::ServerHelloDone
             }
             HandshakeType::ClientKeyExchange => {
@@ -2306,9 +2289,7 @@ impl HandshakeMessagePayload {
                 HandshakePayload::KeyUpdate(KeyUpdateRequest::read(&mut sub)?)
             }
             HandshakeType::EndOfEarlyData => {
-                if sub.any_left() {
-                    return None;
-                }
+                sub.expect_empty("EndOfEarlyData")?;
                 HandshakePayload::EndOfEarlyData
             }
             HandshakeType::Finished => HandshakePayload::Finished(Payload::read(&mut sub)),
@@ -2317,20 +2298,17 @@ impl HandshakeMessagePayload {
             }
             HandshakeType::MessageHash => {
                 // does not appear on the wire
-                return None;
+                return Err(InvalidMessage::UnexpectedMessage("MessageHash"));
             }
             HandshakeType::HelloRetryRequest => {
                 // not legal on wire
-                return None;
+                return Err(InvalidMessage::UnexpectedMessage("HelloRetryRequest"));
             }
             _ => HandshakePayload::Unknown(Payload::read(&mut sub)),
         };
 
-        if sub.any_left() {
-            None
-        } else {
-            Some(Self { typ, payload })
-        }
+        sub.expect_empty("HandshakeMessagePayload")
+            .map(|_| Self { typ, payload })
     }
 
     pub fn build_key_update_notify() -> Self {

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -26,8 +26,11 @@ macro_rules! enum_builder {
                 self.get_u8().encode(bytes);
             }
 
-            fn read(r: &mut Reader) -> Option<Self> {
-                u8::read(r).map($enum_name::from)
+            fn read(r: &mut Reader) -> Result<Self, crate::error::InvalidMessage> {
+                match u8::read(r) {
+                    Ok(x) => Ok($enum_name::from(x)),
+                    Err(_) => Err(crate::error::InvalidMessage::MissingData(stringify!($enum_name))),
+                }
             }
         }
         impl From<u8> for $enum_name {
@@ -72,8 +75,11 @@ macro_rules! enum_builder {
                 self.get_u16().encode(bytes);
             }
 
-            fn read(r: &mut Reader) -> Option<Self> {
-                u16::read(r).map($enum_name::from)
+            fn read(r: &mut Reader) -> Result<Self, crate::error::InvalidMessage> {
+                match u16::read(r) {
+                    Ok(x) => Ok($enum_name::from(x)),
+                    Err(_) => Err(crate::error::InvalidMessage::MissingData(stringify!($enum_name))),
+                }
             }
         }
         impl From<u16> for $enum_name {

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -35,26 +35,26 @@ impl MessagePayload {
         }
     }
 
-    pub fn new(typ: ContentType, vers: ProtocolVersion, payload: Payload) -> Result<Self, Error> {
+    pub fn new(
+        typ: ContentType,
+        vers: ProtocolVersion,
+        payload: Payload,
+    ) -> Result<Self, InvalidMessage> {
         let mut r = Reader::init(&payload.0);
-        let parsed = match typ {
-            ContentType::ApplicationData => return Ok(Self::ApplicationData(payload)),
-            ContentType::Alert => AlertMessagePayload::read(&mut r)
-                .filter(|_| !r.any_left())
-                .map(MessagePayload::Alert),
-            ContentType::Handshake => HandshakeMessagePayload::read_version(&mut r, vers)
-                .filter(|_| !r.any_left())
-                .map(|parsed| Self::Handshake {
+        match typ {
+            ContentType::ApplicationData => Ok(Self::ApplicationData(payload)),
+            ContentType::Alert => AlertMessagePayload::read(&mut r).map(MessagePayload::Alert),
+            ContentType::Handshake => {
+                HandshakeMessagePayload::read_version(&mut r, vers).map(|parsed| Self::Handshake {
                     parsed,
                     encoded: payload,
-                }),
-            ContentType::ChangeCipherSpec => ChangeCipherSpecPayload::read(&mut r)
-                .filter(|_| !r.any_left())
-                .map(MessagePayload::ChangeCipherSpec),
-            _ => None,
-        };
-
-        parsed.ok_or(InvalidMessage::MissingPayload(typ).into())
+                })
+            }
+            ContentType::ChangeCipherSpec => {
+                ChangeCipherSpecPayload::read(&mut r).map(MessagePayload::ChangeCipherSpec)
+            }
+            _ => Err(InvalidMessage::InvalidContentType),
+        }
     }
 
     pub fn content_type(&self) -> ContentType {
@@ -83,13 +83,13 @@ impl OpaqueMessage {
     /// `MessageError` allows callers to distinguish between valid prefixes (might
     /// become valid if we read more data) and invalid data.
     pub fn read(r: &mut Reader) -> Result<Self, MessageError> {
-        let typ = ContentType::read(r).ok_or(MessageError::TooShortForHeader)?;
+        let typ = ContentType::read(r).map_err(|_| MessageError::TooShortForHeader)?;
         // Don't accept any new content-types.
         if let ContentType::Unknown(_) = typ {
             return Err(MessageError::InvalidContentType);
         }
 
-        let version = ProtocolVersion::read(r).ok_or(MessageError::TooShortForHeader)?;
+        let version = ProtocolVersion::read(r).map_err(|_| MessageError::TooShortForHeader)?;
         // Accept only versions 0x03XX for any XX.
         match version {
             ProtocolVersion::Unknown(ref v) if (v & 0xff00) != 0x0300 => {
@@ -98,7 +98,7 @@ impl OpaqueMessage {
             _ => {}
         };
 
-        let len = u16::read(r).ok_or(MessageError::TooShortForHeader)?;
+        let len = u16::read(r).map_err(|_| MessageError::TooShortForHeader)?;
 
         // Reject undersize messages
         //  implemented per section 5.1 of RFC8446 (TLSv1.3)
@@ -114,7 +114,7 @@ impl OpaqueMessage {
 
         let mut sub = r
             .sub(len as usize)
-            .ok_or(MessageError::TooShortForLength)?;
+            .map_err(|_| MessageError::TooShortForLength)?;
         let payload = Payload::read(&mut sub);
 
         Ok(Self {

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -1,12 +1,11 @@
 use crate::enums::ProtocolVersion;
-use crate::error::Error;
+use crate::error::{Error, InvalidMessage};
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, AlertLevel, ContentType, HandshakeType};
 use crate::msgs::handshake::HandshakeMessagePayload;
-use crate::InvalidMessage;
 
 #[derive(Debug)]
 pub enum MessagePayload {

--- a/rustls/src/rand.rs
+++ b/rustls/src/rand.rs
@@ -1,6 +1,5 @@
 //! The single place where we generate random material for our own use.
 
-use crate::msgs::codec;
 use ring::rand::{SecureRandom, SystemRandom};
 
 /// Fill the whole slice with random material.
@@ -22,7 +21,7 @@ pub(crate) fn random_vec(len: usize) -> Result<Vec<u8>, GetRandomFailed> {
 pub(crate) fn random_u32() -> Result<u32, GetRandomFailed> {
     let mut buf = [0u8; 4];
     fill_random(&mut buf)?;
-    codec::decode_u32(&buf).ok_or(GetRandomFailed)
+    Ok(u32::from_be_bytes(buf))
 }
 
 #[derive(Debug)]

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -139,7 +139,7 @@ mod client_hello {
                         .session_storage
                         .get(&client_hello.session_id.get_encoding())
                 })
-                .and_then(|x| persist::ServerSessionValue::read_bytes(&x))
+                .and_then(|x| persist::ServerSessionValue::read_bytes(&x).ok())
                 .filter(|resumedata| {
                     hs::can_resume(self.suite.into(), &cx.data.sni, self.using_ems, resumedata)
                 });

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -132,12 +132,12 @@ mod client_hello {
                 self.config
                     .ticketer
                     .decrypt(ticket)
-                    .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
+                    .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain).ok())
             } else {
                 self.config
                     .session_storage
                     .take(ticket)
-                    .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
+                    .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain).ok())
             }
         }
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -497,19 +497,15 @@ type MessageCipherPair = (Box<dyn MessageDecrypter>, Box<dyn MessageEncrypter>);
 pub(crate) fn decode_ecdh_params<T: Codec>(
     common: &mut CommonState,
     kx_params: &[u8],
-) -> Result<T, Error> {
-    decode_ecdh_params_::<T>(kx_params).ok_or_else(|| {
-        common.send_fatal_alert(AlertDescription::DecodeError);
-        Error::InvalidMessage(InvalidMessage::InvalidDhParams)
-    })
-}
-
-fn decode_ecdh_params_<T: Codec>(kx_params: &[u8]) -> Option<T> {
+) -> Result<T, InvalidMessage> {
     let mut rd = Reader::init(kx_params);
     let ecdh_params = T::read(&mut rd)?;
     match rd.any_left() {
-        false => Some(ecdh_params),
-        true => None,
+        false => Ok(ecdh_params),
+        true => {
+            common.send_fatal_alert(AlertDescription::DecodeError);
+            Err(InvalidMessage::InvalidDhParams)
+        }
     }
 }
 
@@ -518,6 +514,7 @@ pub(crate) const DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::conn::{CommonState, Side};
     use crate::msgs::handshake::{ClientECDHParams, ServerECDHParams};
 
     #[test]
@@ -527,11 +524,14 @@ mod tests {
         let mut server_buf = Vec::new();
         server_params.encode(&mut server_buf);
         server_buf.push(34);
-        assert!(decode_ecdh_params_::<ServerECDHParams>(&server_buf).is_none());
+
+        let mut common = CommonState::new(Side::Client);
+        assert!(decode_ecdh_params::<ServerECDHParams>(&mut common, &server_buf).is_err());
     }
 
     #[test]
     fn client_ecdhe_invalid() {
-        assert!(decode_ecdh_params_::<ClientECDHParams>(&[34]).is_none());
+        let mut common = CommonState::new(Side::Server);
+        assert!(decode_ecdh_params::<ClientECDHParams>(&mut common, &[34]).is_err());
     }
 }

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -1,14 +1,14 @@
 use crate::cipher::{MessageDecrypter, MessageEncrypter};
 use crate::conn::{CommonState, ConnectionRandoms, Side};
 use crate::enums::{CipherSuite, SignatureScheme};
+use crate::error::{Error, InvalidMessage};
+use crate::kx;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::AlertDescription;
 use crate::msgs::handshake::KeyExchangeAlgorithm;
 use crate::suites::{BulkAlgorithm, CipherSuiteCommon, SupportedCipherSuite};
 #[cfg(feature = "secret_extraction")]
 use crate::suites::{ConnectionTrafficSecrets, PartiallyExtractedSecrets};
-use crate::Error;
-use crate::{kx, InvalidMessage};
 
 use ring::aead;
 use ring::digest::Digest;

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -14,8 +14,8 @@ use rustls::client::WebPkiVerifier;
 use rustls::internal::msgs::base::PayloadU16;
 use rustls::server::{ClientCertVerified, ClientCertVerifier};
 use rustls::{
-    AlertDescription, Certificate, ClientConnection, ContentType, DistinguishedNames, Error,
-    InvalidMessage, ServerConfig, ServerConnection, SignatureScheme,
+    AlertDescription, Certificate, ClientConnection, DistinguishedNames, Error, InvalidMessage,
+    ServerConfig, ServerConnection, SignatureScheme,
 };
 use std::sync::Arc;
 
@@ -103,7 +103,7 @@ fn client_verifier_no_schemes() {
             assert_debug_eq(
                 err,
                 Err(ErrorFromPeer::Client(Error::InvalidMessage(
-                    InvalidMessage::MissingPayload(ContentType::Handshake),
+                    InvalidMessage::NoSignatureSchemes,
                 ))),
             );
         }


### PR DESCRIPTION
Built on top of #1172. I think it's good that this produces more fine-grained errors.

cc @complexspaces 