### PR TITLE
add option for skipping domain-name verification of servers

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -416,7 +416,7 @@ pub mod client {
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::verify::{
         CertificateTransparencyPolicy, HandshakeSignatureValid, ServerCertVerified,
-        ServerCertVerifier, WebPkiVerifier,
+        ServerCertVerifier, WebPkiVerifier, WebPkiVerifierAnyServerName,
     };
     #[cfg(feature = "dangerous_configuration")]
     pub use client_conn::danger::DangerousClientConfig;


### PR DESCRIPTION
I am developing a communication network using [Zenoh](https://github.com/eclipse-zenoh/zenoh) with a mTLS feature. Each node specifies a trusted CA cert that is used to verify both connecting clients as well as servers it wants to connect to. The CA is considered the network certificate so any cert signed by it should be fully trusted to partake. This means that i don't care about verifying the domain-name for servers, they could be accepting connections on any interface and the IpAdress could change.

Zenoh depends on rustls for tls communication. It is possible to implement this functionality without updates to rustls by implementing the ServerCertVerifier trait, however I think that this would be a common use case that rustls could fulfill. Also there is a lot of private code for WebPkiVerifier that i would like to reuse that would be duplicated if this would be done in the Zenoh codebase.

Here is the issue @ Zenoh [https://github.com/eclipse-zenoh/zenoh/issues/513](https://github.com/eclipse-zenoh/zenoh/issues/513)

I am completely new to this repository so please help me pass all the required checks! 
I suppose you would want me to write tests for this?

