### PR TITLE
Remove MSRV variant of connect-tests

### DIFF
--- a/.github/workflows/connect-tests.yml
+++ b/.github/workflows/connect-tests.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
   schedule:
-    # We only run connectivity tests on a weekly basis, choosing a weekday and
+    # We run connectivity tests on a daily basis, choosing a
     # a time slightly offset from the top of the hour.
-    - cron: '15 12 * * 3'
+    - cron: '15 18 * * *'
 
 jobs:
   build:
@@ -20,7 +20,6 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.60" # MSRV
         os: [ubuntu-20.04]
         # but only stable on macos/windows (slower platforms)
         include:


### PR DESCRIPTION
MSRV is important (an tested separately) for the core crate (and its dependencies) but doesn't apply to test code.

Run these daily to notice any breakage earlier.

(Currently this is broken due to env_logger -> is-terminal -> rustix -> linux-raw-sys requiring 1.63 -- see https://github.com/rustls/rustls/actions/runs/5531529915/jobs/10092344273 )