### PR TITLE
examples: fix building w/o logging feature.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,9 @@ jobs:
 
       - name: cargo build (debug; no default features)
         run: cargo test --no-default-features
-        working-directory: rustls
 
       - name: cargo test (debug; no default features; tls12)
         run: cargo test --no-default-features --features tls12
-        working-directory: rustls
 
       - name: cargo test (release; no run)
         run: cargo test --release --no-run

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [features]
 default = ["logging"]
-logging = ["log"]
+logging = ["log", "rustls/logging"]
 dangerous_configuration = ["rustls/dangerous_configuration"]
 quic = ["rustls/quic"]
 
@@ -18,7 +18,7 @@ docopt = "~1.1"
 env_logger = "0.9.0" # 0.10 requires an MSRV bump to 1.60
 log = { version = "0.4.4", optional = true }
 mio = { version = "0.8", features = ["net", "os-poll"] }
-rustls = { path = "../rustls" }
+rustls = { path = "../rustls", default-features = false, features = ["tls12"] }
 rustls-pemfile = "1.0.0"
 sct = "0.7"
 serde = "1.0"

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -3,7 +3,15 @@ use std::sync::Arc;
 use mio::net::{TcpListener, TcpStream};
 
 #[macro_use]
+#[cfg(feature = "logging")]
 extern crate log;
+
+#[cfg(not(feature = "logging"))]
+#[macro_use]
+mod log {
+    macro_rules! debug    ( ($($tt:tt)*) => {{}} );
+    macro_rules! error    ( ($($tt:tt)*) => {{}} );
+}
 
 use std::collections::HashMap;
 use std::fs;
@@ -62,8 +70,8 @@ impl TlsServer {
     fn accept(&mut self, registry: &mio::Registry) -> Result<(), io::Error> {
         loop {
             match self.server.accept() {
-                Ok((socket, addr)) => {
-                    debug!("Accepting new connection from {:?}", addr);
+                Ok((socket, _addr)) => {
+                    debug!("Accepting new connection from {:?}", _addr);
 
                     let tls_conn =
                         rustls::ServerConnection::new(Arc::clone(&self.tls_config)).unwrap();
@@ -226,8 +234,8 @@ impl OpenConnection {
         };
 
         // Process newly-received TLS messages.
-        if let Err(err) = self.tls_conn.process_new_packets() {
-            error!("cannot process packet: {:?}", err);
+        if let Err(_err) = self.tls_conn.process_new_packets() {
+            error!("cannot process packet: {:?}", _err);
 
             // last gasp write to send any alerts
             self.do_tls_write_and_handle_error();


### PR DESCRIPTION
Similar to https://github.com/rustls/rustls/pull/1255, cleaning up some breakages I noticed trying to build/test things without default features.

## examples: fix no logging feature usage.
Previously the `tlsserver-mio.rs` example unconditionally used `extern crate log`, causing errors of the following form to be emitted when building examples without the "logging" feature enabled.

<details><summary>Example err:</summary>
<p>

```
error[E0658]: use of unstable library feature 'rustc_private': this
crate is being loaded from the sysroot, an unstable location; did you
mean to load this crate from crates.io via `Cargo.toml` instead?
 --> examples/src/bin/tlsserver-mio.rs:6:1
  |
6 | extern crate log;
  | ^^^^^^^^^^^^^^^^^
  |
```
</p>
</details> 

This commit resolves the breakage, allowing building the examples without logging. To do two of the the log macro shims from rustls/lib.rs are duplicated for use from the example code for this situation. Once fixed, a couple of new clippy findings are addressed for the case where no logging support is enabled and some variables thus appear "unused".

## CI: test examples with --no-default-features.
Previously the example directories weren't being tested with `--no-default-features`, letting bitrot affect those configurations.

This commit includes those directories in the `--no-default-features` task that run `cargo test`.