### PR TITLE
ci: fix setup-go build cache warnings.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.20"
+          cache: false
 
       - name: Run test suite
         working-directory: bogo
@@ -188,11 +189,6 @@ jobs:
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
-
-      - name: Install golang toolchain
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.20"
 
       - name: Measure coverage
         run: ./admin/coverage --lcov --output-path final.info


### PR DESCRIPTION
Since v4 of the [`actions/setup-go`](https://github.com/actions/setup-go) action, [caching is enabled by default](https://github.com/actions/setup-go#v4), When a `go.sum` can't be found in the root of the project, a warning is logged of the form:
> Restore cache failed: Dependencies file is not found in /home/runner/work/rustls/rustls. Supported file pattern: go.sum


Since we don't have a `go.sum` in the project root, this warning was being issued by both tasks that used the `setup-go` action:

* The BoGo test suite task
* The code coverage task

For the first of these, this commit disables caching for the `setup-go` action to avoid the warning. I tried setting [`cache-dependency-path`](https://github.com/actions/setup-go#caching-dependency-files-and-b) to `bogo/bogo/go.sum` or `bogo/go.sum` but in each case the action reported not being able to find the file (probably because of the way we clone the upstream repo on-demand). It might be possible to get this working with more effort, but in the meantime disabling caching leaves us no worse off and squelches a warning.

For the second of these, it's not clear _why_ we were installing the Go toolchain. The BoGo test suite is not being run by this task and so Go is not required. Removing `setup-go` from this task fixes the warning.