### PR TITLE
docs: replace dead Ring link from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ need them.
 
 ### Platform support
 
-Rustls uses [`ring`](https://crates.io/crates/ring) for implementing the
-cryptography in TLS. As a result, rustls only runs on platforms
-[supported by `ring`](https://github.com/briansmith/ring#online-automated-testing).
-At the time of writing this means x86, x86-64, armv7, and aarch64.
+While Rustls itself is platform independent it uses
+[`ring`](https://crates.io/crates/ring) for implementing the cryptography in
+TLS. As a result, rustls only runs on platforms
+supported by `ring`. At the time of writing this means x86, x86-64, armv7, and
+aarch64. For more information see [the supported `ring` CI
+targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
 
 Rustls requires Rust 1.57 or later.
 


### PR DESCRIPTION
Previously we linked to the *ring* README to describe Ring's supported architectures in more detail. Unfortunately that section of the upstream README was removed without a replacement.

This commit emphasizes that while Rustls is platform independent, *ring* is not. To replace the detailed platform support information we now link directly to the relevant *ring* CI configuration for the version in use by Rustls. 

Unfortunately there's no tag for *ring* 0.16.20 (see https://github.com/briansmith/ring/issues/1593) so I've used a permalink to the revision where the version number in `Cargo.toml` was bumped (https://github.com/briansmith/ring/commit/9cc0d45f4d8521f467bb3a621e74b1535e118188).

Resolves https://github.com/rustls/rustls/issues/1275