### PR TITLE
examples: make logging non-optional.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,9 @@ jobs:
 
       - name: cargo build (debug; no default features)
         run: cargo test --no-default-features
-        working-directory: rustls
 
       - name: cargo test (debug; no default features; tls12)
         run: cargo test --no-default-features --features tls12
-        working-directory: rustls
 
       - name: cargo test (release; no run)
         run: cargo test --release --no-run

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,17 +8,15 @@ description = "Rustls example code and tests."
 publish = false
 
 [features]
-default = ["logging"]
-logging = ["log"]
 dangerous_configuration = ["rustls/dangerous_configuration"]
 quic = ["rustls/quic"]
 
 [dependencies]
 docopt = "~1.1"
 env_logger = "0.9.0" # 0.10 requires an MSRV bump to 1.60
-log = { version = "0.4.4", optional = true }
+log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
-rustls = { path = "../rustls" }
+rustls = { path = "../rustls", features = [ "logging" ]}
 rustls-pemfile = "1.0.0"
 sct = "0.7"
 serde = "1.0"


### PR DESCRIPTION
This is an alternative approach to  https://github.com/rustls/rustls/pull/1257 that resolves the `--no-default-features` examples build breakage by making logging mandatory (as suggested by @djc).

## examples: make logging mandatory.
This commit simplifies the examples sub project to make logging mandatory instead of an optional feature flag.

In general this is easier to reason about for small example code, and it resolves a build error that was present when building w/
`--no-default-features` due to the unconditional use of the `log` crate.

## CI: test examples with --no-default-features.
Previously the example directories weren't being tested with `--no-default-features`, letting bitrot affect those configurations.

This commit includes those directories in the `--no-default-features` task that run `cargo test`.