### PR TITLE
perf: avoid clones

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -16,7 +16,6 @@ use rustls::{
 };
 
 use base64::prelude::{Engine, BASE64_STANDARD};
-use env_logger;
 
 use std::io::{self, BufReader, Read, Write};
 use std::sync::Arc;
@@ -415,7 +414,7 @@ fn make_server_cfg(opts: &Options) -> Arc<ServerConfig> {
         .unwrap()
         .with_client_cert_verifier(client_auth)
         .with_single_cert_with_ocsp_and_sct(
-            cert.clone(),
+            cert,
             key,
             opts.server_ocsp_response.clone(),
             opts.server_sct_list.clone(),

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -85,7 +85,7 @@ impl client::ClientSessionStore for ClientSessionMemoryCache {
         self.servers
             .lock()
             .unwrap()
-            .get_or_insert_default_and_edit(server_name.clone(), |data| data.kx_hint = Some(group));
+            .get_or_insert_default_and_edit(server_name, |data| data.kx_hint = Some(group));
     }
 
     fn kx_hint(&self, server_name: &ServerName) -> Option<NamedGroup> {
@@ -105,7 +105,7 @@ impl client::ClientSessionStore for ClientSessionMemoryCache {
         self.servers
             .lock()
             .unwrap()
-            .get_or_insert_default_and_edit(_server_name.clone(), |data| data.tls12 = Some(_value));
+            .get_or_insert_default_and_edit(_server_name, |data| data.tls12 = Some(_value));
     }
 
     fn tls12_session(&self, _server_name: &ServerName) -> Option<persist::Tls12ClientSessionValue> {
@@ -137,7 +137,7 @@ impl client::ClientSessionStore for ClientSessionMemoryCache {
         self.servers
             .lock()
             .unwrap()
-            .get_or_insert_default_and_edit(server_name.clone(), |data| {
+            .get_or_insert_default_and_edit(server_name, |data| {
                 if data.tls13.len() == data.tls13.capacity() {
                     data.tls13.pop_front();
                 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -555,7 +555,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             .get_sigalgs_extension()
             .unwrap_or(&no_sigschemes)
             .iter()
-            .cloned()
+            .copied()
             .filter(|scheme| tls13_sign_schemes.contains(scheme))
             .collect::<Vec<SignatureScheme>>();
 

--- a/rustls/src/kx.rs
+++ b/rustls/src/kx.rs
@@ -20,7 +20,7 @@ impl KeyExchange {
         supported
             .iter()
             .find(|skxg| skxg.name == name)
-            .cloned()
+            .copied()
     }
 
     /// Start a key exchange, using the given SupportedKxGroup.

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -288,6 +288,7 @@
     clippy::single_component_path_imports,
     clippy::new_without_default
 )]
+#![deny(clippy::cloned_instead_of_copied)]
 // Enable documentation for all features on docs.rs
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // XXX: Because of https://github.com/rust-lang/rust/issues/54726, we cannot

--- a/rustls/src/limited_cache.rs
+++ b/rustls/src/limited_cache.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::hash_map::{DefaultHasher, Entry};
 use std::collections::{HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
@@ -85,7 +86,8 @@ where
 
     pub(crate) fn get<Key>(&self, k: &Key) -> Option<&V>
     where
-        Key: Hash + ?Sized,
+        K: Borrow<Key>,
+        Key: Hash + Eq + ?Sized,
     {
         let k_hash = make_hash(&k);
         self.map.get(&k_hash)
@@ -93,7 +95,8 @@ where
 
     pub(crate) fn get_mut<Key>(&mut self, k: &Key) -> Option<&mut V>
     where
-        Key: Hash + ?Sized,
+        K: Borrow<Key>,
+        Key: Hash + Eq + ?Sized,
     {
         let k_hash = make_hash(&k);
         self.map.get_mut(&k_hash)

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -49,7 +49,7 @@ impl server::StoresServerSessions for ServerSessionMemoryCache {
         self.cache
             .lock()
             .unwrap()
-            .insert(key, value);
+            .insert(&key, value);
         true
     }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -46,6 +46,8 @@ pub trait StoresServerSessions: Send + Sync {
     /// Store session secrets encoded in `value` against `key`,
     /// overwrites any existing value against `key`.  Returns `true`
     /// if the value was stored.
+    //
+    // TODO: We could drop `key` to be &[u8].
     fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool;
 
     /// Find a value with the given `key`.  Return it, or None

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -172,7 +172,7 @@ mod client_hello {
                 .kx_groups
                 .iter()
                 .find(|skxg| groups_ext.contains(&skxg.name))
-                .cloned()
+                .copied()
                 .ok_or_else(|| {
                     cx.common.send_fatal_alert(
                         AlertDescription::HandshakeFailure,
@@ -183,7 +183,7 @@ mod client_hello {
             let ecpoint = ECPointFormat::SUPPORTED
                 .iter()
                 .find(|format| ecpoints_ext.contains(format))
-                .cloned()
+                .copied()
                 .ok_or_else(|| {
                     cx.common.send_fatal_alert(
                         AlertDescription::HandshakeFailure,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -220,7 +220,7 @@ mod client_hello {
                         .kx_groups
                         .iter()
                         .find(|group| groups_ext.contains(&group.name))
-                        .cloned();
+                        .copied();
 
                     self.transcript.add_message(chm);
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -166,7 +166,7 @@ impl Tls12CipherSuite {
         self.sign
             .iter()
             .filter(|pref| offered.contains(pref))
-            .cloned()
+            .copied()
             .collect()
     }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1290,7 +1290,7 @@ where
         Ok(())
     }
 
-    fn write_vectored<'b>(&mut self, b: &[io::IoSlice<'b>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, b: &[io::IoSlice<'_>]) -> io::Result<usize> {
         let mut total = 0;
         let mut lengths = vec![];
         for bytes in b {
@@ -3986,7 +3986,7 @@ fn test_client_mtu_reduction() {
         fn flush(&mut self) -> io::Result<()> {
             panic!()
         }
-        fn write_vectored<'b>(&mut self, b: &[io::IoSlice<'b>]) -> io::Result<usize> {
+        fn write_vectored(&mut self, b: &[io::IoSlice<'_>]) -> io::Result<usize> {
             let writes = b
                 .iter()
                 .map(|slice| slice.len())

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3443,9 +3443,7 @@ mod test_quic {
         let mut buf = Vec::with_capacity(512);
         client_hello.encode(&mut buf);
         assert_eq!(
-            server
-                .read_hs(&mut buf.as_slice())
-                .err(),
+            server.read_hs(buf.as_slice()).err(),
             Some(Error::PeerMisbehaved(
                 PeerMisbehaved::MissingQuicTransportParameters
             ))
@@ -3488,7 +3486,7 @@ mod test_quic {
             typ: HandshakeType::ClientHello,
             payload: HandshakePayload::ClientHello(ClientHelloPayload {
                 client_version: ProtocolVersion::TLSv1_2,
-                random: random.clone(),
+                random: random,
                 session_id: SessionId::random().unwrap(),
                 cipher_suites: vec![CipherSuite::TLS13_AES_128_GCM_SHA256],
                 compression_methods: vec![Compression::Null],
@@ -3506,9 +3504,7 @@ mod test_quic {
         let mut buf = Vec::with_capacity(512);
         client_hello.encode(&mut buf);
         assert_eq!(
-            server
-                .read_hs(&mut buf.as_slice())
-                .err(),
+            server.read_hs(buf.as_slice()).err(),
             Some(Error::PeerIncompatible(
                 PeerIncompatible::SupportedVersionsExtensionRequired
             )),
@@ -3549,7 +3545,7 @@ mod test_quic {
             0x08, 0x06, 0x04, 0x80, 0x00, 0xff, 0xff,
         ];
 
-        let client_keys = Keys::initial(Version::V1, &CONNECTION_ID, Side::Client);
+        let client_keys = Keys::initial(Version::V1, CONNECTION_ID, Side::Client);
         assert_eq!(
             client_keys
                 .local
@@ -3685,7 +3681,7 @@ mod test_quic {
         let (first, rest) = header.split_at_mut(1);
         let sample = &payload[..sample_len];
 
-        let server_keys = Keys::initial(Version::V1, &CONNECTION_ID, Side::Server);
+        let server_keys = Keys::initial(Version::V1, CONNECTION_ID, Side::Server);
         server_keys
             .remote
             .header


### PR DESCRIPTION
LimitedCache is used in the codebase with `Vec<u8>` and `ServerName` as a key, whose clone() and memory layout are less efficient than that of a u64. By dropping the requirements of traits like Clone and Default, it may also find utility in other places of the codebase down the road