### PR TITLE
enums: clarify NamedCurve isn't supported curves.

### DIFF
--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -139,6 +139,11 @@ enum_builder! {
     /// The `NamedCurve` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
+    ///
+    /// This enum is used for recognizing elliptic curve parameters advertised
+    /// by a peer during a TLS handshake. It is **not** a list of curves that
+    /// Rustls supports. See [`crate::kx_group`] for the list of supported
+    /// elliptic curve groups.
     @U16
     EnumName: NamedCurve;
     EnumVal{


### PR DESCRIPTION
To avoid any confusion (e.g. https://github.com/rustls/rustls/issues/1332) this commit clarifies the rustdoc comment on the `NamedCurve` enum to indicate that it has entries we don't support.