### PR TITLE
CI: add 32bit cross compilation target.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,6 +218,21 @@ jobs:
       - name: cargo test (debug; all features; -Z minimal-versions)
         run: cargo -Z minimal-versions test --all-features
 
+  cross:
+    name: Check cross compilation targets
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+      - run: cross build --target i686-unknown-linux-gnu
+
   format:
     name: Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit adds a CI task that uses `cross` to cross-compile Rustls for the 32bit `i686-unknown-linux-gnu` target. This can be used as a smoke-test that we haven't broken 32bit compat. Unfortunately GitHub doesn't offer 32bit action runners so we have to cross-compile to achieve this test.

To install `cross` this commit relies on [`install-action`](https://github.com/taiki-e/install-action). This is a new 3rd party action for the Rustls repo, but one that was already being used in `webpki` for `llvm-cov` and `cargo deny`. If we'd prefer to avoid that workflow dependency we could instead `cargo install cross` at the cost of having to use nightly rust and longer CI execution time.

Related to https://github.com/rustls/rustls/issues/1343, https://github.com/rustls/webpki/issues/112