### PR TITLE
Allow user provides more specified certificate validation error as AlertDescription in verifier

### DIFF
--- a/bogo/config.json
+++ b/bogo/config.json
@@ -380,8 +380,10 @@
   },
   "TestLocalErrorMap": {
     "SendServerHelloAsHelloRetryRequest": "remote error: error decoding message",
-    "GarbageCertificate-Server-TLS12": "remote error: access denied",
-    "GarbageCertificate-Server-TLS13": "remote error: access denied",
+    "GarbageCertificate-Server-TLS12": "remote error: bad certificate",
+    "GarbageCertificate-Server-TLS13": "remote error: bad certificate",
+    "GarbageCertificate-Client-TLS12": "remote error: bad certificate",
+    "GarbageCertificate-Client-TLS13": "remote error: bad certificate",
     "Client-VerifyDefault-RSA_PKCS1_SHA1-TLS12": "tls: no common signature algorithms",
     "Server-VerifyDefault-RSA_PKCS1_SHA1-TLS12": "tls: no common signature algorithms",
     "Downgrade-TLS10-Client": "tls: no cipher suite supported by both client and server",

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -3,7 +3,7 @@ use crate::bs_debug;
 use crate::check::inappropriate_handshake_message;
 use crate::conn::{CommonState, ConnectionRandoms, State};
 use crate::enums::{CipherSuite, ProtocolVersion};
-use crate::error::{CertificateError, Error, PeerIncompatible, PeerMisbehaved};
+use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHashBuffer;
 use crate::kx;
 #[cfg(feature = "logging")]
@@ -810,20 +810,4 @@ impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
             )),
         }
     }
-}
-
-pub(super) fn send_cert_error_alert(common: &mut CommonState, err: Error) -> Error {
-    match err {
-        Error::InvalidCertificate(CertificateError::BadEncoding) => {
-            common.send_fatal_alert(AlertDescription::DecodeError);
-        }
-        Error::PeerMisbehaved(_) => {
-            common.send_fatal_alert(AlertDescription::IllegalParameter);
-        }
-        _ => {
-            common.send_fatal_alert(AlertDescription::BadCertificate);
-        }
-    };
-
-    err
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
-use crate::conn::{CommonState, ConnectionRandoms, Side, State};
+use crate::conn::{self, CommonState, ConnectionRandoms, Side, State};
 use crate::enums::ProtocolVersion;
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
@@ -740,7 +740,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
                 &st.server_cert.ocsp_response,
                 now,
             )
-            .map_err(|err| hs::send_cert_error_alert(cx.common, err))?;
+            .map_err(|err| conn::send_cert_error_alert(cx.common, err))?;
 
         // 3.
         // Build up the contents of the signed message.
@@ -766,7 +766,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
             st.config
                 .verifier
                 .verify_tls12_signature(&message, &st.server_cert.cert_chain[0], sig)
-                .map_err(|err| hs::send_cert_error_alert(cx.common, err))?
+                .map_err(|err| conn::send_cert_error_alert(cx.common, err))?
         };
         cx.common.peer_certificates = Some(st.server_cert.cert_chain);
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -740,7 +740,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
                 &st.server_cert.ocsp_response,
                 now,
             )
-            .map_err(|err| conn::send_cert_error_alert(cx.common, err))?;
+            .map_err(|err| conn::send_cert_verify_error_alert(cx.common, err))?;
 
         // 3.
         // Build up the contents of the signed message.
@@ -766,7 +766,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
             st.config
                 .verifier
                 .verify_tls12_signature(&message, &st.server_cert.cert_chain[0], sig)
-                .map_err(|err| conn::send_cert_error_alert(cx.common, err))?
+                .map_err(|err| conn::send_cert_verify_error_alert(cx.common, err))?
         };
         cx.common.peer_certificates = Some(st.server_cert.cert_chain);
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -3,7 +3,7 @@ use crate::check::inappropriate_handshake_message;
 use crate::conn::Protocol;
 #[cfg(feature = "secret_extraction")]
 use crate::conn::Side;
