### PR TITLE
Limit scope of security support based on time

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,16 @@
 
 ## Supported Versions
 
-Security fixes will be backported to the most recent three minor version lines.
+Security fixes will be backported only to the rustls versions for which the
+original semver-compatible release was published less than 2 years ago.
+
+For example, as of 2023-06-13 the latest release is 0.21.1.
+
+* 0.21.0 was released in March of 2023
+* 0.20.0 was released in September of 2021
+* 0.19.0 was released in November of 2020
+
+Therefore 0.20.x and 0.21.x will be updated, while 0.19.x will not be.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
So far, we've promised support for the most recent 3 minor release lines. I think we should scope support based on time, not just the number of releases, because the number of releases can change based on our development pace.

Add an example to demonstrate the intended mechanism. (Might be overkill?)