### PR TITLE
conn: ensure complete_io flushes pending writes.

### DIFF
--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1315,6 +1315,7 @@ fn client_complete_io_for_handshake() {
         .unwrap();
     assert!(rdlen > 0 && wrlen > 0);
     assert!(!client.is_handshaking());
+    assert!(!client.wants_write());
 }
 
 #[test]
@@ -1390,6 +1391,7 @@ fn server_complete_io_for_handshake() {
             .unwrap();
         assert!(rdlen > 0 && wrlen > 0);
         assert!(!server.is_handshaking());
+        assert!(!server.wants_write());
     }
 }
 


### PR DESCRIPTION
Previously, calls to `complete_io()` may return as if handshaking has completed, but leave pending TLS writes queued that won't be sent until a subsequent call to `complete_io()` is made.

This happens because `is_handshaking()` can begin to return false after calls to `process_new_packets()` while there are final handshake packets put in the connection's buffers, but not yet extracted to be sent to the peer. The end result is that calling `complete_io()` once is not sufficient to fully complete a handshake with a peer. A second call was required to flush the pending packets. I left a more [detailed description](https://github.com/rustls/rustls/issues/548#issuecomment-1497809383) of the flow of events in the original bug report.

In this commit the `complete_io()` logic is updated to continue processing IO when calling `process_new_packets()` has queued TLS writes, only returning to the caller when all pending IO has been dealt with and the handshake truly completed.

We can test this behaviour by updating the `client_complete_io_for_handshake` and `server_complete_io_for_handshake` unit tests to assert there are no pending TLS writes after calling `complete_io()`. Prior to this commit these assertions would fail, and with the updated logic they pass as expected.

<details><summary>Test behaviour:</summary>
<p>

Before updating `complete_io`, the new test assertions fail:

```
assertion failed: !client.wants_write()
thread 'client_complete_io_for_handshake' panicked at 'assertion failed: !client.wants_write()', rustls/tests/api.rs:1318:5
```

```
assertion failed: !server.wants_write()
thread 'server_complete_io_for_handshake' panicked at 'assertion failed: !server.wants_write()', rustls/tests/api.rs:1394:9
```

Afterwards, they pass:

```
test client_complete_io_for_handshake ... ok
test server_complete_io_for_handshake ... ok
```
</p>
</details> 

Resolves https://github.com/rustls/rustls/issues/548