### PR TITLE
Lint: remove calls to PhantomData::default

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -26,7 +26,7 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
                 versions: self.state.versions,
                 root_store,
             },
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -217,7 +217,7 @@ impl ClientConfig {
     pub fn builder() -> ConfigBuilder<Self, WantsCipherSuites> {
         ConfigBuilder {
             state: WantsCipherSuites(()),
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -25,7 +25,7 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
                 versions: self.state.versions,
                 verifier: client_cert_verifier,
             },
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -317,7 +317,7 @@ impl ServerConfig {
     pub fn builder() -> ConfigBuilder<Self, WantsCipherSuites> {
         ConfigBuilder {
             state: WantsCipherSuites(()),
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 


### PR DESCRIPTION
[Clippy is currently failing](https://github.com/rustls/rustls/actions/runs/4961710689/jobs/8878850691), e.g.:
```
 error: use of `default` to create a unit struct
   --> rustls/src/server/server_conn.rs:320:30
    |
320 |             side: PhantomData::default(),
    |                              ^^^^^^^^^^^ help: remove this call to `default`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
```

Clippy was happy with this change for me locally.