### PR TITLE
feat: randomize ClientHello extensions

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -17,6 +17,7 @@ rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
 log = { version = "0.4.4", optional = true }
+rand = "0.8.5"
 ring = "0.16.20"
 webpki = { package = "rustls-webpki", version = "0.100.0", features = ["alloc", "std"] }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -34,6 +34,9 @@ use crate::client::{tls13, ClientConfig, ServerName};
 use std::ops::Deref;
 use std::sync::Arc;
 
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
 pub(super) type NextState = Box<dyn State<ClientConnectionData>>;
 pub(super) type NextStateOrError = Result<NextState, Error>;
 pub(super) type ClientContext<'a> = crate::common_state::Context<'a, ClientConnectionData>;
@@ -261,6 +264,9 @@ fn emit_client_hello_for_retry(
                 .collect::<Vec<_>>(),
         )));
     }
+
+    let mut rng = thread_rng();
+    exts.shuffle(&mut rng);
 
     // Extra extensions must be placed before the PSK extension
     exts.extend(extra_exts.iter().cloned());


### PR DESCRIPTION
https://github.com/rustls/rustls/issues/1313

I doubt the solution will be this easy, but I'm opening this as a starting point for discussion. BoringSSL decided to implement this via a flag, and the randomization is applied per connection. This means that all ClientHellos sent on a connection will be consistent. Is this something we want to emulate? https://boringssl-review.googlesource.com/c/boringssl/+/48045 has more details