### PR TITLE
Reduce CIFuzz timeout to 300s

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -15,7 +15,7 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'rustls'
-        fuzz-seconds: 600
+        fuzz-seconds: 150
         dry-run: false
         language: rust
     - name: Upload Crash


### PR DESCRIPTION
In #862, we added CIFuzz integration. This is great, but it runs until a
specific timeout (currently 600s), in addition to needing about 6 minutes
of setup time. This is more than 3 times as long as the next longest CI job
(coverage took about 4m in #1242 just now). Given that we already have
OSS-Fuzz spending quite a bit of time running fuzzing for us and that (as
far as I remember) we have yet to find any issues from the CIFuzz integration,
I feel safe reducing the runtime for CIFuzz to 150s. This should still cover
quite a bit of ground given that we're executing pretty fast Rust code.