### PR TITLE
Move three internal enums to public API

### DIFF
--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -1,7 +1,7 @@
+use crate::enums::{ContentType, HandshakeType};
 use crate::error::Error;
 #[cfg(feature = "logging")]
 use crate::log::warn;
-use crate::msgs::enums::{ContentType, HandshakeType};
 use crate::msgs::message::MessagePayload;
 
 /// For a Message $m, and a HandshakePayload enum member $payload_type,
@@ -17,7 +17,7 @@ macro_rules! require_handshake_msg(
         }, .. } => Ok(hm),
         payload => Err($crate::check::inappropriate_handshake_message(
             payload,
-            &[$crate::msgs::enums::ContentType::Handshake],
+            &[$crate::ContentType::Handshake],
             &[$handshake_type]))
     }
   )
@@ -35,7 +35,7 @@ macro_rules! require_handshake_msg_move(
         payload =>
             Err($crate::check::inappropriate_handshake_message(
                 &payload,
-                &[$crate::msgs::enums::ContentType::Handshake],
+                &[$crate::ContentType::Handshake],
                 &[$handshake_type]))
     }
   )

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -7,7 +7,7 @@ use crate::kx::SupportedKxGroup;
 use crate::log::trace;
 
 #[cfg(feature = "quic")]
-use crate::msgs::enums::AlertDescription;
+use crate::enums::AlertDescription;
 use crate::msgs::enums::NamedGroup;
 use crate::msgs::handshake::ClientExtension;
 use crate::msgs::persist;

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -2,6 +2,7 @@
 use crate::bs_debug;
 use crate::check::inappropriate_handshake_message;
 use crate::conn::{CommonState, ConnectionRandoms, State};
+use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::enums::{CipherSuite, ProtocolVersion};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHashBuffer;
@@ -9,9 +10,8 @@ use crate::kx;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
-use crate::msgs::enums::{AlertDescription, Compression, ContentType};
+use crate::msgs::enums::{Compression, ExtensionType};
 use crate::msgs::enums::{ECPointFormat, PSKKeyExchangeMode};
-use crate::msgs::enums::{ExtensionType, HandshakeType};
 use crate::msgs::handshake::{CertificateStatusRequest, ClientSessionTicket, SCTList};
 use crate::msgs::handshake::{ClientExtension, HasServerExtensions};
 use crate::msgs::handshake::{ClientHelloPayload, HandshakeMessagePayload, HandshakePayload};

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,6 +1,7 @@
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::conn::{self, CommonState, ConnectionRandoms, Side, State};
 use crate::enums::ProtocolVersion;
