### PR TITLE
v0.21.6 preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,10 +276,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --package rustls --all-features -- --deny warnings
-      - run: cargo clippy --package rustls --no-default-features -- --deny warnings
-      - run: cargo clippy --manifest-path=connect-tests/Cargo.toml --all-features -- --deny warnings
-      - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features -- --deny warnings
+      - run: cargo clippy --package rustls --all-features -- --deny warnings --allow unknown-lints
+      - run: cargo clippy --package rustls --no-default-features -- --deny warnings --allow unknown-lints
+      - run: cargo clippy --manifest-path=connect-tests/Cargo.toml --all-features -- --deny warnings --allow unknown-lints
+      - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features -- --deny warnings --allow unknown-lints
 
   clippy-nightly:
     name: Clippy (Nightly)

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,7 +21,7 @@ rustls-pemfile = "1.0.3"
 sct = "0.7"
 serde = "1.0"
 serde_derive = "1.0"
-webpki-roots = "0.24"
+webpki-roots = "0.25"
 
 [dev-dependencies]
 regex = "1.0"

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -12,7 +12,6 @@ fn main() {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.add_trust_anchors(
         webpki_roots::TLS_SERVER_ROOTS
-            .0
             .iter()
             .map(|ta| {
                 OwnedTrustAnchor::from_subject_spki_name_constraints(

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -10,7 +10,7 @@ use rustls::OwnedTrustAnchor;
 
 fn main() {
     let mut root_store = rustls::RootCertStore::empty();
-    root_store.add_server_trust_anchors(
+    root_store.add_trust_anchors(
         webpki_roots::TLS_SERVER_ROOTS
             .0
             .iter()

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -58,7 +58,7 @@ fn main() {
     env_logger::init();
 
     let mut root_store = RootCertStore::empty();
-    root_store.add_server_trust_anchors(
+    root_store.add_trust_anchors(
         webpki_roots::TLS_SERVER_ROOTS
             .0
             .iter()

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -60,7 +60,6 @@ fn main() {
     let mut root_store = RootCertStore::empty();
     root_store.add_trust_anchors(
         webpki_roots::TLS_SERVER_ROOTS
-            .0
             .iter()
             .map(|ta| {
                 OwnedTrustAnchor::from_subject_spki_name_constraints(

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -18,7 +18,6 @@ fn main() {
     let mut root_store = RootCertStore::empty();
     root_store.add_trust_anchors(
         webpki_roots::TLS_SERVER_ROOTS
-            .0
             .iter()
             .map(|ta| {
                 OwnedTrustAnchor::from_subject_spki_name_constraints(

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -16,7 +16,7 @@ use rustls::{OwnedTrustAnchor, RootCertStore};
 
 fn main() {
     let mut root_store = RootCertStore::empty();
-    root_store.add_server_trust_anchors(
+    root_store.add_trust_anchors(
         webpki_roots::TLS_SERVER_ROOTS
             .0
             .iter()

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -379,7 +379,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
         let mut reader = BufReader::new(certfile);
         root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut reader).unwrap());
     } else {
-        root_store.add_server_trust_anchors(
+        root_store.add_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS
                 .0
                 .iter()

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -381,7 +381,6 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     } else {
         root_store.add_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS
-                .0
                 .iter()
                 .map(|ta| {
                     OwnedTrustAnchor::from_subject_spki_name_constraints(

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 edition = "2021"
 rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -19,7 +19,7 @@ rustversion = { version = "1.0.6", optional = true }
 log = { version = "0.4.4", optional = true }
 ring = "0.16.20"
 sct = "0.7.0"
-webpki = { package = "rustls-webpki", version = "0.101.0", features = ["alloc", "std"] }
+webpki = { package = "rustls-webpki", version = "0.101.2", features = ["alloc", "std"] }
 
 [features]
 default = ["logging", "tls12"]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -34,7 +34,7 @@ read_buf = ["rustversion"]
 bencher = "0.1.5"
 env_logger = "0.10"
 log = "0.4.4"
-webpki-roots = "0.24.0"
+webpki-roots = "0.25.0"
 rustls-pemfile = "1.0.3"
 base64 = "0.21"
 

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -110,11 +110,18 @@ impl RootCertStore {
 
     /// Adds all the given TrustAnchors `anchors`.  This does not
     /// fail.
+    pub fn add_trust_anchors(&mut self, trust_anchors: impl Iterator<Item = OwnedTrustAnchor>) {
+        self.roots.extend(trust_anchors);
+    }
+
+    /// Adds all the given TrustAnchors `anchors`.  This does not
+    /// fail.
+    #[deprecated(since = "0.21.6", note = "Please use `add_trust_anchors` instead")]
     pub fn add_server_trust_anchors(
         &mut self,
         trust_anchors: impl Iterator<Item = OwnedTrustAnchor>,
     ) {
-        self.roots.extend(trust_anchors);
+        self.add_trust_anchors(trust_anchors);
     }
 
     /// Parse the given DER-encoded certificates and add all that can be parsed

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -43,7 +43,7 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
                 versions: self.state.versions,
                 verifier,
             },
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -980,7 +980,7 @@ struct ExpectFinished {
 
 impl ExpectFinished {
     // -- Waiting for their finished --
-    fn save_session(&mut self, cx: &mut ClientContext<'_>) {
+    fn save_session(&mut self, cx: &ClientContext<'_>) {
         // Save a ticket.  If we got a new ticket, save that.  Otherwise, save the
         // original ticket again.
         let (mut ticket, lifetime) = match self.ticket.take() {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -105,7 +105,7 @@
 //!
 //! ```rust,no_run
 //! let mut root_store = rustls::RootCertStore::empty();
-//! root_store.add_server_trust_anchors(
+//! root_store.add_trust_anchors(
 //!     webpki_roots::TLS_SERVER_ROOTS
 //!         .0
 //!         .iter()
@@ -138,7 +138,7 @@
 //! # use webpki;
 //! # use std::sync::Arc;
 //! # let mut root_store = rustls::RootCertStore::empty();
-//! # root_store.add_server_trust_anchors(
+//! # root_store.add_trust_anchors(
 //! #  webpki_roots::TLS_SERVER_ROOTS
 //! #      .0
 //! #      .iter()

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -107,7 +107,6 @@
 //! let mut root_store = rustls::RootCertStore::empty();
 //! root_store.add_trust_anchors(
 //!     webpki_roots::TLS_SERVER_ROOTS
-//!         .0
 //!         .iter()
 //!         .map(|ta| {
 //!             rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
@@ -140,7 +139,6 @@
 //! # let mut root_store = rustls::RootCertStore::empty();
 //! # root_store.add_trust_anchors(
 //! #  webpki_roots::TLS_SERVER_ROOTS
-//! #      .0
 //! #      .iter()
 //! #      .map(|ta| {
 //! #          rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -529,7 +529,7 @@ impl From<ServerConnection> for crate::Connection {
 ///     // Proceed with handling the ServerConnection.
 /// }
 /// # }
-//// ```
+/// ```
 pub struct Acceptor {
     inner: Option<ConnectionCommon<ServerConnectionData>>,
 }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -601,6 +601,7 @@ mod client_hello {
         common.send_msg(m, false);
     }
 
+    #[allow(clippy::needless_pass_by_ref_mut)] // cx only mutated if cfg(feature = "quic")
     fn decide_if_early_data_allowed(
         cx: &mut ServerContext<'_>,
         client_hello: &ClientHelloPayload,

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -343,11 +343,13 @@ pub fn verify_server_cert_signed_by_trust_anchor(
     let webpki_now = webpki::Time::try_from(now).map_err(|_| Error::FailedToGetCurrentTime)?;
 
     cert.0
-        .verify_is_valid_tls_server_cert(
+        .verify_for_usage(
             SUPPORTED_SIG_ALGS,
-            &webpki::TlsServerTrustAnchors(&trust_roots),
+            &trust_roots,
             &chain,
             webpki_now,
+            webpki::KeyUsage::server_auth(),
+            &[], // no CRLs
         )
         .map_err(pki_error)
         .map(|_| ())
@@ -633,11 +635,12 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
             .collect::<Vec<_>>();
 
         cert.0
-            .verify_is_valid_tls_client_cert(
+            .verify_for_usage(
                 SUPPORTED_SIG_ALGS,
-                &webpki::TlsClientTrustAnchors(&trust_roots),
+                &trust_roots,
                 &chain,
                 now,
+                webpki::KeyUsage::client_auth(),
                 crls.as_slice(),
             )
             .map_err(pki_error)

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -189,7 +189,6 @@ impl Context {
         let mut roots = anchors::RootCertStore::empty();
         roots.add_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS
-                .0
                 .iter()
                 .map(|ta| {
                     OwnedTrustAnchor::from_subject_spki_name_constraints(

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -187,7 +187,7 @@ struct Context {
 impl Context {
     fn new(name: &'static str, domain: &'static str, certs: &[&'static [u8]]) -> Self {
         let mut roots = anchors::RootCertStore::empty();
-        roots.add_server_trust_anchors(
+        roots.add_trust_anchors(
             webpki_roots::TLS_SERVER_ROOTS
                 .0
                 .iter()


### PR DESCRIPTION
## Description

This PR is targeted at the `rel-0.21` branch to make a maintenance release bumping some dependencies and adding a new deprecation.

- [x] `cargo update`.
- [x] `cargo outdated`.
- [x] `cargo test --all-features`.
- [x] Update `version` in `Cargo.toml`.
- [x] `cargo publish --dry-run -p rustls`
- [x] PR desc updated with release headlines

### Proposed release notes headlines:

- Deprecated `RootCertStore.add_server_trust_anchors`, use `RootCertStore.add_trust_anchors` instead. 
- Updated webpki-roots to 0.25.

### client::builder: fix PhantomData clippy lint

Does what it says on the tin.

### Correct/allow unnecessarily &mut function args

allow unknown-lints on stable clippy, otherwise it warns about us allowing lints that were introduced on nightly

### Fix up nightly clippy issue with incorrect comment

Does what it says on the tin.

### anchors: deprecate add_server_trust_anchors.
The `RootCertStore` type is used for both client and server trust anchors. This commit deprecates the inappropriately named `add_server_trust_anchors` fn and adds a new `add_trust_anchors` fn to use in its place.

Prepares for the removal of the deprecated methods in the next release as part of https://github.com/rustls/rustls/pull/1368

### verify: avoid deprecated webpki methods.

webpki 0.101.2 deprecated some methods/types that must be updated. Since we're switching to the non-deprecated versions that aren't available in <0.101.2 the `Cargo.toml` dependency version is updated to `0.101.2` to ensure builds with `-Z minimal-versions` work as expected.

### deps: update to webpki-roots 0.25, fix deprecations.
Updates the rustls project and rustls-examples project to use webpki-roots 0.25.0 instead of 0.24.0, fixes associated deprecations.

### Cargo: bump version 0.21.5 -> 0.21.6

Increases the version in the 0.21.x release branch to 0.21.6.