### PR TITLE
client: `with_single_cert` -> `with_client_auth_cert`

### DIFF
--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -416,7 +416,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
             let certs = load_certs(certs_file);
             let key = load_private_key(key_file);
             config
-                .with_single_cert(certs, key)
+                .with_client_auth_cert(certs, key)
                 .expect("invalid client auth certs/key")
         }
         (None, None) => config.with_no_client_auth(),

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -348,7 +348,7 @@ fn make_client_config(
         .with_root_certificates(root_store);
 
     let mut cfg = if clientauth == ClientAuth::Yes {
-        cfg.with_single_cert(
+        cfg.with_client_auth_cert(
             params.key_type.get_client_chain(),
             params.key_type.get_client_key(),
         )

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -527,7 +527,8 @@ fn make_client_cfg(opts: &Options) -> Arc<ClientConfig> {
     let mut cfg = if !opts.cert_file.is_empty() && !opts.key_file.is_empty() {
         let cert = load_cert(&opts.cert_file);
         let key = load_key(&opts.key_file);
-        cfg.with_single_cert(cert, key).unwrap()
+        cfg.with_client_auth_cert(cert, key)
+            .unwrap()
     } else {
         cfg.with_no_client_auth()
     };

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -58,7 +58,7 @@ use std::marker::PhantomData;
 ///     .with_safe_default_protocol_versions()
 ///     .unwrap()
 ///     .with_root_certificates(root_certs)
-///     .with_single_cert(certs, private_key)
+///     .with_client_auth_cert(certs, private_key)
 ///     .expect("bad certificate/key");
 /// ```
 ///

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -67,13 +67,29 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
     /// `key_der` is a DER-encoded RSA, ECDSA, or Ed25519 private key.
     ///
     /// This function fails if `key_der` is invalid.
-    pub fn with_single_cert(
+    pub fn with_client_auth_cert(
         self,
         cert_chain: Vec<key::Certificate>,
         key_der: key::PrivateKey,
     ) -> Result<ClientConfig, Error> {
         let resolver = handy::AlwaysResolvesClientCert::new(cert_chain, &key_der)?;
         Ok(self.with_client_cert_resolver(Arc::new(resolver)))
+    }
+
+    /// Sets a single certificate chain and matching private key for use
+    /// in client authentication.
+    ///
+    /// `cert_chain` is a vector of DER-encoded certificates.
+    /// `key_der` is a DER-encoded RSA, ECDSA, or Ed25519 private key.
+    ///
+    /// This function fails if `key_der` is invalid.
+    #[deprecated(since = "0.21.4", note = "Use `with_client_auth_cert` instead")]
+    pub fn with_single_cert(
+        self,
+        cert_chain: Vec<key::Certificate>,
+        key_der: key::PrivateKey,
+    ) -> Result<ClientConfig, Error> {
+        self.with_client_auth_cert(cert_chain, key_der)
     }
 
     /// Do not support client auth.

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -360,7 +360,7 @@ pub fn finish_client_config_with_creds(
 
     config
         .with_root_certificates(root_store)
-        .with_single_cert(kt.get_client_chain(), kt.get_client_key())
+        .with_client_auth_cert(kt.get_client_chain(), kt.get_client_key())
         .unwrap()
 }
 


### PR DESCRIPTION
### client: with_single_cert -> with_client_auth_cert 

This commit renames the `ClientConfig` builder's `with_single_cert`  function to be called `with_client_auth_cert`. The old `with_single_cert` function is left as an alias for `with_client_auth_cert` and marked as deprecated to encourage users to switch to the new name.

I believe this offers better symmetry with the `with_no_client_auth` function that's used to disable client authentication, and more clearly conveys the purpose of this function is for providing a client authentication certificate.