### PR TITLE
small script fixes, gitignore updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ admin/rustfmt
 ._.DS_Store
 **/.DS_Store
 **/._.DS_Store
+/.idea
+/default.profraw

--- a/admin/bench-measure.mk
+++ b/admin/bench-measure.mk
@@ -1,6 +1,6 @@
 RECORD=perf record -F2000 --call-graph dwarf,16000 --
 FLAMEGRAPH=perf script | ~/FlameGraph/stackcollapse-perf.pl | ~/FlameGraph/flamegraph.pl >
-MEMUSAGE=/usr/bin/time -f %M
+MEMUSAGE=/usr/bin/env time -f %M
 
 perf: ./target/release/examples/bench
 	$(RECORD) ./target/release/examples/bench bulk TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256

--- a/admin/bench-range
+++ b/admin/bench-range
@@ -1,8 +1,10 @@
+#!/usr/bin/env python3
+
 import subprocess
 
 suite = 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
 
-print 'len,send,recv'
+print('len,send,recv')
 
 for len in [16, 32, 64, 128, 512, 1024, 4096, 8192, 32768, 65536, 131072, 262144, 1048576]:
     out = subprocess.check_output(['./target/release/examples/bench', 'bulk', suite, str(len)])
@@ -15,4 +17,4 @@ for len in [16, 32, 64, 128, 512, 1024, 4096, 8192, 32768, 65536, 131072, 262144
         if items[3] == 'recv':
             recv = float(items[4])
 
-    print '%d,%g,%g' % (len, send, recv)
+    print('%d,%g,%g' % (len, send, recv))

--- a/admin/capture-certdata
+++ b/admin/capture-certdata
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import subprocess
 import base64

--- a/admin/coverage
+++ b/admin/coverage
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 source <(cargo llvm-cov show-env --export-prefix)
 cargo llvm-cov clean --workspace

--- a/admin/format-bench
+++ b/admin/format-bench
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 
@@ -24,9 +24,9 @@ for line in sys.stdin:
         handshakes.append((suite, role, auth, resumed, float(rate), unit))
 
 for suite, direction, rate, unit in sorted(bulks):
-    print '`%s` | %s | %g %s' % (suite, direction, rate, unit)
+    print('`%s` | %s | %g %s' % (suite, direction, rate, unit))
 
 for suite, role, auth, resumed, rate, unit in sorted(handshakes):
-    print '`%s` <br> %s, %s, %s | %g %s' % (suite, role,
+    print('`%s` <br> %s, %s, %s | %g %s' % (suite, role,
             auth if auth == 'server-auth' else 'mutual-auth',
-            translate_resume(resumed), rate, unit)
+            translate_resume(resumed), rate, unit))

--- a/admin/pull-readme
+++ b/admin/pull-readme
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Extract the introductory documentation into the README.md
 
 set -e

--- a/admin/pull-usage
+++ b/admin/pull-usage
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Extract the example usage into README.md
 
 set -e

--- a/bogo/fetch-and-build
+++ b/bogo/fetch-and-build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/bogo/fetch-and-build
+++ b/bogo/fetch-and-build
@@ -5,7 +5,7 @@ set -ex
 mkdir -p bogo
 pushd bogo
 
-git init
+git init --initial-branch main
 git config core.sparsecheckout 1
 cat << EOF > .git/info/sparse-checkout
 go.mod

--- a/bogo/regen-certs
+++ b/bogo/regen-certs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bogo/runme
+++ b/bogo/runme
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script fetches, builds, and runs the BoringSSL
 # TLS test tool ('BoGo') against rustls.

--- a/test-ca/build-a-pki.sh
+++ b/test-ca/build-a-pki.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -xe
 

--- a/trytls/runme
+++ b/trytls/runme
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This script fetches, builds, and runs the TryTLS
 # TLS test tool against rustls.  The rustls-TryTLS test stub is


### PR DESCRIPTION
## Description

This branch collects up some small improvements I've made locally while trying to familiarize myself with the project and associated tooling.

### chore: update .gitignore.
Running the `admin/coverage` script produces a `default.profraw` in the project root. Prior to this commit that file was not ignored by git. This commit adds it to the ignore list since we don't want this file to be accidentally submitted upstream.

This commit also adds the JetBrains IDE state dir (`.idea`) to the gitignore. This is a small quality of life improvement for users of CLion.

### fix: avoid hardcoded (ba)sh path in helper scripts.
Prior to this commit some helper scripts used hardcoded paths to `/bin/sh` and `/bin/bash` in script shebangs. This will error on systems that don't place `bash` in `/bin/` (e.g. NixOS).

This commit updates the scripts to use `/usr/bin/env` to find `bash` based on the user's `$PATH`. This has better portability and allows the scripts to run without err (or specifying an interpreter explicitly) on systems with atypical `bash` installs.

### fix: avoid hardcoded python3 path, fix prints.
Prior to this commit the admin `bench-range`, `capture-certdata` and `format-bench` Python helpers used a hardcoded path to Python3 in their shebang. This commit updates each to use `/usr/bin/env` to find `python3` in the `$PATH`.

These helpers also used Python2 style `print` statements instead of the Python3 style `print` function. This commit adds the required braces to fix Python3 usage.

**Note to reviewers:** I think these Python scripts may have bitrot. The `bench-range` and `format-bench` programs have additional issues (see https://github.com/rustls/rustls/pull/1203), and the `trytls/runme` script assumes Python 2.7 in a directory path (see https://github.com/rustls/rustls/pull/1202). ~I'll will follow up on these separately from the hardcoded path issues fixed here.~.

### chore: set initial branch name for bogo checkout.
Prior to this commit the `fetch-and-build` script with newer `git` versions would spit out an ANSI coloured warning about choosing an initial branch name for the bogo test-suite checkout.

This commit simply specifies the `--initial-branch` to be `main` to silence the unnecessary output.
