### PR TITLE
Drop log messages on error paths

### DIFF
--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -71,9 +71,12 @@ mod server_hello {
             // public values and don't require constant time comparison
             let has_downgrade_marker = self.randoms.server[24..] == tls12::DOWNGRADE_SENTINEL;
             if tls13_supported && has_downgrade_marker {
-                return Err(cx
-                    .common
-                    .illegal_param(PeerMisbehaved::AttemptedDowngradeToTls12WhenTls13IsSupported));
+                return Err({
+                    cx.common.send_fatal_alert(
+                        AlertDescription::IllegalParameter,
+                        PeerMisbehaved::AttemptedDowngradeToTls12WhenTls13IsSupported,
+                    )
+                });
             }
 
             // Doing EMS?

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -404,9 +404,10 @@ impl State<ClientConnectionData> for ExpectServerKx {
         let ecdhe = opaque_kx
             .unwrap_given_kxa(self.suite.kx)
             .ok_or_else(|| {
-                cx.common
-                    .send_fatal_alert(AlertDescription::DecodeError);
-                InvalidMessage::MissingKeyExchange
+                cx.common.send_fatal_alert(
+                    AlertDescription::DecodeError,
+                    InvalidMessage::MissingKeyExchange,
+                )
             })?;
 
         // Save the signature and signed parameters for later verification.
@@ -1043,8 +1044,7 @@ impl State<ClientConnectionData> for ExpectFinished {
             constant_time::verify_slices_are_equal(&expect_verify_data, &finished.0)
                 .map_err(|_| {
                     cx.common
-                        .send_fatal_alert(AlertDescription::DecryptError);
-                    Error::DecryptError
+                        .send_fatal_alert(AlertDescription::DecryptError, Error::DecryptError)
                 })
                 .map(|_| verify::FinishedMessageVerified::assertion())?;
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -610,7 +610,6 @@ impl State<ClientConnectionData> for ExpectCertificate {
 
         // This is only non-empty for client auth.
         if !cert_chain.context.0.is_empty() {
-            warn!("certificate with non-empty context during handshake");
             return Err(cx.common.send_fatal_alert(
                 AlertDescription::DecodeError,
                 InvalidMessage::InvalidCertRequest,
@@ -620,7 +619,6 @@ impl State<ClientConnectionData> for ExpectCertificate {
         if cert_chain.any_entry_has_duplicate_extension()
             || cert_chain.any_entry_has_unknown_extension()
         {
-            warn!("certificate chain contains unsolicited/unknown extension");
             return Err(cx.common.send_fatal_alert(
                 AlertDescription::UnsupportedExtension,
                 PeerMisbehaved::BadCertChainExtensions,
@@ -1022,7 +1020,6 @@ impl ExpectTraffic {
         #[cfg(feature = "quic")]
         {
             if let Protocol::Quic = common.protocol {
-                warn!("KeyUpdate received in QUIC connection");
                 return Err(common.send_fatal_alert(
                     AlertDescription::UnexpectedMessage,
                     PeerMisbehaved::KeyUpdateReceivedInQuicConnection,

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -217,10 +217,6 @@ impl CommonState {
         }
     }
 
-    pub(crate) fn illegal_param(&mut self, why: PeerMisbehaved) -> Error {
-        self.send_fatal_alert(AlertDescription::IllegalParameter, why)
-    }
-
     /// Fragment `m`, encrypt the fragments, and then queue
     /// the encrypted fragments for sending.
     pub(crate) fn send_msg_encrypt(&mut self, m: PlainMessage) {

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -2,7 +2,7 @@ use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::key;
 #[cfg(feature = "logging")]
-use crate::log::{debug, error, warn};
+use crate::log::{debug, warn};
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
 use crate::msgs::enums::{AlertLevel, KeyUpdateRequest};
@@ -463,7 +463,6 @@ impl CommonState {
             }
         }
 
-        error!("TLS alert received: {:#?}", alert);
         Err(err)
     }
 
@@ -483,7 +482,6 @@ impl CommonState {
         desc: AlertDescription,
         err: impl Into<Error>,
     ) -> Error {
-        warn!("Sending fatal alert {:?}", desc);
         debug_assert!(!self.sent_fatal_alert);
         let m = Message::build_alert(AlertLevel::Fatal, desc);
         self.send_msg(m, self.record_layer.is_encrypting());

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -310,7 +310,6 @@ mod log {
     macro_rules! trace    ( ($($tt:tt)*) => {{}} );
     macro_rules! debug    ( ($($tt:tt)*) => {{}} );
     macro_rules! warn     ( ($($tt:tt)*) => {{}} );
-    macro_rules! error    ( ($($tt:tt)*) => {{}} );
 }
 
 #[macro_use]

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1222,7 +1222,6 @@ impl ExpectTraffic {
         #[cfg(feature = "quic")]
         {
             if let Protocol::Quic = common.protocol {
-                warn!("KeyUpdate received in QUIC connection");
                 return Err(common.send_fatal_alert(
                     AlertDescription::UnexpectedMessage,
                     PeerMisbehaved::KeyUpdateReceivedInQuicConnection,

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -497,15 +497,15 @@ type MessageCipherPair = (Box<dyn MessageDecrypter>, Box<dyn MessageEncrypter>);
 pub(crate) fn decode_ecdh_params<T: Codec>(
     common: &mut CommonState,
     kx_params: &[u8],
-) -> Result<T, InvalidMessage> {
+) -> Result<T, Error> {
     let mut rd = Reader::init(kx_params);
     let ecdh_params = T::read(&mut rd)?;
     match rd.any_left() {
         false => Ok(ecdh_params),
-        true => {
-            common.send_fatal_alert(AlertDescription::DecodeError);
-            Err(InvalidMessage::InvalidDhParams)
-        }
+        true => Err(common.send_fatal_alert(
+            AlertDescription::DecodeError,
+            InvalidMessage::InvalidDhParams,
+        )),
     }
 }
 


### PR DESCRIPTION
Given that we now have very fine-grained error types and make pretty sure that error types are propagated up to the caller, I think it might make sense to reduce our logging on paths that will yield an error anyway, on the premise that the application may chose to do what to do with the error (including logging).

Fixes #1277.