### PR TITLE
Error: hide subvariants of InvalidMessage

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -6,7 +6,6 @@
 
 use rustls::client::{ClientConfig, ClientConnection};
 use rustls::internal::msgs::codec::Codec;
-use rustls::internal::msgs::enums::KeyUpdateRequest;
 use rustls::internal::msgs::persist;
 use rustls::server::{ClientHello, ServerConfig, ServerConnection};
 use rustls::{
@@ -605,7 +604,7 @@ fn handle_err(err: Error) -> ! {
             InvalidMessage::TrailingData("ChangeCipherSpecPayload") | InvalidMessage::InvalidCcs,
         ) => quit(":BAD_CHANGE_CIPHER_SPEC:"),
         Error::InvalidMessage(
-            InvalidMessage::InvalidKeyUpdate(KeyUpdateRequest::Unknown(42))
+            InvalidMessage::InvalidKeyUpdate
             | InvalidMessage::MissingData(_)
             | InvalidMessage::TrailingData(_)
             | InvalidMessage::UnexpectedMessage("HelloRetryRequest")

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -559,7 +559,7 @@ impl CommonState {
             KeyUpdateRequest::UpdateRequested => Ok(self.queued_key_update_message.is_none()),
             _ => {
                 self.send_fatal_alert(AlertDescription::IllegalParameter);
-                Err(InvalidMessage::InvalidKeyUpdate(*key_update_request).into())
+                Err(InvalidMessage::InvalidKeyUpdate.into())
             }
         }
     }

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -1,5 +1,4 @@
 use crate::enums::{AlertDescription, ContentType, HandshakeType};
-use crate::msgs::enums::{CertificateStatusType, ECCurveType, KeyUpdateRequest};
 use crate::msgs::handshake::KeyExchangeAlgorithm;
 use crate::rand;
 
@@ -106,7 +105,7 @@ pub enum InvalidMessage {
     /// An unknown content type was encountered during message decoding.
     InvalidContentType,
     /// A peer sent an invalid certificate status type
-    InvalidCertificateStatusType(CertificateStatusType),
+    InvalidCertificateStatusType,
     /// Context was incorrectly attached to a certificate request during a handshake.
     InvalidCertRequest,
     /// A peer's DH params could not be decoded
@@ -114,7 +113,7 @@ pub enum InvalidMessage {
     /// A message was zero-length when its record kind forbids it.
     InvalidEmptyPayload,
     /// A peer sent an unexpected key update request.
-    InvalidKeyUpdate(KeyUpdateRequest),
+    InvalidKeyUpdate,
     /// A peer's server name could not be decoded
     InvalidServerName,
     /// A TLS message payload was larger then allowed by the specification.
@@ -136,7 +135,7 @@ pub enum InvalidMessage {
     /// A peer sent a non-null compression method.
     UnsupportedCompression,
     /// A peer sent an unknown elliptic curve type.
-    UnsupportedCurve(ECCurveType),
+    UnsupportedCurveType,
     /// A peer sent an unsupported key exchange algorithm.
     UnsupportedKeyExchangeAlgorithm(KeyExchangeAlgorithm),
 }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1531,7 +1531,7 @@ impl Codec for ECParameters {
     fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         let ct = ECCurveType::read(r)?;
         if ct != ECCurveType::NamedCurve {
-            return Err(InvalidMessage::UnsupportedCurve(ct));
+            return Err(InvalidMessage::UnsupportedCurveType);
         }
 
         let grp = NamedGroup::read(r)?;
@@ -2046,7 +2046,7 @@ impl Codec for CertificateStatus {
             CertificateStatusType::OCSP => Ok(Self {
                 ocsp_response: PayloadU24::read(r)?,
             }),
-            _ => Err(InvalidMessage::InvalidCertificateStatusType(typ)),
+            _ => Err(InvalidMessage::InvalidCertificateStatusType),
         }
     }
 }


### PR DESCRIPTION
These subvariants were incidentally making enums from `internals` part of the public API:

 - CertificateStatusType
 - KeyUpdateRequest
 - ECCurveType

But these enums don't add much information. For instance, CertificateStatusType only has one valid value (OCSP), and all other values would be Unknown(u8). Reporting that level of detail for the unexpected response probably belongs more in a byte-by-byte protocol debugger than the workaday Error type.

Also, rename UnsupportedCurve to UnsupportedCurveType to be slightly more accurate.

Part of #920