### PR TITLE
Upgrade env_logger to 0.10

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ quic = ["rustls/quic"]
 
 [dependencies]
 docopt = "~1.1"
-env_logger = "0.9.0" # 0.10 requires an MSRV bump to 1.60
+env_logger = "0.10"
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 rustls = { path = "../rustls", features = [ "logging" ]}

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -32,7 +32,7 @@ read_buf = ["rustversion"]
 
 [dev-dependencies]
 bencher = "0.1.5"
-env_logger = "0.9.0" # 0.10 requires an MSRV bump to 1.60
+env_logger = "0.10"
 log = "0.4.4"
 webpki-roots = "0.23.0"
 rustls-pemfile = "1.0.0"


### PR DESCRIPTION
Just a dev-dependency, so it no longer affects our MSRV (since #1302).