### PR TITLE
client::builder: fix PhantomData clippy lint

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -42,7 +42,7 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
                 versions: self.state.versions,
                 verifier,
             },
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 }


### PR DESCRIPTION
New lint in rust 1.71 released today. I think we've addressed some others of these when it landed in nightly, but this lint is only a warning there - https://github.com/rustls/rustls/actions/runs/5534907687/jobs/10100494233