### PR TITLE
Further client resumption tweaks

### DIFF
--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -429,7 +429,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     config.key_log = Arc::new(rustls::KeyLogFile::new());
 
     if args.flag_no_tickets {
-        config.enable_tickets = false;
+        config.tls12_resumption = Some(rustls::client::Tls12Resumption::SessionIdOnly);
     }
 
     if args.flag_no_sni {

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -429,7 +429,9 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     config.key_log = Arc::new(rustls::KeyLogFile::new());
 
     if args.flag_no_tickets {
-        config.tls12_resumption = Some(rustls::client::Tls12Resumption::SessionIdOnly);
+        config.resumption = config
+            .resumption
+            .tls12_resumption(rustls::client::Tls12Resumption::SessionIdOnly);
     }
 
     if args.flag_no_sni {

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -11,7 +11,7 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use rustls::client::{ClientSessionMemoryCache, NoClientSessionStorage};
+use rustls::client::Resumption;
 use rustls::server::{
     AllowAnyAuthenticatedClient, NoClientAuth, NoServerSessionStorage, ServerSessionMemoryCache,
 };
@@ -358,9 +358,9 @@ fn make_client_config(
     };
 
     if resume != ResumptionParam::No {
-        cfg.session_storage = ClientSessionMemoryCache::new(128);
+        cfg.resumption = Resumption::in_memory_sessions(128);
     } else {
-        cfg.session_storage = Arc::new(NoClientSessionStorage {});
+        cfg.resumption = Resumption::disabled();
     }
 
     cfg

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -1,14 +1,13 @@
-use crate::anchors;
 use crate::builder::{ConfigBuilder, WantsVerifier};
-use crate::client::handy;
-use crate::client::{ClientConfig, ResolvesClientCert};
+use crate::client::{handy, ClientConfig, ResolvesClientCert};
 use crate::error::Error;
-use crate::key;
+use crate::key_log::NoKeyLog;
 use crate::kx::SupportedKxGroup;
 use crate::suites::SupportedCipherSuite;
 use crate::verify::{self, CertificateTransparencyPolicy};
-use crate::versions;
-use crate::NoKeyLog;
+use crate::{anchors, key, versions};
+
+use super::Tls12Resumption;
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -179,7 +178,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             session_storage: handy::ClientSessionMemoryCache::new(256),
             max_fragment_size: None,
             client_auth_cert_resolver,
-            enable_tickets: true,
+            tls12_resumption: Some(Tls12Resumption::SessionIdOrTickets),
             versions: self.state.versions,
             enable_sni: true,
             verifier: self.state.verifier,

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -7,7 +7,7 @@ use crate::suites::SupportedCipherSuite;
 use crate::verify::{self, CertificateTransparencyPolicy};
 use crate::{anchors, key, versions};
 
-use super::Tls12Resumption;
+use super::client_conn::Resumption;
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -175,10 +175,9 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             cipher_suites: self.state.cipher_suites,
             kx_groups: self.state.kx_groups,
             alpn_protocols: Vec::new(),
-            session_storage: handy::ClientSessionMemoryCache::new(256),
+            resumption: Resumption::default(),
             max_fragment_size: None,
             client_auth_cert_resolver,
-            tls12_resumption: Some(Tls12Resumption::SessionIdOrTickets),
             versions: self.state.versions,
             enable_sni: true,
             verifier: self.state.verifier,

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -155,7 +155,7 @@ pub struct ClientConfig {
     /// effect.
     ///
     /// The default is true.
-    pub enable_tickets: bool,
+    pub tls12_resumption: Option<Tls12Resumption>,
 
     /// Supported versions, in no particular order.  The default
     /// is all supported versions.
@@ -187,12 +187,26 @@ pub struct ClientConfig {
     pub enable_early_data: bool,
 }
 
+/// What mechanisms to support for resuming a TLS 1.2 session.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Tls12Resumption {
+    /// Support 1.2 resumption using session ids only.
+    SessionIdOnly,
+    /// Support 1.2 resumption using session ids or RFC 5077 tickets.
+    ///
+    /// See[^1] for why you might like to disable RFC 5077 by instead choosing the `SessionIdOnly`
+    /// option. Note that TLS 1.3 tickets do not have those issues.
+    ///
+    /// [^1]: <https://words.filippo.io/we-need-to-talk-about-session-tickets/>
+    SessionIdOrTickets,
+}
+
 impl fmt::Debug for ClientConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ClientConfig")
             .field("alpn_protocols", &self.alpn_protocols)
             .field("max_fragment_size", &self.max_fragment_size)
-            .field("enable_tickets", &self.enable_tickets)
+            .field("tls12_resumption", &self.tls12_resumption)
             .field("enable_sni", &self.enable_sni)
             .field("enable_early_data", &self.enable_early_data)
             .finish_non_exhaustive()

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -206,7 +206,7 @@ mod test {
     use crate::client::ClientSessionStore;
     use crate::msgs::enums::NamedGroup;
     #[cfg(feature = "tls12")]
-    use crate::msgs::handshake::SessionID;
+    use crate::msgs::handshake::SessionId;
     use crate::msgs::persist::Tls13ClientSessionValue;
     use crate::suites::SupportedCipherSuite;
     use std::convert::TryInto;
@@ -232,7 +232,7 @@ mod test {
                 &name,
                 Tls12ClientSessionValue::new(
                     tls12_suite,
-                    SessionID::empty(),
+                    SessionId::empty(),
                     Vec::new(),
                     Vec::new(),
                     Vec::new(),

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -12,7 +12,7 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 /// An implementer of `ClientSessionStore` which does nothing.
-pub struct NoClientSessionStorage {}
+pub(super) struct NoClientSessionStorage;
 
 impl client::ClientSessionStore for NoClientSessionStorage {
     fn set_kx_hint(&self, _: &ServerName, _: NamedGroup) {}
@@ -71,12 +71,12 @@ pub struct ClientSessionMemoryCache {
 impl ClientSessionMemoryCache {
     /// Make a new ClientSessionMemoryCache.  `size` is the
     /// maximum number of stored sessions.
-    pub fn new(size: usize) -> Arc<Self> {
+    pub fn new(size: usize) -> Self {
         let max_servers =
             size.saturating_add(MAX_TLS13_TICKETS_PER_SERVER - 1) / MAX_TLS13_TICKETS_PER_SERVER;
-        Arc::new(Self {
+        Self {
             servers: Mutex::new(limited_cache::LimitedCache::new(max_servers)),
-        })
+        }
     }
 }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -17,7 +17,7 @@ use crate::msgs::handshake::{CertificateStatusRequest, ClientSessionTicket, Sct}
 use crate::msgs::handshake::{ClientExtension, HasServerExtensions};
 use crate::msgs::handshake::{ClientHelloPayload, HandshakeMessagePayload, HandshakePayload};
 use crate::msgs::handshake::{HelloRetryRequest, KeyShareEntry};
-use crate::msgs::handshake::{Random, SessionID};
+use crate::msgs::handshake::{Random, SessionId};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 use crate::ticketer::TimeBase;
@@ -119,7 +119,7 @@ pub(super) fn start_handshake(
             // we're  doing an abbreviated handshake.  See section 3.4 in
             // RFC5077.
             if !inner.ticket().is_empty() {
-                inner.session_id = SessionID::random()?;
+                inner.session_id = SessionId::random()?;
             }
             session_id = Some(inner.session_id);
         }
@@ -133,8 +133,8 @@ pub(super) fn start_handshake(
     // https://tools.ietf.org/html/draft-ietf-quic-tls-34#section-8.4
     let session_id = match session_id {
         Some(session_id) => session_id,
-        None if cx.common.is_quic() => SessionID::empty(),
-        None => SessionID::random()?,
+        None if cx.common.is_quic() => SessionId::empty(),
+        None => SessionId::random()?,
     };
 
     let random = Random::new()?;
@@ -170,7 +170,7 @@ struct ExpectServerHello {
     early_key_schedule: Option<KeyScheduleEarly>,
     hello: ClientHelloDetails,
     offered_key_share: Option<kx::KeyExchange>,
-    session_id: SessionID,
+    session_id: SessionId,
     sent_tls13_fake_ccs: bool,
     suite: Option<SupportedCipherSuite>,
 }
@@ -189,7 +189,7 @@ fn emit_client_hello_for_retry(
     mut transcript_buffer: HandshakeHashBuffer,
     mut sent_tls13_fake_ccs: bool,
     mut hello: ClientHelloDetails,
-    session_id: SessionID,
+    session_id: SessionId,
     retryreq: Option<&HelloRetryRequest>,
     server_name: ServerName,
     key_share: Option<kx::KeyExchange>,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -45,14 +45,16 @@ fn find_session(
 ) -> Option<persist::Retrieved<ClientSessionValue>> {
     #[allow(clippy::let_and_return, clippy::unnecessary_lazy_evaluations)]
     let found = config
-        .session_storage
+        .resumption
+        .store
         .take_tls13_ticket(server_name)
         .map(ClientSessionValue::Tls13)
         .or_else(|| {
             #[cfg(feature = "tls12")]
             {
                 config
-                    .session_storage
+                    .resumption
+                    .store
                     .tls12_session(server_name)
                     .map(ClientSessionValue::Tls12)
             }
@@ -386,7 +388,7 @@ fn prepare_resumption<'a>(
         Some(resuming) if !resuming.ticket().is_empty() => resuming,
         _ => {
             if config.supports_version(ProtocolVersion::TLSv1_3)
-                || config.tls12_resumption == Some(Tls12Resumption::SessionIdOrTickets)
+                || config.resumption.tls12_resumption == Tls12Resumption::SessionIdOrTickets
             {
                 // If we don't have a ticket, request one.
                 exts.push(ClientExtension::SessionTicket(ClientSessionTicket::Request));
@@ -400,7 +402,7 @@ fn prepare_resumption<'a>(
         None => {
             // TLS 1.2; send the ticket if we have support this protocol version
             if config.supports_version(ProtocolVersion::TLSv1_2)
-                && config.tls12_resumption == Some(Tls12Resumption::SessionIdOrTickets)
+                && config.resumption.tls12_resumption == Tls12Resumption::SessionIdOrTickets
             {
                 exts.push(ClientExtension::SessionTicket(ClientSessionTicket::Offer(
                     Payload::new(resuming.ticket()),

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -362,9 +362,12 @@ fn emit_client_hello_for_retry(
 
 /// Prepare resumption with the session state retrieved from storage.
 ///
-/// This function will push onto `exts` to (a) request a new ticket if we don't have one,
-/// (b) send our TLS 1.2 ticket after retrieving an 1.2 session, (c) send a request for 1.3
-/// early data if allowed and (d) send a 1.3 preshared key if we have one.
+/// This function will push onto `exts` to
+///
+/// (a) request a new ticket if we don't have one,
+/// (b) send our TLS 1.2 ticket after retrieving an 1.2 session,
+/// (c) send a request for 1.3 early data if allowed and
+/// (d) send a 1.3 preshared key if we have one.
 ///
 /// For resumption to work, the currently negotiated cipher suite (if available) must be
 /// able to resume from the resuming session's cipher suite.

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -269,14 +269,7 @@ fn emit_client_hello_for_retry(
     exts.extend(extra_exts.iter().cloned());
 
     // Do we have a SessionID or ticket cached for this host?
-    let tls13_session = prepare_resumption(
-        &input.resuming,
-        &mut exts,
-        retryreq.is_some(),
-        suite,
-        cx,
-        &config,
-    );
+    let tls13_session = prepare_resumption(&input.resuming, &mut exts, suite, cx, config);
 
     // Note what extensions we sent.
     input.hello.sent_extensions = exts
@@ -380,7 +373,6 @@ fn emit_client_hello_for_retry(
 fn prepare_resumption<'a>(
     resuming: &'a Option<persist::Retrieved<ClientSessionValue>>,
     exts: &mut Vec<ClientExtension>,
-    doing_retry: bool,
     suite: Option<SupportedCipherSuite>,
     cx: &mut ClientContext<'_>,
     config: &ClientConfig,
@@ -429,7 +421,7 @@ fn prepare_resumption<'a>(
         suite.can_resume_from(tls13.suite())?;
     }
 
-    tls13::prepare_resumption(config, cx, &tls13, exts, doing_retry);
+    tls13::prepare_resumption(config, cx, &tls13, exts, suite.is_some());
     Some(tls13)
 }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -97,8 +97,6 @@ pub(super) fn start_handshake(
         transcript_buffer.set_client_auth_enabled();
     }
 
-    let support_tls13 = config.supports_version(ProtocolVersion::TLSv1_3);
-
     let mut session_id: Option<SessionID> = None;
     let mut resuming_session = find_session(
         &server_name,
@@ -107,7 +105,7 @@ pub(super) fn start_handshake(
         cx,
     );
 
-    let key_share = if support_tls13 {
+    let key_share = if config.supports_version(ProtocolVersion::TLSv1_3) {
         Some(tls13::initial_key_share(&config, &server_name)?)
     } else {
         None

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -13,7 +13,7 @@ use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
 use crate::msgs::handshake::{
     CertificatePayload, HandshakeMessagePayload, HandshakePayload, NewSessionTicketPayload, Sct,
-    ServerECDHParams, SessionID,
+    ServerECDHParams, SessionId,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -193,7 +193,7 @@ mod server_hello {
 struct ExpectCertificate {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -254,7 +254,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
 struct ExpectCertificateStatusOrServerKx {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -328,7 +328,7 @@ impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
 struct ExpectCertificateStatus {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -382,7 +382,7 @@ impl State<ClientConnectionData> for ExpectCertificateStatus {
 struct ExpectServerKx {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -546,7 +546,7 @@ impl ServerKxDetails {
 struct ExpectServerDoneOrCertReq {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -608,7 +608,7 @@ impl State<ClientConnectionData> for ExpectServerDoneOrCertReq {
 struct ExpectCertificateRequest {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -669,7 +669,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
 struct ExpectServerDone {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     using_ems: bool,
@@ -870,7 +870,7 @@ struct ExpectNewTicket {
     config: Arc<ClientConfig>,
     secrets: ConnectionSecrets,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -914,7 +914,7 @@ struct ExpectCcs {
     config: Arc<ClientConfig>,
     secrets: ConnectionSecrets,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -963,7 +963,7 @@ impl State<ClientConnectionData> for ExpectCcs {
 struct ExpectFinished {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
-    session_id: SessionID,
+    session_id: SessionId,
     server_name: ServerName,
     using_ems: bool,
     transcript: HandshakeHash,

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1019,7 +1019,8 @@ impl ExpectFinished {
         );
 
         self.config
-            .session_storage
+            .resumption
+            .store
             .set_tls12_session(&self.server_name, session_value);
     }
 }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -407,11 +407,10 @@ pub mod client {
     mod tls13;
 
     pub use builder::{WantsClientCert, WantsTransparencyPolicyOrClientCert};
-    pub use client_conn::ClientSessionStore;
-    pub use client_conn::InvalidDnsNameError;
-    pub use client_conn::ResolvesClientCert;
-    pub use client_conn::ServerName;
-    pub use client_conn::{ClientConfig, ClientConnection, ClientConnectionData, WriteEarlyData};
+    pub use client_conn::{
+        ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore,
+        InvalidDnsNameError, ResolvesClientCert, ServerName, Tls12Resumption, WriteEarlyData,
+    };
     pub use handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 
     #[cfg(feature = "dangerous_configuration")]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -409,9 +409,10 @@ pub mod client {
     pub use builder::{WantsClientCert, WantsTransparencyPolicyOrClientCert};
     pub use client_conn::{
         ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore,
-        InvalidDnsNameError, ResolvesClientCert, ServerName, Tls12Resumption, WriteEarlyData,
+        InvalidDnsNameError, ResolvesClientCert, Resumption, ServerName, Tls12Resumption,
+        WriteEarlyData,
     };
-    pub use handy::{ClientSessionMemoryCache, NoClientSessionStorage};
+    pub use handy::ClientSessionMemoryCache;
 
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::verify::{

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -105,18 +105,18 @@ impl From<[u8; 32]> for Random {
 }
 
 #[derive(Copy, Clone)]
-pub struct SessionID {
+pub struct SessionId {
     len: usize,
     data: [u8; 32],
 }
 
-impl fmt::Debug for SessionID {
+impl fmt::Debug for SessionId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         super::base::hex(f, &self.data[..self.len])
     }
 }
 
-impl PartialEq for SessionID {
+impl PartialEq for SessionId {
     fn eq(&self, other: &Self) -> bool {
         if self.len != other.len {
             return false;
@@ -131,7 +131,7 @@ impl PartialEq for SessionID {
     }
 }
 
-impl Codec for SessionID {
+impl Codec for SessionId {
     fn encode(&self, bytes: &mut Vec<u8>) {
         debug_assert!(self.len <= 32);
         bytes.push(self.len as u8);
@@ -155,7 +155,7 @@ impl Codec for SessionID {
     }
 }
 
-impl SessionID {
+impl SessionId {
     pub fn random() -> Result<Self, rand::GetRandomFailed> {
         let mut data = [0u8; 32];
         rand::fill_random(&mut data)?;
@@ -818,7 +818,7 @@ impl ServerExtension {
 pub struct ClientHelloPayload {
     pub client_version: ProtocolVersion,
     pub random: Random,
-    pub session_id: SessionID,
+    pub session_id: SessionId,
     pub cipher_suites: Vec<CipherSuite>,
     pub compression_methods: Vec<Compression>,
     pub extensions: Vec<ClientExtension>,
@@ -841,7 +841,7 @@ impl Codec for ClientHelloPayload {
         let mut ret = Self {
             client_version: ProtocolVersion::read(r)?,
             random: Random::read(r)?,
-            session_id: SessionID::read(r)?,
+            session_id: SessionId::read(r)?,
             cipher_suites: Vec::read(r)?,
             compression_methods: Vec::read(r)?,
             extensions: Vec::new(),
@@ -1089,7 +1089,7 @@ impl TlsListElement for HelloRetryExtension {
 #[derive(Debug)]
 pub struct HelloRetryRequest {
     pub legacy_version: ProtocolVersion,
-    pub session_id: SessionID,
+    pub session_id: SessionId,
     pub cipher_suite: CipherSuite,
     pub extensions: Vec<HelloRetryExtension>,
 }
@@ -1105,7 +1105,7 @@ impl Codec for HelloRetryRequest {
     }
 
     fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
-        let session_id = SessionID::read(r)?;
+        let session_id = SessionId::read(r)?;
         let cipher_suite = CipherSuite::read(r)?;
         let compression = Compression::read(r)?;
 
@@ -1183,7 +1183,7 @@ impl HelloRetryRequest {
 pub struct ServerHelloPayload {
     pub legacy_version: ProtocolVersion,
     pub random: Random,
-    pub session_id: SessionID,
+    pub session_id: SessionId,
     pub cipher_suite: CipherSuite,
     pub compression_method: Compression,
     pub extensions: Vec<ServerExtension>,
@@ -1205,7 +1205,7 @@ impl Codec for ServerHelloPayload {
 
     // minus version and random, which have already been read.
     fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
-        let session_id = SessionID::read(r)?;
+        let session_id = SessionId::read(r)?;
         let suite = CipherSuite::read(r)?;
         let compression = Compression::read(r)?;
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -15,7 +15,7 @@ use crate::msgs::handshake::{
     HelloRetryExtension, HelloRetryRequest, KeyShareEntry, NewSessionTicketExtension,
     NewSessionTicketPayload, NewSessionTicketPayloadTLS13, PresharedKeyBinder,
     PresharedKeyIdentity, PresharedKeyOffer, ProtocolName, Random, Sct, ServerECDHParams,
-    ServerExtension, ServerHelloPayload, ServerKeyExchangePayload, SessionID, UnknownExtension,
+    ServerExtension, ServerHelloPayload, ServerKeyExchangePayload, SessionId, UnknownExtension,
 };
 use crate::verify::DigitallySignedStruct;
 
@@ -50,20 +50,20 @@ fn debug_random() {
 fn rejects_truncated_sessionid() {
     let bytes = [32; 32];
     let mut rd = Reader::init(&bytes);
-    assert!(SessionID::read(&mut rd).is_err());
+    assert!(SessionId::read(&mut rd).is_err());
 }
 
 #[test]
 fn rejects_sessionid_with_bad_length() {
     let bytes = [33; 33];
     let mut rd = Reader::init(&bytes);
-    assert!(SessionID::read(&mut rd).is_err());
+    assert!(SessionId::read(&mut rd).is_err());
 }
 
 #[test]
 fn sessionid_with_different_lengths_are_unequal() {
-    let a = SessionID::read(&mut Reader::init(&[1u8, 1])).unwrap();
-    let b = SessionID::read(&mut Reader::init(&[2u8, 1, 2])).unwrap();
+    let a = SessionId::read(&mut Reader::init(&[1u8, 1])).unwrap();
+    let b = SessionId::read(&mut Reader::init(&[2u8, 1, 2])).unwrap();
     assert_ne!(a, b);
 }
 
@@ -71,7 +71,7 @@ fn sessionid_with_different_lengths_are_unequal() {
 fn accepts_short_sessionid() {
     let bytes = [1; 2];
     let mut rd = Reader::init(&bytes);
-    let sess = SessionID::read(&mut rd).unwrap();
+    let sess = SessionId::read(&mut rd).unwrap();
     println!("{:?}", sess);
 
     assert!(!sess.is_empty());
@@ -83,7 +83,7 @@ fn accepts_short_sessionid() {
 fn accepts_empty_sessionid() {
     let bytes = [0; 1];
     let mut rd = Reader::init(&bytes);
-    let sess = SessionID::read(&mut rd).unwrap();
+    let sess = SessionId::read(&mut rd).unwrap();
     println!("{:?}", sess);
 
     assert!(sess.is_empty());
@@ -98,7 +98,7 @@ fn debug_sessionid() {
         1, 1, 1,
     ];
     let mut rd = Reader::init(&bytes);
-    let sess = SessionID::read(&mut rd).unwrap();
+    let sess = SessionId::read(&mut rd).unwrap();
     assert_eq!(
         "0101010101010101010101010101010101010101010101010101010101010101",
         format!("{:?}", sess)
@@ -362,7 +362,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
     ClientHelloPayload {
         client_version: ProtocolVersion::TLSv1_2,
         random: Random::from([0; 32]),
-        session_id: SessionID::empty(),
+        session_id: SessionId::empty(),
         cipher_suites: vec![CipherSuite::TLS_NULL_WITH_NULL_NULL],
         compression_methods: vec![Compression::Null],
         extensions: vec![
@@ -755,7 +755,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
     ServerHelloPayload {
         legacy_version: ProtocolVersion::TLSv1_2,
         random: Random::from([0; 32]),
-        session_id: SessionID::empty(),
+        session_id: SessionId::empty(),
         cipher_suite: CipherSuite::TLS_NULL_WITH_NULL_NULL,
         compression_method: Compression::Null,
         extensions: vec![
@@ -792,7 +792,7 @@ fn can_clone_all_serverextensions() {
 fn get_sample_helloretryrequest() -> HelloRetryRequest {
     HelloRetryRequest {
         legacy_version: ProtocolVersion::TLSv1_2,
-        session_id: SessionID::empty(),
+        session_id: SessionId::empty(),
         cipher_suite: CipherSuite::TLS_NULL_WITH_NULL_NULL,
         extensions: vec![
             HelloRetryExtension::KeyShare(NamedGroup::X25519),

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -4,7 +4,7 @@ use crate::key;
 use crate::msgs::base::{PayloadU16, PayloadU8};
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::handshake::CertificatePayload;
-use crate::msgs::handshake::SessionID;
+use crate::msgs::handshake::SessionId;
 use crate::ticketer::TimeBase;
 #[cfg(feature = "tls12")]
 use crate::tls12::Tls12CipherSuite;
@@ -140,7 +140,7 @@ pub struct Tls12ClientSessionValue {
     #[cfg(feature = "tls12")]
     suite: &'static Tls12CipherSuite,
     #[cfg(feature = "tls12")]
-    pub(crate) session_id: SessionID,
+    pub(crate) session_id: SessionId,
     #[cfg(feature = "tls12")]
     extended_ms: bool,
     #[doc(hidden)]
@@ -152,7 +152,7 @@ pub struct Tls12ClientSessionValue {
 impl Tls12ClientSessionValue {
     pub(crate) fn new(
         suite: &'static Tls12CipherSuite,
-        session_id: SessionID,
+        session_id: SessionId,
         ticket: Vec<u8>,
         master_secret: Vec<u8>,
         server_cert_chain: Vec<key::Certificate>,
@@ -250,7 +250,7 @@ static MAX_TICKET_LIFETIME: u32 = 7 * 24 * 60 * 60;
 static MAX_FRESHNESS_SKEW_MS: u32 = 60 * 1000;
 
 // --- Server types ---
-pub type ServerSessionKey = SessionID;
+pub type ServerSessionKey = SessionId;
 
 #[derive(Debug)]
 pub struct ServerSessionValue {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -9,7 +9,7 @@ use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
 use crate::log::{debug, trace};
 use crate::msgs::enums::{Compression, ExtensionType};
 #[cfg(feature = "tls12")]
-use crate::msgs::handshake::SessionID;
+use crate::msgs::handshake::SessionId;
 use crate::msgs::handshake::{ClientHelloPayload, Random, ServerExtension};
 use crate::msgs::handshake::{ConvertProtocolNameList, ConvertServerNameList, HandshakePayload};
 use crate::msgs::message::{Message, MessagePayload};
@@ -238,7 +238,7 @@ pub(super) struct ExpectClientHello {
     pub(super) extra_exts: Vec<ServerExtension>,
     pub(super) transcript: HandshakeHashOrBuffer,
     #[cfg(feature = "tls12")]
-    pub(super) session_id: SessionID,
+    pub(super) session_id: SessionId,
     #[cfg(feature = "tls12")]
     pub(super) using_ems: bool,
     pub(super) done_retry: bool,
@@ -258,7 +258,7 @@ impl ExpectClientHello {
             extra_exts,
             transcript: HandshakeHashOrBuffer::Buffer(transcript_buffer),
             #[cfg(feature = "tls12")]
-            session_id: SessionID::empty(),
+            session_id: SessionId::empty(),
             #[cfg(feature = "tls12")]
             using_ems: false,
             done_retry: false,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -12,7 +12,7 @@ use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
 use crate::msgs::handshake::{ClientECDHParams, HandshakeMessagePayload, HandshakePayload};
-use crate::msgs::handshake::{NewSessionTicketPayload, SessionID};
+use crate::msgs::handshake::{NewSessionTicketPayload, SessionId};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 #[cfg(feature = "secret_extraction")]
@@ -37,7 +37,7 @@ mod client_hello {
     use crate::msgs::handshake::ServerECDHParams;
     use crate::msgs::handshake::{CertificateRequestPayload, ClientSessionTicket, Random};
     use crate::msgs::handshake::{CertificateStatus, ECDHEServerKeyExchange};
-    use crate::msgs::handshake::{ClientExtension, SessionID};
+    use crate::msgs::handshake::{ClientExtension, SessionId};
     use crate::msgs::handshake::{ClientHelloPayload, ServerHelloPayload};
     use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
     use crate::sign;
@@ -48,7 +48,7 @@ mod client_hello {
     pub(in crate::server) struct CompleteClientHelloHandling {
         pub(in crate::server) config: Arc<ServerConfig>,
         pub(in crate::server) transcript: HandshakeHash,
-        pub(in crate::server) session_id: SessionID,
+        pub(in crate::server) session_id: SessionId,
         pub(in crate::server) suite: &'static Tls12CipherSuite,
         pub(in crate::server) using_ems: bool,
         pub(in crate::server) randoms: ConnectionRandoms,
@@ -183,9 +183,9 @@ mod client_hello {
 
             // If we're not offered a ticket or a potential session ID, allocate a session ID.
             if !self.config.session_storage.can_cache() {
-                self.session_id = SessionID::empty();
+                self.session_id = SessionId::empty();
             } else if self.session_id.is_empty() && !ticket_received {
-                self.session_id = SessionID::random()?;
+                self.session_id = SessionId::random()?;
             }
 
             self.send_ticket = emit_server_hello(
@@ -247,7 +247,7 @@ mod client_hello {
             mut self,
             cx: &mut ServerContext<'_>,
             client_hello: &ClientHelloPayload,
-            id: &SessionID,
+            id: &SessionId,
             resumedata: persist::ServerSessionValue,
         ) -> hs::NextStateOrError {
             debug!("Resuming connection");
@@ -319,7 +319,7 @@ mod client_hello {
         config: &ServerConfig,
         transcript: &mut HandshakeHash,
         cx: &mut ServerContext<'_>,
-        session_id: SessionID,
+        session_id: SessionId,
         suite: &'static Tls12CipherSuite,
         using_ems: bool,
         ocsp_response: &mut Option<&[u8]>,
@@ -494,7 +494,7 @@ struct ExpectCertificate {
     config: Arc<ServerConfig>,
     transcript: HandshakeHash,
     randoms: ConnectionRandoms,
-    session_id: SessionID,
+    session_id: SessionId,
     suite: &'static Tls12CipherSuite,
     using_ems: bool,
     server_kx: kx::KeyExchange,
@@ -562,7 +562,7 @@ struct ExpectClientKx {
     config: Arc<ServerConfig>,
     transcript: HandshakeHash,
     randoms: ConnectionRandoms,
-    session_id: SessionID,
+    session_id: SessionId,
     suite: &'static Tls12CipherSuite,
     using_ems: bool,
     server_kx: kx::KeyExchange,
@@ -631,7 +631,7 @@ struct ExpectCertificateVerify {
     config: Arc<ServerConfig>,
     secrets: ConnectionSecrets,
     transcript: HandshakeHash,
-    session_id: SessionID,
+    session_id: SessionId,
     using_ems: bool,
     client_cert: Vec<Certificate>,
     send_ticket: bool,
@@ -693,7 +693,7 @@ struct ExpectCcs {
     config: Arc<ServerConfig>,
     secrets: ConnectionSecrets,
     transcript: HandshakeHash,
-    session_id: SessionID,
+    session_id: SessionId,
     using_ems: bool,
     resuming: bool,
     send_ticket: bool,
@@ -826,7 +826,7 @@ struct ExpectFinished {
     config: Arc<ServerConfig>,
     secrets: ConnectionSecrets,
     transcript: HandshakeHash,
-    session_id: SessionID,
+    session_id: SessionId,
     using_ems: bool,
     resuming: bool,
     send_ticket: bool,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -59,7 +59,7 @@ mod client_hello {
     use crate::msgs::handshake::Random;
     use crate::msgs::handshake::ServerExtension;
     use crate::msgs::handshake::ServerHelloPayload;
-    use crate::msgs::handshake::SessionID;
+    use crate::msgs::handshake::SessionId;
     use crate::server::common::ActiveCertifiedKey;
     use crate::sign;
     use crate::tls13::key_schedule::{
@@ -234,7 +234,7 @@ mod client_hello {
                             config: self.config,
                             transcript: HandshakeHashOrBuffer::Hash(self.transcript),
                             #[cfg(feature = "tls12")]
-                            session_id: SessionID::empty(),
+                            session_id: SessionId::empty(),
                             #[cfg(feature = "tls12")]
                             using_ems: false,
                             done_retry: true,
@@ -455,7 +455,7 @@ mod client_hello {
         randoms: &ConnectionRandoms,
         suite: &'static Tls13CipherSuite,
         cx: &mut ServerContext<'_>,
-        session_id: &SessionID,
+        session_id: &SessionId,
         share: &KeyShareEntry,
         chosen_psk_idx: Option<usize>,
         resuming_psk: Option<&[u8]>,
@@ -549,7 +549,7 @@ mod client_hello {
     ) {
         let mut req = HelloRetryRequest {
             legacy_version: ProtocolVersion::TLSv1_2,
-            session_id: SessionID::empty(),
+            session_id: SessionId::empty(),
             cipher_suite: suite.common.suite,
             extensions: Vec::new(),
         };

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3349,7 +3349,7 @@ mod test_quic {
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, NamedGroup};
         use rustls::internal::msgs::handshake::{
-            ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
+            ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionId,
         };
         use rustls::{CipherSuite, HandshakeType, SignatureScheme};
 
@@ -3368,7 +3368,7 @@ mod test_quic {
             payload: HandshakePayload::ClientHello(ClientHelloPayload {
                 client_version: ProtocolVersion::TLSv1_3,
                 random,
-                session_id: SessionID::random().unwrap(),
+                session_id: SessionId::random().unwrap(),
                 cipher_suites: vec![CipherSuite::TLS13_AES_128_GCM_SHA256],
                 compression_methods: vec![Compression::Null],
                 extensions: vec![
@@ -3406,7 +3406,7 @@ mod test_quic {
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, NamedGroup};
         use rustls::internal::msgs::handshake::{
-            ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
+            ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionId,
         };
         use rustls::{CipherSuite, HandshakeType, SignatureScheme};
 
@@ -3432,7 +3432,7 @@ mod test_quic {
             payload: HandshakePayload::ClientHello(ClientHelloPayload {
                 client_version: ProtocolVersion::TLSv1_2,
                 random: random.clone(),
-                session_id: SessionID::random().unwrap(),
+                session_id: SessionId::random().unwrap(),
                 cipher_suites: vec![CipherSuite::TLS13_AES_128_GCM_SHA256],
                 compression_methods: vec![Compression::Null],
                 extensions: vec![

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use rustls::client::ResolvesClientCert;
+use rustls::client::{ResolvesClientCert, Resumption};
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
 use rustls::server::{AllowAnyAnonymousOrAuthenticatedClient, ClientHello, ResolvesServerCert};
@@ -2678,7 +2678,7 @@ struct ClientStorage {
 impl ClientStorage {
     fn new() -> Self {
         Self {
-            storage: rustls::client::ClientSessionMemoryCache::new(1024),
+            storage: Arc::new(rustls::client::ClientSessionMemoryCache::new(1024)),
             ops: Mutex::new(Vec::new()),
         }
     }
@@ -2908,7 +2908,7 @@ fn early_data_configs() -> (Arc<ClientConfig>, Arc<ServerConfig>) {
     let kt = KeyType::Rsa;
     let mut client_config = make_client_config(kt);
     client_config.enable_early_data = true;
-    client_config.session_storage = Arc::new(ClientStorage::new());
+    client_config.resumption = Resumption::store(Arc::new(ClientStorage::new()));
 
     let mut server_config = make_server_config(kt);
     server_config.max_early_data_size = 1234;
@@ -3725,7 +3725,7 @@ fn test_client_sends_helloretryrequest() {
     );
 
     let storage = Arc::new(ClientStorage::new());
-    client_config.session_storage = storage.clone();
+    client_config.resumption = Resumption::store(storage.clone());
 
     // but server only accepts x25519, so a HRR is required
     let server_config =
@@ -3823,13 +3823,13 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     //   into kx group cache.
     let mut client_config_1 =
         make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
-    client_config_1.session_storage = shared_storage.clone();
+    client_config_1.resumption = Resumption::store(shared_storage.clone());
 
     // second, client only supports secp-384 and so kx group cache
     //   contains an unusable value.
     let mut client_config_2 =
         make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::SECP384R1]);
-    client_config_2.session_storage = shared_storage.clone();
+    client_config_2.resumption = Resumption::store(shared_storage.clone());
 
     let server_config = make_server_config(KeyType::Rsa);
 
@@ -3869,7 +3869,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     let shared_storage = Arc::new(ClientStorage::new());
 
     let mut client_config = make_client_config(KeyType::Rsa);
-    client_config.session_storage = shared_storage.clone();
+    client_config.resumption = Resumption::store(shared_storage.clone());
     let client_config = Arc::new(client_config);
 
     let mut server_config = make_server_config(KeyType::Rsa);
@@ -4170,7 +4170,7 @@ fn test_client_rejects_illegal_tls13_ccs() {
 fn test_client_tls12_no_resume_after_server_downgrade() {
     let mut client_config = common::make_client_config(KeyType::Ed25519);
     let client_storage = Arc::new(ClientStorage::new());
-    client_config.session_storage = client_storage.clone();
+    client_config.resumption = Resumption::store(client_storage.clone());
     let client_config = Arc::new(client_config);
 
     let server_config_1 = Arc::new(common::finish_server_config(


### PR DESCRIPTION
Includes the resumption enum discussed in #1235 in the last commit, but I'm honestly not sure it's worth it? There seem to be a lot of little edge cases with 1.2 resumption that still remain unaddressed; for example, after resuming we store the same ticket again, but with a `lifetime` of 0, which seems kind of useless? The client should also be discarding the session ID if it received a ticket, but it's currently storing both. Not sure how much of this is intentional.