### PR TITLE
stream: remove premature EOF signal.

### DIFF
--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -55,17 +55,9 @@ where
         // We call complete_io() in a loop since a single call may read only
         // a partial packet from the underlying transport. A full packet is
         // needed to get more plaintext, which we must do if EOF has not been
-        // hit. Otherwise, we will prematurely signal EOF by returning 0. We
-        // determine if EOF has actually been hit by checking if 0 bytes were
-        // read from the underlying transport.
+        // hit.
         while self.conn.wants_read() {
-            let at_eof = self.conn.complete_io(self.sock)?.0 == 0;
-            if at_eof {
-                if let Ok(io_state) = self.conn.process_new_packets() {
-                    if at_eof && io_state.plaintext_bytes_to_read() == 0 {
-                        return Ok(0);
-                    }
-                }
+            if self.conn.complete_io(self.sock)?.0 == 0 {
                 break;
             }
         }
@@ -80,17 +72,9 @@ where
         // We call complete_io() in a loop since a single call may read only
         // a partial packet from the underlying transport. A full packet is
         // needed to get more plaintext, which we must do if EOF has not been
-        // hit. Otherwise, we will prematurely signal EOF by returning without
-        // writing anything. We determine if EOF has actually been hit by
-        // checking if 0 bytes were read from the underlying transport.
+        // hit.
         while self.conn.wants_read() {
-            let at_eof = self.conn.complete_io(self.sock)?.0 == 0;
-            if at_eof {
-                if let Ok(io_state) = self.conn.process_new_packets() {
-                    if at_eof && io_state.plaintext_bytes_to_read() == 0 {
-                        return Ok(());
-                    }
-                }
+            if self.conn.complete_io(self.sock)?.0 == 0 {
                 break;
             }
         }


### PR DESCRIPTION
Opening this as a draft because:

1. I'm not 100% confident this is the right fix. I'm not sure I understand the intent of the "premature signalling" that is being removed. It was added in https://github.com/rustls/rustls/commit/c94c223e4cabe49eb42b6e91ad307ff0813722e3 by @ctz.
2. I think it needs test coverage, but I'm not sure the best place to implement that (_and, selfishly I don't want to spend too much time on testing if my assumptions about the premature signalling are wrong_). ~Unlike most of the existing unit tests to be able to use `Stream` we need to bind sockets and do network I/O. Any hints here would be useful.~

## Description

Previously the `Stream` `read` and `read_buf` would:

* Call `complete_io` once.
* If the conn still `wants_read`, it would call `complete_io` in a loop.
  * If `complete_io` returned EOF, it would `process_new_packets` 
  * If there were no `plaintext_bytes_to_read`, the `Stream` would return `Ok(0)` to signal premature EOF. 
  * Otherwise it would break the loop.

This seems unnecessary, and obscures whether the EOF was "clean" or unexpected based on the peer notifying intent to close pre-EOF.

Instead,

* Call `complete_io` once.
* If the conn still `wants_read`, call `complete_io` in a loop.
  * If `complete_io` returns EOF, break the loop.
* Call `reader().read()` to potentially return read plaintext, return `Ok(0)` for a clean EOF, or return an error for premature EOF.

There's no need to call `process_new_packets` ourselves because `complete_io` does this after reading TLS bytes.

I believe there's no need to signal EOF prematurely if there's no plaintext bytes to read, because `reader().read()` handles this for us (and handles turning an unsignalled EOF into an err).

Resolves https://github.com/rustls/rustls/issues/1188