### PR TITLE
docs: add small README for fuzz testing suite.

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,26 @@
+# Fuzz Testing
+
+Rustls supports fuzz testing using [cargo-fuzz]. Fuzz tests are automatically
+run during continuous integration using [oss-fuzz]. You may also run fuzz tests
+locally. See the [cargo-fuzz setup] instructions for requirements.
+
+```bash
+# List available fuzzing targets.
+$ cargo fuzz list
+client
+deframer
+fragment
+message
+persist
+servert
+
+# Run the message fuzz target for a fixed period of time (expressed in seconds).
+$ cargo fuzz run message -- -max_total_time=120
+
+# Clean up generated corpus files
+git clean --interactive -- ./corpus
+```
+
+[cargo-fuzz]: https://rust-fuzz.github.io/book/cargo-fuzz.html
+[oss-fuzz]: https://google.github.io/oss-fuzz/
+[cargo-fuzz setup]: https://rust-fuzz.github.io/book/cargo-fuzz/setup.html


### PR DESCRIPTION
This commit adds a README to the `fuzz` subdirectory of the project root. The README has a few small pointers to help a developer get started running the fuzz tests locally, and a link to the upstream cargo-fuzz docs for more information.