### PR TITLE
Enable feature(doc_auto_cfg)

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -172,7 +172,6 @@ pub struct ClientConfig<C: CryptoProvider> {
     /// Allows traffic secrets to be extracted after the handshake,
     /// e.g. for kTLS setup.
     #[cfg(feature = "secret_extraction")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "secret_extraction")))]
     pub enable_secret_extraction: bool,
 
     /// Whether to send data on the first flight ("early data") in
@@ -422,7 +421,6 @@ pub(super) mod danger {
 
     /// Accessor for dangerous configuration options.
     #[derive(Debug)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
     pub struct DangerousClientConfig<'a, C: CryptoProvider> {
         /// The underlying ClientConfig
         pub cfg: &'a mut ClientConfig<C>,
@@ -630,7 +628,6 @@ impl ClientConnection {
 
     /// Extract secrets, so they can be used when configuring kTLS, for example.
     #[cfg(feature = "secret_extraction")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "secret_extraction")))]
     pub fn extract_secrets(self) -> Result<ExtractedSecrets, Error> {
         self.inner.extract_secrets()
     }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -85,7 +85,6 @@ impl Connection {
 
     /// Extract secrets, to set up kTLS for example
     #[cfg(feature = "secret_extraction")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "secret_extraction")))]
     pub fn extract_secrets(self) -> Result<ExtractedSecrets, Error> {
         match self {
             Self::Client(conn) => conn.extract_secrets(),
@@ -548,7 +547,6 @@ impl<Data> ConnectionCommon<Data> {
 
     /// Extract secrets, so they can be used when configuring kTLS, for example.
     #[cfg(feature = "secret_extraction")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "secret_extraction")))]
     pub fn extract_secrets(self) -> Result<ExtractedSecrets, Error> {
         if !self.enable_secret_extraction {
             return Err(Error::General("Secret extraction is disabled".into()));

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -291,7 +291,7 @@
     clippy::new_without_default
 )]
 // Enable documentation for all features on docs.rs
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 // XXX: Because of https://github.com/rust-lang/rust/issues/54726, we cannot
 // write `#![rustversion::attr(nightly, feature(read_buf))]` here. Instead,
 // build.rs set `read_buf` for (only) Rust Nightly to get the same effect.
@@ -400,7 +400,6 @@ pub use crate::suites::{
     BulkAlgorithm, SupportedCipherSuite, ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES,
 };
 #[cfg(feature = "secret_extraction")]
-#[cfg_attr(docsrs, doc(cfg(feature = "secret_extraction")))]
 pub use crate::suites::{ConnectionTrafficSecrets, ExtractedSecrets};
 pub use crate::ticketer::TicketSwitcher;
 #[cfg(feature = "tls12")]
@@ -514,7 +513,6 @@ pub use crypto::ring::kx_group;
 pub mod sign;
 
 #[cfg(feature = "quic")]
-#[cfg_attr(docsrs, doc(cfg(feature = "quic")))]
 /// APIs for implementing QUIC TLS
 pub mod quic;
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -248,7 +248,6 @@ pub struct ServerConfig<C: CryptoProvider> {
     /// Allows traffic secrets to be extracted after the handshake,
     /// e.g. for kTLS setup.
     #[cfg(feature = "secret_extraction")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "secret_extraction")))]
     pub enable_secret_extraction: bool,
 
     /// Amount of early data to accept for sessions created by
@@ -486,7 +485,6 @@ impl ServerConnection {
 
     /// Extract secrets, so they can be used when configuring kTLS, for example.
     #[cfg(feature = "secret_extraction")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "secret_extraction")))]
     pub fn extract_secrets(self) -> Result<ExtractedSecrets, Error> {
         self.inner.extract_secrets()
     }

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -220,7 +220,6 @@ pub(crate) fn compatible_sigscheme_for_suites(
 /// to configure kTLS for a socket, and have the kernel take over encryption
 /// and/or decryption.
 #[cfg(feature = "secret_extraction")]
-#[cfg_attr(docsrs, doc(cfg(feature = "secret_extraction")))]
 pub struct ExtractedSecrets {
     /// sequence number and secrets for the "tx" (transmit) direction
     pub tx: (u64, ConnectionTrafficSecrets),
@@ -245,7 +244,6 @@ pub(crate) struct PartiallyExtractedSecrets {
 /// The only other piece of information needed is the sequence number,
 /// which is in [ExtractedSecrets].
 #[cfg(feature = "secret_extraction")]
-#[cfg_attr(docsrs, doc(cfg(feature = "secret_extraction")))]
 #[non_exhaustive]
 pub enum ConnectionTrafficSecrets {
     /// Secrets for the AES_128_GCM AEAD algorithm

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -21,7 +21,6 @@ use crate::msgs::handshake::DistinguishedName;
 
 /// Zero-sized marker type representing verification of a signature.
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct HandshakeSignatureValid(());
 
 impl HandshakeSignatureValid {
@@ -43,7 +42,6 @@ impl FinishedMessageVerified {
 /// Zero-sized marker type representing verification of a server cert chain.
 #[allow(unreachable_pub)]
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct ServerCertVerified(());
 
 #[allow(unreachable_pub)]
@@ -56,7 +54,6 @@ impl ServerCertVerified {
 
 /// Zero-sized marker type representing verification of a client cert chain.
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct ClientCertVerified(());
 
 impl ClientCertVerified {
@@ -69,7 +66,6 @@ impl ClientCertVerified {
 /// Something that can verify a server certificate chain, and verify
 /// signatures made by certificates.
 #[allow(unreachable_pub)]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub trait ServerCertVerifier: Send + Sync {
     /// Verify the end-entity certificate `end_entity` is valid for the
     /// hostname `dns_name` and chains to at least one trust anchor.
@@ -150,7 +146,6 @@ impl fmt::Debug for dyn ServerCertVerifier {
 
 /// Something that can verify a client certificate chain
 #[allow(unreachable_pub)]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub trait ClientCertVerifier: Send + Sync {
     /// Returns `true` to enable the server to request a client certificate and
     /// `false` to skip requesting a client certificate. Defaults to `true`.

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -42,7 +42,6 @@ static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[
 /// same order that the server sent them and may be empty.
 #[allow(dead_code)]
 #[cfg_attr(not(feature = "dangerous_configuration"), allow(unreachable_pub))]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub fn verify_server_cert_signed_by_trust_anchor(
     cert: &ParsedCertificate,
     roots: &RootCertStore,
@@ -70,7 +69,6 @@ pub fn verify_server_cert_signed_by_trust_anchor(
 /// note: this only verifies the name and should be used in conjuction with more verification
 /// like [verify_server_cert_signed_by_trust_anchor]
 #[cfg_attr(not(feature = "dangerous_configuration"), allow(unreachable_pub))]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub fn verify_server_name(cert: &ParsedCertificate, server_name: &ServerName) -> Result<(), Error> {
     match server_name {
         ServerName::DnsName(dns_name) => {
@@ -145,7 +143,6 @@ impl ServerCertVerifier for WebPkiServerVerifier {
 
 /// Default `ServerCertVerifier`, see the trait impl for more information.
 #[allow(unreachable_pub)]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct WebPkiServerVerifier {
     roots: RootCertStore,
 }
@@ -642,7 +639,6 @@ fn crl_error_from_webpki() {
 
 /// wrapper around internal representation of a parsed certificate. This is used in order to avoid parsing twice when specifying custom verification
 #[cfg_attr(not(feature = "dangerous_configuration"), allow(unreachable_pub))]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub struct ParsedCertificate<'a>(pub(crate) webpki::EndEntityCert<'a>);
 
 impl<'a> TryFrom<&'a Certificate> for ParsedCertificate<'a> {


### PR DESCRIPTION
This removes duplicated manual feature gates for documentation and leaves it to `cargo doc` to derive the same information from the actual feature gates.

I didn't find any gaps in the auto-generated features and what we had before, but now things like `rustls::cipher_suite::TLS_ECDHE_*` are correctly marked tls12-only.

fixes #1393 