### PR TITLE
directly use core:: & alloc:: API instead of std:: re-exports

### DIFF
--- a/rustls/src/bs_debug.rs
+++ b/rustls/src/bs_debug.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 /// Alternative implementation of `fmt::Debug` for byte slice.
 ///

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -3,8 +3,8 @@ use crate::error::Error;
 use crate::suites::{SupportedCipherSuite, DEFAULT_CIPHER_SUITES};
 use crate::versions;
 
-use std::fmt;
-use std::marker::PhantomData;
+use core::fmt;
+use core::marker::PhantomData;
 
 /// Building a [`ServerConfig`] or [`ClientConfig`] in a linker-friendly and
 /// complete way.
@@ -105,7 +105,7 @@ pub struct ConfigBuilder<Side: ConfigSide, State> {
 
 impl<Side: ConfigSide, State: fmt::Debug> fmt::Debug for ConfigBuilder<Side, State> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let side_name = std::any::type_name::<Side>();
+        let side_name = core::any::type_name::<Side>();
         let (ty, param) = side_name
             .split_once('<')
             .unwrap_or((side_name, ""));

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -10,8 +10,8 @@ use crate::{anchors, key, versions};
 
 use super::client_conn::Resumption;
 
-use std::marker::PhantomData;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use core::marker::PhantomData;
 
 impl<C: CryptoProvider> ConfigBuilder<ClientConfig<C>, WantsVerifier<C>> {
     /// Choose how to verify server certificates.

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -21,11 +21,12 @@ use crate::KeyLog;
 use super::handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 use super::hs;
 
-use std::marker::PhantomData;
+use alloc::sync::Arc;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+use core::{fmt, mem};
+use std::io;
 use std::net::IpAddr;
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
-use std::{fmt, io, mem};
 
 /// A trait for the ability to store client session data, so that sessions
 /// can be resumed in future connections.
@@ -414,7 +415,7 @@ impl TryFrom<&str> for ServerName {
 #[cfg(feature = "dangerous_configuration")]
 pub(super) mod danger {
     use crate::crypto::CryptoProvider;
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     use super::verify::ServerCertVerifier;
     use super::ClientConfig;

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -6,7 +6,7 @@ use crate::msgs::handshake::ServerExtension;
 use crate::msgs::handshake::{CertificatePayload, DistinguishedName};
 use crate::{sign, SignatureScheme};
 
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 #[derive(Debug)]
 pub(super) struct ServerCertDetails {

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -8,8 +8,9 @@ use crate::sign;
 use crate::NamedGroup;
 use crate::ServerName;
 
-use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
+use std::sync::Mutex;
 
 /// An implementer of `ClientSessionStore` which does nothing.
 pub(super) struct NoClientSessionStorage;
@@ -209,7 +210,7 @@ mod test {
     use crate::msgs::handshake::SessionId;
     use crate::msgs::persist::Tls13ClientSessionValue;
     use crate::suites::SupportedCipherSuite;
-    use std::convert::TryInto;
+    use core::convert::TryInto;
 
     #[test]
     fn test_noclientsessionstorage_does_nothing() {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -32,8 +32,8 @@ use crate::client::client_conn::ClientConnectionData;
 use crate::client::common::ClientHelloDetails;
 use crate::client::{tls13, ClientConfig, ServerName};
 
-use std::ops::Deref;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use core::ops::Deref;
 
 pub(super) type NextState = Box<dyn State<ClientConnectionData>>;
 pub(super) type NextStateOrError = Result<NextState, Error>;

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -34,7 +34,7 @@ use crate::rand::GetRandomFailed;
 
 use subtle::ConstantTimeEq;
 
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 pub(super) use server_hello::CompleteServerHelloHandling;
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -44,7 +44,7 @@ use crate::ticketer::TimeBase;
 use subtle::ConstantTimeEq;
 
 use crate::sign::{CertifiedKey, Signer};
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 // Extensions we expect in plaintext in the ServerHello.
 static ALLOWED_PLAINTEXT_EXTS: &[ExtensionType] = &[
@@ -322,7 +322,7 @@ pub(super) fn emit_fake_ccs(sent_tls13_fake_ccs: &mut bool, common: &mut CommonS
         return;
     }
 
-    if std::mem::replace(sent_tls13_fake_ccs, true) {
+    if core::mem::replace(sent_tls13_fake_ccs, true) {
         return;
     }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -10,10 +10,10 @@ use crate::msgs::message::{Message, MessagePayload, PlainMessage};
 use crate::suites::{ExtractedSecrets, PartiallyExtractedSecrets};
 use crate::vecbuf::ChunkVecBuffer;
 
-use std::fmt::Debug;
+use core::fmt::Debug;
+use core::mem;
+use core::ops::{Deref, DerefMut};
 use std::io;
-use std::mem;
-use std::ops::{Deref, DerefMut};
 
 /// A client or server connection.
 #[derive(Debug)]

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -1,7 +1,7 @@
 use crate::rand::GetRandomFailed;
 use crate::{Error, NamedGroup};
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// *ring* based CryptoProvider.
 pub mod ring;

--- a/rustls/src/crypto/ring.rs
+++ b/rustls/src/crypto/ring.rs
@@ -8,8 +8,8 @@ use ring::aead;
 use ring::agreement::{agree_ephemeral, EphemeralPrivateKey, UnparsedPublicKey};
 use ring::rand::{SecureRandom, SystemRandom};
 
-use std::fmt;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use core::fmt;
 
 /// Default crypto provider.
 #[derive(Debug)]
@@ -258,14 +258,14 @@ fn ticketswitcher_switching_test() {
     assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
     {
         // Trigger new ticketer
-        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(10)));
+        t.maybe_roll(TimeBase(now.0 + core::time::Duration::from_secs(10)));
     }
     let cipher2 = t.encrypt(b"ticket 2").unwrap();
     assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
     assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
     {
         // Trigger new ticketer
-        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(20)));
+        t.maybe_roll(TimeBase(now.0 + core::time::Duration::from_secs(20)));
     }
     let cipher3 = t.encrypt(b"ticket 3").unwrap();
     assert!(t.decrypt(&cipher1).is_none());
@@ -287,7 +287,7 @@ fn ticketswitcher_recover_test() {
     t.generator = fail_generator;
     {
         // Failed new ticketer
-        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(10)));
+        t.maybe_roll(TimeBase(now.0 + core::time::Duration::from_secs(10)));
     }
     t.generator = make_ticket_generator;
     let cipher2 = t.encrypt(b"ticket 2").unwrap();
@@ -295,7 +295,7 @@ fn ticketswitcher_recover_test() {
     assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
     {
         // recover
-        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(20)));
+        t.maybe_roll(TimeBase(now.0 + core::time::Duration::from_secs(20)));
     }
     let cipher3 = t.encrypt(b"ticket 3").unwrap();
     assert!(t.decrypt(&cipher1).is_none());

--- a/rustls/src/dns_name.rs
+++ b/rustls/src/dns_name.rs
@@ -1,6 +1,7 @@
-/// DNS name validation according to RFC1035, but with underscores allowed.
+//! DNS name validation according to RFC1035, but with underscores allowed.
+
+use core::fmt;
 use std::error::Error as StdError;
-use std::fmt;
 
 /// A type which encapsulates an owned string that is a syntactically valid DNS name.
 #[derive(Clone, Eq, Hash, PartialEq, Debug)]

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -2,9 +2,9 @@ use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::msgs::handshake::KeyExchangeAlgorithm;
 use crate::rand;
 
+use alloc::sync::Arc;
+use core::fmt;
 use std::error::Error as StdError;
-use std::fmt;
-use std::sync::Arc;
 use std::time::SystemTimeError;
 
 /// rustls reports protocol errors using this type.
@@ -568,7 +568,7 @@ mod tests {
             ApplicationVerificationFailure,
             ApplicationVerificationFailure
         );
-        let other = Other(std::sync::Arc::from(Box::from("")));
+        let other = Other(alloc::sync::Arc::from(Box::from("")));
         assert_ne!(other, other);
         assert_ne!(BadEncoding, Expired);
     }
@@ -589,7 +589,7 @@ mod tests {
         assert_eq!(UnsupportedDeltaCrl, UnsupportedDeltaCrl);
         assert_eq!(UnsupportedIndirectCrl, UnsupportedIndirectCrl);
         assert_eq!(UnsupportedRevocationReason, UnsupportedRevocationReason);
-        let other = Other(std::sync::Arc::from(Box::from("")));
+        let other = Other(alloc::sync::Arc::from(Box::from("")));
         assert_ne!(other, other);
         assert_ne!(BadSignature, InvalidCrlNumber);
     }

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -1,8 +1,8 @@
 use crate::msgs::codec::Codec;
 use crate::msgs::handshake::HandshakeMessagePayload;
 use crate::msgs::message::{Message, MessagePayload};
+use core::mem;
 use ring::digest;
-use std::mem;
 
 /// Early stage buffering of handshake payloads.
 ///

--- a/rustls/src/key.rs
+++ b/rustls/src/key.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use crate::Error;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -301,6 +301,8 @@
 #![cfg_attr(read_buf, feature(read_buf))]
 #![cfg_attr(bench, feature(test))]
 
+extern crate alloc;
+
 // Import `test` sysroot crate for `Bencher` definitions.
 #[cfg(bench)]
 #[allow(unused_extern_crates)]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -261,7 +261,9 @@
 #![forbid(unsafe_code, unused_must_use)]
 #![cfg_attr(not(any(read_buf, bench)), forbid(unstable_features))]
 #![deny(
+    clippy::alloc_instead_of_core,
     clippy::clone_on_ref_ptr,
+    clippy::std_instead_of_core,
     clippy::use_self,
     trivial_casts,
     trivial_numeric_casts,

--- a/rustls/src/limited_cache.rs
+++ b/rustls/src/limited_cache.rs
@@ -1,7 +1,8 @@
-use std::borrow::Borrow;
+use alloc::collections::VecDeque;
+use core::borrow::Borrow;
+use core::hash::Hash;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, VecDeque};
-use std::hash::Hash;
+use std::collections::HashMap;
 
 /// A HashMap-alike, which never gets larger than a specified
 /// capacity, and evicts the oldest insertion to maintain this.
@@ -20,7 +21,7 @@ pub(crate) struct LimitedCache<K: Clone + Hash + Eq, V> {
 
 impl<K, V> LimitedCache<K, V>
 where
-    K: Eq + Hash + Clone + std::fmt::Debug,
+    K: Eq + Hash + Clone + core::fmt::Debug,
     V: Default,
 {
     /// Create a new LimitedCache with the given rough capacity.

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use crate::error::InvalidMessage;
 use crate::key;

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::error::InvalidMessage;
 

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -1,5 +1,5 @@
+use core::ops::Range;
 use std::io;
-use std::ops::Range;
 
 use super::base::Payload;
 use super::codec::Codec;

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -15,8 +15,8 @@ use crate::msgs::enums::{
 use crate::rand;
 use crate::verify::DigitallySignedStruct;
 
+use core::fmt;
 use std::collections;
-use std::fmt;
 
 /// Create a newtype wrapper around a given type.
 ///

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -600,7 +600,7 @@ fn test_truncated_helloretry_extension_is_detected() {
 
 fn test_helloretry_extension_getter(typ: ExtensionType, getter: fn(&HelloRetryRequest) -> bool) {
     let mut hrr = get_sample_helloretryrequest();
-    let mut exts = std::mem::take(&mut hrr.extensions);
+    let mut exts = core::mem::take(&mut hrr.extensions);
     exts.retain(|ext| ext.get_type() == typ);
 
     assert!(!getter(&hrr));
@@ -714,7 +714,7 @@ fn test_cert_extension_getter(typ: ExtensionType, getter: fn(&CertificateEntry) 
     let mut ce = get_sample_certificatepayloadtls13()
         .entries
         .remove(0);
-    let mut exts = std::mem::take(&mut ce.exts);
+    let mut exts = core::mem::take(&mut ce.exts);
     exts.retain(|ext| ext.get_type() == typ);
 
     assert!(!getter(&ce));

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -11,9 +11,9 @@ use crate::ticketer::TimeBase;
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
 
-use std::cmp;
+use core::cmp;
 #[cfg(feature = "tls12")]
-use std::mem;
+use core::mem;
 
 pub struct Retrieved<T> {
     pub value: T,
@@ -47,7 +47,7 @@ impl Retrieved<&Tls13ClientSessionValue> {
     }
 }
 
-impl<T: std::ops::Deref<Target = ClientSessionCommon>> Retrieved<T> {
+impl<T: core::ops::Deref<Target = ClientSessionCommon>> Retrieved<T> {
     pub fn has_expired(&self) -> bool {
         let common = &*self.value;
         common.lifetime_secs != 0
@@ -58,7 +58,7 @@ impl<T: std::ops::Deref<Target = ClientSessionCommon>> Retrieved<T> {
     }
 }
 
-impl<T> std::ops::Deref for Retrieved<T> {
+impl<T> core::ops::Deref for Retrieved<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -128,7 +128,7 @@ impl Tls13ClientSessionValue {
     }
 }
 
-impl std::ops::Deref for Tls13ClientSessionValue {
+impl core::ops::Deref for Tls13ClientSessionValue {
     type Target = ClientSessionCommon;
 
     fn deref(&self) -> &Self::Target {
@@ -195,7 +195,7 @@ impl Tls12ClientSessionValue {
 }
 
 #[cfg(feature = "tls12")]
-impl std::ops::Deref for Tls12ClientSessionValue {
+impl core::ops::Deref for Tls12ClientSessionValue {
     type Target = ClientSessionCommon;
 
     fn deref(&self) -> &Self::Target {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -14,10 +14,10 @@ use crate::tls13::{Tls13CipherSuite, TLS13_AES_128_GCM_SHA256_INTERNAL};
 
 use ring::{aead, hkdf};
 
-use std::collections::VecDeque;
-use std::fmt::{self, Debug};
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
+use core::fmt::{self, Debug};
+use core::ops::{Deref, DerefMut};
 
 /// A QUIC client or server connection.
 #[derive(Debug)]

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -9,8 +9,8 @@ use crate::verify;
 use crate::versions;
 use crate::NoKeyLog;
 
-use std::marker::PhantomData;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use core::marker::PhantomData;
 
 impl<C: CryptoProvider> ConfigBuilder<ServerConfig<C>, WantsVerifier<C>> {
     /// Choose how to verify client certificates.

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -6,8 +6,9 @@ use crate::server;
 use crate::server::ClientHello;
 use crate::sign;
 
+use alloc::sync::Arc;
 use std::collections;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 /// Something which never stores sessions.
 pub struct NoServerSessionStorage {}

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -26,7 +26,7 @@ use super::tls12;
 use crate::server::common::ActiveCertifiedKey;
 use crate::server::tls13;
 
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 pub(super) type NextState = Box<dyn State<ServerConnectionData>>;
 pub(super) type NextStateOrError = Result<NextState, Error>;

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -20,10 +20,11 @@ use crate::KeyLog;
 
 use super::hs;
 
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
-use std::{fmt, io};
+use alloc::sync::Arc;
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+use std::io;
 
 /// A trait for the ability to store server session data.
 ///

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -28,7 +28,7 @@ use super::server_conn::{ProducesTickets, ServerConfig, ServerConnectionData};
 
 use subtle::ConstantTimeEq;
 
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 pub(super) use client_hello::CompleteClientHelloHandling;
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -34,7 +34,7 @@ use crate::verify;
 use super::hs::{self, HandshakeHashOrBuffer, ServerContext};
 use super::server_conn::ServerConnectionData;
 
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 use subtle::ConstantTimeEq;
 

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -6,9 +6,9 @@ use crate::x509::{wrap_in_asn1_len, wrap_in_sequence};
 use ring::io::der;
 use ring::signature::{self, EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair};
 
+use alloc::sync::Arc;
+use core::fmt;
 use std::error::Error as StdError;
-use std::fmt;
-use std::sync::Arc;
 
 /// An abstract signing key.
 pub trait SigningKey: Send + Sync {

--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -1,7 +1,7 @@
 use crate::conn::{ConnectionCommon, SideData};
 
+use core::ops::{Deref, DerefMut};
 use std::io::{IoSlice, Read, Result, Write};
-use std::ops::{Deref, DerefMut};
 
 /// This type implements `io::Read` and `io::Write`, encapsulating
 /// a Connection `C` and an underlying transport `T`, such as a socket.

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureAlgorithm, SignatureScheme};
 #[cfg(feature = "tls12")]

--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -2,7 +2,8 @@ use crate::rand;
 use crate::server::ProducesTickets;
 use crate::Error;
 
-use std::mem;
+use core::mem;
+use core::time::Duration;
 use std::sync::{Mutex, MutexGuard};
 use std::time;
 
@@ -11,7 +12,7 @@ use std::time;
 ///
 /// This is guaranteed to be on or after the UNIX epoch.
 #[derive(Clone, Copy, Debug)]
-pub struct TimeBase(pub(crate) time::Duration);
+pub struct TimeBase(pub(crate) Duration);
 
 impl TimeBase {
     #[inline]

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -13,7 +13,7 @@ use crate::suites::{ConnectionTrafficSecrets, PartiallyExtractedSecrets};
 use ring::aead;
 use ring::digest::Digest;
 
-use std::fmt;
+use core::fmt;
 
 mod cipher;
 pub(crate) use cipher::{AesGcm, ChaCha20Poly1305, Tls12AeadAlgorithm};

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -10,7 +10,7 @@ use crate::suites::{BulkAlgorithm, CipherSuiteCommon, SupportedCipherSuite};
 
 use ring::aead;
 
-use std::fmt;
+use core::fmt;
 
 pub(crate) mod key_schedule;
 

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -1,5 +1,5 @@
-use std::cmp;
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
+use core::cmp;
 use std::io;
 use std::io::Read;
 
@@ -110,7 +110,7 @@ impl ChunkVecBuffer {
     pub(crate) fn read_buf(&mut self, mut cursor: io::BorrowedCursor<'_>) -> io::Result<()> {
         while !self.is_empty() && cursor.capacity() > 0 {
             let chunk = self.chunks[0].as_slice();
-            let used = std::cmp::min(chunk.len(), cursor.capacity());
+            let used = core::cmp::min(chunk.len(), cursor.capacity());
             cursor.append(&chunk[..used]);
             self.consume(used);
         }

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use crate::anchors::{OwnedTrustAnchor, RootCertStore};
 use crate::client::ServerName;
@@ -15,7 +15,7 @@ use crate::msgs::handshake::DistinguishedName;
 
 use ring::digest::Digest;
 
-use std::sync::Arc;
+use alloc::sync::Arc;
 use std::time::SystemTime;
 
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -4,7 +4,8 @@
 // Note: we don't use any of the standard 'cargo bench', 'test::Bencher',
 // etc. because it's unstable at the time of writing.
 
-use std::time::{Duration, Instant, SystemTime};
+use core::time::Duration;
+use std::time::{Instant, SystemTime};
 
 use crate::key;
 use crate::verify;

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use crate::enums::ProtocolVersion;
 


### PR DESCRIPTION
This is a first step towards adding `no_std` support to RusTLS. It makes easier to spot what parts of the code-base depend on the standard library. The clippy lints should prevent std re-exports being added back (although the lints do have false positives: https://github.com/rust-lang/rust-clippy/issues/11159 ). When `no_std` support is implemented and tested in CI, it won't be necessary to rely on the clippy lints.
