### PR TITLE
Use type + builder pattern for client resumption config API

### DIFF
--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -429,7 +429,9 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     config.key_log = Arc::new(rustls::KeyLogFile::new());
 
     if args.flag_no_tickets {
-        config.tls12_resumption = Some(rustls::client::Tls12Resumption::SessionIdOnly);
+        config.resumption = config
+            .resumption
+            .tls12_resumption(Some(rustls::client::Tls12Resumption::SessionIdOnly));
     }
 
     if args.flag_no_sni {

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -294,7 +294,7 @@ impl KeyType {
 fn make_server_config(
     params: &BenchmarkParam,
     client_auth: ClientAuth,
-    resume: Resumption,
+    resume: ResumptionParam,
     max_fragment_size: Option<usize>,
 ) -> ServerConfig {
     let client_auth = match client_auth {
@@ -318,9 +318,9 @@ fn make_server_config(
         .with_single_cert(params.key_type.get_chain(), params.key_type.get_key())
         .expect("bad certs/private key?");
 
-    if resume == Resumption::SessionID {
+    if resume == ResumptionParam::SessionID {
         cfg.session_storage = ServerSessionMemoryCache::new(128);
-    } else if resume == Resumption::Tickets {
+    } else if resume == ResumptionParam::Tickets {
         cfg.ticketer = Ticketer::new().unwrap();
     } else {
         cfg.session_storage = Arc::new(NoServerSessionStorage {});
@@ -333,7 +333,7 @@ fn make_server_config(
 fn make_client_config(
     params: &BenchmarkParam,
     clientauth: ClientAuth,
-    resume: Resumption,
+    resume: ResumptionParam,
 ) -> ClientConfig {
     let mut root_store = RootCertStore::empty();
     let mut rootbuf =
@@ -357,10 +357,10 @@ fn make_client_config(
         cfg.with_no_client_auth()
     };
 
-    if resume != Resumption::No {
-        cfg.resumption.store = ClientSessionMemoryCache::new(128);
+    if resume != ResumptionParam::No {
+        cfg.resumption = Resumption::in_memory_sessions(128);
     } else {
-        cfg.resumption.store = Arc::new(NoClientSessionStorage {});
+        cfg.resumption = Resumption::disabled();
     }
 
     cfg
@@ -377,13 +377,17 @@ fn apply_work_multiplier(work: u64) -> u64 {
     ((work as f64) * mul).round() as u64
 }
 
-fn bench_handshake(params: &BenchmarkParam, clientauth: ClientAuth, resume: Resumption) {
+fn bench_handshake(params: &BenchmarkParam, clientauth: ClientAuth, resume: ResumptionParam) {
     let client_config = Arc::new(make_client_config(params, clientauth, resume));
     let server_config = Arc::new(make_server_config(params, clientauth, resume, None));
 
     assert!(params.ciphersuite.version() == params.version);
 
-    let rounds = apply_work_multiplier(if resume == Resumption::No { 512 } else { 4096 });
+    let rounds = apply_work_multiplier(if resume == ResumptionParam::No {
+        512
+    } else {
+        4096
+    });
     let mut client_time = 0f64;
     let mut server_time = 0f64;
 
@@ -449,11 +453,15 @@ fn do_handshake(client: &mut ClientConnection, server: &mut ServerConnection) {
 }
 
 fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, max_fragment_size: Option<usize>) {
-    let client_config = Arc::new(make_client_config(params, ClientAuth::No, Resumption::No));
+    let client_config = Arc::new(make_client_config(
+        params,
+        ClientAuth::No,
+        ResumptionParam::No,
+    ));
     let server_config = Arc::new(make_server_config(
         params,
         ClientAuth::No,
-        Resumption::No,
+        ResumptionParam::No,
         max_fragment_size,
     ));
 
@@ -509,11 +517,15 @@ fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, max_fragment_size: O
 }
 
 fn bench_memory(params: &BenchmarkParam, conn_count: u64) {
-    let client_config = Arc::new(make_client_config(params, ClientAuth::No, Resumption::No));
+    let client_config = Arc::new(make_client_config(
+        params,
+        ClientAuth::No,
+        ResumptionParam::No,
+    ));
     let server_config = Arc::new(make_server_config(
         params,
         ClientAuth::No,
-        Resumption::No,
+        ResumptionParam::No,
         None,
     ));
 
@@ -599,11 +611,11 @@ fn selected_tests(mut args: env::Args) {
         "handshake" | "handshake-resume" | "handshake-ticket" => match args.next() {
             Some(suite) => {
                 let resume = if mode == "handshake" {
-                    Resumption::No
+                    ResumptionParam::No
                 } else if mode == "handshake-resume" {
-                    Resumption::SessionID
+                    ResumptionParam::SessionID
                 } else {
-                    Resumption::Tickets
+                    ResumptionParam::Tickets
                 };
 
                 for param in lookup_matching_benches(&suite).iter() {
@@ -643,12 +655,12 @@ fn all_tests() {
     for test in ALL_BENCHMARKS.iter() {
         bench_bulk(test, 1024 * 1024, None);
         bench_bulk(test, 1024 * 1024, Some(10000));
-        bench_handshake(test, ClientAuth::No, Resumption::No);
-        bench_handshake(test, ClientAuth::Yes, Resumption::No);
-        bench_handshake(test, ClientAuth::No, Resumption::SessionID);
-        bench_handshake(test, ClientAuth::Yes, Resumption::SessionID);
-        bench_handshake(test, ClientAuth::No, Resumption::Tickets);
-        bench_handshake(test, ClientAuth::Yes, Resumption::Tickets);
+        bench_handshake(test, ClientAuth::No, ResumptionParam::No);
+        bench_handshake(test, ClientAuth::Yes, ResumptionParam::No);
+        bench_handshake(test, ClientAuth::No, ResumptionParam::SessionID);
+        bench_handshake(test, ClientAuth::Yes, ResumptionParam::SessionID);
+        bench_handshake(test, ClientAuth::No, ResumptionParam::Tickets);
+        bench_handshake(test, ClientAuth::Yes, ResumptionParam::Tickets);
     }
 }
 

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -11,7 +11,7 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use rustls::client::{ClientSessionMemoryCache, NoClientSessionStorage};
+use rustls::client::Resumption;
 use rustls::server::{
     AllowAnyAuthenticatedClient, NoClientAuth, NoServerSessionStorage, ServerSessionMemoryCache,
 };
@@ -127,13 +127,13 @@ enum ClientAuth {
 }
 
 #[derive(PartialEq, Clone, Copy)]
-enum Resumption {
+enum ResumptionParam {
     No,
     SessionID,
     Tickets,
 }
 
-impl Resumption {
+impl ResumptionParam {
     fn label(&self) -> &'static str {
         match *self {
             Self::No => "no-resume",
@@ -358,9 +358,9 @@ fn make_client_config(
     };
 
     if resume != Resumption::No {
-        cfg.session_storage = ClientSessionMemoryCache::new(128);
+        cfg.resumption.store = ClientSessionMemoryCache::new(128);
     } else {
-        cfg.session_storage = Arc::new(NoClientSessionStorage {});
+        cfg.resumption.store = Arc::new(NoClientSessionStorage {});
     }
 
     cfg

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -551,7 +551,7 @@ fn make_client_cfg(opts: &Options) -> Arc<ClientConfig> {
     }
 
     let persist = ClientCacheWithoutKxHints::new(opts.resumption_delay);
-    cfg.session_storage = persist;
+    cfg.resumption.store = persist;
     cfg.enable_sni = opts.use_sni;
     cfg.max_fragment_size = opts.max_fragment;
 

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -4,7 +4,7 @@
 // https://boringssl.googlesource.com/boringssl/+/master/ssl/test
 //
 
-use rustls::client::{ClientConfig, ClientConnection};
+use rustls::client::{ClientConfig, ClientConnection, Resumption};
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::persist;
 use rustls::server::{ClientHello, ServerConfig, ServerConnection};
@@ -550,8 +550,7 @@ fn make_client_cfg(opts: &Options) -> Arc<ClientConfig> {
         });
     }
 
-    let persist = ClientCacheWithoutKxHints::new(opts.resumption_delay);
-    cfg.resumption.store = persist;
+    cfg.resumption = Resumption::store(ClientCacheWithoutKxHints::new(opts.resumption_delay));
     cfg.enable_sni = opts.use_sni;
     cfg.max_fragment_size = opts.max_fragment;
 

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -7,11 +7,11 @@ use crate::suites::SupportedCipherSuite;
 use crate::verify::{self, CertificateTransparencyPolicy};
 use crate::{anchors, key, versions};
 
-use super::Tls12Resumption;
-
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::SystemTime;
+
+use super::client_conn::Resumption;
 
 impl ConfigBuilder<ClientConfig, WantsVerifier> {
     /// Choose how to verify client certificates.
@@ -175,10 +175,9 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             cipher_suites: self.state.cipher_suites,
             kx_groups: self.state.kx_groups,
             alpn_protocols: Vec::new(),
-            session_storage: handy::ClientSessionMemoryCache::new(256),
+            resumption: Resumption::default(),
             max_fragment_size: None,
             client_auth_cert_resolver,
-            tls12_resumption: Some(Tls12Resumption::SessionIdOrTickets),
             versions: self.state.versions,
             enable_sni: true,
             verifier: self.state.verifier,

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -117,7 +117,8 @@ pub trait ResolvesClientCert: Send + Sync {
 /// # Defaults
 ///
 /// * [`ClientConfig::max_fragment_size`]: the default is `None`: TLS packets are not fragmented to a specific size.
-/// * [`ClientConfig::session_storage`]: the default stores 256 sessions in memory.
+/// * [`ClientConfig::resumption`]: supports resumption with up to 256 server names, using session
+///    ids or tickets, with a max of eight tickets per server.
 /// * [`ClientConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ClientConfig::key_log`]: key material is not logged.
 #[derive(Clone)]

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -12,7 +12,7 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 /// An implementer of `ClientSessionStore` which does nothing.
-pub struct NoClientSessionStorage {}
+pub(super) struct NoClientSessionStorage;
 
 impl client::ClientSessionStore for NoClientSessionStorage {
     fn set_kx_hint(&self, _: &ServerName, _: NamedGroup) {}
@@ -71,7 +71,7 @@ pub struct ClientSessionMemoryCache {
 impl ClientSessionMemoryCache {
     /// Make a new ClientSessionMemoryCache.  `size` is the
     /// maximum number of stored sessions.
-    pub fn new(size: usize) -> Arc<Self> {
+    pub(super) fn new(size: usize) -> Arc<Self> {
         let max_servers =
             size.saturating_add(MAX_TLS13_TICKETS_PER_SERVER - 1) / MAX_TLS13_TICKETS_PER_SERVER;
         Arc::new(Self {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1019,7 +1019,8 @@ impl ExpectFinished {
         );
 
         self.config
-            .session_storage
+            .resumption
+            .store
             .set_tls12_session(&self.server_name, session_value);
     }
 }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -408,7 +408,8 @@ pub mod client {
     pub use builder::{WantsClientCert, WantsTransparencyPolicyOrClientCert};
     pub use client_conn::{
         ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore,
-        InvalidDnsNameError, ResolvesClientCert, ServerName, Tls12Resumption, WriteEarlyData,
+        InvalidDnsNameError, ResolvesClientCert, Resumption, ServerName, Tls12Resumption,
+        WriteEarlyData,
     };
     pub use handy::ClientSessionMemoryCache;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -410,7 +410,7 @@ pub mod client {
         ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore,
         InvalidDnsNameError, ResolvesClientCert, ServerName, Tls12Resumption, WriteEarlyData,
     };
-    pub use handy::{ClientSessionMemoryCache, NoClientSessionStorage};
+    pub use handy::ClientSessionMemoryCache;
 
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::verify::{

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3894,13 +3894,19 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
             .unwrap()
             .unwrap();
         let message = Message::try_from(deframed.message).unwrap();
-        let MessagePayload::Handshake { parsed: parsed_handshake, .. } = message.payload else {
+        if let MessagePayload::Handshake {
+            parsed: parsed_handshake,
+            ..
+        } = message.payload
+        {
+            if let HandshakePayload::ClientHello(client_hello_payload) = parsed_handshake.payload {
+                client_hello_payload.extensions
+            } else {
+                panic!("expected client hello, got {:?}", parsed_handshake.payload);
+            }
+        } else {
             panic!("expected handshake message, got {:?}", message.payload);
-        };
-        let HandshakePayload::ClientHello(client_hello_payload) = parsed_handshake.payload else {
-            panic!("expected client hello, got {:?}", parsed_handshake.payload);
-        };
-        client_hello_payload.extensions
+        }
     }
 
     // 5 subsequent client hellos: all are resumptions

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2912,7 +2912,7 @@ fn early_data_configs() -> (Arc<ClientConfig>, Arc<ServerConfig>) {
     let kt = KeyType::Rsa;
     let mut client_config = make_client_config(kt);
     client_config.enable_early_data = true;
-    client_config.session_storage = Arc::new(ClientStorage::new());
+    client_config.resumption.store = Arc::new(ClientStorage::new());
 
     let mut server_config = make_server_config(kt);
     server_config.max_early_data_size = 1234;
@@ -3725,7 +3725,7 @@ fn test_client_sends_helloretryrequest() {
     );
 
     let storage = Arc::new(ClientStorage::new());
-    client_config.session_storage = storage.clone();
+    client_config.resumption.store = storage.clone();
 
     // but server only accepts x25519, so a HRR is required
     let server_config =
@@ -3823,13 +3823,13 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     //   into kx group cache.
     let mut client_config_1 =
         make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
-    client_config_1.session_storage = shared_storage.clone();
+    client_config_1.resumption.store = shared_storage.clone();
 
     // second, client only supports secp-384 and so kx group cache
     //   contains an unusable value.
     let mut client_config_2 =
         make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::SECP384R1]);
-    client_config_2.session_storage = shared_storage.clone();
+    client_config_2.resumption.store = shared_storage.clone();
 
     let server_config = make_server_config(KeyType::Rsa);
 
@@ -3869,7 +3869,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     let shared_storage = Arc::new(ClientStorage::new());
 
     let mut client_config = make_client_config(KeyType::Rsa);
-    client_config.session_storage = shared_storage.clone();
+    client_config.resumption.store = shared_storage.clone();
     let client_config = Arc::new(client_config);
 
     let mut server_config = make_server_config(KeyType::Rsa);
@@ -4170,7 +4170,7 @@ fn test_client_rejects_illegal_tls13_ccs() {
 fn test_client_tls12_no_resume_after_server_downgrade() {
     let mut client_config = common::make_client_config(KeyType::Ed25519);
     let client_storage = Arc::new(ClientStorage::new());
-    client_config.session_storage = client_storage.clone();
+    client_config.resumption = Resumption::store(client_storage.clone());
     let client_config = Arc::new(client_config);
 
     let server_config_1 = Arc::new(common::finish_server_config(

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use rustls::client::ResolvesClientCert;
+use rustls::client::{ResolvesClientCert, Resumption};
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
 use rustls::server::{AllowAnyAnonymousOrAuthenticatedClient, ClientHello, ResolvesServerCert};

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2912,7 +2912,7 @@ fn early_data_configs() -> (Arc<ClientConfig>, Arc<ServerConfig>) {
     let kt = KeyType::Rsa;
     let mut client_config = make_client_config(kt);
     client_config.enable_early_data = true;
-    client_config.resumption.store = Arc::new(ClientStorage::new());
+    client_config.resumption = Resumption::store(Arc::new(ClientStorage::new()));
 
     let mut server_config = make_server_config(kt);
     server_config.max_early_data_size = 1234;
@@ -3725,7 +3725,7 @@ fn test_client_sends_helloretryrequest() {
     );
 
     let storage = Arc::new(ClientStorage::new());
-    client_config.resumption.store = storage.clone();
+    client_config.resumption = Resumption::store(storage.clone());
 
     // but server only accepts x25519, so a HRR is required
     let server_config =
@@ -3823,13 +3823,13 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     //   into kx group cache.
     let mut client_config_1 =
         make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
-    client_config_1.resumption.store = shared_storage.clone();
+    client_config_1.resumption = Resumption::store(shared_storage.clone());
 
     // second, client only supports secp-384 and so kx group cache
     //   contains an unusable value.
     let mut client_config_2 =
         make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::SECP384R1]);
-    client_config_2.resumption.store = shared_storage.clone();
+    client_config_2.resumption = Resumption::store(shared_storage.clone());
 
     let server_config = make_server_config(KeyType::Rsa);
 
@@ -3869,7 +3869,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     let shared_storage = Arc::new(ClientStorage::new());
 
     let mut client_config = make_client_config(KeyType::Rsa);
-    client_config.resumption.store = shared_storage.clone();
+    client_config.resumption = Resumption::store(shared_storage.clone());
     let client_config = Arc::new(client_config);
 
     let mut server_config = make_server_config(KeyType::Rsa);


### PR DESCRIPTION
@jsha been a busy day, I was thinking along the lines of something like this. Instead of having a setter on `ClientConfig`, use a field with a type that uses some kind of builder pattern to wrap up states that make sense. This doesn't quite build and the builder methods don't quite abstract over the right states, but would like your thoughts.

Let's "lock" this branch explicitly: anyone should feel free to hack on it to whip it into shape, I can pick it up in the morning and polish it up.