### PR TITLE
v0.21.5 maintenance release prep

### DIFF
--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -377,7 +377,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
 
         let certfile = fs::File::open(cafile).expect("Cannot open CA file");
         let mut reader = BufReader::new(certfile);
-        root_store.add_parsable_certificates(rustls_pemfile::certs(&mut reader).unwrap());
+        root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut reader).unwrap());
     } else {
         root_store.add_server_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.21.4"
+version = "0.21.5"
 edition = "2021"
 rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -338,7 +338,7 @@ fn make_client_config(
     let mut root_store = RootCertStore::empty();
     let mut rootbuf =
         io::BufReader::new(fs::File::open(params.key_type.path_for("ca.cert")).unwrap());
-    root_store.add_parsable_certificates(rustls_pemfile::certs(&mut rootbuf).unwrap());
+    root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
 
     let cfg = ClientConfig::builder()
         .with_cipher_suites(&[params.ciphersuite])

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -124,10 +124,7 @@ impl RootCertStore {
     /// include ancient or syntactically invalid certificates.
     ///
     /// Returns the number of certificates added, and the number that were ignored.
-    pub fn add_parsable_certificates<C: AsRef<[u8]>>(
-        &mut self,
-        der_certs: impl IntoIterator<Item = C>,
-    ) -> (usize, usize) {
+    pub fn add_parsable_certificates(&mut self, der_certs: &[impl AsRef<[u8]>]) -> (usize, usize) {
         let mut valid_count = 0;
         let mut invalid_count = 0;
 

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -342,7 +342,7 @@ pub fn finish_client_config(
 ) -> ClientConfig {
     let mut root_store = RootCertStore::empty();
     let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
-    root_store.add_parsable_certificates(rustls_pemfile::certs(&mut rootbuf).unwrap());
+    root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
 
     config
         .with_root_certificates(root_store)
@@ -355,7 +355,6 @@ pub fn finish_client_config_with_creds(
 ) -> ClientConfig {
     let mut root_store = RootCertStore::empty();
     let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
-    // Passing a reference here just for testing.
     root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
 
     config


### PR DESCRIPTION
## Description

This PR is targeted at the `rel-0.21` branch to make a maintenance release fixing the semver breakage in the previous 0.21.4 maintenance release.

- [x] `cargo update`.
- [x] `cargo outdated`.
- [x] `cargo test --all-features`.
- [x] Update `version` in `Cargo.toml`.
- [x] `cargo publish --dry-run -p rustls`
- [x] PR desc updated with release headlines

## Proposed release notes headlines:

-  Reverted `RootCertStore::add_parsable_certificates` now takes a  `impl IntoIterator<Item = impl AsRef<[u8]>>`.

### Revert "Take IntoIterator in add_parsable_certificates()"

This reverts commit https://github.com/rustls/rustls/commit/7924f00a81612e615f9e6d18ba3a5098dd994b32.

It turns out to not be as semver compatible as we thought. See https://github.com/rustls/rustls/issues/1352

### cargo: prepare 0.21.5 release.

Updates `Cargo.toml` version 0.21.4 -> 0.21.5.


