### PR TITLE
fuzz: cargo fmt updates and a clippy fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,6 +217,8 @@ jobs:
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --all -- --check
+      - name: Check formatting (fuzz workspace)
+        run: cargo fmt --all --manifest-path=fuzz/Cargo.toml -- --check
 
   clippy:
     name: Clippy
@@ -231,6 +233,7 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --package rustls --all-features -- --deny warnings
+      - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features -- --deny warnings
 
   clippy-nightly:
     name: Clippy (Nightly)
@@ -245,3 +248,4 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --package rustls --all-features
+      - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features -- --deny warnings

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -4,11 +4,7 @@ extern crate libfuzzer_sys;
 extern crate rustls;
 extern crate webpki;
 
-use rustls::{
-    ClientConfig,
-    ClientConnection,
-    RootCertStore
-};
+use rustls::{ClientConfig, ClientConnection, RootCertStore};
 use std::io;
 use std::sync::Arc;
 

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -4,7 +4,7 @@ extern crate libfuzzer_sys;
 extern crate rustls;
 
 use rustls::internal::msgs::codec::Reader;
-use rustls::internal::msgs::message::{Message, PlainMessage, OpaqueMessage};
+use rustls::internal::msgs::message::{Message, OpaqueMessage, PlainMessage};
 
 fuzz_target!(|data: &[u8]| {
     let mut rdr = Reader::init(data);

--- a/fuzz/fuzzers/persist.rs
+++ b/fuzz/fuzzers/persist.rs
@@ -11,7 +11,8 @@ where
     T: Codec,
 {
     let mut rdr = Reader::init(data);
-    T::read(&mut rdr);
+
+    let _ = T::read(&mut rdr);
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzzers/persist.rs
+++ b/fuzz/fuzzers/persist.rs
@@ -1,11 +1,15 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate rustls;
 
+use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::persist;
-use rustls::internal::msgs::codec::{Reader, Codec};
 
-fn try_type<T>(data: &[u8]) where T: Codec {
+fn try_type<T>(data: &[u8])
+where
+    T: Codec,
+{
     let mut rdr = Reader::init(data);
     T::read(&mut rdr);
 }

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -3,8 +3,8 @@
 extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::{ServerConfig, ServerConnection};
 use rustls::server::ResolvesServerCert;
+use rustls::{ServerConfig, ServerConnection};
 
 use std::io;
 use std::sync::Arc;


### PR DESCRIPTION
Three small cleanups I stumbled into while fixing some errors I caused in a WIP refactor elsewhere.

## fuzz: cargo fmt updates - 19c98b47da48af218ad11490f753ea21f8d2b77a

Applies the diff created by running `cargo fmt` across the `fuzz` subcrate.


## fuzz: fix unused Result clippy finding - faf25944e5016d672507ba946577074ab73a494b.

Tiny fix for a clippy error to throw away an otherwise unused`Result` in the persist fuzzer. We don't care if there's an `Error`, just that nothing panics or otherwise goes off the rails.

<details>
<summary>Clippy error:</summary>

```
warning: unused `std::result::Result` that must be used
  --> fuzzers/persist.rs:14:5
   |
14 |     T::read(&mut rdr);
   |     ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: this `Result` may be an `Err` variant, which should be handled
```
</details>

## CI: add fmt and clippy coverage for fuzz workspace. - 37c2275ffd2eb2b33f30d4c3b8179c1d3f870776
The `fuzz` subdirectory is set up as a separate workspace from the main workspace that contains `rustls` and `examples`. Because of this running `cargo fmt --all` and other similar tooling doesn't include the `fuzz` directory. This can lead to 
formatting/clippy drift over time. 

In this commit the `build.yml` config is extended to also run `clippy` and `fmt` on the `fuzz` subdirectory using `--manifest-path`.