### PR TITLE
docs: Add note on unsupported self-signed certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ rustls does not and will not support:
 * Compression.
 * Discrete-log Diffie-Hellman.
 * Automatic protocol version downgrade.
+* Self-signed certificates.
 
 There are plenty of other libraries that provide these features should you
 need them.

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -48,6 +48,7 @@
 //! * Compression.
 //! * Discrete-log Diffie-Hellman.
 //! * Automatic protocol version downgrade.
+//! * Self-signed certificates.
 //!
 //! There are plenty of other libraries that provide these features should you
 //! need them.


### PR DESCRIPTION
This clarifies the rustls position on self-signed certificates.
Users writing tests using rustls should be aware that a
self-signed cert won't work as expected.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
