### PR TITLE
Fix typo in `ConfigBuilder::with_root_certificates()`

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 impl ConfigBuilder<ClientConfig, WantsVerifier> {
-    /// Choose how to verify client certificates.
+    /// Choose how to verify server certificates.
     pub fn with_root_certificates(
         self,
         root_store: anchors::RootCertStore,


### PR DESCRIPTION
Just stumbled on that. Pretty sure root certificates for `ClientConfig` are used to verify server certificates.