### PR TITLE
Move MSRV to 1.60

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.57
+          toolchain: "1.60"
 
       - run: cargo check --lib --all-features -p rustls
 

--- a/.github/workflows/connect-tests.yml
+++ b/.github/workflows/connect-tests.yml
@@ -20,7 +20,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.57 # MSRV
+          - "1.60" # MSRV
         os: [ubuntu-20.04]
         # but only stable on macos/windows (slower platforms)
         include:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Release history
 
+* Next release:
+  - Bump MSRV to 1.60 to track similar change in dependencies.
 * Release 0.21.1 (2023-05-01)
   - Remove `warn`-level logging from code paths that also return a `rustls::Error` with
     the same information.
@@ -142,7 +144,7 @@ supported by `ring`. At the time of writing this means x86, x86-64, armv7, and
 aarch64. For more information see [the supported `ring` CI
 targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
 
-Rustls requires Rust 1.57 or later.
+Rustls requires Rust 1.60 or later.
 
 # Example code
 There are two example programs which use

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls-connect-tests"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"
 description = "Rustls connectivity based integration tests."
 publish = false

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,7 +13,7 @@ quic = ["rustls/quic"]
 
 [dependencies]
 docopt = "~1.1"
-env_logger = "0.9.0" # 0.10 requires an MSRV bump to 1.60
+env_logger = "0.10"
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 rustls = { path = "../rustls", features = [ "logging" ]}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls-examples"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"
 description = "Rustls example code and tests."
 publish = false

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -32,7 +32,7 @@ read_buf = ["rustversion"]
 
 [dev-dependencies]
 bencher = "0.1.5"
-env_logger = "0.9.0" # 0.10 requires an MSRV bump to 1.60
+env_logger = "0.10"
 log = "0.4.4"
 webpki-roots = "0.23.0"
 rustls-pemfile = "1.0.0"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls"
 version = "0.21.1"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -135,7 +135,8 @@ impl MessageDeframer {
 
             // If it's not a handshake message, just return it -- no joining necessary.
             if msg.typ != ContentType::Handshake {
-                self.discard(start + rd.used());
+                let end = start + rd.used();
+                self.discard(end);
                 return Ok(Some(Deframed {
                     want_close_before_decrypt: false,
                     aligned: true,


### PR DESCRIPTION
Doing this to fix the build after `log` changed to 1.60 in a minor release. Have also incorporated #1303 