### PR TITLE
docs: fix broken link in ClientCertVerifier docs.

### DIFF
--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -264,7 +264,10 @@ pub trait ClientCertVerifier: Send + Sync {
     ///
     /// Note that none of the certificates have been parsed yet, so it is the responsibility of
     /// the implementor to handle invalid data. It is recommended that the implementor returns
-    /// [`Error::InvalidCertificate(CertificateError::BadEncoding)`] when these cases are encountered.
+    /// an [InvalidCertificate] error with the [BadEncoding] variant when these cases are encountered.
+    ///
+    /// [InvalidCertificate]: Error#variant.InvalidCertificate
+    /// [BadEncoding]: CertificateError#variant.BadEncoding
     fn verify_client_cert(
         &self,
         end_entity: &Certificate,


### PR DESCRIPTION
Fixing a small docs err I noticed reading through the state of client certificate support.

Previously the `ClientCertVerifier` rust docs had a broken link to the `Error::InvalidCertificate(CertificateError::BadEncoding)` type.

This commit breaks up the link into two parts, one for the `Error::InvalidCertificate` variant and one for the `CertificateError::BadEncoding` variant.


<details><summary>Screenshots:</summary>
<p>

Before:
![before](https://user-images.githubusercontent.com/292650/229533015-bad63831-9810-46be-ab9f-25421c28b6cd.png)

After:
![after](https://user-images.githubusercontent.com/292650/229533040-c6f5adbb-2643-409f-a1fd-0c855efc03b5.png)

</p>
</details> 