### PR TITLE
deps: update webpki 0.100.0 -> 0.100.1.

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -19,7 +19,7 @@ rustversion = { version = "1.0.6", optional = true }
 log = { version = "0.4.4", optional = true }
 ring = "0.16.20"
 sct = "0.7.0"
-webpki = { package = "rustls-webpki", version = "0.100.0", features = ["alloc", "std"] }
+webpki = { package = "rustls-webpki", version = "0.100.1", features = ["alloc", "std"] }
 
 [features]
 default = ["logging", "tls12"]


### PR DESCRIPTION
This commit updates the Rustls webpki dependency from 0.100.0 to 0.100.1. This update picks up a fix to remove a certificate serial number length check that rejected miss-encoded certificates, including at least one root certificate.

See [rustls#1246](https://github.com/rustls/rustls/issues/1246) and [webpki#39](https://github.com/rustls/webpki/pull/39) for more information.