-use crate::conn::{CommonState, ConnectionRandoms, State};
+use crate::conn::{self, CommonState, ConnectionRandoms, State};
 use crate::enums::{ProtocolVersion, SignatureScheme};
 use crate::error::{Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
@@ -669,7 +669,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify {
                 &self.server_cert.ocsp_response,
                 now,
             )
-            .map_err(|err| hs::send_cert_error_alert(cx.common, err))?;
+            .map_err(|err| conn::send_cert_error_alert(cx.common, err))?;
 
         // 2. Verify their signature on the handshake.
         let handshake_hash = self.transcript.get_current_hash();
@@ -681,7 +681,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify {
                 &self.server_cert.cert_chain[0],
                 cert_verify,
             )
-            .map_err(|err| hs::send_cert_error_alert(cx.common, err))?;
+            .map_err(|err| conn::send_cert_error_alert(cx.common, err))?;
 
         cx.common.peer_certificates = Some(self.server_cert.cert_chain);
         self.transcript.add_message(&m);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -669,7 +669,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify {
                 &self.server_cert.ocsp_response,
                 now,
             )
-            .map_err(|err| conn::send_cert_error_alert(cx.common, err))?;
+            .map_err(|err| conn::send_cert_verify_error_alert(cx.common, err))?;
 
         // 2. Verify their signature on the handshake.
         let handshake_hash = self.transcript.get_current_hash();
@@ -681,7 +681,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify {
                 &self.server_cert.cert_chain[0],
                 cert_verify,
             )
-            .map_err(|err| conn::send_cert_error_alert(cx.common, err))?;
+            .map_err(|err| conn::send_cert_verify_error_alert(cx.common, err))?;
 
         cx.common.peer_certificates = Some(self.server_cert.cert_chain);
         self.transcript.add_message(&m);

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1433,16 +1433,19 @@ pub trait SideData {}
 const DEFAULT_RECEIVED_PLAINTEXT_LIMIT: usize = 16 * 1024;
 const DEFAULT_BUFFER_LIMIT: usize = 64 * 1024;
 
-pub(crate) fn send_cert_error_alert(common: &mut CommonState, err: Error) -> Error {
+pub(crate) fn send_cert_verify_error_alert(common: &mut CommonState, err: Error) -> Error {
     match err {
         Error::InvalidCertificate(CertificateError::BadEncoding) => {
             common.send_fatal_alert(AlertDescription::DecodeError);
+        }
+        Error::InvalidCertificate(_) => {
+            common.send_fatal_alert(AlertDescription::BadCertificate);
         }
         Error::PeerMisbehaved(_) => {
             common.send_fatal_alert(AlertDescription::IllegalParameter);
         }
         _ => {
-            common.send_fatal_alert(AlertDescription::BadCertificate);
+            common.send_fatal_alert(AlertDescription::HandshakeFailure);
         }
     };
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1,6 +1,6 @@
 use crate::enums::ProtocolVersion;
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
-use crate::{key, CertificateError};
+use crate::key;
 #[cfg(feature = "logging")]
 use crate::log::{debug, error, trace, warn};
 use crate::msgs::alert::AlertMessagePayload;
@@ -1435,11 +1435,9 @@ const DEFAULT_BUFFER_LIMIT: usize = 64 * 1024;
 
 pub(crate) fn send_cert_verify_error_alert(common: &mut CommonState, err: Error) -> Error {
     match err {
-        Error::InvalidCertificate(CertificateError::BadEncoding) => {
-            common.send_fatal_alert(AlertDescription::DecodeError);
-        }
-        Error::InvalidCertificate(_) => {
-            common.send_fatal_alert(AlertDescription::BadCertificate);
+        Error::InvalidCertificate(ref e) => {
+            // the clone focus on the `Arc` wrapped error in `CertificateError`
+            common.send_fatal_alert(e.clone().into());
         }
         Error::PeerMisbehaved(_) => {
             common.send_fatal_alert(AlertDescription::IllegalParameter);

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -325,9 +325,16 @@ impl From<CertificateError> for AlertDescription {
         use CertificateError::*;
         match e {
             BadEncoding | UnhandledCriticalExtension | NotValidForName => Self::BadCertificate,
+            // RFC 5246/RFC 8446
+            // certificate_expired
+            //  A certificate has expired or **is not currently valid**.
             Expired | NotValidYet => Self::CertificateExpired,
             UnknownIssuer => Self::UnknownCA,
             BadSignature => Self::DecryptError,
+            // RFC 5246/RFC 8446
+            // certificate_unknown
+            //  Some other (unspecified) issue arose in processing the
+            //  certificate, rendering it unacceptable.
             Other(_) => Self::CertificateUnknown,
         }
     }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -668,7 +668,7 @@ impl State<ServerConnectionData> for ExpectCertificateVerify {
                     // impossible to reach this state.
                     cx.common
                         .send_fatal_alert(AlertDescription::AccessDenied);
-                    Err(Error::General("client authentication not set up".into()))
+                    return Err(Error::General("client authentication not set up".into()));
                 }
             }
         };

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -58,7 +58,7 @@ fn client_can_override_certificate_verification_and_reject_certificate() {
                     ErrorFromPeer::Client(Error::InvalidMessage(
                         InvalidMessage::HandshakePayloadTooLarge,
                     )),
-                    ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::BadCertificate)),
+                    ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::HandshakeFailure)),
                 ]),
             );
         }
@@ -89,7 +89,7 @@ fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
                 ErrorFromPeer::Client(Error::InvalidMessage(
                     InvalidMessage::HandshakePayloadTooLarge,
                 )),
-                ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::BadCertificate)),
+                ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::HandshakeFailure)),
             ]),
         );
     }
@@ -118,7 +118,7 @@ fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
                 ErrorFromPeer::Client(Error::InvalidMessage(
                     InvalidMessage::HandshakePayloadTooLarge,
                 )),
-                ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::BadCertificate)),
+                ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::HandshakeFailure)),
             ]),
         );
     }


### PR DESCRIPTION
As I said in https://discord.com/channels/976380008299917365/1015156984007381033/1040188576727572530
In this pull request, following change applied:
## Align server and client certificate verification mechanisms
Now, the server side and client side `verifier` will act same behavior when return `Erro`. See the new `conn::send_cert_error_alert`.

Before this change, the server side verifier only sends `BadCertificate` in certificate chain verification and `AccessDenied` in TLS message verification. The client side sends, well, just see old `client::hs::send_cert_error_alert`.
## Allow user provides more specific certificate validation error
After reading RFC, choice in [OpenSSL Implementation](https://github.com/openssl/openssl/blob/45bb98bfa223efd3258f445ad443f878011450f0/ssl/statem/statem_lib.c#L1434) and choice in [BoringSSL Implementation](https://github.com/google/boringssl/blob/583c60bd4bf76d61b2634a58bcda99a92de106cb/ssl/ssl_x509.cc#L1361), 
I choose the following new `Error` to `TLS Alert` mapping, see `rustls/src/error.rs`.

---
## Potential break change?
Of course, each peer may receive different `TLS Alert`, but after fault alert, connection will be closed, I think it doesn't matter.

In API level, there isn't any change.

---
By the way, I didn't implement but how about allow user send specified `TLS Alert` directly in their owned verifier instead of using provided `Error` mapping?
