### PR TITLE
ci: add a cargo-semver-checks action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,6 +234,18 @@ jobs:
         uses: taiki-e/install-action@cross
       - run: cross build --target i686-unknown-linux-gnu
 
+  semver:
+    name: Check semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   format:
     name: Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit updates the `build.yml` GitHub actions workflow to additionally include a step that checks semver compatibility w/ [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks).

Notably this check passing is necessary but not sufficient for knowing that we're maintaining semver: if this tool produces a finding we know we aren't matching semver, but if it doesn't, we may still be breaking semver in a way the tool can't detect.

**Note**: I haven't made this a _required_ check in our branch protection. I think it might be better to see how this works for a bit before we block any PRs/queued merges on the results.