### PR TITLE
small bench-range/format-bench script fixes.

### DIFF
--- a/admin/bench-range
+++ b/admin/bench-range
@@ -1,18 +1,23 @@
 import subprocess
+import os
 
 suite = 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
 
-print 'len,send,recv'
+print('len,send,recv')
 
-for len in [16, 32, 64, 128, 512, 1024, 4096, 8192, 32768, 65536, 131072, 262144, 1048576]:
-    out = subprocess.check_output(['./target/release/examples/bench', 'bulk', suite, str(len)])
+for bitlen in [16, 32, 64, 128, 512, 1024, 4096, 8192, 32768, 65536, 131072, 262144, 1048576]:
+    out = subprocess.check_output(['./target/release/examples/bench', 'bulk', suite, str(bitlen)])
     lines = out.splitlines()
 
-    for l in out.splitlines():
+    send = recv = 0.0
+    for l in lines:
         items = l.split()
-        if items[3] == 'send':
-            send = float(items[4])
-        if items[3] == 'recv':
-            recv = float(items[4])
+        if len(items) < 6:
+            print("output of bench target has changed. Please update script.")
+            os.exit(1)
+        if items[4] == b'send':
+            send = float(items[5])
+        if items[4] == b'recv':
+            recv = float(items[5])
 
-    print '%d,%g,%g' % (len, send, recv)
+    print('%d,%g,%g' % (bitlen, send, recv))

--- a/admin/format-bench
+++ b/admin/format-bench
@@ -17,16 +17,16 @@ for line in sys.stdin:
     pieces = line.split()
 
     if pieces[0] == 'bulk':
-        _, version, suite, direction, rate, unit = pieces
+        _, version, suite, _, direction, rate, unit = pieces
         bulks.append((suite, direction, float(rate), unit))
     elif pieces[0] == 'handshakes':
-        _, version, suite, role, auth, resumed, rate, unit = pieces
+        _, version, _, suite, role, auth, resumed, rate, unit = pieces
         handshakes.append((suite, role, auth, resumed, float(rate), unit))
 
 for suite, direction, rate, unit in sorted(bulks):
-    print '`%s` | %s | %g %s' % (suite, direction, rate, unit)
+    print('`%s` | %s | %g %s' % (suite, direction, rate, unit))
 
 for suite, role, auth, resumed, rate, unit in sorted(handshakes):
-    print '`%s` <br> %s, %s, %s | %g %s' % (suite, role,
+    print('`%s` <br> %s, %s, %s | %g %s' % (suite, role,
             auth if auth == 'server-auth' else 'mutual-auth',
-            translate_resume(resumed), rate, unit)
+            translate_resume(resumed), rate, unit))


### PR DESCRIPTION
## Description

This branch continues from https://github.com/rustls/rustls/pull/1201 and fixes the `admin/bench-range` and `admin/format-bench` Python helpers.

### bug: update bench-range for current bench output.
Prior to this commit the `admin/bench-range` Python script would error when run. There were a handful of problems:

* The use of `print x` instead of `print(x)` breaks Python3. 
* The output of `target/release/examples/bench` has changed so that the indices the script expected to find specific values were off by one.
* The comparison of the data to expected string values was failing due to Python3 returning binary strings for file I/O whereas the script was comparing against non-binary values. E.g. `b"foo" != "foo"`.

<details>
<summary>
This commit fixes all three issues and the `bench-range` script now functions as expected:
</summary>

```
[nix-shell:~/Code/Rust/rustls]$ python3 ./admin/bench-range
len,send,recv
16,134.65,69.67
32,238.36,129.89
64,479.49,261.53
128,864.63,496.1
512,2629.75,1578.72
1024,3765.23,2565.9
4096,5755.44,4006.35
8192,5768.88,4455.48
32768,6066.21,4853.95
65536,6146.38,4904.58
131072,4401.98,4487.98
262144,3338.44,4618.72
1048576,2782.14,4839.22
```
</details>

### bug: update format-bench for current bench output.

Similar to the `admin/bench-range` helper script the `admin/format-bench` script needed some TLC to run with the current
bench output:

* The use of `print x` instead of `print(x)` breaks Python3.
* The output of `target/release/examples/bench` has changed to add an additional column that must be accounted for in the script.

Unlike `bench-range` because we're using stdin the string comparison is OK without a byte prefix.

<details>
<summary>This commit fixes the two issues and the `format-bench` script now functions as expected:</summary>

```
[nix-shell:~/Code/Rust/rustls]$ ./target/release/examples/bench handshake TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 128 | python3 ./admin/format-bench
`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` <br> client, server-auth, full | 5420.97 handshake/s
`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` <br> server, server-auth, full | 2151.39 handshake/s

[nix-shell:~/Code/Rust/rustls]$ ./target/release/examples/bench bulk TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 128 | python3 ./admin/format-bench
`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` | recv | 512.18 MB/s
`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` | send | 901.66 MB/s
```
</details>