### PR TITLE
Enable unit-test-like benchmarks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
           done
 
   benchmarks:
-    name: Smoke-test benchmarks
+    name: Run benchmarks
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
@@ -144,10 +144,15 @@ jobs:
           persist-credentials: false
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Smoke-test benchmark program
         run: cargo run --release --example bench
+
+      - name: Run micro-benchmarks
+        run: cargo bench
+        env:
+          RUSTFLAGS: --cfg=bench
 
   docs:
     name: Check for documentation errors

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -261,7 +261,7 @@
 
 // Require docs for public APIs, deny unsafe code, etc.
 #![forbid(unsafe_code, unused_must_use)]
-#![cfg_attr(not(read_buf), forbid(unstable_features))]
+#![cfg_attr(not(any(read_buf, bench)), forbid(unstable_features))]
 #![deny(
     clippy::clone_on_ref_ptr,
     clippy::use_self,
@@ -301,6 +301,12 @@
 // is used to avoid needing `rustversion` to be compiled twice during
 // cross-compiling.
 #![cfg_attr(read_buf, feature(read_buf))]
+#![cfg_attr(bench, feature(test))]
+
+// Import `test` sysroot crate for `Bencher` definitions.
+#[cfg(bench)]
+#[allow(unused_extern_crates)]
+extern crate test;
 
 // log for logging (optional).
 #[cfg(feature = "logging")]

--- a/rustls/src/tls12/prf.rs
+++ b/rustls/src/tls12/prf.rs
@@ -65,3 +65,19 @@ mod tests {
         assert_eq!(expect.to_vec(), output.to_vec());
     }
 }
+
+#[cfg(bench)]
+mod benchmarks {
+    #[bench]
+    fn bench_sha256(b: &mut test::Bencher) {
+        let label = &b"extended master secret"[..];
+        let seed = [0u8; 32];
+        let key = &b"secret"[..];
+
+        b.iter(|| {
+            let mut out = [0u8; 48];
+            super::prf(&mut out, ring::hmac::HMAC_SHA256, key, &label, &seed);
+            test::black_box(out);
+        });
+    }
+}


### PR DESCRIPTION
Run these locally using:

```
$ RUSTFLAGS='--cfg=bench' cargo +nightly bench
```

The method of introducing a new `bench` build configuration is explained in https://github.com/RCasatta/qr_code/commit/c037ab97bfc55dd74e6fbe86581472e1f28b7773 and the odd use of `extern crate` is explained in https://doc.rust-lang.org/nightly/edition-guide/rust-2018/path-changes.html#an-exception