### PR TITLE
Take `Iterator` in `add_parsable_certificates()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Release history
 
+* Next release:
+  - `RootCertStore::add_parsable_certificates` now takes a
+    `impl IntoIterator<Item = impl AsRef<[u8]>>`.
 * Release 0.21.3 (2023-07-05)
   - Added `with_crls` function to `AllowAnyAuthenticatedClient` and
     `AllowAnyAnonymousOrAuthenticatedClient` client certificate verifiers to

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -377,7 +377,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
 
         let certfile = fs::File::open(cafile).expect("Cannot open CA file");
         let mut reader = BufReader::new(certfile);
-        root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut reader).unwrap());
+        root_store.add_parsable_certificates(rustls_pemfile::certs(&mut reader).unwrap());
     } else {
         root_store.add_server_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -338,7 +338,7 @@ fn make_client_config(
     let mut root_store = RootCertStore::empty();
     let mut rootbuf =
         io::BufReader::new(fs::File::open(params.key_type.path_for("ca.cert")).unwrap());
-    root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
+    root_store.add_parsable_certificates(rustls_pemfile::certs(&mut rootbuf).unwrap());
 
     let cfg = ClientConfig::builder()
         .with_cipher_suites(&[params.ciphersuite])

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -124,7 +124,10 @@ impl RootCertStore {
     /// include ancient or syntactically invalid certificates.
     ///
     /// Returns the number of certificates added, and the number that were ignored.
-    pub fn add_parsable_certificates(&mut self, der_certs: &[impl AsRef<[u8]>]) -> (usize, usize) {
+    pub fn add_parsable_certificates<C: AsRef<[u8]>>(
+        &mut self,
+        der_certs: impl IntoIterator<Item = C>,
+    ) -> (usize, usize) {
         let mut valid_count = 0;
         let mut invalid_count = 0;
 

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -342,7 +342,7 @@ pub fn finish_client_config(
 ) -> ClientConfig {
     let mut root_store = RootCertStore::empty();
     let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
-    root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
+    root_store.add_parsable_certificates(rustls_pemfile::certs(&mut rootbuf).unwrap());
 
     config
         .with_root_certificates(root_store)
@@ -355,6 +355,7 @@ pub fn finish_client_config_with_creds(
 ) -> ClientConfig {
     let mut root_store = RootCertStore::empty();
     let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
+    // Passing a reference here just for testing.
     root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
 
     config


### PR DESCRIPTION
I suggest we actually take `IntoIterator` here instead of `Iterator`, which on it's own probably doesn't do much, but combine it with `Item = impl AsRef<[u8]>`, which would require adding a generic but removes the lifetime, and it would unburden the user significantly, being able to pass in almost anything without any further modification.

WDYT?

Fixes #1304.