### PR TITLE
ci: cross compile and cargo semver checks.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,6 +218,21 @@ jobs:
       - name: cargo test (debug; all features; -Z minimal-versions)
         run: cargo -Z minimal-versions test --all-features
 
+  cross:
+    name: Check cross compilation targets
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+      - run: cross build --target i686-unknown-linux-gnu
+
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,18 @@ jobs:
         uses: taiki-e/install-action@cross
       - run: cross build --target i686-unknown-linux-gnu
 
+  semver:
+    name: Check semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   format:
     name: Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
This branch brings over the 32-bit cross compilation step and the cargo semver check step from `main` into the `rel-0.21` feature branch.