### PR TITLE
docs: add rustdoc for DigitallySignedStruct.

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1592,6 +1592,7 @@ impl Codec for ECParameters {
     }
 }
 
+/// This type combines a [`SignatureScheme`] and a signature payload produced with that scheme.
 #[derive(Debug, Clone)]
 pub struct DigitallySignedStruct {
     pub scheme: SignatureScheme,


### PR DESCRIPTION
The front-page index for the Rustls lib includes a list of re-exported structs comprising the public API. I noticed that of all of the structs included only `DigitallySignedStruct` was missing commentary about its purpose.

This tiny commit adds a simple rustdoc comment for this type. Now all of the structs mentioned in the front-page index have some documentation.