### PR TITLE
examples: print server address

### DIFF
--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -669,6 +669,7 @@ fn main() {
     let config = make_config(&args);
 
     let mut listener = TcpListener::bind(addr).expect("cannot listen on port");
+    println!("listening on {addr}");
     let mut poll = mio::Poll::new().unwrap();
     poll.registry()
         .register(&mut listener, LISTENER, mio::Interest::READABLE)


### PR DESCRIPTION
Print a line with the server address when starting the `tlsserver-mio`. Follow-up from #1391.

In Quinn, we noticed a lot of users failed to run the examples because (dual stack) IP networking doesn't always match user's expectations (especially on some OSes, I think macOS was a big offender here?). So for example, we listen on `::1`  by default and the user using `tlsclient-mio` will try to connect to `localhost` which might resolve to 127.0.0.1, and fail.