### PR TITLE
lib: export CertRevocationListError enum.

### DIFF
--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -420,7 +420,7 @@ pub enum CertRevocationListError {
     /// The CRL contained a revoked certificate with an unsupported revocation reason.
     /// See RFC 5280 Section 5.3.1[^1] for a list of supported revocation reasons.
     ///
-    /// [^1]: https://www.rfc-editor.org/rfc/rfc5280#section-5.3.1
+    /// [^1]: <https://www.rfc-editor.org/rfc/rfc5280#section-5.3.1>
     UnsupportedRevocationReason,
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -382,7 +382,10 @@ pub use crate::enums::{
     AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,
     SignatureScheme,
 };
-pub use crate::error::{CertificateError, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
+pub use crate::error::{
+    CertRevocationListError, CertificateError, Error, InvalidMessage, PeerIncompatible,
+    PeerMisbehaved,
+};
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;


### PR DESCRIPTION
The top level `Error::InvalidCertRevocationList` was exported, but not its inner `CertRevocationListError` enum. This should be done to match other enums (e.g. the `Error::InvalidCertificate`'s exported `CertificateError` enum).

Also fix a small `cargo doc` warning about automatic linking a URL.