### PR TITLE
expose verify helper functions

### DIFF
--- a/rustls/src/key.rs
+++ b/rustls/src/key.rs
@@ -100,7 +100,7 @@ impl fmt::Debug for Certificate {
 }
 
 /// wrapper around internal representation of a parsed certificate. This is used in order to avoid parsing twice when specifying custom verification
-#[allow(unreachable_pub)]
+#[cfg_attr(not(feature = "dangerous_configuration"), allow(unreachable_pub))]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct ParsedCertificate<'a>(pub(crate) webpki::EndEntityCert<'a>);
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -424,7 +424,7 @@ pub mod client {
 
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::verify::{
-        verify_signed_by_trust_anchor, HandshakeSignatureValid, ServerCertVerified,
+        verify_server_cert_signed_by_trust_anchor, HandshakeSignatureValid, ServerCertVerified,
         ServerCertVerifier, WebPkiVerifier,
     };
     #[cfg(feature = "dangerous_configuration")]
@@ -461,6 +461,8 @@ pub mod server {
 
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::dns_name::DnsName;
+    #[cfg(feature = "dangerous_configuration")]
+    pub use crate::key::ParsedCertificate;
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::verify::{ClientCertVerified, ClientCertVerifier};
 }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -424,8 +424,8 @@ pub mod client {
 
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::verify::{
-        verify_server_cert_signed_by_trust_anchor, HandshakeSignatureValid, ServerCertVerified,
-        ServerCertVerifier, WebPkiVerifier,
+        verify_server_cert_signed_by_trust_anchor, verify_server_name, HandshakeSignatureValid,
+        ServerCertVerified, ServerCertVerifier, WebPkiVerifier,
     };
     #[cfg(feature = "dangerous_configuration")]
     pub use client_conn::danger::DangerousClientConfig;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -424,7 +424,8 @@ pub mod client {
 
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::verify::{
-        HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, WebPkiVerifier,
+        verify_signed_by_trust_anchor, HandshakeSignatureValid, ServerCertVerified,
+        ServerCertVerifier, WebPkiVerifier,
     };
     #[cfg(feature = "dangerous_configuration")]
     pub use client_conn::danger::DangerousClientConfig;

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -313,7 +313,8 @@ impl fmt::Debug for dyn ClientCertVerifier {
 /// `intermediates` contains all certificates other than `end_entity` that
 /// were sent as part of the server's [Certificate] message. It is in the
 /// same order that the server sent them and may be empty.
-#[allow(unreachable_pub, dead_code)]
+#[allow(dead_code)]
+#[cfg_attr(not(feature = "dangerous_configuration"), allow(unreachable_pub))]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub fn verify_server_cert_signed_by_trust_anchor(
     cert: &ParsedCertificate,
@@ -339,7 +340,7 @@ pub fn verify_server_cert_signed_by_trust_anchor(
 /// Verify that the `end_entity` has a name or alternative name matching the `server_name`
 /// note: this only verifies the name and should be used in conjuction with more verification
 /// like [verify_server_cert_signed_by_trust_anchor]
-#[allow(unreachable_pub, dead_code)]
+#[cfg_attr(not(feature = "dangerous_configuration"), allow(unreachable_pub))]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub fn verify_server_name(cert: &ParsedCertificate, server_name: &ServerName) -> Result<(), Error> {
     match server_name {

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -307,14 +307,15 @@ impl fmt::Debug for dyn ClientCertVerifier {
     }
 }
 
-/// Verify that the end-entity certificate `end_entity` is valid and chains to at least one of the [OwnedTrustAnchor] in the `roots` [RootCertStore].
+/// Verify that the end-entity certificate `end_entity` is a valid server cert
+/// and chains to at least one of the [OwnedTrustAnchor] in the `roots` [RootCertStore].
 ///
 /// `intermediates` contains all certificates other than `end_entity` that
 /// were sent as part of the server's [Certificate] message. It is in the
 /// same order that the server sent them and may be empty.
 #[allow(unreachable_pub, dead_code)]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
-pub fn verify_signed_by_trust_anchor(
+pub fn verify_server_cert_signed_by_trust_anchor(
     end_entity: &Certificate,
     roots: &RootCertStore,
     intermediates: &[Certificate],
@@ -334,6 +335,8 @@ pub fn verify_signed_by_trust_anchor(
 }
 
 /// Verify that the `end_entity` has a name or alternative name matching the `server_name`
+/// note: this only verifies the name and should be used in conjuction with more verification
+/// like [verify_server_cert_signed_by_trust_anchor]
 #[allow(unreachable_pub, dead_code)]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub fn verify_server_name(end_entity: &Certificate, server_name: &ServerName) -> Result<(), Error> {

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -7,9 +7,8 @@ use crate::common::{
     do_handshake, do_handshake_until_both_error, make_client_config_with_versions,
     make_pair_for_arc_configs, make_server_config, ErrorFromPeer, ALL_KEY_TYPES,
 };
-use rustls::client::{
-    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, WebPkiVerifier,
-};
+use rustls::client::WebPkiVerifier;
+use rustls::client::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::DigitallySignedStruct;
 use rustls::{AlertDescription, Certificate, Error, InvalidMessage, SignatureScheme};
 use std::sync::Arc;

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -7,8 +7,9 @@ use crate::common::{
     do_handshake, do_handshake_until_both_error, make_client_config_with_versions,
     make_pair_for_arc_configs, make_server_config, ErrorFromPeer, ALL_KEY_TYPES,
 };
-use rustls::client::WebPkiVerifier;
-use rustls::client::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::client::{
+    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, WebPkiVerifier,
+};
 use rustls::DigitallySignedStruct;
 use rustls::{AlertDescription, Certificate, Error, InvalidMessage, SignatureScheme};
 use std::sync::Arc;


### PR DESCRIPTION
Alternative to: https://github.com/rustls/rustls/pull/1320 that makes it less easy to create a ServerCertVerifier that skips domain name verification. 

I chose not to call the new public functions from the WebPkiVerifier impl block because they need to parse the Certificate to webpki::EndEntity. If I did call the new functions, then the cert would be parsed twice.