### PR TITLE
verifier: use (stateless) builder API for client verifier.

### DIFF
--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -11,7 +11,7 @@ use rustls::OwnedTrustAnchor;
 
 fn main() {
     let mut root_store = rustls::RootCertStore::empty();
-    root_store.add_server_trust_anchors(
+    root_store.add_trust_anchors(
         webpki_roots::TLS_SERVER_ROOTS
             .iter()
             .map(|ta| {

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -60,7 +60,7 @@ fn main() {
     env_logger::init();
 
     let mut root_store = RootCertStore::empty();
-    root_store.add_server_trust_anchors(
+    root_store.add_trust_anchors(
         webpki_roots::TLS_SERVER_ROOTS
             .iter()
             .map(|ta| {

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -17,7 +17,7 @@ use rustls::{OwnedTrustAnchor, RootCertStore};
 
 fn main() {
     let mut root_store = RootCertStore::empty();
-    root_store.add_server_trust_anchors(
+    root_store.add_trust_anchors(
         webpki_roots::TLS_SERVER_ROOTS
             .iter()
             .map(|ta| {

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -380,7 +380,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig<Ring>> {
         let mut reader = BufReader::new(certfile);
         root_store.add_parsable_certificates(rustls_pemfile::certs(&mut reader).unwrap());
     } else {
-        root_store.add_server_trust_anchors(
+        root_store.add_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS
                 .iter()
                 .map(|ta| {

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -576,12 +576,12 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig<Ring>> {
         }
         let crls = load_crls(&args.flag_crl);
         if args.flag_require_auth {
-            WebPkiClientVerifier::builder(client_auth_roots)
+            WebPkiClientVerifier::builder(client_auth_roots.into())
                 .with_crls(crls)
                 .build()
                 .unwrap()
         } else {
-            WebPkiClientVerifier::builder(client_auth_roots)
+            WebPkiClientVerifier::builder(client_auth_roots.into())
                 .with_crls(crls)
                 .allow_unauthenticated()
                 .build()

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -303,7 +303,7 @@ fn make_server_config(
             for root in roots {
                 client_auth_roots.add(&root).unwrap();
             }
-            WebPkiClientVerifier::builder(client_auth_roots.clone())
+            WebPkiClientVerifier::builder(client_auth_roots.into())
                 .build()
                 .unwrap()
         }

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -13,9 +13,7 @@ use std::time::{Duration, Instant};
 
 use rustls::client::Resumption;
 use rustls::crypto::ring::Ring;
-use rustls::server::{
-    AllowAnyAuthenticatedClient, NoClientAuth, NoServerSessionStorage, ServerSessionMemoryCache,
-};
+use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::RootCertStore;
 use rustls::Ticketer;
 use rustls::{ClientConfig, ClientConnection};
@@ -305,9 +303,11 @@ fn make_server_config(
             for root in roots {
                 client_auth_roots.add(&root).unwrap();
             }
-            Arc::new(AllowAnyAuthenticatedClient::new(client_auth_roots))
+            WebPkiClientVerifier::builder(client_auth_roots.clone())
+                .build()
+                .unwrap()
         }
-        ClientAuth::No => NoClientAuth::boxed(),
+        ClientAuth::No => WebPkiClientVerifier::no_client_auth(),
     };
 
     let mut cfg = ServerConfig::builder()

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -388,7 +388,7 @@ fn make_server_cfg(opts: &Options) -> Arc<ServerConfig<Ring>> {
                 mandatory: opts.require_any_client_cert,
             })
         } else {
-            server::NoClientAuth::boxed()
+            server::WebPkiClientVerifier::no_client_auth()
         };
 
     let cert = load_cert(&opts.cert_file);

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -110,10 +110,7 @@ impl RootCertStore {
 
     /// Adds all the given TrustAnchors `anchors`.  This does not
     /// fail.
-    pub fn add_server_trust_anchors(
-        &mut self,
-        trust_anchors: impl Iterator<Item = OwnedTrustAnchor>,
-    ) {
+    pub fn add_trust_anchors(&mut self, trust_anchors: impl Iterator<Item = OwnedTrustAnchor>) {
         self.roots.extend(trust_anchors);
     }
 

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -24,7 +24,7 @@ impl<C: CryptoProvider> ConfigBuilder<ClientConfig<C>, WantsVerifier<C>> {
                 cipher_suites: self.state.cipher_suites,
                 kx_groups: self.state.kx_groups,
                 versions: self.state.versions,
-                verifier: Arc::new(verify::WebPkiVerifier::new(root_store)),
+                verifier: Arc::new(verify::WebPkiServerVerifier::new(root_store)),
             },
             side: PhantomData,
         }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -432,7 +432,7 @@ pub mod client {
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::verify::{
         verify_server_cert_signed_by_trust_anchor, verify_server_name, HandshakeSignatureValid,
-        ServerCertVerified, ServerCertVerifier, WebPkiVerifier,
+        ServerCertVerified, ServerCertVerifier, WebPkiServerVerifier,
     };
     #[cfg(feature = "dangerous_configuration")]
     pub use client_conn::danger::DangerousClientConfig;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -103,7 +103,7 @@
 //!
 //! ```rust,no_run
 //! let mut root_store = rustls::RootCertStore::empty();
-//! root_store.add_server_trust_anchors(
+//! root_store.add_trust_anchors(
 //!     webpki_roots::TLS_SERVER_ROOTS
 //!         .iter()
 //!         .map(|ta| {
@@ -135,7 +135,7 @@
 //! # use webpki;
 //! # use std::sync::Arc;
 //! # let mut root_store = rustls::RootCertStore::empty();
-//! # root_store.add_server_trust_anchors(
+//! # root_store.add_trust_anchors(
 //! #  webpki_roots::TLS_SERVER_ROOTS
 //! #      .iter()
 //! #      .map(|ta| {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -453,11 +453,9 @@ pub mod server {
     #[cfg(feature = "tls12")]
     mod tls12;
     mod tls13;
+    pub(crate) mod verifier_builder;
 
-    pub use crate::verify::{
-        AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
-        UnparsedCertRevocationList,
-    };
+    pub use crate::verify::{UnparsedCertRevocationList, WebPkiClientVerifier};
     pub use builder::WantsServerCert;
     pub use handy::ResolvesServerCertUsingSni;
     pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
@@ -466,6 +464,7 @@ pub mod server {
         Accepted, Acceptor, ReadEarlyData, ServerConfig, ServerConnection, ServerConnectionData,
     };
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
+    pub use verifier_builder::{ClientCertVerifierBuilder, ClientCertVerifierBuilderError};
 
     #[cfg(feature = "dangerous_configuration")]
     pub use crate::dns_name::DnsName;

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -5,7 +5,7 @@ use crate::key;
 use crate::server::handy;
 use crate::server::{ResolvesServerCert, ServerConfig};
 use crate::suites::SupportedCipherSuite;
-use crate::verify;
+use crate::verify::{self, WebPkiClientVerifier};
 use crate::versions;
 use crate::NoKeyLog;
 
@@ -31,7 +31,7 @@ impl<C: CryptoProvider> ConfigBuilder<ServerConfig<C>, WantsVerifier<C>> {
 
     /// Disable client authentication.
     pub fn with_no_client_auth(self) -> ConfigBuilder<ServerConfig<C>, WantsServerCert<C>> {
-        self.with_client_cert_verifier(verify::NoClientAuth::boxed())
+        self.with_client_cert_verifier(WebPkiClientVerifier::no_client_auth())
     }
 }
 

--- a/rustls/src/server/verifier_builder.rs
+++ b/rustls/src/server/verifier_builder.rs
@@ -30,7 +30,7 @@ impl ClientCertVerifierBuilder {
     /// on the builder.
     pub fn with_roots(mut self, roots: RootCertStore) -> Self {
         self.roots
-            .add_server_trust_anchors(roots.roots.into_iter());
+            .add_trust_anchors(roots.roots.into_iter());
         self
     }
 

--- a/rustls/src/server/verifier_builder.rs
+++ b/rustls/src/server/verifier_builder.rs
@@ -1,0 +1,269 @@
+use std::sync::Arc;
+
+use crate::server::UnparsedCertRevocationList;
+use crate::verify::{AnonymousClientPolicy, ClientCertVerifier, WebPkiClientVerifier};
+use crate::{CertRevocationListError, RootCertStore};
+
+/// A builder for configuring a `webpki` client certificate verifier.
+///
+/// For more information, see the [`WebPkiClientVerifier`] documentation.
+#[derive(Debug, Clone)]
+pub struct ClientCertVerifierBuilder {
+    roots: RootCertStore,
+    crls: Vec<UnparsedCertRevocationList>,
+    anon_policy: AnonymousClientPolicy,
+}
+
+impl ClientCertVerifierBuilder {
+    pub(crate) fn new(roots: RootCertStore) -> Self {
+        Self {
+            roots,
+            crls: Vec::new(),
+            anon_policy: AnonymousClientPolicy::Deny,
+        }
+    }
+
+    /// Add additional `roots` to use to verify client certificates.
+    ///
+    /// All clients must provide a client certificate unless you have allowed unauthenticated
+    /// clients by calling [allow_unauthenticated()][ClientCertVerifierBuilder::allow_unauthenticated]
+    /// on the builder.
+    pub fn with_roots(mut self, roots: RootCertStore) -> Self {
+        self.roots
+            .add_server_trust_anchors(roots.roots.into_iter());
+        self
+    }
+
+    /// Verify the revocation state of presented client certificates against the provided
+    /// certificate revocation lists (CRLs). Calling `with_crls` multiple times appends the
+    /// given CRLs to the existing collection.
+    pub fn with_crls(mut self, crls: impl IntoIterator<Item = UnparsedCertRevocationList>) -> Self {
+        self.crls.extend(crls);
+        self
+    }
+
+    /// Allow unauthenticated clients to connect.
+    ///
+    /// Clients that offer a client certificate issued by a trusted root, and clients that offer no
+    /// client certificate will be allowed to connect.
+    pub fn allow_unauthenticated(mut self) -> Self {
+        self.anon_policy = AnonymousClientPolicy::Allow;
+        self
+    }
+
+    /// Build a client certificate verifier. The built verifier will be used for the server to offer
+    /// client certificate authentication, to control how offered client certificates are validated,
+    /// and to determine what to do with anonymous clients that do not respond to the client
+    /// certificate authentication offer with a client certificate.
+    ///
+    /// Once built, the provided `Arc<dyn ClientCertVerifier>` can be used with a Rustls
+    /// [crate::server::ServerConfig] to configure client certificate validation using
+    /// [`with_client_cert_verifier`][crate::ConfigBuilder<ClientConfig, WantsVerifier>::with_client_cert_verifier].
+    ///
+    /// # Errors
+    /// This function will return a `ClientCertVerifierBuilderError` if:
+    /// 1. No trust anchors have been provided.
+    /// 2. DER encoded CRLs have been provided that can not be parsed successfully.
+    pub fn build(self) -> Result<Arc<dyn ClientCertVerifier>, ClientCertVerifierBuilderError> {
+        if self.roots.is_empty() {
+            return Err(ClientCertVerifierBuilderError::NoRootAnchors);
+        }
+
+        Ok(Arc::new(WebPkiClientVerifier::new(
+            self.roots,
+            self.crls
+                .into_iter()
+                .map(|der_crl| der_crl.parse())
+                .collect::<Result<Vec<_>, CertRevocationListError>>()?,
+            self.anon_policy,
+        )))
+    }
+}
+
+/// One or more root trust anchors must be provided to create a [ClientCertVerifierBuilder].
+/// If you wish to disable client authentication, then use [WebPkiClientVerifier::no_client_auth]
+/// instead of constructing a builder.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum ClientCertVerifierBuilderError {
+    /// No root trust anchors were provided.
+    NoRootAnchors,
+    /// A provided CRL could not be parsed.
+    InvalidCrl(CertRevocationListError),
+}
+
+impl From<CertRevocationListError> for ClientCertVerifierBuilderError {
+    fn from(value: CertRevocationListError) -> Self {
+        Self::InvalidCrl(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::server::{ClientCertVerifierBuilderError, UnparsedCertRevocationList};
+    use crate::verify::WebPkiClientVerifier;
+    use crate::{Certificate, RootCertStore};
+
+    fn load_crls(crls_der: &[&[u8]]) -> Vec<UnparsedCertRevocationList> {
+        crls_der
+            .iter()
+            .map(|pem_bytes| {
+                UnparsedCertRevocationList(
+                    rustls_pemfile::crls(&mut &pem_bytes[..])
+                        .unwrap()
+                        .first()
+                        .unwrap()
+                        .to_vec(),
+                )
+            })
+            .collect()
+    }
+
+    fn test_crls() -> Vec<UnparsedCertRevocationList> {
+        load_crls(&[
+            include_bytes!("../../../test-ca/ecdsa/client.revoked.crl.pem").as_slice(),
+            include_bytes!("../../../test-ca/rsa/client.revoked.crl.pem").as_slice(),
+        ])
+    }
+
+    fn load_roots(roots_der: &[&[u8]]) -> RootCertStore {
+        let mut roots = RootCertStore::empty();
+        roots_der.iter().for_each(|der| {
+            roots
+                .add(&Certificate(der.to_vec()))
+                .unwrap()
+        });
+        roots
+    }
+
+    fn test_roots() -> RootCertStore {
+        load_roots(&[
+            include_bytes!("../../../test-ca/ecdsa/ca.der").as_slice(),
+            include_bytes!("../../../test-ca/rsa/ca.der").as_slice(),
+        ])
+    }
+
+    #[test]
+    fn test_noauth() {
+        // We should be able to build a verifier that turns off client authentication.
+        WebPkiClientVerifier::no_client_auth();
+    }
+
+    #[test]
+    fn test_required_auth() {
+        // We should be able to build a verifier that requires client authentication, and does
+        // no revocation checking.
+        let builder = WebPkiClientVerifier::builder(test_roots());
+        // The builder should be Debug.
+        println!("{:?}", builder);
+        builder.build().unwrap();
+    }
+
+    #[test]
+    fn test_required_auth_add_roots() {
+        // We should be able to call `with_roots` to add more roots.
+        let initial_roots = test_roots();
+        let extra_roots = load_roots(&[include_bytes!("../../../test-ca/eddsa/ca.der").as_slice()]);
+        let builder =
+            WebPkiClientVerifier::builder(initial_roots.clone()).with_roots(extra_roots.clone());
+        // The builder should be Debug.
+        println!("{:?}", builder);
+        // There should be the expected number of roots.
+        assert_eq!(builder.roots.len(), initial_roots.len() + extra_roots.len());
+        builder.build().unwrap();
+    }
+
+    #[test]
+    fn test_optional_auth() {
+        // We should be able to build a verifier that allows client authentication, and anonymous
+        // access, and does no revocation checking.
+        let builder = WebPkiClientVerifier::builder(test_roots()).allow_unauthenticated();
+        // The builder should be Debug.
+        println!("{:?}", builder);
+        builder.build().unwrap();
+    }
+
+    #[test]
+    fn test_without_crls_required_auth() {
+        // We should be able to build a verifier that requires client authentication, and does
+        // no revocation checking, that hasn't been configured to determine how to handle
+        // unauthenticated clients yet.
+        let builder = WebPkiClientVerifier::builder(test_roots());
+        // The builder should be Debug.
+        println!("{:?}", builder);
+        builder.build().unwrap();
+    }
+
+    #[test]
+    fn test_without_crls_opptional_auth() {
+        // We should be able to build a verifier that allows client authentication,
+        // and anonymous access, that does no revocation checking.
+        let builder = WebPkiClientVerifier::builder(test_roots()).allow_unauthenticated();
+        // The builder should be Debug.
+        println!("{:?}", builder);
+        builder.build().unwrap();
+    }
+
+    #[test]
+    fn test_with_invalid_crls() {
+        // Trying to build a verifier with invalid CRLs should error at build time.
+        let result = WebPkiClientVerifier::builder(test_roots())
+            .with_crls(vec![UnparsedCertRevocationList(vec![0xFF])])
+            .build();
+        assert!(matches!(
+            result,
+            Err(ClientCertVerifierBuilderError::InvalidCrl(_))
+        ));
+    }
+
+    #[test]
+    fn test_with_crls_multiple_calls() {
+        // We should be able to call `with_crls` multiple times.
+        let initial_crls = test_crls();
+        let extra_crls =
+            load_crls(&[
+                include_bytes!("../../../test-ca/eddsa/client.revoked.crl.pem").as_slice(),
+            ]);
+        let builder = WebPkiClientVerifier::builder(test_roots())
+            .with_crls(initial_crls.clone())
+            .with_crls(extra_crls.clone());
+
+        // There should be the expected number of crls.
+        assert_eq!(builder.crls.len(), initial_crls.len() + extra_crls.len());
+        // The builder should be Debug.
+        println!("{:?}", builder);
+        builder.build().unwrap();
+    }
+
+    #[test]
+    fn test_with_crls_required_auth_implicit() {
+        // We should be able to build a verifier that requires client authentication, and that does
+        // revocation checking with CRLs, and that does not allow any anonymous access.
+        let builder = WebPkiClientVerifier::builder(test_roots()).with_crls(test_crls());
+        // The builder should be Debug.
+        println!("{:?}", builder);
+        builder.build().unwrap();
+    }
+
+    #[test]
+    fn test_with_crls_optional_auth() {
+        // We should be able to build a verifier that supports client authentication, that does
+        // revocation checking with CRLs, and that allows anonymous access.
+        let builder = WebPkiClientVerifier::builder(test_roots())
+            .with_crls(test_crls())
+            .allow_unauthenticated();
+        // The builder should be Debug.
+        println!("{:?}", builder);
+        builder.build().unwrap();
+    }
+
+    #[test]
+    fn test_builder_no_roots() {
+        // Trying to create a builder with no trust anchors should fail at build time
+        let result = WebPkiClientVerifier::builder(RootCertStore::empty()).build();
+        assert!(matches!(
+            result,
+            Err(ClientCertVerifierBuilderError::NoRootAnchors)
+        ));
+    }
+}

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -181,7 +181,7 @@ pub trait ServerCertVerifier: Send + Sync {
     /// This trait method has a default implementation that reflects the schemes
     /// supported by webpki.
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        WebPkiVerifier::verification_schemes()
+        WebPkiServerVerifier::verification_schemes()
     }
 }
 
@@ -299,7 +299,7 @@ pub trait ClientCertVerifier: Send + Sync {
     /// This trait method has a default implementation that reflects the schemes
     /// supported by webpki.
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        WebPkiVerifier::verification_schemes()
+        WebPkiServerVerifier::verification_schemes()
     }
 }
 
@@ -370,7 +370,7 @@ pub fn verify_server_name(cert: &ParsedCertificate, server_name: &ServerName) ->
     Ok(())
 }
 
-impl ServerCertVerifier for WebPkiVerifier {
+impl ServerCertVerifier for WebPkiServerVerifier {
     /// Will verify the certificate is valid in the following ways:
     /// - Signed by a  trusted `RootCertStore` CA
     /// - Not Expired
@@ -399,12 +399,12 @@ impl ServerCertVerifier for WebPkiVerifier {
 /// Default `ServerCertVerifier`, see the trait impl for more information.
 #[allow(unreachable_pub)]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
-pub struct WebPkiVerifier {
+pub struct WebPkiServerVerifier {
     roots: RootCertStore,
 }
 
 #[allow(unreachable_pub)]
-impl WebPkiVerifier {
+impl WebPkiServerVerifier {
     /// Constructs a new `WebPkiVerifier`.
     ///
     /// `roots` is the set of trust anchors to trust for issuing server certs.

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -471,7 +471,7 @@ impl UnparsedCertRevocationList {
 /// # use rustls::RootCertStore;
 /// # use rustls::server::WebPkiClientVerifier;
 /// # let roots = RootCertStore::empty();
-/// let client_verifier = WebPkiClientVerifier::builder(roots)
+/// let client_verifier = WebPkiClientVerifier::builder(roots.into())
 ///   .build()
 ///   .unwrap();
 /// ```
@@ -482,7 +482,7 @@ impl UnparsedCertRevocationList {
 /// # use rustls::RootCertStore;
 /// # use rustls::server::WebPkiClientVerifier;
 /// # let roots = RootCertStore::empty();
-/// let client_verifier = WebPkiClientVerifier::builder(roots)
+/// let client_verifier = WebPkiClientVerifier::builder(roots.into())
 ///   .allow_unauthenticated()
 ///   .build()
 ///   .unwrap();
@@ -503,7 +503,7 @@ impl UnparsedCertRevocationList {
 /// # use rustls::server::{WebPkiClientVerifier};
 /// # let roots = RootCertStore::empty();
 /// # let crls = Vec::new();
-/// let client_verifier = WebPkiClientVerifier::builder(roots)
+/// let client_verifier = WebPkiClientVerifier::builder(roots.into())
 ///   .with_crls(crls)
 ///   .build()
 ///   .unwrap();
@@ -511,7 +511,7 @@ impl UnparsedCertRevocationList {
 ///
 /// [^1]: <https://github.com/rustls/webpki>
 pub struct WebPkiClientVerifier {
-    roots: RootCertStore,
+    roots: Arc<RootCertStore>,
     subjects: Vec<DistinguishedName>,
     crls: Vec<webpki::OwnedCertRevocationList>,
     anonymous_policy: AnonymousClientPolicy,
@@ -524,7 +524,7 @@ impl WebPkiClientVerifier {
     /// wish to disable client authentication use [WebPkiClientVerifier::no_client_auth()] instead.
     ///
     /// For more information, see the [`ClientCertVerifierBuilder`] documentation.
-    pub fn builder(roots: RootCertStore) -> ClientCertVerifierBuilder {
+    pub fn builder(roots: Arc<RootCertStore>) -> ClientCertVerifierBuilder {
         ClientCertVerifierBuilder::new(roots)
     }
 
@@ -545,7 +545,7 @@ impl WebPkiClientVerifier {
     /// `anonymous_policy` controls whether client authentication is required, or if anonymous
     /// clients can connect.
     pub(crate) fn new(
-        roots: RootCertStore,
+        roots: Arc<RootCertStore>,
         crls: Vec<webpki::OwnedCertRevocationList>,
         anonymous_policy: AnonymousClientPolicy,
     ) -> Self {

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -1,4 +1,6 @@
+use alloc::sync::Arc;
 use core::fmt;
+use std::time::SystemTime;
 
 use crate::anchors::{OwnedTrustAnchor, RootCertStore};
 use crate::client::ServerName;
@@ -12,11 +14,9 @@ use crate::log::trace;
 use crate::msgs::base::PayloadU16;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::handshake::DistinguishedName;
+use crate::server::ClientCertVerifierBuilder;
 
 use ring::digest::Digest;
-
-use alloc::sync::Arc;
-use std::time::SystemTime;
 
 type SignatureAlgorithms = &'static [&'static dyn webpki::SignatureVerificationAlgorithm];
 
@@ -445,6 +445,7 @@ fn trust_roots(roots: &RootCertStore) -> Vec<webpki::TrustAnchor> {
 }
 
 /// An unparsed DER encoded Certificate Revocation List (CRL).
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct UnparsedCertRevocationList(pub Vec<u8>);
 
 impl UnparsedCertRevocationList {
@@ -457,58 +458,120 @@ impl UnparsedCertRevocationList {
     }
 }
 
-/// A `ClientCertVerifier` that will ensure that every client provides a trusted
-/// certificate, without any name checking. Optionally, client certificates will
-/// have their revocation status checked using the DER encoded CRLs provided.
-pub struct AllowAnyAuthenticatedClient {
+/// A client certificate verifier that uses the `webpki` crate[^1] to perform client certificate
+/// validation. It must be created via the [WebPkiClientVerifier::builder()] function.
+///
+/// Once built, the provided `Arc<dyn ClientCertVerifier>` can be used with a Rustls [crate::server::ServerConfig]
+/// to configure client certificate validation using [`with_client_cert_verifier`][crate::ConfigBuilder<ClientConfig, WantsVerifier>::with_client_cert_verifier].
+///
+/// Example:
+///
+/// To require all clients present a client certificate issued by a trusted CA:
+/// ```no_run
+/// # use rustls::RootCertStore;
+/// # use rustls::server::WebPkiClientVerifier;
+/// # let roots = RootCertStore::empty();
+/// let client_verifier = WebPkiClientVerifier::builder(roots)
+///   .build()
+///   .unwrap();
+/// ```
+///
+/// Or, to allow clients presenting a client certificate authenticated by a trusted CA, or
+/// anonymous clients that present no client certificate:
+/// ```no_run
+/// # use rustls::RootCertStore;
+/// # use rustls::server::WebPkiClientVerifier;
+/// # let roots = RootCertStore::empty();
+/// let client_verifier = WebPkiClientVerifier::builder(roots)
+///   .allow_unauthenticated()
+///   .build()
+///   .unwrap();
+/// ```
+///
+/// If you wish to disable advertising client authentication:
+/// ```no_run
+/// # use rustls::RootCertStore;
+/// # use rustls::server::WebPkiClientVerifier;
+/// # let roots = RootCertStore::empty();
+/// let client_verifier = WebPkiClientVerifier::no_client_auth();
+/// ```
+///
+/// You can also configure the client verifier to check for certificate revocation with
+/// client certificate revocation lists (CRLs):
+/// ```no_run
+/// # use rustls::RootCertStore;
+/// # use rustls::server::{WebPkiClientVerifier};
+/// # let roots = RootCertStore::empty();
+/// # let crls = Vec::new();
+/// let client_verifier = WebPkiClientVerifier::builder(roots)
+///   .with_crls(crls)
+///   .build()
+///   .unwrap();
+/// ```
+///
+/// [^1]: <https://github.com/rustls/webpki>
+pub struct WebPkiClientVerifier {
     roots: RootCertStore,
     subjects: Vec<DistinguishedName>,
     crls: Vec<webpki::OwnedCertRevocationList>,
+    anonymous_policy: AnonymousClientPolicy,
 }
 
-impl AllowAnyAuthenticatedClient {
-    /// Construct a new `AllowAnyAuthenticatedClient`.
+impl WebPkiClientVerifier {
+    /// Create builder to build up the `webpki` client certificate verifier configuration.
+    /// Client certificate authentication will be offered by the server, and client certificates
+    /// will be verified using the trust anchors found in the provided `roots`. If you
+    /// wish to disable client authentication use [WebPkiClientVerifier::no_client_auth()] instead.
+    ///
+    /// For more information, see the [`ClientCertVerifierBuilder`] documentation.
+    pub fn builder(roots: RootCertStore) -> ClientCertVerifierBuilder {
+        ClientCertVerifierBuilder::new(roots)
+    }
+
+    /// Create a new `WebPkiClientVerifier` that disables client authentication. The server will
+    /// not offer client authentication and anonymous clients will be accepted.
+    ///
+    /// This is in contrast to using `WebPkiClientVerifier::builder().allow_unauthenticated().build()`,
+    /// which will produce a verifier that will offer client authentication, but not require it.
+    pub fn no_client_auth() -> Arc<dyn ClientCertVerifier> {
+        Arc::new(NoClientAuth {})
+    }
+
+    /// Construct a new `WebpkiClientVerifier`.
     ///
     /// `roots` is the list of trust anchors to use for certificate validation.
-    pub fn new(roots: RootCertStore) -> Self {
+    /// `crls` are an iterable of owned certificate revocation lists (CRLs) to use for
+    /// client certificate validation.
+    /// `anonymous_policy` controls whether client authentication is required, or if anonymous
+    /// clients can connect.
+    pub(crate) fn new(
+        roots: RootCertStore,
+        crls: Vec<webpki::OwnedCertRevocationList>,
+        anonymous_policy: AnonymousClientPolicy,
+    ) -> Self {
         Self {
             subjects: roots
                 .roots
                 .iter()
                 .map(|r| r.subject().clone())
                 .collect(),
-            crls: Vec::new(),
+            crls,
             roots,
+            anonymous_policy,
         }
-    }
-
-    /// Update the verifier to validate client certificates against the provided DER format
-    /// unparsed certificate revocation lists (CRLs).
-    pub fn with_crls(
-        self,
-        crls: impl IntoIterator<Item = UnparsedCertRevocationList>,
-    ) -> Result<Self, CertRevocationListError> {
-        Ok(Self {
-            crls: crls
-                .into_iter()
-                .map(|der_crl| der_crl.parse())
-                .collect::<Result<Vec<_>, CertRevocationListError>>()?,
-            ..self
-        })
-    }
-
-    /// Wrap this verifier in an [`Arc`] and coerce it to `dyn ClientCertVerifier`
-    #[inline(always)]
-    pub fn boxed(self) -> Arc<dyn ClientCertVerifier> {
-        // This function is needed because `ClientCertVerifier` is only reachable if the
-        // `dangerous_configuration` feature is enabled, which makes coercing hard to outside users
-        Arc::new(self)
     }
 }
 
-impl ClientCertVerifier for AllowAnyAuthenticatedClient {
+impl ClientCertVerifier for WebPkiClientVerifier {
     fn offer_client_auth(&self) -> bool {
         true
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        match self.anonymous_policy {
+            AnonymousClientPolicy::Allow => false,
+            AnonymousClientPolicy::Deny => true,
+        }
     }
 
     fn client_auth_root_subjects(&self) -> &[DistinguishedName] {
@@ -558,68 +621,13 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
     }
 }
 
-/// A `ClientCertVerifier` that will allow both anonymous and authenticated
-/// clients, without any name checking.
-///
-/// Client authentication will be requested during the TLS handshake. If the
-/// client offers a certificate then this acts like
-/// `AllowAnyAuthenticatedClient`, otherwise this acts like `NoClientAuth`.
-pub struct AllowAnyAnonymousOrAuthenticatedClient {
-    inner: AllowAnyAuthenticatedClient,
-}
-
-impl AllowAnyAnonymousOrAuthenticatedClient {
-    /// Construct a new `AllowAnyAnonymousOrAuthenticatedClient`.
-    ///
-    /// `roots` is the list of trust anchors to use for certificate validation.
-    pub fn new(roots: RootCertStore) -> Self {
-        Self {
-            inner: AllowAnyAuthenticatedClient::new(roots),
-        }
-    }
-
-    /// Update the verifier to validate client certificates against the provided DER format
-    /// unparsed certificate revocation lists (CRLs).
-    pub fn with_crls(
-        self,
-        crls: impl IntoIterator<Item = UnparsedCertRevocationList>,
-    ) -> Result<Self, CertRevocationListError> {
-        Ok(Self {
-            inner: self.inner.with_crls(crls)?,
-        })
-    }
-
-    /// Wrap this verifier in an [`Arc`] and coerce it to `dyn ClientCertVerifier`
-    #[inline(always)]
-    pub fn boxed(self) -> Arc<dyn ClientCertVerifier> {
-        // This function is needed because `ClientCertVerifier` is only reachable if the
-        // `dangerous_configuration` feature is enabled, which makes coercing hard to outside users
-        Arc::new(self)
-    }
-}
-
-impl ClientCertVerifier for AllowAnyAnonymousOrAuthenticatedClient {
-    fn offer_client_auth(&self) -> bool {
-        self.inner.offer_client_auth()
-    }
-
-    fn client_auth_mandatory(&self) -> bool {
-        false
-    }
-
-    fn client_auth_root_subjects(&self) -> &[DistinguishedName] {
-        self.inner.client_auth_root_subjects()
-    }
-
-    fn verify_client_cert(
-        &self,
-        end_entity: &Certificate,
-        intermediates: &[Certificate],
-        now: SystemTime,
-    ) -> Result<ClientCertVerified, Error> {
-        self.inner
-            .verify_client_cert(end_entity, intermediates, now)
-    }
+/// Controls how the [WebPkiClientVerifier] handles anonymous clients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AnonymousClientPolicy {
+    /// Clients that do not present a client certificate are allowed.
+    Allow,
+    /// Clients that do not present a client certificate are denied.
+    Deny,
 }
 
 pub(crate) fn pki_error(error: webpki::Error) -> Error {
@@ -647,19 +655,11 @@ pub(crate) fn pki_error(error: webpki::Error) -> Error {
     }
 }
 
-/// Turns off client authentication.
-pub struct NoClientAuth;
-
-impl NoClientAuth {
-    /// Construct a [`NoClientAuth`], wrap it in an [`Arc`] and coerce it to
-    /// `dyn ClientCertVerifier`.
-    #[inline(always)]
-    pub fn boxed() -> Arc<dyn ClientCertVerifier> {
-        // This function is needed because `ClientCertVerifier` is only reachable if the
-        // `dangerous_configuration` feature is enabled, which makes coercing hard to outside users
-        Arc::new(Self)
-    }
-}
+/// Turns off client authentication. In contrast to using
+/// `WebPkiClientVerifier::builder(roots).allow_unauthenticated().build()`, the `NoClientAuth`
+/// `ClientCertVerifier` will not offer client authentication at all, vs offering but not
+/// requiring it.
+pub(crate) struct NoClientAuth;
 
 impl ClientCertVerifier for NoClientAuth {
     fn offer_client_auth(&self) -> bool {

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -188,7 +188,7 @@ struct Context {
 impl Context {
     fn new(name: &'static str, domain: &'static str, certs: &[&'static [u8]]) -> Self {
         let mut roots = anchors::RootCertStore::empty();
-        roots.add_server_trust_anchors(
+        roots.add_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS
                 .iter()
                 .map(|ta| {

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -213,7 +213,7 @@ impl Context {
     }
 
     fn bench(&self, count: usize) {
-        let verifier = verify::WebPkiVerifier::new(self.roots.clone());
+        let verifier = verify::WebPkiServerVerifier::new(self.roots.clone());
         const OCSP_RESPONSE: &[u8] = &[];
         let mut times = Vec::new();
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -14,7 +14,7 @@ use rustls::crypto::ring::Ring;
 use rustls::crypto::CryptoProvider;
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
-use rustls::server::{AllowAnyAnonymousOrAuthenticatedClient, ClientHello, ResolvesServerCert};
+use rustls::server::{ClientHello, ResolvesServerCert, WebPkiClientVerifier};
 #[cfg(feature = "secret_extraction")]
 use rustls::ConnectionTrafficSecrets;
 use rustls::{
@@ -481,11 +481,14 @@ fn server_allow_any_anonymous_or_authenticated_client() {
     let kt = KeyType::Rsa;
     for client_cert_chain in [None, Some(kt.get_client_chain())].iter() {
         let client_auth_roots = get_client_root_store(kt);
-        let client_auth = AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots);
+        let client_auth = WebPkiClientVerifier::builder(client_auth_roots.clone())
+            .allow_unauthenticated()
+            .build()
+            .unwrap();
 
         let server_config = ServerConfig::<Ring>::builder()
             .with_safe_defaults()
-            .with_client_cert_verifier(Arc::new(client_auth))
+            .with_client_cert_verifier(client_auth)
             .with_single_cert(kt.get_chain(), kt.get_key())
             .unwrap();
         let server_config = Arc::new(server_config);

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -9,7 +9,7 @@ use crate::common::{
     make_client_config_with_versions, make_client_config_with_versions_with_auth,
     make_pair_for_arc_configs, server_name, ErrorFromPeer, KeyType, ALL_KEY_TYPES,
 };
-use rustls::client::WebPkiVerifier;
+use rustls::client::WebPkiServerVerifier;
 use rustls::crypto::ring::Ring;
 use rustls::internal::msgs::handshake::DistinguishedName;
 use rustls::server::{ClientCertVerified, ClientCertVerifier};
@@ -204,7 +204,7 @@ impl ClientCertVerifier for MockClientVerifier {
         if let Some(schemes) = &self.offered_schemes {
             schemes.clone()
         } else {
-            WebPkiVerifier::verification_schemes()
+            WebPkiServerVerifier::verification_schemes()
         }
     }
 }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -8,9 +8,7 @@ use rustls::crypto::ring::Ring;
 use rustls::crypto::CryptoProvider;
 use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, OpaqueMessage, PlainMessage};
-use rustls::server::{
-    AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, UnparsedCertRevocationList,
-};
+use rustls::server::{UnparsedCertRevocationList, WebPkiClientVerifier};
 use rustls::Connection;
 use rustls::Error;
 use rustls::RootCertStore;
@@ -306,13 +304,14 @@ pub fn make_server_config_with_mandatory_client_auth_crls(
 ) -> ServerConfig<Ring> {
     let client_auth_roots = get_client_root_store(kt);
 
-    let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots)
+    let client_auth = WebPkiClientVerifier::builder(client_auth_roots)
         .with_crls(crls)
+        .build()
         .unwrap();
 
     ServerConfig::builder()
         .with_safe_defaults()
-        .with_client_cert_verifier(Arc::new(client_auth))
+        .with_client_cert_verifier(client_auth)
         .with_single_cert(kt.get_chain(), kt.get_key())
         .unwrap()
 }
@@ -327,13 +326,15 @@ pub fn make_server_config_with_optional_client_auth(
 ) -> ServerConfig<Ring> {
     let client_auth_roots = get_client_root_store(kt);
 
-    let client_auth = AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots)
+    let client_auth = WebPkiClientVerifier::builder(client_auth_roots)
         .with_crls(crls)
+        .allow_unauthenticated()
+        .build()
         .unwrap();
 
     ServerConfig::builder()
         .with_safe_defaults()
-        .with_client_cert_verifier(Arc::new(client_auth))
+        .with_client_cert_verifier(client_auth)
         .with_single_cert(kt.get_chain(), kt.get_key())
         .unwrap()
 }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -287,7 +287,7 @@ pub fn make_server_config_with_kx_groups(
     )
 }
 
-pub fn get_client_root_store(kt: KeyType) -> RootCertStore {
+pub fn get_client_root_store(kt: KeyType) -> Arc<RootCertStore> {
     let mut roots = kt.get_chain();
     // drop server cert
     roots.drain(0..1);
@@ -295,7 +295,7 @@ pub fn get_client_root_store(kt: KeyType) -> RootCertStore {
     for root in roots {
         client_auth_roots.add(&root).unwrap();
     }
-    client_auth_roots
+    client_auth_roots.into()
 }
 
 pub fn make_server_config_with_mandatory_client_auth_crls(

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -8,7 +8,7 @@ use crate::common::{
     make_pair_for_arc_configs, make_server_config, ErrorFromPeer, ALL_KEY_TYPES,
 };
 use rustls::client::{
-    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, WebPkiVerifier,
+    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, WebPkiServerVerifier,
 };
 use rustls::DigitallySignedStruct;
 use rustls::{AlertDescription, Certificate, Error, InvalidMessage, SignatureScheme};
@@ -262,7 +262,7 @@ impl Default for MockServerVerifier {
             cert_rejection_error: None,
             tls12_signature_error: None,
             tls13_signature_error: None,
-            signature_schemes: WebPkiVerifier::verification_schemes(),
+            signature_schemes: WebPkiServerVerifier::verification_schemes(),
         }
     }
 }


### PR DESCRIPTION
**Note: this is an alternative implementation to https://github.com/rustls/rustls/pull/1365, that avoids using the [Typestate pattern](http://cliffle.com/blog/rust-typestate/).**

### verifier: use builder API for client verifier.

Previously users configuring a `ServerConfig` that wanted to use a webpki backed client certificate verifier had to make a choice of which concrete implementation to construct, and how to configure it (e.g. with trust anchors and CRLs). This made for a somewhat cumbersome experience.

In its place, this commit:

* Adds a `WebPkiClientVerifier` type that replace both the `AllowAnyAuthenticatedClient` and `AllowAnyAnonymousOrAuthenticatedClient` verifiers. The name emphasizes that the implementation is backed by `rustls/webpki` to help distinguish it from platform verifiers.

  The new type can only be constructed external to the crate using a `ClientCertVerifierBuilder` builder that walks the user through specifying roots, CRLs, and policy for anonymous clients.

* Turns the `NoClientAuth` verifier into a crate internal type that also only be constructed via the `ClientCertVerifierBuilder`.

* Removes the `boxed()` fn's of the above, since they won't be needed anymore - consumers will construct a `Arc<dyn ClientCertVerifier>` through the builder and don't need to have `ClientCertVerifier` in-scope via the dangerous config feature.

* Updates all existing usages in tests and examples to use the new builder API.

### anchors: add_server_trust_anchors -> add_trust_anchors

The `RootCertStore` type is used for both client and server trust anchors. This commit renames the `add_server_trust_anchors` method to be `add_trust_anchors` to reflect its general purpose.

### verify: WebPkiVerifier -> WebPkiServerVerifier.
In previous commits we reworked the primary implementation of the `ClientCertVerifier` trait to be named `WebPkiClientVerifier`.

This commit updates the corresponding `ServerCertVerifier` implementation in `WebPkiVerifier` to be named `WebPkiServerVerifier` to match the client naming scheme and to better emphasize its role.

### verify: take Arc<RootCertStore>.

As [pointed out by Jsha](https://github.com/rustls/rustls/issues/1360#issuecomment-1634705941), an implementation of the `Acceptor` API may want to create a verifier on something approaching a per-handshake basis in order to provide up-to-date CRLs and client trust anchors.

We can improve on the cost of this operation by allowing shared use of a `RootCertStore` across verifiers by wrapping it in an `Arc`.

This commit updates the `WebPkiClientVerifier`, and `ClientCertVerifierBuilder` to take a `Arc<RootCertStore>` instead of
`RootCertStore`. 

One side-effect of this change is the removal of the `add_roots` fn of the `ClientCertVerifierBuilder` - once we take an `Arc` we can't modify the backing `RootCertStore` without introducing some form of locking. I think the use-case for adding additional `RootCertStore`'s after constructing the builder is weak enough that we should drop that feature rather than introduce locking.
