### PR TITLE
QUIC: restore fixes dropped from the connection type split.

### DIFF
--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -209,6 +209,25 @@ impl ServerConnection {
     pub fn reject_early_data(&mut self) {
         self.inner.core.reject_early_data()
     }
+
+    /// Retrieves the server name, if any, used to select the certificate and
+    /// private key.
+    ///
+    /// This returns `None` until some time after the client's server name indication
+    /// (SNI) extension value is processed during the handshake. It will never be
+    /// `None` when the connection is ready to send or process application data,
+    /// unless the client does not support SNI.
+    ///
+    /// This is useful for application protocols that need to enforce that the
+    /// server name matches an application layer protocol hostname. For
+    /// example, HTTP/1.1 servers commonly expect the `Host:` header field of
+    /// every request on a connection to match the hostname in the SNI extension
+    /// when the client provides the SNI extension.
+    ///
+    /// The server name is also used to match sessions during session resumption.
+    pub fn server_name(&self) -> Option<&str> {
+        self.inner.core.get_sni_str()
+    }
 }
 
 impl Deref for ServerConnection {

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -375,23 +375,22 @@ impl ServerConnection {
         })
     }
 
-    /// Retrieves the SNI hostname, if any, used to select the certificate and
+    /// Retrieves the server name, if any, used to select the certificate and
     /// private key.
     ///
-    /// This returns `None` until some time after the client's SNI extension
-    /// value is processed during the handshake. It will never be `None` when
-    /// the connection is ready to send or process application data, unless the
-    /// client does not support SNI.
+    /// This returns `None` until some time after the client's server name indication
+    /// (SNI) extension value is processed during the handshake. It will never be
+    /// `None` when the connection is ready to send or process application data,
+    /// unless the client does not support SNI.
     ///
     /// This is useful for application protocols that need to enforce that the
-    /// SNI hostname matches an application layer protocol hostname. For
+    /// server name matches an application layer protocol hostname. For
     /// example, HTTP/1.1 servers commonly expect the `Host:` header field of
     /// every request on a connection to match the hostname in the SNI extension
     /// when the client provides the SNI extension.
     ///
-    /// The SNI hostname is also used to match sessions during session
-    /// resumption.
-    pub fn sni_hostname(&self) -> Option<&str> {
+    /// The server name is also used to match sessions during session resumption.
+    pub fn server_name(&self) -> Option<&str> {
         self.inner.core.data.get_sni_str()
     }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -391,7 +391,7 @@ impl ServerConnection {
     ///
     /// The server name is also used to match sessions during session resumption.
     pub fn server_name(&self) -> Option<&str> {
-        self.inner.core.data.get_sni_str()
+        self.inner.core.get_sni_str()
     }
 
     /// Application-controlled portion of the resumption ticket supplied by the client, if any.
@@ -758,6 +758,10 @@ impl ConnectionCore<ServerConnectionData> {
             "cannot retroactively reject early data"
         );
         self.data.early_data.reject();
+    }
+
+    pub(crate) fn get_sni_str(&self) -> Option<&str> {
+        self.data.get_sni_str()
     }
 }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1807,9 +1807,9 @@ fn server_exposes_offered_sni() {
                 .unwrap();
         let mut server = ServerConnection::new(Arc::new(make_server_config(kt))).unwrap();
 
-        assert_eq!(None, server.sni_hostname());
+        assert_eq!(None, server.server_name());
         do_handshake(&mut client, &mut server);
-        assert_eq!(Some("second.testserver.com"), server.sni_hostname());
+        assert_eq!(Some("second.testserver.com"), server.server_name());
     }
 }
 
@@ -1824,9 +1824,9 @@ fn server_exposes_offered_sni_smashed_to_lowercase() {
                 .unwrap();
         let mut server = ServerConnection::new(Arc::new(make_server_config(kt))).unwrap();
 
-        assert_eq!(None, server.sni_hostname());
+        assert_eq!(None, server.server_name());
         do_handshake(&mut client, &mut server);
-        assert_eq!(Some("second.testserver.com"), server.sni_hostname());
+        assert_eq!(Some("second.testserver.com"), server.server_name());
     }
 }
 
@@ -1846,7 +1846,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
             ClientConnection::new(Arc::new(client_config), dns_name("thisdoesNOTexist.com"))
                 .unwrap();
 
-        assert_eq!(None, server.sni_hostname());
+        assert_eq!(None, server.server_name());
         transfer(&mut client, &mut server);
         assert_debug_eq(
             server.process_new_packets(),
@@ -1854,7 +1854,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
                 "no server certificate chain resolved".to_string(),
             )),
         );
-        assert_eq!(Some("thisdoesnotexist.com"), server.sni_hostname());
+        assert_eq!(Some("thisdoesnotexist.com"), server.server_name());
     }
 }
 


### PR DESCRIPTION
## Description 

This is a follow-up to https://github.com/rustls/rustls/pull/1216

It looks like there was a little bit of `git` confusion before the `quic-conns` branch from #1216 was merged. The net result was that three of the changes I had woven into that branch were accidentally dropped with a late force push. This branch restores the lost changes in order to ensure the [downstream Quinn crate](https://github.com/quinn-rs/quinn/pull/1515) can update to the pending release when available. See the discussion in #1216 for more information.

### server: rename sni_hostname -> server_name. - 115b1f889e2366bde5c6a5f23505d83f5b902e09

The documentation retains mention of "server name indication" (SNI) for  folks that search the documentation with that more specific technical term. For users not steeped in the deeper lore of TLS the new name will be easier to find/understand.

### quic: add server_name to ServerConnection. -  bb1232660fa6e8131aa09cf04783102e64b33218

After splitting up the quic server connection types consumers lost the ability to dig out the server name from the SNI extension the server received. This commit adds the `server_name` function to `quic::ServerConnection` to restore that ability.

### quic: add export_keying_material to Connection. - aa29eb8c863bc6dc41921e515496ba4cbb467a42

When the `quic::Connection` type was split out from the broader TLS types consumers lost the ability to call `export_keying_material` to achieve RFC 5705 keying material export. This commit adds the `export_keying_material` fn to the `quic::Connection` type to restore that functionality.