### PR TITLE
handshake: show illegal SNI hostname as lossy str.

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -229,7 +229,10 @@ impl ServerNamePayload {
             match webpki::DnsNameRef::try_from_ascii(&raw.0) {
                 Ok(dns_name) => dns_name.into(),
                 Err(_) => {
-                    warn!("Illegal SNI hostname received {:?}", raw.0);
+                    warn!(
+                        "Illegal SNI hostname received {:?}",
+                        String::from_utf8_lossy(&raw.0)
+                    );
                     return Err(InvalidMessage::InvalidServerName);
                 }
             }


### PR DESCRIPTION
Previously when an illegal SNI hostname was received rustls would `warn!` the received value as a raw `Vec<u8>`, making it hard for a human to read the value received. E.g.:
```
WARN connection{id=2 source="RedisSource"}: rustls::msgs::handshake: Illegal SNI hostname received [49, 50, 55, 46, 48, 46, 48, 46, 49] 
```

This commit changes to `warn!` the `from_utf8_lossy` string version of the hostname. This will make it easier for end users to diagnose the root cause.