### PR TITLE
docs: fix broken x509-parser FromDer trait links.

### DIFF
--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -51,10 +51,10 @@ impl OwnedTrustAnchor {
 
     /// Return the subject field.
     ///
-    /// This can be decoded using [x509-parser's FromDer trait](https://docs.rs/x509-parser/latest/x509_parser/traits/trait.FromDer.html).
+    /// This can be decoded using [x509-parser's FromDer trait](https://docs.rs/x509-parser/latest/x509_parser/prelude/trait.FromDer.html).
     ///
     /// ```ignore
-    /// use x509_parser::traits::FromDer;
+    /// use x509_parser::prelude::FromDer;
     /// println!("{}", x509_parser::x509::X509Name::from_der(anchor.subject())?.1);
     /// ```
     pub fn subject(&self) -> &[u8] {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1806,11 +1806,11 @@ pub type DistinguishedName = PayloadU16;
 /// DER or BER encoded [`Subject` field from RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6)
 /// for a single certificate. The Subject field is
 /// [encoded as an RFC 5280 `Name`](https://datatracker.ietf.org/doc/html/rfc5280#page-116).
-/// It can be decoded using [x509-parser's FromDer trait](https://docs.rs/x509-parser/latest/x509_parser/traits/trait.FromDer.html).
+/// It can be decoded using [x509-parser's FromDer trait](https://docs.rs/x509-parser/latest/x509_parser/prelude/trait.FromDer.html).
 ///
 /// ```ignore
 /// for name in distinguished_names {
-///     use x509_parser::traits::FromDer;
+///     use x509_parser::prelude::FromDer;
 ///     println!("{}", x509_parser::x509::X509Name::from_der(&name.0)?.1);
 /// }
 /// ```


### PR DESCRIPTION
The upstream `x509-parser` crate [moved the `FromDer` trait](https://github.com/rusticata/x509-parser/commit/ac4620696d8c4031f0d4bc01334ded8f76a5bf10) from a `traits` submodule to a `prelude` submodule, breaking the docs link/example in the Rustls `DistinguishedName` and `OwnedTrustAnchor.subject` doc strings.

This commit fixes the links/examples to use the current location of the `FromDer` trait.