### PR TITLE
verify: remove two unneeded allow(deprecated) annotations.

### DIFF
--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -574,7 +574,6 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
         true
     }
 
-    #[allow(deprecated)]
     fn client_auth_root_subjects(&self) -> &[DistinguishedName] {
         &self.subjects
     }
@@ -723,7 +722,6 @@ impl DigitallySignedStruct {
 }
 
 impl Codec for DigitallySignedStruct {
-    #![allow(deprecated)]
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.scheme.encode(bytes);
         self.sig.encode(bytes);


### PR DESCRIPTION
Digging around in the `verify.rs` code to [write this comment](https://github.com/rustls/rustls/pull/1289#issuecomment-1526261555) I realized the two `#[allow(deprecated)]` annotations in `verify.rs` are no longer needed.

This branch removes both. These are the only instances of such annotations I can find in our Rust code. 