### PR TITLE
Bring back support for encoding/decoding client session values

### DIFF
--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -1,4 +1,4 @@
-use crate::enums::{AlertDescription, ContentType, HandshakeType};
+use crate::enums::{AlertDescription, CipherSuite, ContentType, HandshakeType};
 use crate::msgs::enums::{CertificateStatusType, ECCurveType, KeyUpdateRequest};
 use crate::msgs::handshake::KeyExchangeAlgorithm;
 use crate::rand;
@@ -132,6 +132,8 @@ pub enum InvalidMessage {
     UnexpectedMessage(&'static str),
     /// An unknown TLS protocol was encountered during message decoding.
     UnknownProtocolVersion,
+    /// An unsupported cipher suite was encountered during message decoding.
+    UnsupportedCipherSuite(CipherSuite),
     /// A peer sent a non-null compression method.
     UnsupportedCompression,
     /// A peer sent an unknown elliptic curve type.


### PR DESCRIPTION
With the current implementation, it seems impossible to support cache implementations that don't use an in-memory representation (that preserves the opaque structure of `Tls13ClientSessionValue`/`Tls12ClientSessionValue`).

In order to facilitate this use case, bring back some of the code that was removed in #1145 (in slightly different form).