### PR TITLE
anchors: add a pointer from add to add_parseable.

### DIFF
--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -102,6 +102,10 @@ impl RootCertStore {
     }
 
     /// Add a single DER-encoded certificate to the store.
+    ///
+    /// This is suitable for a small set of root certificates that are expected to parse
+    /// successfully. If you're adding a larger collection of certificates, for instance from
+    /// a system root store, prefer [`RootCertStore::add_parsable_certificates`].
     pub fn add(&mut self, der: &key::Certificate) -> Result<(), Error> {
         let ta = webpki::TrustAnchor::try_from_cert_der(&der.0)
             .map_err(|_| Error::InvalidCertificate(CertificateError::BadEncoding))?;


### PR DESCRIPTION
Users that are iterating over a pile of root certificates (e.g. from their system truststore) may call `RootCertStore::add` without realizing that it will reject invalid certificates (_and unfortunately some root stores contain a non-zero number..._). These users should prefer the more permissive `add_parseable_certificates`.

This commit introduces a rustdoc pointer from `add` to `add_parseable_certificates` to hopefully make this more discoverable.

See https://github.com/rustls/rustls/issues/1246