### PR TITLE
Echo `session_id` in HRR

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -19,7 +19,7 @@ rustversion = { version = "1.0.6", optional = true }
 log = { version = "0.4.4", optional = true }
 ring = "0.16.20"
 subtle = "2.5.0"
-webpki = { package = "rustls-webpki", version = "0.101.0", features = ["alloc", "std"] }
+webpki = { package = "rustls-webpki", version = "0.101.2", features = ["alloc", "std"] }
 
 [features]
 default = ["logging", "tls12"]

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -744,6 +744,28 @@ impl<C: CryptoProvider> ExpectServerHelloOrHelloRetryRequest<C> {
             });
         }
 
+        // Or does not echo the session_id from our ClientHello:
+        //
+        // > the HelloRetryRequest has the same format as a ServerHello message,
+        // > and the legacy_version, legacy_session_id_echo, cipher_suite, and
+        // > legacy_compression_method fields have the same meaning
+        // <https://www.rfc-editor.org/rfc/rfc8446#section-4.1.4>
+        //
+        // and
+        //
+        // > A client which receives a legacy_session_id_echo field that does not
+        // > match what it sent in the ClientHello MUST abort the handshake with an
+        // > "illegal_parameter" alert.
+        // <https://www.rfc-editor.org/rfc/rfc8446#section-4.1.3>
+        if hrr.session_id != self.next.input.session_id {
+            return Err({
+                cx.common.send_fatal_alert(
+                    AlertDescription::IllegalParameter,
+                    PeerMisbehaved::IllegalHelloRetryRequestWithWrongSessionId,
+                )
+            });
+        }
+
         // Or asks us to talk a protocol we didn't offer, or doesn't support HRR at all.
         match hrr.get_supported_versions() {
             Some(ProtocolVersion::TLSv1_3) => {

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -180,6 +180,7 @@ pub enum PeerMisbehaved {
     IllegalHelloRetryRequestWithUnofferedCipherSuite,
     IllegalHelloRetryRequestWithUnofferedNamedGroup,
     IllegalHelloRetryRequestWithUnsupportedVersion,
+    IllegalHelloRetryRequestWithWrongSessionId,
     IllegalMiddleboxChangeCipherSpec,
     IllegalTlsInnerPlaintext,
     IncorrectBinder,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -236,6 +236,7 @@ mod client_hello {
                         emit_hello_retry_request(
                             &mut self.transcript,
                             self.suite,
+                            client_hello.session_id,
                             cx.common,
                             group.name(),
                         );
@@ -570,12 +571,13 @@ mod client_hello {
     fn emit_hello_retry_request(
         transcript: &mut HandshakeHash,
         suite: &'static Tls13CipherSuite,
+        session_id: SessionId,
         common: &mut CommonState,
         group: NamedGroup,
     ) {
         let mut req = HelloRetryRequest {
             legacy_version: ProtocolVersion::TLSv1_2,
-            session_id: SessionId::empty(),
+            session_id,
             cipher_suite: suite.common.suite,
             extensions: Vec::new(),
         };

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -329,11 +329,13 @@ pub fn verify_server_cert_signed_by_trust_anchor(
     let webpki_now = webpki::Time::try_from(now).map_err(|_| Error::FailedToGetCurrentTime)?;
 
     cert.0
-        .verify_is_valid_tls_server_cert(
+        .verify_for_usage(
             SUPPORTED_SIG_ALGS,
-            &webpki::TlsServerTrustAnchors(&trust_roots),
+            &trust_roots,
             &chain,
             webpki_now,
+            webpki::KeyUsage::server_auth(),
+            &[], // no CRLs
         )
         .map_err(pki_error)
         .map(|_| ())
@@ -532,12 +534,13 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
             .collect::<Vec<_>>();
 
         cert.0
-            .verify_is_valid_tls_client_cert(
+            .verify_for_usage(
                 SUPPORTED_SIG_ALGS,
-                &webpki::TlsClientTrustAnchors(&trust_roots),
+                &trust_roots,
                 &chain,
                 now,
-                crls.as_slice(),
+                webpki::KeyUsage::client_auth(),
+                &crls,
             )
             .map_err(pki_error)
             .map(|_| ClientCertVerified::assertion())

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4022,6 +4022,64 @@ fn test_client_sends_helloretryrequest() {
     ));
 }
 
+#[test]
+fn test_server_requests_retry_with_echoed_session_id() {
+    use rustls::internal::msgs::handshake::SessionId;
+    let expected_session_id = SessionId::random::<Ring>().unwrap();
+
+    let assert_client_sends_hello_with_secp384 = |msg: &mut Message| -> Altered {
+        if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
+            if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
+                let keyshares = ch
+                    .get_keyshare_extension()
+                    .expect("missing key share extension");
+                assert_eq!(keyshares.len(), 1);
+                assert_eq!(keyshares[0].group, rustls::NamedGroup::secp384r1);
+
+                ch.session_id = expected_session_id;
+                *encoded = Payload::new(parsed.get_encoding());
+            }
+        }
+        Altered::InPlace
+    };
+
+    let assert_server_requests_retry_and_echoes_session_id = |msg: &mut Message| -> Altered {
+        if let MessagePayload::Handshake { parsed, .. } = &mut msg.payload {
+            if let HandshakePayload::HelloRetryRequest(hrr) = &mut parsed.payload {
+                let group = hrr.get_requested_key_share_group();
+                assert_eq!(group, Some(rustls::NamedGroup::X25519));
+
+                assert_eq!(hrr.session_id, expected_session_id);
+            }
+        }
+        Altered::InPlace
+    };
+
+    // client prefers a secp384r1 key share, server only accepts x25519
+    let client_config = make_client_config_with_kx_groups(
+        KeyType::Rsa,
+        &[&rustls::kx_group::SECP384R1, &rustls::kx_group::X25519],
+    );
+
+    let server_config =
+        make_server_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
+
+    let (client, server) = make_pair_for_configs(client_config, server_config);
+    let (mut client, mut server) = (client.into(), server.into());
+    transfer_altered(
+        &mut client,
+        assert_client_sends_hello_with_secp384,
+        &mut server,
+    );
+    server.process_new_packets().unwrap();
+    transfer_altered(
+        &mut server,
+        assert_server_requests_retry_and_echoes_session_id,
+        &mut client,
+    );
+    client.process_new_packets().unwrap();
+}
+
 #[cfg(feature = "tls12")]
 #[test]
 fn test_client_attempts_to_use_unsupported_kx_group() {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4023,9 +4023,9 @@ fn test_client_sends_helloretryrequest() {
 }
 
 #[test]
-fn test_server_requests_retry_with_echoed_session_id() {
+fn test_client_rejects_hrr_with_varied_session_id() {
     use rustls::internal::msgs::handshake::SessionId;
-    let expected_session_id = SessionId::random::<Ring>().unwrap();
+    let different_session_id = SessionId::random::<Ring>().unwrap();
 
     let assert_client_sends_hello_with_secp384 = |msg: &mut Message| -> Altered {
         if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
@@ -4036,7 +4036,7 @@ fn test_server_requests_retry_with_echoed_session_id() {
                 assert_eq!(keyshares.len(), 1);
                 assert_eq!(keyshares[0].group, rustls::NamedGroup::secp384r1);
 
-                ch.session_id = expected_session_id;
+                ch.session_id = different_session_id;
                 *encoded = Payload::new(parsed.get_encoding());
             }
         }
@@ -4049,7 +4049,7 @@ fn test_server_requests_retry_with_echoed_session_id() {
                 let group = hrr.get_requested_key_share_group();
                 assert_eq!(group, Some(rustls::NamedGroup::X25519));
 
-                assert_eq!(hrr.session_id, expected_session_id);
+                assert_eq!(hrr.session_id, different_session_id);
             }
         }
         Altered::InPlace
@@ -4077,7 +4077,12 @@ fn test_server_requests_retry_with_echoed_session_id() {
         assert_server_requests_retry_and_echoes_session_id,
         &mut client,
     );
-    client.process_new_packets().unwrap();
+    assert_eq!(
+        client.process_new_packets(),
+        Err(Error::PeerMisbehaved(
+            PeerMisbehaved::IllegalHelloRetryRequestWithWrongSessionId
+        ))
+    );
 }
 
 #[cfg(feature = "tls12")]


### PR DESCRIPTION
On the server, we should've been echoing the `session_id` in HelloRetryRequest messages (we already did for ServerHellos).

On the client, there's a requirement that we detect this and fail the connection with an `illegal_parameter` alert.

fixes #1373