### PR TITLE
bug: fix trytls runner for modern Python.

### DIFF
--- a/trytls/runme
+++ b/trytls/runme
@@ -7,8 +7,18 @@
 set -xe
 
 if [ ! -e trytls/ ] ; then
-  pip install --prefix trytls/ trytls
+  # NOTE: Upstream 'trytls' breaks on Python3.8. Once a fix PR[0] lands
+  # we can remove this 'git+ssh' dependency in favour of upstream 'trytls'.
+  #
+  # [0]: https://github.com/ouspg/trytls/pull/314
+  pip install \
+    --prefix trytls/ \
+    setuptools \
+    git+ssh://git@github.com/cpu/trytls.git@cpu-python3.8-fix
 fi
 
-export PYTHONPATH=trytls/lib/python2.7/site-packages/
-./trytls/bin/trytls https ../target/${RELEASE:-debug}/examples/trytls_shim
+LIB_VERSIONS=(trytls/lib/*)
+LIB_VERSION=$(basename "${LIB_VERSIONS[0]:-python-310}")
+
+export PYTHONPATH=trytls/lib/"$LIB_VERSION"/site-packages/
+./trytls/bin/trytls https "../target/${RELEASE:-debug}/examples/trytls_shim"


### PR DESCRIPTION
## Description

Prior to this commit the `trytls/runme` script had a handful of small problems:

1. It assumed Python 2.7 was used for the `pip` install.
2. The upstream `trytls` package errors on Python 3.8 due to use of a now removed deprecated `platform` function.

This commit fixes both of these problems. The first, by detecting the Python lib dir that was created. The second, by using a fork of the upstream project that has a fix for Python 3.8+ systems in place. A TODO note is left to remind us to switch back to the upstream once a fix PR lands (https://github.com/ouspg/trytls/pull/314).

These changes are sufficient to get the `trytls` runner working again on a Python 3.10 system.

## Run Results

<details>
<summary>Here's the output from `trytls` with these updates applied: </summary>

```
platform: Linux (NixOS 22.11)
runner: trytls 0.3.7 (CPython 3.10.9)
stub: ../target/debug/examples/trytls_shim
 PASS protect against Apple's TLS vulnerability CVE-2014-1266 [reject www.ssllabs.com:10443]
      output: AlertReceived(HandshakeFailure)
 PASS protect against the FREAK attack [reject www.ssllabs.com:10444]
      output: AlertReceived(HandshakeFailure)
 PASS protect against the Logjam attack [reject www.ssllabs.com:10445]
      output: AlertReceived(HandshakeFailure)
ERROR support for TLS server name indication (SNI) [accept badssl.com:443]
      reason: stub exited with return code 1
      output: operation would block
 SKIP self-signed certificate [reject self-signed.badssl.com:443]
      reason: could not detect SNI support
 SKIP expired certificate [reject expired.badssl.com:443]
      reason: could not detect SNI support
 SKIP wrong hostname in certificate [reject wrong.host.badssl.com:443]
      reason: could not detect SNI support
 SKIP SHA-256 signature algorithm [accept sha256.badssl.com:443]
      reason: could not detect SNI support
 SKIP certificate with 1000 different Subject Alternative Names [accept 1000-sans.badssl.com:443]
      reason: could not detect SNI support
 SKIP incomplete chain of trust [reject incomplete-chain.badssl.com:443]
      reason: could not detect SNI support
 SKIP Superfish CA [reject superfish.badssl.com:443]
      reason: could not detect SNI support
 SKIP eDellRoot CA [reject edellroot.badssl.com:443]
      reason: could not detect SNI support
 SKIP DSDTestProvider CA [reject dsdtestprovider.badssl.com:443]
      reason: could not detect SNI support
 SKIP untrusted root certificate [reject untrusted-root.badssl.com:443]
      reason: could not detect SNI support
 SKIP denies use of RC4 ciphers (RFC 7465) [reject rc4.badssl.com:443]
      reason: could not detect SNI support
 SKIP denies use of RC4 with MD5 ciphers [reject rc4-md5.badssl.com:443]
      reason: could not detect SNI support
 SKIP denies use of null cipher [reject null.badssl.com:443]
      reason: could not detect SNI support
 SKIP denies use of 480 bit Diffie-Hellman (DH) [reject dh480.badssl.com:443]
      reason: could not detect SNI support
 SKIP denies use of 512 bit Diffie-Hellman (DH) [reject dh512.badssl.com:443]
      reason: could not detect SNI support
 FAIL valid certificate Common Name [accept domain-match.badtls.io:10000]
      output: InvalidCertificate(Expired)
 FAIL valid wildcard certificate Common Name [accept wildcard-match.badtls.io:10001]
      output: InvalidCertificate(Expired)
 FAIL support for Subject Alternative Name (SAN) [accept san-match.badtls.io:10002]
      output: InvalidCertificate(Expired)
 FAIL TLS handshake with 1024 bit Diffie-Hellman (DH) [accept dh1024.badtls.io:10005]
      output: InvalidCertificate(Expired)
 PASS certificate expired in year 1963 [reject expired-1963.badtls.io:11000]
      output: InvalidCertificate(BadEncoding)
 PASS certificate validity starts in future [reject future.badtls.io:11001]
      output: InvalidCertificate(NotValidYet)
 PASS mismatch in certificate's Common Name [reject domain-mismatch.badtls.io:11002]
      output: InvalidCertificate(Expired)
 PASS Subject Alternative Name (SAN) mismatch [reject san-mismatch.badtls.io:11003]
      output: InvalidCertificate(Expired)
 PASS certificate has invalid key usage for HTTPS connection [reject bad-key-usage.badtls.io:11005]
      output: InvalidCertificate(Expired)
 PASS expired certificate [reject expired.badtls.io:11006]
      output: InvalidCertificate(Expired)
 PASS invalid wildcard certificate Common Name [reject wildcard.mismatch.badtls.io:11007]
      output: InvalidCertificate(Expired)
 PASS denies use of RC4 ciphers (RFC 7465) [reject rc4.badtls.io:11008]
      output: AlertReceived(HandshakeFailure)
 PASS denies use of MD5 signature algorithm (RFC 6151) [reject weak-sig.badtls.io:11004]
      output: AlertReceived(HandshakeFailure)
 PASS denies use of RC4 with MD5 ciphers [reject rc4-md5.badtls.io:11009]
      output: AlertReceived(HandshakeFailure)
ERROR valid localhost certificate [accept localhost:<temp port>]
      reason: stub exited with return code 1
      output: operation would block
 PASS invalid localhost certificate [reject localhost:<temp port>]
      output: InvalidCertificate(NotValidForName)
ERROR use only the given CA bundle, not system's [reject sha256.badssl.com:443]
      reason: stub exited with return code 1
      output: operation would block
```
</details>

```bash
[nix-shell:~/Code/Rust/rustls/trytls]$ grep -c ERROR output.txt
3
[nix-shell:~/Code/Rust/rustls/trytls]$ grep -c PASS output.txt
14
```
It looks like three tests are ERRORing:
```
[nix-shell:~/Code/Rust/rustls/trytls]$ grep ERROR output.txt
ERROR support for TLS server name indication (SNI) [accept badssl.com:443]
ERROR valid localhost certificate [accept localhost:<temp port>]
ERROR use only the given CA bundle, not system's [reject sha256.badssl.com:443]
```

Perhaps someone more familiar with the project can speak to whether these ERROR results are expected, or if further investigation is merited!