### PR TITLE
Privatize ClientSessionStore

### DIFF
--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -429,7 +429,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     config.key_log = Arc::new(rustls::KeyLogFile::new());
 
     if args.flag_no_tickets {
-        config.enable_tickets = false;
+        config.set_session_support(rustls::client::ClientSessionSupport::SessionOnly(256));
     }
 
     if args.flag_no_sni {

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -11,7 +11,7 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use rustls::client::{ClientSessionMemoryCache, NoClientSessionStorage};
+use rustls::client::ClientSessionSupport;
 use rustls::server::{
     AllowAnyAuthenticatedClient, NoClientAuth, NoServerSessionStorage, ServerSessionMemoryCache,
 };
@@ -358,9 +358,9 @@ fn make_client_config(
     };
 
     if resume != Resumption::No {
-        cfg.session_storage = ClientSessionMemoryCache::new(128);
+        cfg.set_session_support(ClientSessionSupport::SessionsOrTickets(128));
     } else {
-        cfg.session_storage = Arc::new(NoClientSessionStorage {});
+        cfg.set_session_support(ClientSessionSupport::None);
     }
 
     cfg

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -4,7 +4,7 @@
 // https://boringssl.googlesource.com/boringssl/+/master/ssl/test
 //
 
-use rustls::client::{ClientConfig, ClientConnection};
+use rustls::client::{ClientConfig, ClientConnection, ClientSessionSupport};
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::enums::KeyUpdateRequest;
 use rustls::internal::msgs::persist;
@@ -552,7 +552,7 @@ fn make_client_cfg(opts: &Options) -> Arc<ClientConfig> {
     }
 
     let persist = ClientCacheWithoutKxHints::new(opts.resumption_delay);
-    cfg.session_storage = persist;
+    cfg.set_session_support(ClientSessionSupport::Custom(persist));
     cfg.enable_sni = opts.use_sni;
     cfg.max_fragment_size = opts.max_fragment;
 

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -1,4 +1,5 @@
 use crate::client;
+use crate::client::client_conn::ClientSessionStore;
 use crate::enums::SignatureScheme;
 use crate::error::Error;
 use crate::key;
@@ -12,9 +13,10 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 /// An implementer of `ClientSessionStore` which does nothing.
+#[doc(hidden)]
 pub struct NoClientSessionStorage {}
 
-impl client::ClientSessionStore for NoClientSessionStorage {
+impl ClientSessionStore for NoClientSessionStorage {
     fn set_kx_hint(&self, _: &ServerName, _: NamedGroup) {}
 
     fn kx_hint(&self, _: &ServerName) -> Option<NamedGroup> {
@@ -64,6 +66,7 @@ impl Default for ServerData {
 /// in memory.
 ///
 /// It enforces a limit on the number of entries to bound memory usage.
+#[doc(hidden)]
 pub struct ClientSessionMemoryCache {
     servers: Mutex<limited_cache::LimitedCache<ServerName, ServerData>>,
 }
@@ -80,7 +83,7 @@ impl ClientSessionMemoryCache {
     }
 }
 
-impl client::ClientSessionStore for ClientSessionMemoryCache {
+impl ClientSessionStore for ClientSessionMemoryCache {
     fn set_kx_hint(&self, server_name: &ServerName, group: NamedGroup) {
         self.servers
             .lock()
@@ -203,7 +206,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
 #[cfg(test)]
 mod test {
     use super::NoClientSessionStorage;
-    use crate::client::ClientSessionStore;
+    use crate::client::client_conn::ClientSessionStore;
     use crate::msgs::enums::NamedGroup;
     #[cfg(feature = "tls12")]
     use crate::msgs::handshake::SessionID;

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -38,9 +38,10 @@ use crate::{sign, KeyLog};
 
 use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;
+use crate::client::client_conn::ClientSessionStore;
 use crate::client::common::ServerCertDetails;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails};
-use crate::client::{hs, ClientConfig, ClientSessionStore, ServerName};
+use crate::client::{hs, ClientConfig, ServerName};
 
 use crate::ticketer::TimeBase;
 use ring::constant_time;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -405,6 +405,7 @@ pub mod client {
 
     pub use builder::{WantsClientCert, WantsTransparencyPolicyOrClientCert};
     pub use client_conn::ClientSessionStore;
+    pub use client_conn::ClientSessionSupport;
     pub use client_conn::InvalidDnsNameError;
     pub use client_conn::ResolvesClientCert;
     pub use client_conn::ServerName;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use rustls::client::ResolvesClientCert;
+use rustls::client::{ClientSessionSupport, ResolvesClientCert};
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
 use rustls::server::{AllowAnyAnonymousOrAuthenticatedClient, ClientHello, ResolvesServerCert};
@@ -2912,7 +2912,7 @@ fn early_data_configs() -> (Arc<ClientConfig>, Arc<ServerConfig>) {
     let kt = KeyType::Rsa;
     let mut client_config = make_client_config(kt);
     client_config.enable_early_data = true;
-    client_config.session_storage = Arc::new(ClientStorage::new());
+    client_config.set_session_support(ClientSessionSupport::Custom(Arc::new(ClientStorage::new())));
 
     let mut server_config = make_server_config(kt);
     server_config.max_early_data_size = 1234;
@@ -3725,7 +3725,7 @@ fn test_client_sends_helloretryrequest() {
     );
 
     let storage = Arc::new(ClientStorage::new());
-    client_config.session_storage = storage.clone();
+    client_config.set_session_support(ClientSessionSupport::Custom(storage.clone()));
 
     // but server only accepts x25519, so a HRR is required
     let server_config =
@@ -3823,13 +3823,13 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     //   into kx group cache.
     let mut client_config_1 =
         make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
-    client_config_1.session_storage = shared_storage.clone();
+    client_config_1.set_session_support(ClientSessionSupport::Custom(shared_storage.clone()));
 
     // second, client only supports secp-384 and so kx group cache
     //   contains an unusable value.
     let mut client_config_2 =
         make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::SECP384R1]);
-    client_config_2.session_storage = shared_storage.clone();
+    client_config_2.set_session_support(ClientSessionSupport::Custom(shared_storage.clone()));
 
     let server_config = make_server_config(KeyType::Rsa);
 
@@ -3869,7 +3869,8 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     let shared_storage = Arc::new(ClientStorage::new());
 
     let mut client_config = make_client_config(KeyType::Rsa);
-    client_config.session_storage = shared_storage.clone();
+    client_config.set_session_support(ClientSessionSupport::Custom(shared_storage.clone()));
+
     let client_config = Arc::new(client_config);
 
     let mut server_config = make_server_config(KeyType::Rsa);
@@ -4170,7 +4171,7 @@ fn test_client_rejects_illegal_tls13_ccs() {
 fn test_client_tls12_no_resume_after_server_downgrade() {
     let mut client_config = common::make_client_config(KeyType::Ed25519);
     let client_storage = Arc::new(ClientStorage::new());
-    client_config.session_storage = client_storage.clone();
+    client_config.set_session_support(ClientSessionSupport::Custom(client_storage.clone()));
     let client_config = Arc::new(client_config);
 
     let server_config_1 = Arc::new(common::finish_server_config(


### PR DESCRIPTION
In favor of ClientConfig::set_session_support, which selects among built-in implementations to either enable or disable session caching.

This allows removing the API surface for ClientSessionStore itself, and also ClientSessionMemoryCache and NoClientSessionStorage. However, these stay as doc(hidden) rather than fully private, because they are used in tests/api.rs and bogo_shim.rs, which use the public API.

Part of https://github.com/rustls/rustls/issues/466#issuecomment-1478728279.