### PR TITLE
ClientCertVerifier: remove "abort connection" return values

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -197,8 +197,8 @@ impl server::ClientCertVerifier for DummyClientAuth {
         self.mandatory
     }
 
-    fn client_auth_root_subjects(&self) -> Vec<DistinguishedName> {
-        Vec::new()
+    fn client_auth_root_subjects(&self) -> &[DistinguishedName] {
+        &[]
     }
 
     fn verify_client_cert(

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -193,12 +193,12 @@ impl server::ClientCertVerifier for DummyClientAuth {
         true
     }
 
-    fn client_auth_mandatory(&self) -> Option<bool> {
-        Some(self.mandatory)
+    fn client_auth_mandatory(&self) -> bool {
+        self.mandatory
     }
 
-    fn client_auth_root_subjects(&self) -> Option<Vec<DistinguishedName>> {
-        Some(Vec::new())
+    fn client_auth_root_subjects(&self) -> Vec<DistinguishedName> {
+        Vec::new()
     }
 
     fn verify_client_cert(

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -1,12 +1,12 @@
-use crate::key;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
+use crate::{key, DistinguishedName};
 use crate::{CertificateError, Error};
 
 /// A trust anchor, commonly known as a "Root Certificate."
 #[derive(Debug, Clone)]
 pub struct OwnedTrustAnchor {
-    subject: Vec<u8>,
+    subject: DistinguishedName,
     spki: Vec<u8>,
     name_constraints: Option<Vec<u8>>,
 }
@@ -15,7 +15,7 @@ impl OwnedTrustAnchor {
     /// Get a `webpki::TrustAnchor` by borrowing the owned elements.
     pub(crate) fn to_trust_anchor(&self) -> webpki::TrustAnchor {
         webpki::TrustAnchor {
-            subject: &self.subject,
+            subject: self.subject.as_ref(),
             spki: &self.spki,
             name_constraints: self.name_constraints.as_deref(),
         }
@@ -41,7 +41,7 @@ impl OwnedTrustAnchor {
         name_constraints: Option<impl Into<Vec<u8>>>,
     ) -> Self {
         Self {
-            subject: subject.into(),
+            subject: DistinguishedName::from(subject.into()),
             spki: spki.into(),
             name_constraints: name_constraints.map(|x| x.into()),
         }
@@ -55,7 +55,7 @@ impl OwnedTrustAnchor {
     /// use x509_parser::prelude::FromDer;
     /// println!("{}", x509_parser::x509::X509Name::from_der(anchor.subject())?.1);
     /// ```
-    pub fn subject(&self) -> &[u8] {
+    pub fn subject(&self) -> &DistinguishedName {
         &self.subject
     }
 }

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -1,8 +1,6 @@
 use crate::key;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
-use crate::msgs::handshake::DistinguishedName;
-use crate::x509;
 use crate::{CertificateError, Error};
 
 /// A trust anchor, commonly known as a "Root Certificate."
@@ -84,21 +82,6 @@ impl RootCertStore {
     /// Say how many certificates are in the container.
     pub fn len(&self) -> usize {
         self.roots.len()
-    }
-
-    /// Return the Subject Names for certificates in the container.
-    #[deprecated(since = "0.20.7", note = "Use OwnedTrustAnchor::subject() instead")]
-    pub fn subjects(&self) -> Vec<DistinguishedName> {
-        let mut r = Vec::new();
-
-        for ota in &self.roots {
-            let mut name = Vec::new();
-            name.extend_from_slice(&ota.subject);
-            x509::wrap_in_sequence(&mut name);
-            r.push(DistinguishedName::from(name));
-        }
-
-        r
     }
 
     /// Add a single DER-encoded certificate to the store.

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -447,14 +447,7 @@ mod client_hello {
 
         let verify_schemes = client_auth.supported_verify_schemes();
 
-        let names = client_auth
-            .client_auth_root_subjects()
-            .ok_or_else(|| {
-                debug!("could not determine root subjects based on SNI");
-                cx.common
-                    .send_fatal_alert(AlertDescription::AccessDenied);
-                Error::General("client rejected by client_auth_root_subjects".into())
-            })?;
+        let names = client_auth.client_auth_root_subjects();
 
         let cr = CertificateRequestPayload {
             certtypes: vec![
@@ -518,13 +511,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         let mandatory = self
             .config
             .verifier
-            .client_auth_mandatory()
-            .ok_or_else(|| {
-                debug!("could not determine if client auth is mandatory based on SNI");
-                cx.common
-                    .send_fatal_alert(AlertDescription::AccessDenied);
-                Error::General("client rejected by client_auth_mandatory".into())
-            })?;
+            .client_auth_mandatory();
 
         trace!("certs {:?}", cert_chain);
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -40,8 +40,8 @@ mod client_hello {
     use crate::msgs::handshake::{ClientExtension, SessionID};
     use crate::msgs::handshake::{ClientHelloPayload, ServerHelloPayload};
     use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
+    use crate::sign;
     use crate::verify::DigitallySignedStruct;
-    use crate::{sign, DistinguishedName};
 
     use super::*;
 
@@ -450,9 +450,7 @@ mod client_hello {
         let names = config
             .verifier
             .client_auth_root_subjects()
-            .iter()
-            .map(|n| DistinguishedName::from(n.clone()))
-            .collect::<Vec<_>>();
+            .to_vec();
 
         let cr = CertificateRequestPayload {
             certtypes: vec![

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -40,8 +40,8 @@ mod client_hello {
     use crate::msgs::handshake::{ClientExtension, SessionID};
     use crate::msgs::handshake::{ClientHelloPayload, ServerHelloPayload};
     use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
-    use crate::sign;
     use crate::verify::DigitallySignedStruct;
+    use crate::{sign, DistinguishedName};
 
     use super::*;
 
@@ -447,7 +447,12 @@ mod client_hello {
 
         let verify_schemes = client_auth.supported_verify_schemes();
 
-        let names = client_auth.client_auth_root_subjects();
+        let names = config
+            .verifier
+            .client_auth_root_subjects()
+            .iter()
+            .map(|n| DistinguishedName::from(n.clone()))
+            .collect::<Vec<_>>();
 
         let cr = CertificateRequestPayload {
             certtypes: vec![

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -41,7 +41,6 @@ pub(super) use client_hello::CompleteClientHelloHandling;
 
 mod client_hello {
     use crate::enums::SignatureScheme;
-    use crate::kx;
     use crate::msgs::base::{Payload, PayloadU8};
     use crate::msgs::ccs::ChangeCipherSpecPayload;
     use crate::msgs::enums::NamedGroup;
@@ -66,6 +65,7 @@ mod client_hello {
         KeyScheduleEarly, KeyScheduleHandshake, KeySchedulePreHandshake,
     };
     use crate::verify::DigitallySignedStruct;
+    use crate::{kx, DistinguishedName};
 
     use super::*;
 
@@ -698,7 +698,10 @@ mod client_hello {
 
         let names = config
             .verifier
-            .client_auth_root_subjects();
+            .client_auth_root_subjects()
+            .iter()
+            .map(|n| DistinguishedName::from(n.clone()))
+            .collect::<Vec<_>>();
 
         if !names.is_empty() {
             cr.extensions

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -698,13 +698,7 @@ mod client_hello {
 
         let names = config
             .verifier
-            .client_auth_root_subjects()
-            .ok_or_else(|| {
-                debug!("could not determine root subjects based on SNI");
-                cx.common
-                    .send_fatal_alert(AlertDescription::AccessDenied);
-                Error::General("client rejected by client_auth_root_subjects".into())
-            })?;
+            .client_auth_root_subjects();
 
         if !names.is_empty() {
             cr.extensions
@@ -892,13 +886,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         let mandatory = self
             .config
             .verifier
-            .client_auth_mandatory()
-            .ok_or_else(|| {
-                debug!("could not determine if client auth is mandatory based on SNI");
-                cx.common
-                    .send_fatal_alert(AlertDescription::AccessDenied);
-                Error::General("client rejected by client_auth_mandatory".into())
-            })?;
+            .client_auth_mandatory();
 
         let (end_entity, intermediates) = match client_cert.split_first() {
             None => {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -41,6 +41,7 @@ pub(super) use client_hello::CompleteClientHelloHandling;
 
 mod client_hello {
     use crate::enums::SignatureScheme;
+    use crate::kx;
     use crate::msgs::base::{Payload, PayloadU8};
     use crate::msgs::ccs::ChangeCipherSpecPayload;
     use crate::msgs::enums::NamedGroup;
@@ -65,7 +66,6 @@ mod client_hello {
         KeyScheduleEarly, KeyScheduleHandshake, KeySchedulePreHandshake,
     };
     use crate::verify::DigitallySignedStruct;
-    use crate::{kx, DistinguishedName};
 
     use super::*;
 
@@ -699,9 +699,7 @@ mod client_hello {
         let names = config
             .verifier
             .client_auth_root_subjects()
-            .iter()
-            .map(|n| DistinguishedName::from(n.clone()))
-            .collect::<Vec<_>>();
+            .to_vec();
 
         if !names.is_empty() {
             cr.extensions

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -551,7 +551,7 @@ impl AllowAnyAuthenticatedClient {
             subjects: roots
                 .roots
                 .iter()
-                .map(|r| DistinguishedName::from(r.subject().to_vec()))
+                .map(|r| r.subject().clone())
                 .collect(),
             roots,
         }

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -53,7 +53,7 @@ fn client_verifier_works() {
             subjects: get_client_root_store(*kt)
                 .roots
                 .iter()
-                .map(|r| DistinguishedName::from(r.subject().to_vec()))
+                .map(|r| r.subject().clone())
                 .collect(),
             mandatory: true,
             offered_schemes: None,
@@ -81,7 +81,7 @@ fn client_verifier_no_schemes() {
             subjects: get_client_root_store(*kt)
                 .roots
                 .iter()
-                .map(|r| DistinguishedName::from(r.subject().to_vec()))
+                .map(|r| r.subject().clone())
                 .collect(),
             mandatory: true,
             offered_schemes: Some(vec![]),
@@ -114,7 +114,7 @@ fn client_verifier_no_auth_yes_root() {
             subjects: get_client_root_store(*kt)
                 .roots
                 .iter()
-                .map(|r| DistinguishedName::from(r.subject().to_vec()))
+                .map(|r| r.subject().clone())
                 .collect(),
             mandatory: true,
             offered_schemes: None,
@@ -151,7 +151,7 @@ fn client_verifier_fails_properly() {
             subjects: get_client_root_store(*kt)
                 .roots
                 .iter()
-                .map(|r| DistinguishedName::from(r.subject().to_vec()))
+                .map(|r| r.subject().clone())
                 .collect(),
             mandatory: true,
             offered_schemes: None,

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -186,8 +186,8 @@ impl ClientCertVerifier for MockClientVerifier {
         self.mandatory
     }
 
-    fn client_auth_root_subjects(&self) -> Vec<DistinguishedName> {
-        self.subjects.clone()
+    fn client_auth_root_subjects(&self) -> &[DistinguishedName] {
+        &self.subjects
     }
 
     fn verify_client_cert(

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -50,14 +50,12 @@ fn client_verifier_works() {
     for kt in ALL_KEY_TYPES.iter() {
         let client_verifier = MockClientVerifier {
             verified: ver_ok,
-            subjects: Some(
-                get_client_root_store(*kt)
-                    .roots
-                    .iter()
-                    .map(|r| DistinguishedName::from(r.subject().to_vec()))
-                    .collect(),
-            ),
-            mandatory: Some(true),
+            subjects: get_client_root_store(*kt)
+                .roots
+                .iter()
+                .map(|r| DistinguishedName::from(r.subject().to_vec()))
+                .collect(),
+            mandatory: true,
             offered_schemes: None,
         };
 
@@ -80,14 +78,12 @@ fn client_verifier_no_schemes() {
     for kt in ALL_KEY_TYPES.iter() {
         let client_verifier = MockClientVerifier {
             verified: ver_ok,
-            subjects: Some(
-                get_client_root_store(*kt)
-                    .roots
-                    .iter()
-                    .map(|r| DistinguishedName::from(r.subject().to_vec()))
-                    .collect(),
-            ),
-            mandatory: Some(true),
+            subjects: get_client_root_store(*kt)
+                .roots
+                .iter()
+                .map(|r| DistinguishedName::from(r.subject().to_vec()))
+                .collect(),
+            mandatory: true,
             offered_schemes: Some(vec![]),
         };
 
@@ -109,86 +105,18 @@ fn client_verifier_no_schemes() {
     }
 }
 
-// Common case, we do not find a root store to resolve to
-#[test]
-fn client_verifier_no_root() {
-    for kt in ALL_KEY_TYPES.iter() {
-        let client_verifier = MockClientVerifier {
-            verified: ver_ok,
-            subjects: None,
-            mandatory: Some(true),
-            offered_schemes: None,
-        };
-
-        let server_config = server_config_with_verifier(*kt, client_verifier);
-        let server_config = Arc::new(server_config);
-
-        for version in rustls::ALL_VERSIONS {
-            let client_config = make_client_config_with_versions_with_auth(*kt, &[version]);
-            let mut server = ServerConnection::new(Arc::clone(&server_config)).unwrap();
-            let mut client =
-                ClientConnection::new(Arc::new(client_config), dns_name("notlocalhost")).unwrap();
-            let errs = do_handshake_until_both_error(&mut client, &mut server);
-            assert_eq!(
-                errs,
-                Err(vec![
-                    ErrorFromPeer::Server(Error::General(
-                        "client rejected by client_auth_root_subjects".into()
-                    )),
-                    ErrorFromPeer::Client(Error::AlertReceived(AlertDescription::AccessDenied))
-                ])
-            );
-        }
-    }
-}
-
-// If we cannot resolve a root, we cannot decide if auth is mandatory
-#[test]
-fn client_verifier_no_auth_no_root() {
-    for kt in ALL_KEY_TYPES.iter() {
-        let client_verifier = MockClientVerifier {
-            verified: ver_unreachable,
-            subjects: None,
-            mandatory: Some(true),
-            offered_schemes: None,
-        };
-
-        let server_config = server_config_with_verifier(*kt, client_verifier);
-        let server_config = Arc::new(server_config);
-
-        for version in rustls::ALL_VERSIONS {
-            let client_config = make_client_config_with_versions(*kt, &[version]);
-            let mut server = ServerConnection::new(Arc::clone(&server_config)).unwrap();
-            let mut client =
-                ClientConnection::new(Arc::new(client_config), dns_name("notlocalhost")).unwrap();
-            let errs = do_handshake_until_both_error(&mut client, &mut server);
-            assert_eq!(
-                errs,
-                Err(vec![
-                    ErrorFromPeer::Server(Error::General(
-                        "client rejected by client_auth_root_subjects".into()
-                    )),
-                    ErrorFromPeer::Client(Error::AlertReceived(AlertDescription::AccessDenied))
-                ])
-            );
-        }
-    }
-}
-
 // If we do have a root, we must do auth
 #[test]
 fn client_verifier_no_auth_yes_root() {
     for kt in ALL_KEY_TYPES.iter() {
         let client_verifier = MockClientVerifier {
             verified: ver_unreachable,
-            subjects: Some(
-                get_client_root_store(*kt)
-                    .roots
-                    .iter()
-                    .map(|r| DistinguishedName::from(r.subject().to_vec()))
-                    .collect(),
-            ),
-            mandatory: Some(true),
+            subjects: get_client_root_store(*kt)
+                .roots
+                .iter()
+                .map(|r| DistinguishedName::from(r.subject().to_vec()))
+                .collect(),
+            mandatory: true,
             offered_schemes: None,
         };
 
@@ -220,14 +148,12 @@ fn client_verifier_fails_properly() {
     for kt in ALL_KEY_TYPES.iter() {
         let client_verifier = MockClientVerifier {
             verified: ver_err,
-            subjects: Some(
-                get_client_root_store(*kt)
-                    .roots
-                    .iter()
-                    .map(|r| DistinguishedName::from(r.subject().to_vec()))
-                    .collect(),
-            ),
-            mandatory: Some(true),
+            subjects: get_client_root_store(*kt)
+                .roots
+                .iter()
+                .map(|r| DistinguishedName::from(r.subject().to_vec()))
+                .collect(),
+            mandatory: true,
             offered_schemes: None,
         };
 
@@ -248,59 +174,20 @@ fn client_verifier_fails_properly() {
     }
 }
 
-#[test]
-// If a verifier returns a None on Mandatory-ness, then we error out
-fn client_verifier_must_determine_client_auth_requirement_to_continue() {
-    for kt in ALL_KEY_TYPES.iter() {
-        let client_verifier = MockClientVerifier {
-            verified: ver_ok,
-            subjects: Some(
-                get_client_root_store(*kt)
-                    .roots
-                    .iter()
-                    .map(|r| DistinguishedName::from(r.subject().to_vec()))
-                    .collect(),
-            ),
-            mandatory: None,
-            offered_schemes: None,
-        };
-
-        let server_config = server_config_with_verifier(*kt, client_verifier);
-        let server_config = Arc::new(server_config);
-
-        for version in rustls::ALL_VERSIONS {
-            let client_config = make_client_config_with_versions_with_auth(*kt, &[version]);
-            let mut server = ServerConnection::new(Arc::clone(&server_config)).unwrap();
-            let mut client =
-                ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
-            let errs = do_handshake_until_both_error(&mut client, &mut server);
-            assert_eq!(
-                errs,
-                Err(vec![
-                    ErrorFromPeer::Server(Error::General(
-                        "client rejected by client_auth_mandatory".into()
-                    )),
-                    ErrorFromPeer::Client(Error::AlertReceived(AlertDescription::AccessDenied))
-                ])
-            );
-        }
-    }
-}
-
 pub struct MockClientVerifier {
     pub verified: fn() -> Result<ClientCertVerified, Error>,
-    pub subjects: Option<Vec<DistinguishedName>>,
-    pub mandatory: Option<bool>,
+    pub subjects: Vec<DistinguishedName>,
+    pub mandatory: bool,
     pub offered_schemes: Option<Vec<SignatureScheme>>,
 }
 
 impl ClientCertVerifier for MockClientVerifier {
-    fn client_auth_mandatory(&self) -> Option<bool> {
+    fn client_auth_mandatory(&self) -> bool {
         self.mandatory
     }
 
-    fn client_auth_root_subjects(&self) -> Option<Vec<DistinguishedName>> {
-        self.subjects.as_ref().cloned()
+    fn client_auth_root_subjects(&self) -> Vec<DistinguishedName> {
+        self.subjects.clone()
     }
 
     fn verify_client_cert(


### PR DESCRIPTION
[Originally](https://github.com/rustls/rustls/commit/03b1ef03d), ClientCertVerifier took an `sni` parameter to `client_auth_mandatory` and `client_auth_root_subjects`. If, for a given SNI, the implementation could not decide whether client auth was mandatory or pick a set of root subjects (for instance, because the list of appropriate root subjects was a map from hostnames to subjects), the implementation could return None, which would abort the connection.

Later, in #787, we removed the `sni` parameter. With the new Acceptor API, implementations can condition client authentication on the SNI by reading the ClientHello into an Acceptor, and then constructing an appropriate ServerConfig with a ClientCertVerifier.

Since there's no `sni` parameter, there's no useful data for `client_auth_mandatory` and `client_auth_root_subjects` to decide to return `None`. So we should remove the `Option` in their return types. This happens to allow us to remove some branches during handshaking.

While we're at it, change client_auth_root_subjects return type from (`Vec<DistinguishedName>`) to `&[DistinguishedName]`. The old signature required N+1 allocations per handshake where N = the number of subjects. The new signature can reuse a stored list of subjects, which seems like a common use case. Note: we still do those allocations internally, when we clone the returned values into a Vec<DistinguishedName> to be part of a CertificateRequestPayload, which expects to own all its data. However, this method signature allows us to make future optimizations to reduce allocations.

Related: #920