### PR TITLE
Localise DnsName types

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -44,3 +44,7 @@ path = "fuzzers/client.rs"
 [[bin]]
 name = "server"
 path = "fuzzers/server.rs"
+
+[[bin]]
+name = "server_name"
+path = "fuzzers/server_name.rs"

--- a/fuzz/fuzzers/server_name.rs
+++ b/fuzz/fuzzers/server_name.rs
@@ -1,0 +1,12 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate rustls;
+
+use rustls::client::ServerName;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = std::str::from_utf8(data)
+        .map_err(|_| ())
+        .and_then(|s| ServerName::try_from(s).map_err(|_| ()));
+});

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,6 +1,7 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCommon, ConnectionCore};
+use crate::dns_name;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
 use crate::kx::SupportedKxGroup;
@@ -20,7 +21,6 @@ use crate::KeyLog;
 use super::handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 use super::hs;
 
-use std::error::Error as StdError;
 use std::marker::PhantomData;
 use std::net::IpAddr;
 use std::ops::{Deref, DerefMut};
@@ -334,25 +334,40 @@ impl Default for Resumption {
 /// # let _: ServerName = x;
 /// ```
 #[non_exhaustive]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub enum ServerName {
     /// The server is identified by a DNS name.  The name
     /// is sent in the TLS Server Name Indication (SNI)
     /// extension.
-    DnsName(verify::DnsName),
+    DnsName(dns_name::DnsName),
 
     /// The server is identified by an IP address. SNI is not
     /// done.
     IpAddress(IpAddr),
 }
 
