### PR TITLE
Remove RootCertStore::subjects from public API

### DIFF
--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -87,8 +87,7 @@ impl RootCertStore {
     }
 
     /// Return the Subject Names for certificates in the container.
-    #[deprecated(since = "0.20.7", note = "Use OwnedTrustAnchor::subject() instead")]
-    pub fn subjects(&self) -> DistinguishedNames {
+    pub(crate) fn subjects(&self) -> DistinguishedNames {
         let mut r = DistinguishedNames::new();
 
         for ota in &self.roots {

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -2,10 +2,8 @@ use super::ResolvesClientCert;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::enums::ExtensionType;
-use crate::msgs::handshake::CertificatePayload;
-use crate::msgs::handshake::SCTList;
-use crate::msgs::handshake::ServerExtension;
-use crate::{sign, DistinguishedNames, SignatureScheme};
+use crate::msgs::handshake::{CertificatePayload, DistinguishedNames, SCTList, ServerExtension};
+use crate::{sign, SignatureScheme};
 
 use std::sync::Arc;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -380,7 +380,6 @@ pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;
 pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
 pub use crate::msgs::enums::NamedGroup;
-pub use crate::msgs::handshake::DistinguishedNames;
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     BulkAlgorithm, SupportedCipherSuite, ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -380,6 +380,7 @@ pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;
 pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
 pub use crate::msgs::enums::NamedGroup;
+pub use crate::msgs::handshake::DistinguishedNames;
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     BulkAlgorithm, SupportedCipherSuite, ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES,

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -564,7 +564,6 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
         true
     }
 
-    #[allow(deprecated)]
     fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
         Some(self.roots.subjects())
     }


### PR DESCRIPTION
This was previously deprecated in favor of OwnedTrustAnchor::subject(). ~~Removing this from the public API means that VecU16OfPayloadU16 is no longer part of the public API.~~ Edit: I wasn't building with `--all-features`, and so missed the fact that VecU16OfPayloadU16 / DistinguishedNames is part of the [ClientCertVerifier API](https://docs.rs/rustls/latest/rustls/server/trait.ClientCertVerifier.html#tymethod.client_auth_root_subjects), so it has to stay for now.

Part of #920