### PR TITLE
feat: impl safer export_keyring_material interface.

### DIFF
--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2029,25 +2029,21 @@ fn do_exporter_test(client_config: ClientConfig, server_config: ServerConfig) {
     );
     do_handshake(&mut client, &mut server);
 
-    assert_debug_eq(
-        client.export_keying_material(&mut client_secret, b"label", Some(b"context")),
-        Ok(()),
-    );
-    assert_debug_eq(
-        server.export_keying_material(&mut server_secret, b"label", Some(b"context")),
-        Ok(()),
-    );
+    assert!(client
+        .export_keying_material(&mut client_secret, b"label", Some(b"context"))
+        .is_ok());
+    assert!(server
+        .export_keying_material(&mut server_secret, b"label", Some(b"context"))
+        .is_ok());
     assert_eq!(client_secret.to_vec(), server_secret.to_vec());
 
-    assert_debug_eq(
-        client.export_keying_material(&mut client_secret, b"label", None),
-        Ok(()),
-    );
+    assert!(client
+        .export_keying_material(&mut client_secret, b"label", None)
+        .is_ok());
     assert_ne!(client_secret.to_vec(), server_secret.to_vec());
-    assert_debug_eq(
-        server.export_keying_material(&mut server_secret, b"label", None),
-        Ok(()),
-    );
+    assert!(server
+        .export_keying_material(&mut server_secret, b"label", None)
+        .is_ok(),);
     assert_eq!(client_secret.to_vec(), server_secret.to_vec());
 }
 


### PR DESCRIPTION
## Description

Prior to this branch the `export_keyring_material` function used a mutable out buffer for writing exported key material, and returned an empty Ok result when there was no error doing so.

This commit updates the function such that the ownership of the output buffer passes through the export function and is returned as the Ok result when there is no error.

Doing this makes for a safer interface for end users: the output buffer will be dropped if `export_keyring_material` errors. Callers can only access the buffer again using the Ok result.

## Kudos

All credit due to @davidv1992 for the implementation idea and initial code from https://github.com/rustls/rustls/pull/1159. I simply adopted the branch, fixed a compile error,  updated the affected unit tests and added a small rustdoc update.