### PR TITLE
expand documentation for Certificate and PrivateKey

### DIFF
--- a/rustls/src/key.rs
+++ b/rustls/src/key.rs
@@ -62,14 +62,6 @@ pub struct PrivateKey(pub Vec<u8>);
 /// to parse PEM files. The [`rcgen`](https://docs.rs/rcgen/latest/rcgen/) crate can be used to
 /// generate certificates and private keys.
 ///
-/// ## Note
-///
-/// If you are receiving certificates from an untrusted client or server, it is essential
-/// to validate the contents of the certificate manually. This typically involves verifying
-/// the certificate's signature, checking its expiration date, verifying the certificate
-/// chain (including intermediate and root certificates), and performing additional checks
-/// based on your specific requirements.
-///
 /// ## Examples
 ///
 /// Parsing a PEM file to extract DER-encoded certificates:


### PR DESCRIPTION
Some of the rustls documentation is... not that helpful to those unfamiliar with TLS and certificates. The `Certificate` and `PrivateKey` types had particularly little documentation. This is my attempt to improve the situation.

I've included code samples using `rustls_pemfile`. tried to give some info to quickly check "does this file I have match roughly what rustls would expect" and provide some links to more info and the `rcgen` crate, if a user wants to generate a new certificate or private key.



