### PR TITLE
Added a resolver fetch callback and wouldblock handling

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -344,6 +344,7 @@ mod kx;
 mod suites;
 mod ticketer;
 mod versions;
+mod would_block;
 
 /// Internal classes which may be useful outside the library.
 /// The contents of this section DO NOT form part of the stable interface.
@@ -393,6 +394,7 @@ pub use crate::tls12::Tls12CipherSuite;
 pub use crate::tls13::Tls13CipherSuite;
 pub use crate::verify::DigitallySignedStruct;
 pub use crate::versions::{SupportedProtocolVersion, ALL_VERSIONS, DEFAULT_VERSIONS};
+pub use crate::would_block::{WouldBlockCallback, WouldBlockCell};
 
 /// Items for use in a client.
 pub mod client {
@@ -446,7 +448,7 @@ pub mod server {
     pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
     pub use server_conn::StoresServerSessions;
     pub use server_conn::{
-        Accepted, Acceptor, ReadEarlyData, ServerConfig, ServerConnection, ServerConnectionData,
+        Accepted, Acceptor, ReadEarlyData, ServerConfig, ServerConnection, ServerConnectionData, CertFetchResult
     };
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
 

--- a/rustls/src/msgs/alert.rs
+++ b/rustls/src/msgs/alert.rs
@@ -3,7 +3,7 @@ use crate::error::InvalidMessage;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::AlertLevel;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AlertMessagePayload {
     pub level: AlertLevel,
     pub description: AlertDescription,

--- a/rustls/src/msgs/ccs.rs
+++ b/rustls/src/msgs/ccs.rs
@@ -1,7 +1,7 @@
 use crate::error::InvalidMessage;
 use crate::msgs::codec::{Codec, Reader};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ChangeCipherSpecPayload;
 
 impl Codec for ChangeCipherSpecPayload {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -817,7 +817,7 @@ impl ServerExtension {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ClientHelloPayload {
     pub client_version: ProtocolVersion,
     pub random: Random,
@@ -1031,7 +1031,7 @@ impl ClientHelloPayload {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HelloRetryExtension {
     KeyShare(NamedGroup),
     Cookie(PayloadU16),
@@ -1089,7 +1089,7 @@ impl TlsListElement for HelloRetryExtension {
     const SIZE_LEN: ListLength = ListLength::U16;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HelloRetryRequest {
     pub legacy_version: ProtocolVersion,
     pub session_id: SessionId,
@@ -1182,7 +1182,7 @@ impl HelloRetryRequest {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ServerHelloPayload {
     pub legacy_version: ProtocolVersion,
     pub random: Random,
@@ -1295,7 +1295,7 @@ impl TlsListElement for key::Certificate {
 // That's annoying. It means the parsing is not
 // context-free any more.
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CertificateExtension {
     CertificateStatus(CertificateStatus),
     SignedCertificateTimestamp(Vec<Sct>),
@@ -1369,7 +1369,7 @@ impl TlsListElement for CertificateExtension {
     const SIZE_LEN: ListLength = ListLength::U16;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificateEntry {
     pub cert: key::Certificate,
     pub exts: Vec<CertificateExtension>,
@@ -1437,7 +1437,7 @@ impl TlsListElement for CertificateEntry {
     const SIZE_LEN: ListLength = ListLength::U24 { max: 0x1_0000 };
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificatePayloadTLS13 {
     pub context: PayloadU8,
     pub entries: Vec<CertificateEntry>,
@@ -1531,7 +1531,7 @@ pub enum KeyExchangeAlgorithm {
 // We don't support arbitrary curves.  It's a terrible
 // idea and unnecessary attack surface.  Please,
 // get a grip.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ECParameters {
     pub curve_type: ECCurveType,
     pub named_group: NamedGroup,
@@ -1574,7 +1574,7 @@ impl Codec for ClientECDHParams {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ServerECDHParams {
     pub curve_params: ECParameters,
     pub public: PayloadU8,
@@ -1609,7 +1609,7 @@ impl Codec for ServerECDHParams {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ECDHEServerKeyExchange {
     pub params: ServerECDHParams,
     pub dss: DigitallySignedStruct,
@@ -1629,7 +1629,7 @@ impl Codec for ECDHEServerKeyExchange {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ServerKeyExchangePayload {
     ECDHE(ECDHEServerKeyExchange),
     Unknown(Payload),
@@ -1757,7 +1757,7 @@ impl TlsListElement for DistinguishedName {
     const SIZE_LEN: ListLength = ListLength::U16;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificateRequestPayload {
     pub certtypes: Vec<ClientCertificateType>,
     pub sigschemes: Vec<SignatureScheme>,
@@ -1789,7 +1789,7 @@ impl Codec for CertificateRequestPayload {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CertReqExtension {
     SignatureAlgorithms(Vec<SignatureScheme>),
     AuthorityNames(Vec<DistinguishedName>),
@@ -1850,7 +1850,7 @@ impl TlsListElement for CertReqExtension {
     const SIZE_LEN: ListLength = ListLength::U16;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificateRequestPayloadTLS13 {
     pub context: PayloadU8,
     pub extensions: Vec<CertReqExtension>,
@@ -1898,7 +1898,7 @@ impl CertificateRequestPayloadTLS13 {
 }
 
 // -- NewSessionTicket --
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NewSessionTicketPayload {
     pub lifetime_hint: u32,
     pub ticket: PayloadU16,
@@ -1931,7 +1931,7 @@ impl Codec for NewSessionTicketPayload {
 }
 
 // -- NewSessionTicket electric boogaloo --
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum NewSessionTicketExtension {
     EarlyData(u32),
     Unknown(UnknownExtension),
@@ -1979,7 +1979,7 @@ impl TlsListElement for NewSessionTicketExtension {
     const SIZE_LEN: ListLength = ListLength::U16;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NewSessionTicketPayloadTLS13 {
     pub lifetime: u32,
     pub age_add: u32,
@@ -2058,7 +2058,7 @@ impl Codec for NewSessionTicketPayloadTLS13 {
 // -- RFC6066 certificate status types
 
 /// Only supports OCSP
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificateStatus {
     pub ocsp_response: PayloadU24,
 }
@@ -2093,7 +2093,7 @@ impl CertificateStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HandshakePayload {
     HelloRequest,
     ClientHello(ClientHelloPayload),
@@ -2145,7 +2145,7 @@ impl HandshakePayload {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HandshakeMessagePayload {
     pub typ: HandshakeType,
     pub payload: HandshakePayload,

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -8,7 +8,7 @@ use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::AlertLevel;
 use crate::msgs::handshake::HandshakeMessagePayload;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum MessagePayload {
     Alert(AlertMessagePayload),
     Handshake {
@@ -208,7 +208,7 @@ impl PlainMessage {
 }
 
 /// A message with decoded payload
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Message {
     pub version: ProtocolVersion,
     pub payload: MessagePayload,

--- a/rustls/src/would_block.rs
+++ b/rustls/src/would_block.rs
@@ -1,0 +1,58 @@
+use std::{pin::Pin, future::Future, sync::{Mutex, Arc, atomic::{Ordering, AtomicU64}}, fmt, task::Poll};
+
+use crate::msgs::message::Message;
+
+/// Callback that that would cause this operation to block
+/// In order to free this blocking event the future must
+/// be polled until completion
+pub type WouldBlockCallback = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+static ID_SEED: AtomicU64 = AtomicU64::new(0);
+
+/// The blocking callback cell allows a callback to be passed
+/// back to the caller via the result system while being cloned
+#[derive(Clone)]
+pub struct WouldBlockCell {
+    id: u64,
+    with_message: Message,
+    inner: Arc<Mutex<Option<WouldBlockCallback>>>,
+}
+impl fmt::Debug
+for WouldBlockCell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "fetch-callback-cell")
+    }
+}
+impl PartialEq for WouldBlockCell {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl WouldBlockCell {
+    /// Creates a new cell from a callback
+    pub(crate) fn new(callback: WouldBlockCallback, with_message: &Message) -> Self {
+        Self {
+            id: ID_SEED.fetch_add(1, Ordering::SeqCst),
+            with_message: with_message.clone(),
+            inner: Arc::new(Mutex::new(Some(callback)))
+        }
+    }
+
+    /// Get the message that triggered this blocking action
+    pub(crate) fn into_msg(self) -> Message {
+        self.with_message
+    }
+}
+
+impl Future
+for WouldBlockCell {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        let mut guard = self.inner.lock().unwrap();
+        if let Some(callback) = guard.as_mut() {
+            callback.as_mut().poll(cx)
+        } else {
+            Poll::Ready(())
+        }
+    }
+}


### PR DESCRIPTION
This patch implements a feature needed for ACME - the problem being that some certificates need to be fetched from IO engines (e.g. S3 buckets) or generated via proof of ownership challenges, however `rustls` uses blocking logic on the certificate resolve method and hence would lock up the thread. This is especially apparent in `tokio-rustls` which such blocking code would also freeze up the `tokio` shared thread pool.

The motivations for the choices in this patch are:
- minimize the impact to the external API, with forwards compatibility.
- do not add an async runtime to `rustls` itself
- minimize the amount of code changes as much as possible but while still giving the needed functionality.

This patch needs to arrive along with this one
https://github.com/tokio-rs/tls/pull/147

Before I update the references this patch needs to make upstream