### PR TITLE
ci: run client examples in CI connect tests.

### DIFF
--- a/.github/workflows/connect-tests.yml
+++ b/.github/workflows/connect-tests.yml
@@ -44,3 +44,9 @@ jobs:
       - run: cargo test --manifest-path=connect-tests/Cargo.toml
         env:
           RUST_BACKTRACE: 1
+
+      - run: cargo run --bin simpleclient
+
+      - run: cargo run --bin limitedclient
+
+      - run: cargo run --bin simple_0rtt_client


### PR DESCRIPTION
We want to catch breakages in these client examples when they occur, but also don't want to run them during normal CI since they connect to external hosts and may occasionally flake.

This commit adds `simpleclient`, `limitedclient`, and `simple_0rtt_client` test runs to the `connect-tests.yml` CI configuration we run on a weekly basis.