### PR TITLE
Correct unnecessarily &mut function args

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,10 +277,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --package rustls --all-features -- --deny warnings
-      - run: cargo clippy --package rustls --no-default-features -- --deny warnings
-      - run: cargo clippy --manifest-path=connect-tests/Cargo.toml --all-features -- --deny warnings
-      - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features -- --deny warnings
+      - run: cargo clippy --package rustls --all-features -- --deny warnings --allow unknown-lints
+      - run: cargo clippy --package rustls --no-default-features -- --deny warnings --allow unknown-lints
+      - run: cargo clippy --manifest-path=connect-tests/Cargo.toml --all-features -- --deny warnings --allow unknown-lints
+      - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features -- --deny warnings --allow unknown-lints
 
   clippy-nightly:
     name: Clippy (Nightly)

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -952,7 +952,7 @@ struct ExpectFinished {
 
 impl ExpectFinished {
     // -- Waiting for their finished --
-    fn save_session(&mut self, cx: &mut ClientContext<'_>) {
+    fn save_session(&mut self, cx: &ClientContext<'_>) {
         // Save a ticket.  If we got a new ticket, save that.  Otherwise, save the
         // original ticket again.
         let (mut ticket, lifetime) = match self.ticket.take() {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -598,6 +598,7 @@ mod client_hello {
         common.send_msg(m, false);
     }
 
+    #[allow(clippy::needless_pass_by_ref_mut)] // cx only mutated if cfg(feature = "quic")
     fn decide_if_early_data_allowed(
         cx: &mut ServerContext<'_>,
         client_hello: &ClientHelloPayload,


### PR DESCRIPTION
As of just now, nightly clippy is pointing out these arguments don't need to be `&mut`:

```
warning: this argument is a mutable reference, but not used mutably
   --> rustls/src/client/tls12.rs:955:36
    |
955 |     fn save_session(&mut self, cx: &mut ClientContext<'_>) {
    |                                    ^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&ClientContext<'_>`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
    = note: `#[warn(clippy::needless_pass_by_ref_mut)]` on by default

warning: this argument is a mutable reference, but not used mutably
   --> rustls/src/server/tls13.rs:602:13
    |
602 |         cx: &mut ServerContext<'_>,
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&ServerContext<'_>`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut

warning: `rustls` (lib) generated 2 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s

```