### PR TITLE
Make SessionId part of the public API

### DIFF
--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -129,7 +129,7 @@ enum ClientAuth {
 #[derive(PartialEq, Clone, Copy)]
 enum Resumption {
     No,
-    SessionID,
+    SessionId,
     Tickets,
 }
 
@@ -137,7 +137,7 @@ impl Resumption {
     fn label(&self) -> &'static str {
         match *self {
             Self::No => "no-resume",
-            Self::SessionID => "sessionid",
+            Self::SessionId => "sessionid",
             Self::Tickets => "tickets",
         }
     }
@@ -318,7 +318,7 @@ fn make_server_config(
         .with_single_cert(params.key_type.get_chain(), params.key_type.get_key())
         .expect("bad certs/private key?");
 
-    if resume == Resumption::SessionID {
+    if resume == Resumption::SessionId {
         cfg.session_storage = ServerSessionMemoryCache::new(128);
     } else if resume == Resumption::Tickets {
         cfg.ticketer = Ticketer::new().unwrap();
@@ -601,7 +601,7 @@ fn selected_tests(mut args: env::Args) {
                 let resume = if mode == "handshake" {
                     Resumption::No
                 } else if mode == "handshake-resume" {
-                    Resumption::SessionID
+                    Resumption::SessionId
                 } else {
                     Resumption::Tickets
                 };
@@ -645,8 +645,8 @@ fn all_tests() {
         bench_bulk(test, 1024 * 1024, Some(10000));
         bench_handshake(test, ClientAuth::No, Resumption::No);
         bench_handshake(test, ClientAuth::Yes, Resumption::No);
-        bench_handshake(test, ClientAuth::No, Resumption::SessionID);
-        bench_handshake(test, ClientAuth::Yes, Resumption::SessionID);
+        bench_handshake(test, ClientAuth::No, Resumption::SessionId);
+        bench_handshake(test, ClientAuth::Yes, Resumption::SessionId);
         bench_handshake(test, ClientAuth::No, Resumption::Tickets);
         bench_handshake(test, ClientAuth::Yes, Resumption::Tickets);
     }

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -200,7 +200,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
 mod test {
     use super::*;
     use crate::client::ClientSessionStore;
-    use crate::internal::msgs::handshake::SessionID;
+    use crate::sessionid::SessionId;
     use std::convert::TryInto;
 
     #[cfg(feature = "tls12")]
@@ -225,7 +225,7 @@ mod test {
             &name,
             persist::Tls12ClientSessionValue::new(
                 tls12_suite,
-                SessionID::empty(),
+                SessionId::empty(),
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -12,10 +12,11 @@ use crate::msgs::enums::AlertDescription;
 use crate::msgs::enums::{ContentType, HandshakeType};
 use crate::msgs::handshake::{
     CertificatePayload, DecomposedSignatureScheme, DigitallySignedStruct, HandshakeMessagePayload,
-    HandshakePayload, NewSessionTicketPayload, SCTList, ServerECDHParams, SessionID,
+    HandshakePayload, NewSessionTicketPayload, SCTList, ServerECDHParams,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
+use crate::sessionid::SessionId;
 use crate::sign::Signer;
 #[cfg(feature = "secret_extraction")]
 use crate::suites::PartiallyExtractedSecrets;
@@ -192,7 +193,7 @@ mod server_hello {
 struct ExpectCertificate {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -253,7 +254,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
 struct ExpectCertificateStatusOrServerKx {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -327,7 +328,7 @@ impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
 struct ExpectCertificateStatus {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -381,7 +382,7 @@ impl State<ClientConnectionData> for ExpectCertificateStatus {
 struct ExpectServerKx {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -545,7 +546,7 @@ impl ServerKxDetails {
 struct ExpectServerDoneOrCertReq {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -607,7 +608,7 @@ impl State<ClientConnectionData> for ExpectServerDoneOrCertReq {
 struct ExpectCertificateRequest {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -668,7 +669,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
 struct ExpectServerDone {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -863,7 +864,7 @@ struct ExpectNewTicket {
     config: Arc<ClientConfig>,
     secrets: ConnectionSecrets,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -907,7 +908,7 @@ struct ExpectCcs {
     config: Arc<ClientConfig>,
     secrets: ConnectionSecrets,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -956,7 +957,7 @@ impl State<ClientConnectionData> for ExpectCcs {
 struct ExpectFinished {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     using_ems: bool,
     transcript: HandshakeHash,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -323,6 +323,7 @@ mod hash_hs;
 mod limited_cache;
 mod rand;
 mod record_layer;
+mod sessionid;
 mod stream;
 #[cfg(feature = "tls12")]
 mod tls12;
@@ -380,6 +381,7 @@ pub use crate::msgs::enums::{
     AlertDescription, ContentType, HandshakeType, NamedGroup, SignatureAlgorithm,
 };
 pub use crate::msgs::handshake::{DigitallySignedStruct, DistinguishedNames};
+pub use crate::sessionid::SessionId;
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     BulkAlgorithm, SupportedCipherSuite, ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES,

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -160,7 +160,7 @@ impl fmt::Debug for PayloadU8 {
 }
 
 // Format an iterator of u8 into a hex string
-pub(super) fn hex<'a>(
+pub(crate) fn hex<'a>(
     f: &mut fmt::Formatter<'_>,
     payload: impl IntoIterator<Item = &'a u8>,
 ) -> fmt::Result {

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -16,9 +16,9 @@ use crate::msgs::handshake::{
     HelloRetryExtension, HelloRetryRequest, KeyShareEntry, NewSessionTicketExtension,
     NewSessionTicketPayload, NewSessionTicketPayloadTLS13, PresharedKeyBinder,
     PresharedKeyIdentity, PresharedKeyOffer, Random, ServerECDHParams, ServerExtension,
-    ServerHelloPayload, ServerKeyExchangePayload, SessionID, SupportedPointFormats,
-    UnknownExtension,
+    ServerHelloPayload, ServerKeyExchangePayload, SupportedPointFormats, UnknownExtension,
 };
+use crate::sessionid::SessionId;
 use webpki::DnsNameRef;
 
 #[test]
@@ -50,20 +50,20 @@ fn debug_random() {
 fn rejects_truncated_sessionid() {
     let bytes = [32; 32];
     let mut rd = Reader::init(&bytes);
-    assert!(SessionID::read(&mut rd).is_err());
+    assert!(SessionId::read(&mut rd).is_err());
 }
 
 #[test]
 fn rejects_sessionid_with_bad_length() {
     let bytes = [33; 33];
     let mut rd = Reader::init(&bytes);
-    assert!(SessionID::read(&mut rd).is_err());
+    assert!(SessionId::read(&mut rd).is_err());
 }
 
 #[test]
 fn sessionid_with_different_lengths_are_unequal() {
-    let a = SessionID::read(&mut Reader::init(&[1u8, 1])).unwrap();
-    let b = SessionID::read(&mut Reader::init(&[2u8, 1, 2])).unwrap();
+    let a = SessionId::read(&mut Reader::init(&[1u8, 1])).unwrap();
+    let b = SessionId::read(&mut Reader::init(&[2u8, 1, 2])).unwrap();
     assert_ne!(a, b);
 }
 
@@ -71,7 +71,7 @@ fn sessionid_with_different_lengths_are_unequal() {
 fn accepts_short_sessionid() {
     let bytes = [1; 2];
     let mut rd = Reader::init(&bytes);
-    let sess = SessionID::read(&mut rd).unwrap();
+    let sess = SessionId::read(&mut rd).unwrap();
     println!("{:?}", sess);
 
     assert!(!sess.is_empty());
@@ -83,7 +83,7 @@ fn accepts_short_sessionid() {
 fn accepts_empty_sessionid() {
     let bytes = [0; 1];
     let mut rd = Reader::init(&bytes);
-    let sess = SessionID::read(&mut rd).unwrap();
+    let sess = SessionId::read(&mut rd).unwrap();
     println!("{:?}", sess);
 
     assert!(sess.is_empty());
@@ -98,7 +98,7 @@ fn debug_sessionid() {
         1, 1, 1,
     ];
     let mut rd = Reader::init(&bytes);
-    let sess = SessionID::read(&mut rd).unwrap();
+    let sess = SessionId::read(&mut rd).unwrap();
     assert_eq!(
         "0101010101010101010101010101010101010101010101010101010101010101",
         format!("{:?}", sess)
@@ -395,7 +395,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
     ClientHelloPayload {
         client_version: ProtocolVersion::TLSv1_2,
         random: Random::from([0; 32]),
-        session_id: SessionID::empty(),
+        session_id: SessionId::empty(),
         cipher_suites: vec![CipherSuite::TLS_NULL_WITH_NULL_NULL],
         compression_methods: vec![Compression::Null],
         extensions: vec![
@@ -788,7 +788,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
     ServerHelloPayload {
         legacy_version: ProtocolVersion::TLSv1_2,
         random: Random::from([0; 32]),
-        session_id: SessionID::empty(),
+        session_id: SessionId::empty(),
         cipher_suite: CipherSuite::TLS_NULL_WITH_NULL_NULL,
         compression_method: Compression::Null,
         extensions: vec![
@@ -825,7 +825,7 @@ fn can_clone_all_serverextensions() {
 fn get_sample_helloretryrequest() -> HelloRetryRequest {
     HelloRetryRequest {
         legacy_version: ProtocolVersion::TLSv1_2,
-        session_id: SessionID::empty(),
+        session_id: SessionId::empty(),
         cipher_suite: CipherSuite::TLS_NULL_WITH_NULL_NULL,
         extensions: vec![
             HelloRetryExtension::KeyShare(NamedGroup::X25519),

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -4,7 +4,7 @@ use crate::key;
 use crate::msgs::base::{PayloadU16, PayloadU8};
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::handshake::CertificatePayload;
-use crate::msgs::handshake::SessionID;
+use crate::sessionid::SessionId;
 use crate::ticketer::TimeBase;
 #[cfg(feature = "tls12")]
 use crate::tls12::Tls12CipherSuite;
@@ -164,7 +164,7 @@ impl std::ops::Deref for Tls13ClientSessionValue {
 #[derive(Debug, Clone)]
 pub struct Tls12ClientSessionValue {
     suite: &'static Tls12CipherSuite,
-    pub session_id: SessionID,
+    pub session_id: SessionId,
     extended_ms: bool,
     pub common: ClientSessionCommon,
 }
@@ -173,7 +173,7 @@ pub struct Tls12ClientSessionValue {
 impl Tls12ClientSessionValue {
     pub fn new(
         suite: &'static Tls12CipherSuite,
-        session_id: SessionID,
+        session_id: SessionId,
         ticket: Vec<u8>,
         master_secret: Vec<u8>,
         server_cert_chain: Vec<key::Certificate>,
@@ -270,7 +270,7 @@ static MAX_TICKET_LIFETIME: u32 = 7 * 24 * 60 * 60;
 static MAX_FRESHNESS_SKEW_MS: u32 = 60 * 1000;
 
 // --- Server types ---
-pub type ServerSessionKey = SessionID;
+pub type ServerSessionKey = SessionId;
 
 #[derive(Debug)]
 pub struct ServerSessionValue {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -8,13 +8,13 @@ use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
 use crate::log::{debug, trace};
 use crate::msgs::enums::HandshakeType;
 use crate::msgs::enums::{AlertDescription, Compression, ExtensionType};
-#[cfg(feature = "tls12")]
-use crate::msgs::handshake::SessionID;
 use crate::msgs::handshake::{ClientHelloPayload, Random, ServerExtension};
 use crate::msgs::handshake::{ConvertProtocolNameList, ConvertServerNameList, HandshakePayload};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 use crate::server::{ClientHello, ServerConfig};
+#[cfg(feature = "tls12")]
+use crate::sessionid::SessionId;
 use crate::suites;
 use crate::SupportedCipherSuite;
 
@@ -238,7 +238,7 @@ pub(super) struct ExpectClientHello {
     pub(super) extra_exts: Vec<ServerExtension>,
     pub(super) transcript: HandshakeHashOrBuffer,
     #[cfg(feature = "tls12")]
-    pub(super) session_id: SessionID,
+    pub(super) session_id: SessionId,
     #[cfg(feature = "tls12")]
     pub(super) using_ems: bool,
     pub(super) done_retry: bool,
@@ -258,7 +258,7 @@ impl ExpectClientHello {
             extra_exts,
             transcript: HandshakeHashOrBuffer::Buffer(transcript_buffer),
             #[cfg(feature = "tls12")]
-            session_id: SessionID::empty(),
+            session_id: SessionId::empty(),
             #[cfg(feature = "tls12")]
             using_ems: false,
             done_retry: false,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -57,8 +57,8 @@ mod client_hello {
     use crate::msgs::handshake::Random;
     use crate::msgs::handshake::ServerExtension;
     use crate::msgs::handshake::ServerHelloPayload;
-    use crate::msgs::handshake::SessionID;
     use crate::server::common::ActiveCertifiedKey;
+    use crate::sessionid::SessionId;
     use crate::sign;
     use crate::tls13::key_schedule::{
         KeyScheduleEarly, KeyScheduleHandshake, KeySchedulePreHandshake,
@@ -231,7 +231,7 @@ mod client_hello {
                             config: self.config,
                             transcript: HandshakeHashOrBuffer::Hash(self.transcript),
                             #[cfg(feature = "tls12")]
-                            session_id: SessionID::empty(),
+                            session_id: SessionId::empty(),
                             #[cfg(feature = "tls12")]
                             using_ems: false,
                             done_retry: true,
@@ -452,7 +452,7 @@ mod client_hello {
         randoms: &ConnectionRandoms,
         suite: &'static Tls13CipherSuite,
         cx: &mut ServerContext<'_>,
-        session_id: &SessionID,
+        session_id: &SessionId,
         share: &KeyShareEntry,
         chosen_psk_idx: Option<usize>,
         resuming_psk: Option<&[u8]>,
@@ -546,7 +546,7 @@ mod client_hello {
     ) {
         let mut req = HelloRetryRequest {
             legacy_version: ProtocolVersion::TLSv1_2,
-            session_id: SessionID::empty(),
+            session_id: SessionId::empty(),
             cipher_suite: suite.common.suite,
             extensions: Vec::new(),
         };

--- a/rustls/src/sessionid.rs
+++ b/rustls/src/sessionid.rs
@@ -1,0 +1,87 @@
+#![allow(non_camel_case_types)]
+use crate::error::InvalidMessage;
+use crate::msgs::codec::{Codec, Reader};
+use crate::rand;
+
+use std::fmt;
+
+/// A SessionID value from a [ClientHello].
+///
+/// [ClientHello]: https://www.rfc-editor.org/rfc/rfc5246#page-41
+#[derive(Copy, Clone)]
+pub struct SessionId {
+    len: usize,
+    data: [u8; 32],
+}
+
+impl fmt::Debug for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        super::msgs::base::hex(f, &self.data[..self.len])
+    }
+}
+
+impl PartialEq for SessionId {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len != other.len {
+            return false;
+        }
+
+        let mut diff = 0u8;
+        for i in 0..self.len {
+            diff |= self.data[i] ^ other.data[i];
+        }
+
+        diff == 0u8
+    }
+}
+
+impl Codec for SessionId {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        debug_assert!(self.len <= 32);
+        bytes.push(self.len as u8);
+        bytes.extend_from_slice(&self.data[..self.len]);
+    }
+
+    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+        let len = u8::read(r)? as usize;
+        if len > 32 {
+            return Err(InvalidMessage::TrailingData("SessionId"));
+        }
+
+        let bytes = match r.take(len) {
+            Some(bytes) => bytes,
+            None => return Err(InvalidMessage::MissingData("SessionId")),
+        };
+
+        let mut out = [0u8; 32];
+        out[..len].clone_from_slice(&bytes[..len]);
+        Ok(Self { data: out, len })
+    }
+}
+
+impl SessionId {
+    /// Generate a random SessionId.
+    pub fn random() -> Result<Self, rand::GetRandomFailed> {
+        let mut data = [0u8; 32];
+        rand::fill_random(&mut data)?;
+        Ok(Self { data, len: 32 })
+    }
+
+    /// Create an empty SessionId.
+    pub fn empty() -> Self {
+        Self {
+            data: [0u8; 32],
+            len: 0,
+        }
+    }
+
+    /// Return the length of the SessionId.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the length of the SessionId is zero.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3357,7 +3357,7 @@ mod test_quic {
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, HandshakeType, NamedGroup};
         use rustls::internal::msgs::handshake::{
-            ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
+            ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionId,
         };
         use rustls::internal::msgs::message::PlainMessage;
         use rustls::{CipherSuite, SignatureScheme};
@@ -3379,7 +3379,7 @@ mod test_quic {
                 payload: HandshakePayload::ClientHello(ClientHelloPayload {
                     client_version: ProtocolVersion::TLSv1_3,
                     random,
-                    session_id: SessionID::random().unwrap(),
+                    session_id: SessionId::random().unwrap(),
                     cipher_suites: vec![CipherSuite::TLS13_AES_128_GCM_SHA256],
                     compression_methods: vec![Compression::Null],
                     extensions: vec![
@@ -3420,7 +3420,7 @@ mod test_quic {
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, HandshakeType, NamedGroup};
         use rustls::internal::msgs::handshake::{
-            ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
+            ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionId,
         };
         use rustls::internal::msgs::message::PlainMessage;
         use rustls::{CipherSuite, SignatureScheme};
@@ -3446,7 +3446,7 @@ mod test_quic {
                 payload: HandshakePayload::ClientHello(ClientHelloPayload {
                     client_version: ProtocolVersion::TLSv1_2,
                     random: random.clone(),
-                    session_id: SessionID::random().unwrap(),
+                    session_id: SessionId::random().unwrap(),
                     cipher_suites: vec![CipherSuite::TLS13_AES_128_GCM_SHA256],
                     compression_methods: vec![Compression::Null],
                     extensions: vec![


### PR DESCRIPTION
This is exposed as part of the ClientSessionStore trait, but was previously public under `internals`.

Also, rename from SessionID to SessionId to follow Rust idioms for naming of acronyms.

Follows up on #1048, #1036, #920.