### PR TITLE
stream: avoid swallowing unexpected eof condition.

### DIFF
--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -55,17 +55,9 @@ where
         // We call complete_io() in a loop since a single call may read only
         // a partial packet from the underlying transport. A full packet is
         // needed to get more plaintext, which we must do if EOF has not been
-        // hit. Otherwise, we will prematurely signal EOF by returning 0. We
-        // determine if EOF has actually been hit by checking if 0 bytes were
-        // read from the underlying transport.
+        // hit.
         while self.conn.wants_read() {
-            let at_eof = self.conn.complete_io(self.sock)?.0 == 0;
-            if at_eof {
-                if let Ok(io_state) = self.conn.process_new_packets() {
-                    if at_eof && io_state.plaintext_bytes_to_read() == 0 {
-                        return Ok(0);
-                    }
-                }
+            if self.conn.complete_io(self.sock)?.0 == 0 {
                 break;
             }
         }
@@ -80,17 +72,9 @@ where
         // We call complete_io() in a loop since a single call may read only
         // a partial packet from the underlying transport. A full packet is
         // needed to get more plaintext, which we must do if EOF has not been
-        // hit. Otherwise, we will prematurely signal EOF by returning without
-        // writing anything. We determine if EOF has actually been hit by
-        // checking if 0 bytes were read from the underlying transport.
+        // hit.
         while self.conn.wants_read() {
-            let at_eof = self.conn.complete_io(self.sock)?.0 == 0;
-            if at_eof {
-                if let Ok(io_state) = self.conn.process_new_packets() {
-                    if at_eof && io_state.plaintext_bytes_to_read() == 0 {
-                        return Ok(());
-                    }
-                }
+            if self.conn.complete_io(self.sock)?.0 == 0 {
                 break;
             }
         }


### PR DESCRIPTION
## Description

Previously the `Stream` and `OwnedStream` type's `read` and `read_buf` functions had code to try and "prematurely signal EOF" by returning `Ok(0)` if no bytes were read from the underlying transport after calling `complete_io`.

In practice this has the effect of swallowing an error condition when the remote peer has closed their end of the connection without properly signalling their intent to do so. When this happens the client must read an `UnexpectedEof` error to prevent a truncation attack. Clients reading through a `Stream` type with the pre-existing code would always read a normal EOF, whereas using a connection directly without the stream abstraction would present the correct error. 

There doesn't appear to be a reason to "prematurely" signal anything - if we read 0 bytes from `complete_io()` we should instead break our `wants_read()` loop to allow execution to continue to a `self.conn.reader().read(...)` or `self.conn.reader().read_buf(...)` call where the common connection code can properly handle this case (using the logic added in https://github.com/rustls/rustls/pull/790), turning the result into the desired `UnexpectedEof` error. Similarly there's no need to call `process_new_packets()` ourselves because `complete_io()` does this after reading TLS bytes. 

Making this change resolves the problem of distinguishing unexpected EOF from expected EOF when using `Stream` or `OwnedStream` and doesn't appear to break any other functionality expected of the `Stream` types. I did some git spelunking and wasn't able to determine the original purpose of the premature signalling logic (It was added in https://github.com/rustls/rustls/commit/c94c223e4cabe49eb42b6e91ad307ff0813722e3 by @ctz.) but I suspect code churn elsewhere makes it no longer necessary. If I've missed an important detail I'm happy to revisit.

## Testing

To emphasize the bug fix I've separated out the unit test as a commit added prior to the fix.

<details>
<summary> Before applying the fix an Ok 0 byte result from a read is returned where we expect an error:</summary>

```
$> cargo test --package rustls --all-features --test api 'unclean_close'

running 4 tests
test client_streamowned_read_unclean_close ... FAILED
test client_streamowned_readbuf_unclean_close ... FAILED
test client_stream_readbuf_unclean_close ... FAILED
test client_stream_read_unclean_close ... FAILED

failures:

---- client_streamowned_read_unclean_close stdout ----
thread 'client_streamowned_read_unclean_close' panicked at 'called `Result::unwrap_err()` on an `Ok` value: 0', rustls/tests/api.rs:189:37

---- client_streamowned_readbuf_unclean_close stdout ----
thread 'client_streamowned_readbuf_unclean_close' panicked at 'called `Result::unwrap_err()` on an `Ok` value: ()', rustls/tests/api.rs:211:10

---- client_stream_readbuf_unclean_close stdout ----
thread 'client_stream_readbuf_unclean_close' panicked at 'called `Result::unwrap_err()` on an `Ok` value: ()', rustls/tests/api.rs:211:10

---- client_stream_read_unclean_close stdout ----
thread 'client_stream_read_unclean_close' panicked at 'called `Result::unwrap_err()` on an `Ok` value: 0', rustls/tests/api.rs:189:37
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    client_stream_read_unclean_close
    client_stream_readbuf_unclean_close
    client_streamowned_read_unclean_close
    client_streamowned_readbuf_unclean_close

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 134 filtered out; finished in 0.00s
```
</details>

<details>
<summary>After applying the fix the tests begin to pass:</summary>

```
$> cargo test --package rustls --all-features --test api 'unclean_close'

running 4 tests
test client_stream_readbuf_unclean_close ... ok
test client_stream_read_unclean_close ... ok
test client_streamowned_readbuf_unclean_close ... ok
test client_streamowned_read_unclean_close ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 134 filtered out; finished in 0.01s
```
</details>

Resolves https://github.com/rustls/rustls/issues/1188, https://github.com/tokio-rs/tls/pull/128, https://github.com/tokio-rs/tls/issues/141