+impl fmt::Debug for ServerName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::DnsName(d) => f
+                .debug_tuple("DnsName")
+                .field(&d.as_ref())
+                .finish(),
+            Self::IpAddress(i) => f
+                .debug_tuple("IpAddress")
+                .field(i)
+                .finish(),
+        }
+    }
+}
+
 impl ServerName {
     /// Return the name that should go in the SNI extension.
     /// If [`None`] is returned, the SNI extension is not included
     /// in the handshake.
-    pub(crate) fn for_sni(&self) -> Option<webpki::DnsNameRef> {
+    pub(crate) fn for_sni(&self) -> Option<dns_name::DnsNameRef> {
         match self {
-            Self::DnsName(dns_name) => Some(dns_name.0.as_ref()),
+            Self::DnsName(dns_name) => Some(dns_name.borrow()),
             Self::IpAddress(_) => None,
         }
     }
@@ -361,30 +376,17 @@ impl ServerName {
 /// Attempt to make a ServerName from a string by parsing
 /// it as a DNS name.
 impl TryFrom<&str> for ServerName {
-    type Error = InvalidDnsNameError;
+    type Error = dns_name::InvalidDnsNameError;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match webpki::DnsNameRef::try_from_ascii_str(s) {
-            Ok(dns) => Ok(Self::DnsName(verify::DnsName(dns.into()))),
-            Err(webpki::InvalidDnsNameError) => match s.parse() {
+        match dns_name::DnsNameRef::try_from(s) {
+            Ok(dns) => Ok(Self::DnsName(dns.to_owned())),
+            Err(dns_name::InvalidDnsNameError) => match s.parse() {
                 Ok(ip) => Ok(Self::IpAddress(ip)),
-                Err(_) => Err(InvalidDnsNameError),
+                Err(_) => Err(dns_name::InvalidDnsNameError),
             },
         }
     }
 }
-
-/// The provided input could not be parsed because
-/// it is not a syntactically-valid DNS Name.
-#[derive(Debug)]
-pub struct InvalidDnsNameError;
-
-impl fmt::Display for InvalidDnsNameError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("invalid dns name")
-    }
-}
-
-impl StdError for InvalidDnsNameError {}
 
 /// Container for unsafe APIs
 #[cfg(feature = "dangerous_configuration")]

--- a/rustls/src/dns_name.rs
+++ b/rustls/src/dns_name.rs
@@ -1,0 +1,219 @@
+/// DNS name validation according to RFC1035, but with underscores allowed.
+use std::error::Error as StdError;
+use std::fmt;
+
+/// A type which encapsulates an owned string that is a syntactically valid DNS name.
+#[derive(Clone, Eq, Hash, PartialEq, Debug)]
+pub struct DnsName(String);
+
+impl<'a> DnsName {
+    /// Produce a borrowed `DnsNameRef` from this owned `DnsName`.
+    pub fn borrow(&'a self) -> DnsNameRef<'a> {
+        DnsNameRef(self.as_ref())
+    }
+
+    /// Validate the given bytes are a DNS name if they are viewed as ASCII.
+    pub fn try_from_ascii(bytes: &[u8]) -> Result<Self, InvalidDnsNameError> {
+        // nb. a sequence of bytes that is accepted by `validate()` is both
+        // valid UTF-8, and valid ASCII.
+        String::from_utf8(bytes.to_vec())
+            .map_err(|_| InvalidDnsNameError)
+            .and_then(Self::try_from)
+    }
+}
+
+impl TryFrom<String> for DnsName {
+    type Error = InvalidDnsNameError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        validate(value.as_bytes())?;
+        Ok(Self(value))
+    }
+}
+
+impl AsRef<str> for DnsName {
+    fn as_ref(&self) -> &str {
+        AsRef::<str>::as_ref(&self.0)
+    }
+}
+
+/// A type which encapsulates a borrowed string that is a syntactically valid DNS name.
+#[derive(Eq, Hash, PartialEq, Debug)]
+pub struct DnsNameRef<'a>(&'a str);
+
+impl<'a> DnsNameRef<'a> {
+    /// Copy this object to produce an owned `DnsName`.
+    pub fn to_owned(&'a self) -> DnsName {
+        DnsName(self.0.to_string())
+    }
+
+    /// Copy this object to produce an owned `DnsName`, smashing the case to lowercase
+    /// in one operation.
+    pub fn to_lowercase_owned(&'a self) -> DnsName {
+        DnsName(self.0.to_lowercase())
+    }
+}
+
+impl<'a> TryFrom<&'a str> for DnsNameRef<'a> {
+    type Error = InvalidDnsNameError;
+
+    fn try_from(value: &'a str) -> Result<DnsNameRef<'a>, Self::Error> {
+        validate(value.as_bytes())?;
+        Ok(DnsNameRef(value))
+    }
+}
+
+impl<'a> AsRef<str> for DnsNameRef<'a> {
+    fn as_ref(&self) -> &str {
+        self.0
+    }
+}
+
+/// The provided input could not be parsed because
+/// it is not a syntactically-valid DNS Name.
+#[derive(Debug)]
+pub struct InvalidDnsNameError;
+
+impl fmt::Display for InvalidDnsNameError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid dns name")
+    }
+}
+
+impl StdError for InvalidDnsNameError {}
+
+fn validate(input: &[u8]) -> Result<(), InvalidDnsNameError> {
+    use State::*;
+    let mut state = Start;
+
+    /// "Labels must be 63 characters or less."
+    const MAX_LABEL_LENGTH: usize = 63;
+
+    for ch in input {
+        state = match (state, ch) {
+            (Start | Next | Hyphen { .. }, b'.') => return Err(InvalidDnsNameError),
+            (Subsequent { .. }, b'.') => Next,
+            (Subsequent { len }, _) if len >= MAX_LABEL_LENGTH => return Err(InvalidDnsNameError),
+            (Start | Next, b'a'..=b'z' | b'A'..=b'Z') => Subsequent { len: 1 },
+            (Subsequent { len }, b'-') => Hyphen { len: len + 1 },
+            (
+                Subsequent { len } | Hyphen { len },
+                b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'-' | b'0'..=b'9',
+            ) => Subsequent { len: len + 1 },
+            _ => return Err(InvalidDnsNameError),
+        };
+    }
+
+    if matches!(state, Start | Hyphen { .. }) {
+        return Err(InvalidDnsNameError);
+    }
+
+    Ok(())
+}
+
+enum State {
+    Start,
+    Next,
+    Subsequent { len: usize },
+    Hyphen { len: usize },
+}
+
+#[cfg(test)]
+mod test {
+    static TESTS: &[(&'static str, bool)] = &[
+        ("", false),
+        ("localhost", true),
+        ("LOCALHOST", true),
+        (".localhost", false),
+        ("..localhost", false),
+        ("1.2.3.4", false),
+        ("127.0.0.1", false),
+        ("absolute.", true),
+        ("absolute..", false),
+        ("multiple.labels.absolute.", true),
+        ("foo.bar.com", true),
+        ("infix-hyphen-allowed.com", true),
+        ("-prefixhypheninvalid.com", false),
+        ("suffixhypheninvalid-.com", false),
+        ("foo.lastlabelendswithhyphen-", false),
+        ("infix_underscore_allowed.com", true),
+        ("_prefixunderscoreinvalid.com", false),
+        ("labelendswithnumber1.bar.com", true),
+        ("xn--bcher-kva.example", true),
+        (
+            "sixtythreesixtythreesixtythreesixtythreesixtythreesixtythreesix.com",
+            true,
+        ),
+        (
+            "sixtyfoursixtyfoursixtyfoursixtyfoursixtyfoursixtyfoursixtyfours.com",
+            false,
+        ),
+    ];
+
+    #[test]
+    fn test_validation() {
+        for (input, expected) in TESTS {
+            println!("test: {:?} expected valid? {:?}", input, expected);
+            let name_ref = super::DnsNameRef::try_from(*input);
+            assert_eq!(*expected, name_ref.is_ok());
+            let name = super::DnsName::try_from(input.to_string());
+            assert_eq!(*expected, name.is_ok());
+        }
+    }
+
+    #[test]
+    fn error_is_debug() {
+        assert_eq!(
+            format!("{:?}", super::InvalidDnsNameError),
+            "InvalidDnsNameError"
+        );
+    }
+
+    #[test]
+    fn error_is_display() {
+        assert_eq!(
+            format!("{}", super::InvalidDnsNameError),
+            "invalid dns name"
+        );
+    }
+
+    #[test]
+    fn dns_name_is_debug() {
+        let example = super::DnsName::try_from("example.com".to_string()).unwrap();
+        assert_eq!(format!("{:?}", example), "DnsName(\"example.com\")");
+    }
+
+    #[test]
+    fn dns_name_traits() {
+        let example = super::DnsName::try_from("example.com".to_string()).unwrap();
+        assert_eq!(example, example); // PartialEq
+
+        use std::collections::HashSet;
+        let mut h = HashSet::<super::DnsName>::new();
+        h.insert(example);
+    }
+
+    #[test]
+    fn try_from_ascii_rejects_bad_utf8() {
+        assert_eq!(
+            format!("{:?}", super::DnsName::try_from_ascii(b"\x80")),
+            "Err(InvalidDnsNameError)"
+        );
+    }
+
+    #[test]
+    fn dns_name_ref_is_debug() {
+        let example = super::DnsNameRef::try_from("example.com").unwrap();
+        assert_eq!(format!("{:?}", example), "DnsNameRef(\"example.com\")");
+    }
+
+    #[test]
+    fn dns_name_ref_traits() {
+        let example = super::DnsNameRef::try_from("example.com").unwrap();
+        assert_eq!(example, example); // PartialEq
+
+        use std::collections::HashSet;
+        let mut h = HashSet::<super::DnsNameRef>::new();
+        h.insert(example);
+    }
+}

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -318,6 +318,7 @@ mod anchors;
 mod cipher;
 mod common_state;
 mod conn;
+mod dns_name;
 mod error;
 mod hash_hs;
 mod limited_cache;
@@ -405,11 +406,11 @@ pub mod client {
     mod tls12;
     mod tls13;
 
+    pub use crate::dns_name::InvalidDnsNameError;
     pub use builder::{WantsClientCert, WantsTransparencyPolicyOrClientCert};
     pub use client_conn::{
         ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore,
-        InvalidDnsNameError, ResolvesClientCert, Resumption, ServerName, Tls12Resumption,
-        WriteEarlyData,
+        ResolvesClientCert, Resumption, ServerName, Tls12Resumption, WriteEarlyData,
     };
     pub use handy::ClientSessionMemoryCache;
 
@@ -451,7 +452,9 @@ pub mod server {
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
 
     #[cfg(feature = "dangerous_configuration")]
-    pub use crate::verify::{ClientCertVerified, ClientCertVerifier, DnsName};
+    pub use crate::dns_name::DnsName;
+    #[cfg(feature = "dangerous_configuration")]
+    pub use crate::verify::{ClientCertVerified, ClientCertVerifier};
 }
 
 pub use server::{ServerConfig, ServerConnection};

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -1,3 +1,4 @@
+use crate::dns_name::DnsNameRef;
 use crate::enums::{CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme};
 use crate::key::Certificate;
 use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
@@ -18,8 +19,6 @@ use crate::msgs::handshake::{
     ServerExtension, ServerHelloPayload, ServerKeyExchangePayload, SessionId, UnknownExtension,
 };
 use crate::verify::DigitallySignedStruct;
-
-use webpki::DnsNameRef;
 
 #[test]
 fn rejects_short_random() {
@@ -222,11 +221,8 @@ fn can_roundtrip_multiname_sni() {
 
             assert!(req.has_duplicate_names_for_type());
 
-            let dns_name_str: &str = req
-                .get_single_hostname()
-                .unwrap()
-                .into();
-            assert_eq!(dns_name_str, "hi");
+            let dns_name = req.get_single_hostname().unwrap();
+            assert_eq!(dns_name.as_ref(), "hi");
 
             assert_eq!(req[0].typ, ServerNameType::HostName);
             assert_eq!(req[1].typ, ServerNameType::HostName);
@@ -369,7 +365,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::ECPointFormats(ECPointFormat::SUPPORTED.to_vec()),
             ClientExtension::NamedGroups(vec![NamedGroup::X25519]),
             ClientExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
-            ClientExtension::make_sni(DnsNameRef::try_from_ascii_str("hello").unwrap()),
+            ClientExtension::make_sni(DnsNameRef::try_from("hello").unwrap()),
             ClientExtension::SessionTicket(ClientSessionTicket::Request),
             ClientExtension::SessionTicket(ClientSessionTicket::Offer(Payload(vec![]))),
             ClientExtension::Protocols(vec![ProtocolName::from(vec![0])]),

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -1,3 +1,4 @@
+use crate::dns_name;
 use crate::error::Error;
 use crate::key;
 use crate::limited_cache;
@@ -155,12 +156,12 @@ impl ResolvesServerCertUsingSni {
     /// it's not valid for the supplied certificate, or if the certificate
     /// chain is syntactically faulty.
     pub fn add(&mut self, name: &str, ck: sign::CertifiedKey) -> Result<(), Error> {
-        let checked_name = webpki::DnsNameRef::try_from_ascii_str(name)
-            .map_err(|_| Error::General("Bad DNS name".into()))?
-            .to_owned();
+        let checked_name = dns_name::DnsNameRef::try_from(name)
+            .map_err(|_| Error::General("Bad DNS name".into()))
+            .map(|dns| dns.to_lowercase_owned())?;
 
-        ck.cross_check_end_entity_cert(Some(checked_name.as_ref()))?;
-        let as_str: &str = checked_name.as_ref().into();
+        ck.cross_check_end_entity_cert(Some(&checked_name.borrow()))?;
+        let as_str: &str = checked_name.as_ref();
         self.by_name
             .insert(as_str.to_string(), Arc::new(ck));
         Ok(())
@@ -268,7 +269,7 @@ mod test {
     #[test]
     fn test_resolvesservercertusingsni_handles_unknown_name() {
         let rscsni = ResolvesServerCertUsingSni::new();
-        let name = webpki::DnsNameRef::try_from_ascii_str("hello.com")
+        let name = dns_name::DnsNameRef::try_from("hello.com")
             .unwrap()
             .to_owned();
         assert!(rscsni

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -1,5 +1,6 @@
 use crate::common_state::State;
 use crate::conn::ConnectionRandoms;
+use crate::dns_name;
 #[cfg(feature = "tls12")]
 use crate::enums::CipherSuite;
 use crate::enums::{AlertDescription, HandshakeType, ProtocolVersion, SignatureScheme};
@@ -32,7 +33,7 @@ pub(super) type ServerContext<'a> = crate::common_state::Context<'a, ServerConne
 
 pub(super) fn can_resume(
     suite: SupportedCipherSuite,
-    sni: &Option<webpki::DnsName>,
+    sni: &Option<dns_name::DnsName>,
     using_ems: bool,
     resumedata: &persist::ServerSessionValue,
 ) -> bool {
@@ -476,7 +477,7 @@ pub(super) fn process_client_hello<'a>(
     // send an Illegal Parameter alert instead of the Internal Error alert
     // (or whatever) that we'd send if this were checked later or in a
     // different way.
-    let sni: Option<webpki::DnsName> = match client_hello.get_sni_extension() {
+    let sni: Option<dns_name::DnsName> = match client_hello.get_sni_extension() {
         Some(sni) => {
             if sni.has_duplicate_names_for_type() {
                 return Err(cx.common.send_fatal_alert(
@@ -486,7 +487,7 @@ pub(super) fn process_client_hello<'a>(
             }
 
             if let Some(hostname) = sni.get_single_hostname() {
-                Some(hostname.into())
+                Some(hostname.to_lowercase_owned())
             } else {
                 return Err(cx.common.send_fatal_alert(
                     AlertDescription::IllegalParameter,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,6 +1,7 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
 use crate::common_state::{CommonState, Context, Side, State};
 use crate::conn::{ConnectionCommon, ConnectionCore};
+use crate::dns_name;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
 use crate::kx::SupportedKxGroup;
@@ -107,7 +108,7 @@ pub trait ResolvesServerCert: Send + Sync {
 
 /// A struct representing the received Client Hello
 pub struct ClientHello<'a> {
-    server_name: &'a Option<webpki::DnsName>,
+    server_name: &'a Option<dns_name::DnsName>,
     signature_schemes: &'a [SignatureScheme],
     alpn: Option<&'a Vec<ProtocolName>>,
     cipher_suites: &'a [CipherSuite],
@@ -116,7 +117,7 @@ pub struct ClientHello<'a> {
 impl<'a> ClientHello<'a> {
     /// Creates a new ClientHello
     pub(super) fn new(
-        server_name: &'a Option<webpki::DnsName>,
+        server_name: &'a Option<dns_name::DnsName>,
         signature_schemes: &'a [SignatureScheme],
         alpn: Option<&'a Vec<ProtocolName>>,
         cipher_suites: &'a [CipherSuite],
@@ -140,7 +141,7 @@ impl<'a> ClientHello<'a> {
     pub fn server_name(&self) -> Option<&str> {
         self.server_name
             .as_ref()
-            .map(<webpki::DnsName as AsRef<str>>::as_ref)
+            .map(<dns_name::DnsName as AsRef<str>>::as_ref)
     }
 
     /// Get the compatible signature schemes.
@@ -789,7 +790,7 @@ impl ConnectionCore<ServerConnectionData> {
 /// State associated with a server connection.
 #[derive(Default)]
 pub struct ServerConnectionData {
-    pub(super) sni: Option<webpki::DnsName>,
+    pub(super) sni: Option<dns_name::DnsName>,
     pub(super) received_resumption_data: Option<Vec<u8>>,
     pub(super) resumption_data: Vec<u8>,
     pub(super) early_data: EarlyDataState,

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -1,4 +1,3 @@
-use crate::dns_name;
 use crate::enums::{SignatureAlgorithm, SignatureScheme};
 use crate::error::Error;
 use crate::key;
@@ -69,60 +68,6 @@ impl CertifiedKey {
     /// The end-entity certificate.
     pub fn end_entity_cert(&self) -> Result<&key::Certificate, SignError> {
         self.cert.get(0).ok_or(SignError(()))
-    }
-
-    /// Check the certificate chain for validity:
-    /// - it should be non-empty list
-    /// - the first certificate should be parsable as a x509v3,
-    /// - the first certificate should quote the given server name
-    ///   (if provided)
-    ///
-    /// These checks are not security-sensitive.  They are the
-    /// *server* attempting to detect accidental misconfiguration.
-    pub(crate) fn cross_check_end_entity_cert(
-        &self,
-        name: Option<&dns_name::DnsNameRef>,
-    ) -> Result<(), Error> {
-        // Always reject an empty certificate chain.
-        let end_entity_cert = self
-            .end_entity_cert()
-            .map_err(|SignError(())| {
-                Error::General("No end-entity certificate in certificate chain".to_string())
-            })?;
-
-        // Reject syntactically-invalid end-entity certificates.
-        let end_entity_cert =
-            webpki::EndEntityCert::try_from(end_entity_cert.as_ref()).map_err(|_| {
-                Error::General(
-                    "End-entity certificate in certificate \
-                                  chain is syntactically invalid"
-                        .to_string(),
-                )
-            })?;
-
-        if let Some(name) = name {
-            // If SNI was offered then the certificate must be valid for
-            // that hostname. Note that this doesn't fully validate that the
-            // certificate is valid; it only validates that the name is one
-            // that the certificate is valid for, if the certificate is
-            // valid.
-            let general_error = || {
-                Error::General(
-                    "The server certificate is not \
-                                             valid for the given name"
-                        .to_string(),
-                )
-            };
-
-            let name = webpki::DnsNameRef::try_from_ascii(name.as_ref().as_bytes())
-                .map_err(|_| general_error())?;
-
-            end_entity_cert
-                .verify_is_valid_for_subject_name(webpki::SubjectNameRef::DnsName(name))
-                .map_err(|_| general_error())?;
-        }
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
The goal of this is getting closer to avoiding a dependency on the `webpki` crate if our user chooses to not validate certificates with it.

After this PR, `webpki` remains referenced from:

- `src/verify.rs` (home of the default verifier)
- `src/server/handy.rs` (checking certificates against SNI names during configuration)
- `src/anchors.rs` (producing `webpki::TrustAnchor`s)