+use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
@@ -8,8 +9,6 @@ use crate::log::{debug, trace, warn};
 use crate::msgs::base::{Payload, PayloadU8};
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::AlertDescription;
-use crate::msgs::enums::{ContentType, HandshakeType};
 use crate::msgs::handshake::{
     CertificatePayload, DecomposedSignatureScheme, DigitallySignedStruct, HandshakeMessagePayload,
     HandshakePayload, NewSessionTicketPayload, SCTList, ServerECDHParams, SessionID,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -4,6 +4,7 @@ use crate::conn::Protocol;
 #[cfg(feature = "secret_extraction")]
 use crate::conn::Side;
 use crate::conn::{self, CommonState, ConnectionRandoms, State};
+use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::enums::{ProtocolVersion, SignatureScheme};
 use crate::error::{Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
@@ -12,9 +13,8 @@ use crate::kx;
 use crate::log::{debug, trace, warn};
 use crate::msgs::base::{Payload, PayloadU8};
 use crate::msgs::ccs::ChangeCipherSpecPayload;
-use crate::msgs::enums::AlertDescription;
+use crate::msgs::enums::ExtensionType;
 use crate::msgs::enums::KeyUpdateRequest;
-use crate::msgs::enums::{ContentType, ExtensionType, HandshakeType};
 use crate::msgs::handshake::ClientExtension;
 use crate::msgs::handshake::DigitallySignedStruct;
 use crate::msgs::handshake::EncryptedExtensions;

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1,4 +1,5 @@
 use crate::enums::ProtocolVersion;
+use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::key;
 #[cfg(feature = "logging")]
@@ -6,8 +7,7 @@ use crate::log::{debug, error, trace, warn};
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
 use crate::msgs::deframer::{Deframed, MessageDeframer};
-use crate::msgs::enums::{AlertDescription, AlertLevel, ContentType};
-use crate::msgs::enums::{HandshakeType, KeyUpdateRequest};
+use crate::msgs::enums::{AlertLevel, KeyUpdateRequest};
 use crate::msgs::fragmenter::MessageFragmenter;
 use crate::msgs::handshake::Random;
 use crate::msgs::message::{

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -3,6 +3,94 @@
 use crate::msgs::codec::{Codec, Reader};
 
 enum_builder! {
+    /// The `AlertDescription` TLS protocol enum.  Values in this enum are taken
+    /// from the various RFCs covering TLS, and are listed by IANA.
+    /// The `Unknown` item is used when processing unrecognised ordinals.
+    @U8
+    EnumName: AlertDescription;
+    EnumVal{
+        CloseNotify => 0x00,
+        UnexpectedMessage => 0x0a,
+        BadRecordMac => 0x14,
+        DecryptionFailed => 0x15,
+        RecordOverflow => 0x16,
+        DecompressionFailure => 0x1e,
+        HandshakeFailure => 0x28,
+        NoCertificate => 0x29,
+        BadCertificate => 0x2a,
+        UnsupportedCertificate => 0x2b,
+        CertificateRevoked => 0x2c,
+        CertificateExpired => 0x2d,
+        CertificateUnknown => 0x2e,
+        IllegalParameter => 0x2f,
+        UnknownCA => 0x30,
+        AccessDenied => 0x31,
+        DecodeError => 0x32,
+        DecryptError => 0x33,
+        ExportRestriction => 0x3c,
+        ProtocolVersion => 0x46,
+        InsufficientSecurity => 0x47,
+        InternalError => 0x50,
+        InappropriateFallback => 0x56,
+        UserCanceled => 0x5a,
+        NoRenegotiation => 0x64,
+        MissingExtension => 0x6d,
+        UnsupportedExtension => 0x6e,
+        CertificateUnobtainable => 0x6f,
+        UnrecognisedName => 0x70,
+        BadCertificateStatusResponse => 0x71,
+        BadCertificateHashValue => 0x72,
+        UnknownPSKIdentity => 0x73,
+        CertificateRequired => 0x74,
+        NoApplicationProtocol => 0x78
+    }
+}
+
+enum_builder! {
+    /// The `HandshakeType` TLS protocol enum.  Values in this enum are taken
+    /// from the various RFCs covering TLS, and are listed by IANA.
+    /// The `Unknown` item is used when processing unrecognised ordinals.
+    @U8
+    EnumName: HandshakeType;
+    EnumVal{
+        HelloRequest => 0x00,
+        ClientHello => 0x01,
+        ServerHello => 0x02,
+        HelloVerifyRequest => 0x03,
+        NewSessionTicket => 0x04,
+        EndOfEarlyData => 0x05,
+        HelloRetryRequest => 0x06,
+        EncryptedExtensions => 0x08,
+        Certificate => 0x0b,
+        ServerKeyExchange => 0x0c,
+        CertificateRequest => 0x0d,
+        ServerHelloDone => 0x0e,
+        CertificateVerify => 0x0f,
+        ClientKeyExchange => 0x10,
+        Finished => 0x14,
+        CertificateURL => 0x15,
+        CertificateStatus => 0x16,
+        KeyUpdate => 0x18,
+        MessageHash => 0xfe
+    }
+}
+
+enum_builder! {
+    /// The `ContentType` TLS protocol enum.  Values in this enum are taken
+    /// from the various RFCs covering TLS, and are listed by IANA.
+    /// The `Unknown` item is used when processing unrecognised ordinals.
+    @U8
+    EnumName: ContentType;
+    EnumVal{
+        ChangeCipherSpec => 0x14,
+        Alert => 0x15,
+        Handshake => 0x16,
+        ApplicationData => 0x17,
+        Heartbeat => 0x18
+    }
+}
+
+enum_builder! {
     /// The `ProtocolVersion` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -1,7 +1,5 @@
-use crate::msgs::enums::{
-    AlertDescription, CertificateStatusType, ContentType, ECCurveType, HandshakeType,
-    KeyUpdateRequest,
-};
+use crate::enums::{AlertDescription, ContentType, HandshakeType};
+use crate::msgs::enums::{CertificateStatusType, ECCurveType, KeyUpdateRequest};
 use crate::msgs::handshake::KeyExchangeAlgorithm;
 use crate::rand;
 
@@ -437,7 +435,7 @@ mod tests {
 
     #[test]
     fn smoke() {
-        use crate::msgs::enums::{AlertDescription, ContentType, HandshakeType};
+        use crate::enums::{AlertDescription, ContentType, HandshakeType};
         use sct;
 
         let all = vec![

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -370,15 +370,15 @@ pub use crate::builder::{
 pub use crate::conn::{
     CommonState, Connection, ConnectionCommon, IoState, Reader, Side, SideData, Writer,
 };
-pub use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
+pub use crate::enums::{
+    AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureScheme,
+};
 pub use crate::error::{CertificateError, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;
 pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
-pub use crate::msgs::enums::{
-    AlertDescription, ContentType, HandshakeType, NamedGroup, SignatureAlgorithm,
-};
+pub use crate::msgs::enums::{NamedGroup, SignatureAlgorithm};
 pub use crate::msgs::handshake::{DigitallySignedStruct, DistinguishedNames};
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{

--- a/rustls/src/msgs/alert.rs
+++ b/rustls/src/msgs/alert.rs
@@ -1,6 +1,7 @@
+use crate::enums::AlertDescription;
 use crate::error::InvalidMessage;
 use crate::msgs::codec::{Codec, Reader};
-use crate::msgs::enums::{AlertDescription, AlertLevel};
+use crate::msgs::enums::AlertLevel;
 
 #[derive(Debug)]
 pub struct AlertMessagePayload {

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -3,9 +3,8 @@ use std::ops::Range;
 
 use super::base::Payload;
 use super::codec::Codec;
-use super::enums::ContentType;
 use super::message::PlainMessage;
-use crate::enums::ProtocolVersion;
+use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::msgs::codec;
 use crate::msgs::message::{MessageError, OpaqueMessage};

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -70,50 +70,6 @@ enum_builder! {
 }
 
 enum_builder! {
-    /// The `ContentType` TLS protocol enum.  Values in this enum are taken
-    /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
-    @U8
-    EnumName: ContentType;
-    EnumVal{
-        ChangeCipherSpec => 0x14,
-        Alert => 0x15,
-        Handshake => 0x16,
-        ApplicationData => 0x17,
-        Heartbeat => 0x18
-    }
-}
-
-enum_builder! {
-    /// The `HandshakeType` TLS protocol enum.  Values in this enum are taken
-    /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
-    @U8
-    EnumName: HandshakeType;
-    EnumVal{
-        HelloRequest => 0x00,
-        ClientHello => 0x01,
-        ServerHello => 0x02,
-        HelloVerifyRequest => 0x03,
-        NewSessionTicket => 0x04,
-        EndOfEarlyData => 0x05,
-        HelloRetryRequest => 0x06,
-        EncryptedExtensions => 0x08,
-        Certificate => 0x0b,
-        ServerKeyExchange => 0x0c,
-        CertificateRequest => 0x0d,
-        ServerHelloDone => 0x0e,
-        CertificateVerify => 0x0f,
-        ClientKeyExchange => 0x10,
-        Finished => 0x14,
-        CertificateURL => 0x15,
-        CertificateStatus => 0x16,
-        KeyUpdate => 0x18,
-        MessageHash => 0xfe
-    }
-}
-
-enum_builder! {
     /// The `AlertLevel` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
@@ -122,50 +78,6 @@ enum_builder! {
     EnumVal{
         Warning => 0x01,
         Fatal => 0x02
-    }
-}
-
-enum_builder! {
-    /// The `AlertDescription` TLS protocol enum.  Values in this enum are taken
-    /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
-    @U8
-    EnumName: AlertDescription;
-    EnumVal{
-        CloseNotify => 0x00,
-        UnexpectedMessage => 0x0a,
-        BadRecordMac => 0x14,
-        DecryptionFailed => 0x15,
-        RecordOverflow => 0x16,
-        DecompressionFailure => 0x1e,
-        HandshakeFailure => 0x28,
-        NoCertificate => 0x29,
-        BadCertificate => 0x2a,
-        UnsupportedCertificate => 0x2b,
-        CertificateRevoked => 0x2c,
-        CertificateExpired => 0x2d,
-        CertificateUnknown => 0x2e,
-        IllegalParameter => 0x2f,
-        UnknownCA => 0x30,
-        AccessDenied => 0x31,
-        DecodeError => 0x32,
-        DecryptError => 0x33,
-        ExportRestriction => 0x3c,
-        ProtocolVersion => 0x46,
-        InsufficientSecurity => 0x47,
-        InternalError => 0x50,
-        InappropriateFallback => 0x56,
-        UserCanceled => 0x5a,
-        NoRenegotiation => 0x64,
-        MissingExtension => 0x6d,
-        UnsupportedExtension => 0x6e,
-        CertificateUnobtainable => 0x6f,
-        UnrecognisedName => 0x70,
-        BadCertificateStatusResponse => 0x71,
-        BadCertificateHashValue => 0x72,
-        UnknownPSKIdentity => 0x73,
-        CertificateRequired => 0x74,
-        NoApplicationProtocol => 0x78
     }
 }
 

--- a/rustls/src/msgs/enums_test.rs
+++ b/rustls/src/msgs/enums_test.rs
@@ -52,12 +52,18 @@ fn test_enums() {
         ClientCertificateType::ECDSAFixedECDH,
     );
     test_enum8::<Compression>(Compression::Null, Compression::LSZ);
-    test_enum8::<ContentType>(ContentType::ChangeCipherSpec, ContentType::Heartbeat);
-    test_enum8::<HandshakeType>(HandshakeType::HelloRequest, HandshakeType::MessageHash);
+    test_enum8::<crate::ContentType>(
+        crate::ContentType::ChangeCipherSpec,
+        crate::ContentType::Heartbeat,
+    );
+    test_enum8::<crate::HandshakeType>(
+        crate::HandshakeType::HelloRequest,
+        crate::HandshakeType::MessageHash,
+    );
     test_enum8::<AlertLevel>(AlertLevel::Warning, AlertLevel::Fatal);
-    test_enum8::<AlertDescription>(
-        AlertDescription::CloseNotify,
-        AlertDescription::NoApplicationProtocol,
+    test_enum8::<crate::AlertDescription>(
+        crate::AlertDescription::CloseNotify,
+        crate::AlertDescription::NoApplicationProtocol,
     );
     test_enum8::<HeartbeatMessageType>(
         HeartbeatMessageType::Request,

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -1,5 +1,5 @@
+use crate::enums::ContentType;
 use crate::enums::ProtocolVersion;
-use crate::msgs::enums::ContentType;
 use crate::msgs::message::{BorrowedPlainMessage, PlainMessage};
 use crate::Error;
 pub const MAX_FRAGMENT_LEN: usize = 16384;
@@ -68,9 +68,9 @@ impl MessageFragmenter {
 #[cfg(test)]
 mod tests {
     use super::{MessageFragmenter, PACKET_OVERHEAD};
+    use crate::enums::ContentType;
     use crate::enums::ProtocolVersion;
     use crate::msgs::base::Payload;
-    use crate::msgs::enums::ContentType;
     use crate::msgs::message::{BorrowedPlainMessage, PlainMessage};
 
     fn msg_eq(

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1,5 +1,5 @@
 #![allow(non_camel_case_types)]
-use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
+use crate::enums::{CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme};
 use crate::error::InvalidMessage;
 use crate::key;
 use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
@@ -7,8 +7,8 @@ use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{
     CertificateStatusType, ClientCertificateType, Compression, ECCurveType, ECPointFormat,
-    ExtensionType, HandshakeType, HashAlgorithm, KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode,
-    ServerNameType, SignatureAlgorithm,
+    ExtensionType, HashAlgorithm, KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType,
+    SignatureAlgorithm,
 };
 use crate::rand;
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -1,9 +1,9 @@
-use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
+use crate::enums::{CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme};
 use crate::key::Certificate;
 use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
 use crate::msgs::codec::{put_u16, Codec, Reader};
 use crate::msgs::enums::{
-    ClientCertificateType, Compression, ECCurveType, ExtensionType, HandshakeType, HashAlgorithm,
+    ClientCertificateType, Compression, ECCurveType, ExtensionType, HashAlgorithm,
     KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType, SignatureAlgorithm,
 };
 use crate::msgs::handshake::{

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -1,10 +1,11 @@
 use crate::enums::ProtocolVersion;
+use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::error::{Error, InvalidMessage};
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::{Codec, Reader};
-use crate::msgs::enums::{AlertDescription, AlertLevel, ContentType, HandshakeType};
+use crate::msgs::enums::AlertLevel;
 use crate::msgs::handshake::HandshakeMessagePayload;
 
 #[derive(Debug)]

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -1,8 +1,9 @@
+use crate::enums::{AlertDescription, HandshakeType};
 use crate::msgs::base::{PayloadU16, PayloadU24, PayloadU8};
 
 use super::base::Payload;
 use super::codec::Reader;
-use super::enums::{AlertDescription, AlertLevel, HandshakeType};
+use super::enums::AlertLevel;
 use super::message::{Message, OpaqueMessage, PlainMessage};
 
 use std::fs;

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -2,8 +2,8 @@
 use crate::cipher::{Iv, IvLen};
 pub use crate::client::ClientQuicExt;
 use crate::conn::{CommonState, Side};
+use crate::enums::AlertDescription;
 use crate::error::Error;
-use crate::msgs::enums::AlertDescription;
 pub use crate::server::ServerQuicExt;
 use crate::suites::BulkAlgorithm;
 use crate::tls13::key_schedule::hkdf_expand;

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -1,13 +1,12 @@
 use crate::conn::{CommonState, ConnectionRandoms, State};
 #[cfg(feature = "tls12")]
 use crate::enums::CipherSuite;
-use crate::enums::{ProtocolVersion, SignatureScheme};
+use crate::enums::{AlertDescription, HandshakeType, ProtocolVersion, SignatureScheme};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
-use crate::msgs::enums::HandshakeType;
-use crate::msgs::enums::{AlertDescription, Compression, ExtensionType};
+use crate::msgs::enums::{Compression, ExtensionType};
 #[cfg(feature = "tls12")]
 use crate::msgs::handshake::SessionID;
 use crate::msgs::handshake::{ClientHelloPayload, Random, ServerExtension};

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,13 +1,13 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
 use crate::conn::{CommonState, ConnectionCommon, Side, State};
+#[cfg(feature = "quic")]
+use crate::enums::AlertDescription;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
 use crate::kx::SupportedKxGroup;
 #[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::msgs::base::{Payload, PayloadU8};
-#[cfg(feature = "quic")]
-use crate::msgs::enums::AlertDescription;
 use crate::msgs::handshake::{ClientHelloPayload, ServerExtension};
 use crate::msgs::message::Message;
 use crate::sign;

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,6 +1,7 @@
 use crate::check::inappropriate_message;
 use crate::conn::{send_cert_verify_error_alert, CommonState, ConnectionRandoms, Side, State};
 use crate::enums::ProtocolVersion;
+use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
@@ -9,7 +10,6 @@ use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::msgs::handshake::{ClientECDHParams, HandshakeMessagePayload, HandshakePayload};
 use crate::msgs::handshake::{NewSessionTicketPayload, SessionID};
 use crate::msgs::message::{Message, MessagePayload};

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -3,14 +3,14 @@ use crate::check::inappropriate_handshake_message;
 use crate::conn::Side;
 use crate::conn::{send_cert_verify_error_alert, CommonState, ConnectionRandoms, State};
 use crate::enums::ProtocolVersion;
+use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::{AlertDescription, KeyUpdateRequest};
-use crate::msgs::enums::{ContentType, HandshakeType};
+use crate::msgs::enums::KeyUpdateRequest;
 use crate::msgs::handshake::HandshakeMessagePayload;
 use crate::msgs::handshake::HandshakePayload;
 use crate::msgs::handshake::{NewSessionTicketExtension, NewSessionTicketPayloadTLS13};

--- a/rustls/src/tls12/cipher.rs
+++ b/rustls/src/tls12/cipher.rs
@@ -1,9 +1,9 @@
 use crate::cipher::{make_nonce, Iv, MessageDecrypter, MessageEncrypter};
+use crate::enums::ContentType;
 use crate::enums::ProtocolVersion;
 use crate::error::Error;
 use crate::msgs::base::Payload;
 use crate::msgs::codec;
-use crate::msgs::enums::ContentType;
 use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
 use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -1,10 +1,10 @@
 use crate::cipher::{MessageDecrypter, MessageEncrypter};
 use crate::conn::{CommonState, ConnectionRandoms, Side};
+use crate::enums::AlertDescription;
 use crate::enums::{CipherSuite, SignatureScheme};
 use crate::error::{Error, InvalidMessage};
 use crate::kx;
 use crate::msgs::codec::{Codec, Reader};
-use crate::msgs::enums::AlertDescription;
 use crate::msgs::handshake::KeyExchangeAlgorithm;
 use crate::suites::{BulkAlgorithm, CipherSuiteCommon, SupportedCipherSuite};
 #[cfg(feature = "secret_extraction")]

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -1,9 +1,9 @@
 use crate::cipher::{make_nonce, Iv, MessageDecrypter, MessageEncrypter};
+use crate::enums::ContentType;
 use crate::enums::{CipherSuite, ProtocolVersion};
 use crate::error::{Error, PeerMisbehaved};
 use crate::msgs::base::Payload;
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::ContentType;
 use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
 use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 use crate::suites::{BulkAlgorithm, CipherSuiteCommon, SupportedCipherSuite};

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3354,12 +3354,12 @@ mod test_quic {
 
         use ring::rand::SecureRandom;
         use rustls::internal::msgs::base::PayloadU16;
-        use rustls::internal::msgs::enums::{Compression, HandshakeType, NamedGroup};
+        use rustls::internal::msgs::enums::{Compression, NamedGroup};
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
         };
         use rustls::internal::msgs::message::PlainMessage;
-        use rustls::{CipherSuite, SignatureScheme};
+        use rustls::{CipherSuite, HandshakeType, SignatureScheme};
 
         let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
@@ -3417,12 +3417,12 @@ mod test_quic {
 
         use ring::rand::SecureRandom;
         use rustls::internal::msgs::base::PayloadU16;
-        use rustls::internal::msgs::enums::{Compression, HandshakeType, NamedGroup};
+        use rustls::internal::msgs::enums::{Compression, NamedGroup};
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
         };
         use rustls::internal::msgs::message::PlainMessage;
-        use rustls::{CipherSuite, SignatureScheme};
+        use rustls::{CipherSuite, HandshakeType, SignatureScheme};
 
         let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
@@ -3674,9 +3674,9 @@ mod test_quic {
 #[test]
 fn test_client_does_not_offer_sha1() {
     use rustls::internal::msgs::{
-        codec::Reader, enums::HandshakeType, handshake::HandshakePayload, message::MessagePayload,
-        message::OpaqueMessage,
+        codec::Reader, handshake::HandshakePayload, message::MessagePayload, message::OpaqueMessage,
     };
+    use rustls::HandshakeType;
 
     for kt in ALL_KEY_TYPES.iter() {
         for version in rustls::ALL_VERSIONS {


### PR DESCRIPTION
These enums (AlertDescription, ContentType, and HandshakeType) were previously only available as part of the private API.  Eight months ago we added a public reexport of their names, but did not remove the private version to avoid semver breakage.

Now that we have a semver-incompatible version coming up we can move these fully to the public API.

This follows up on https://github.com/rustls/rustls/issues/1036#issuecomment-1140389210, and follows the example of #1048 where we previously made enums formally part of the public API by moving them out of the `msgs` directory.