### PR TITLE
no-default-features: clippy fixes and CI coverage.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,6 +231,7 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --package rustls --all-features -- --deny warnings
+      - run: cargo clippy --package rustls --no-default-features -- --deny warnings
       - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features -- --deny warnings
 
   clippy-nightly:
@@ -246,4 +247,5 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --package rustls --all-features
+      - run: cargo clippy --package rustls --no-default-features -- --deny warnings
       - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features -- --deny warnings

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -42,7 +42,7 @@ fn find_session(
     config: &ClientConfig,
     #[cfg(feature = "quic")] cx: &mut ClientContext<'_>,
 ) -> Option<persist::Retrieved<ClientSessionValue>> {
-    #[allow(clippy::let_and_return)]
+    #[allow(clippy::let_and_return, clippy::unnecessary_lazy_evaluations)]
     let found = config
         .session_storage
         .take_tls13_ticket(server_name)
@@ -614,6 +614,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
         // handshake_traffic_secret.
         match suite {
             SupportedCipherSuite::Tls13(suite) => {
+                #[allow(clippy::bind_instead_of_map)]
                 let resuming_session = self
                     .resuming_session
                     .and_then(|resuming| match resuming.value {

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -144,6 +144,7 @@ pub struct Tls12ClientSessionValue {
     #[cfg(feature = "tls12")]
     extended_ms: bool,
     #[doc(hidden)]
+    #[cfg(feature = "tls12")]
     pub(crate) common: ClientSessionCommon,
 }
 


### PR DESCRIPTION
## msgs: gate ClientSessionCommon on "tls12".
The `common` field of the `Tls12ClientSessionValue` type is only used when the "tls12" feature is enabled.

To avoid an unused clippy err and to reduce the size of the struct when not using TLS1.2 this commit feature-gates the field on "tls12".

<details><summary>Clippy error:
</summary>
<p>

```
[nix-shell:~/Code/Rust/rustls]$ cargo build -p rustls --no-default-features
   Compiling rustls v0.21.0-alpha.1 (/home/daniel/Code/Rust/rustls/rustls)
warning: field `common` is never read
   --> rustls/src/msgs/persist.rs:147:16
    |
139 | pub struct Tls12ClientSessionValue {
    |            ----------------------- field in this struct
...
147 |     pub(crate) common: ClientSessionCommon,
    |                ^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
    = note: `Tls12ClientSessionValue` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis

warning: `rustls` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.73s
```

</p>
</details> 

## CI: clippy coverage for --no-default-features.
Previously we ran clippy (both stable and nightly) only for `--all-features` builds. This allows warnings specific to
`--no-default-features` to slip by.

This commit adds clippy invocations that build w/ `--no-default-features` so we can catch warnings specific to this configuration during CI.

## client/hs: ignore some aggressive clippy warnings. 
This commit adds two `allow` directives for clippy warnings present when building with `--no-default-features`:

1. Ignore `clippy::unnecessary_lazy_evaluations` for `find_session`. The    suggestion to use `or` instead of `or_else` to avoid unnecessary lazy evaluation breaks a unit test (`test_client_tls12_no_resume_after_server_downgrade`).

2. Ignore `clippy::bind_instead_of_map` for `handle`. The suggestion to use `map` doesn't play well with the inner `match` that has a `None` arm for TLS 1.2 feature builds.

In both cases it felt to me like `clippy` wasn't aware of the feature interplay and so it was better to silence the warnings than contort the code to avoid them. If folks would prefer I work harder at resolving the warnings I'm open to try :-)