### PR TITLE
WIP: client certificate revocation checking support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
 ]
 exclude = ["admin/rustfmt"]
 resolver = "2"
+
+[patch.crates-io]
+webpki = { package='rustls-webpki', git = 'https://github.com/cpu/webpki.git', branch = 'cpu-crl-support-rustls-fixes' }

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -558,10 +558,16 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
         for root in roots {
             client_auth_roots.add(&root).unwrap();
         }
+        // TODO(@cpu): Parse CRLs from Args.
+        let crls = Vec::default();
         if args.flag_require_auth {
-            AllowAnyAuthenticatedClient::new(client_auth_roots).boxed()
+            AllowAnyAuthenticatedClient::new(client_auth_roots, crls)
+                .expect("invalid client auth config")
+                .boxed()
         } else {
-            AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots).boxed()
+            AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots, crls)
+                .expect("invalid client auth config")
+                .boxed()
         }
     } else {
         NoClientAuth::boxed()

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -304,7 +304,7 @@ fn make_server_config(
             for root in roots {
                 client_auth_roots.add(&root).unwrap();
             }
-            Arc::new(AllowAnyAuthenticatedClient::new(client_auth_roots))
+            Arc::new(AllowAnyAuthenticatedClient::new(client_auth_roots, Vec::default()).unwrap())
         }
         ClientAuth::No => NoClientAuth::boxed(),
     };

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -66,6 +66,10 @@ pub enum Error {
     /// implementation.
     InvalidCertificate(CertificateError),
 
+    /// A provided certificate revocation list (CRL) was invalid.
+    // TODO(@cpu): provide more detail, maybe with a sub-enum, or by exposing webpki::Error?
+    InvalidCrl,
+
     /// The presented SCT(s) were invalid.
     InvalidSct(sct::Error),
 
@@ -418,6 +422,9 @@ impl fmt::Display for Error {
             Self::AlertReceived(ref alert) => write!(f, "received fatal alert: {:?}", alert),
             Self::InvalidCertificate(ref err) => {
                 write!(f, "invalid peer certificate: {:?}", err)
+            }
+            Self::InvalidCrl => {
+                write!(f, "invalid certificate revocation list")
             }
             Self::NoCertificatesPresented => write!(f, "peer sent no certificates"),
             Self::UnsupportedNameType => write!(f, "presented server name type wasn't supported"),

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -440,7 +440,8 @@ pub mod server {
     mod tls13;
 
     pub use crate::verify::{
-        AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
+        AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, CertRevocationList,
+        NoClientAuth,
     };
     pub use builder::WantsServerCert;
     pub use handy::ResolvesServerCertUsingSni;

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -575,6 +575,7 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
             &webpki::TlsClientTrustAnchors(&trustroots),
             &chain,
             now,
+            &[], // TODO(@cpu): provide CRLs as appropriate.
         )
         .map_err(pki_error)
         .map(|_| ClientCertVerified::assertion())

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -479,7 +479,9 @@ fn server_allow_any_anonymous_or_authenticated_client() {
     let kt = KeyType::Rsa;
     for client_cert_chain in [None, Some(kt.get_client_chain())].iter() {
         let client_auth_roots = get_client_root_store(kt);
-        let client_auth = AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots);
+        // TODO(@cpu): allow building test config with CRLs.
+        let client_auth =
+            AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots, Vec::default()).unwrap();
 
         let server_config = ServerConfig::builder()
             .with_safe_defaults()

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -284,7 +284,8 @@ pub fn get_client_root_store(kt: KeyType) -> RootCertStore {
 pub fn make_server_config_with_mandatory_client_auth(kt: KeyType) -> ServerConfig {
     let client_auth_roots = get_client_root_store(kt);
 
-    let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots);
+    // TODO(@cpu): allow building test configuration with CRLs.
+    let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots, Vec::default()).unwrap();
 
     ServerConfig::builder()
         .with_safe_defaults()


### PR DESCRIPTION
**Note: left as a draft since it relies on unreleased Webpki code, and because there are some open questions left to resolve**

This branch is an initial implementation of client certificate revocation checking using the recently added webpki CRL support.
