### PR TITLE
Implement CPU instruction benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,14 @@
 [workspace]
 members = [
+  # CI benchmarks
+  "ci-bench",
   # tests and example code
   "examples",
   # the main library and tests
+  "rustls",
+]
+default-members = [
+  "examples",
   "rustls",
 ]
 exclude = ["admin/rustfmt"]

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rustls-ci-bench"
+version = "0.0.1"
+edition = "2021"
+license = "Apache-2.0 OR ISC OR MIT"
+description = "Rustls CPU instruction counting benchmarks."
+publish = false
+
+[dependencies]
+anyhow = "1.0.73"
+byteorder = "1.4.3"
+clap = { version = "4.3.21", features = ["derive"] }
+itertools = "0.11.0"
+rayon = "1.7.0"
+rustls = { path = "../rustls" }
+rustls-pemfile = "1.0.3"
+

--- a/ci-bench/README.md
+++ b/ci-bench/README.md
@@ -1,0 +1,110 @@
+# CI Bench
+
+This crate is meant for CI benchmarking. It measures CPU instructions using `cachegrind`, outputs
+the results in CSV format and allows comparing results from multiple runs.
+
+## Usage
+
+You can get detailed usage information through `cargo run --release -- --help`. Below are the most
+important bits.
+
+### Running all benchmarks
+
+_Note: this step requires having `valgrind` in your path._
+
+Use `cargo run --release -- run-all > out.csv` to generate a CSV with the instruction counts for
+the different scenarios we support. The result should look like the following:
+
+```csv
+handshake_no_resume_1.2_rsa_aes_server,11327015
+handshake_no_resume_1.2_rsa_aes_client,4314952
+handshake_session_id_1.2_rsa_aes_server,11342136
+handshake_session_id_1.2_rsa_aes_client,4327564
+handshake_tickets_1.2_rsa_aes_server,11347746
+handshake_tickets_1.2_rsa_aes_client,4331424
+transfer_no_resume_1.2_rsa_aes_server,8775780
+transfer_no_resume_1.2_rsa_aes_client,8818847
+handshake_no_resume_1.3_rsa_aes_server,11517007
+handshake_no_resume_1.3_rsa_aes_client,4212770
+...
+... rest omitted for brevity
+...
+```
+
+### Comparing results
+
+Use `cargo run --release -- compare out1.csv out2.csv`. It will output a report using
+GitHub-flavored markdown (used by the CI itself to give feedback about PRs). We currently
+consider differences of 0.2% to be significant, but might tweak it in the future after we gain
+experience with the benchmarking setup.
+
+### Supported scenarios
+
+We benchmark the following scenarios:
+
+- Handshake without resumption (`handshake_no_resume`)
+- Handshake with ticket resumption (`handshake_tickets`)
+- Handshake with session id resumption (`handshake_session_id`)
+- Encrypt, transfer and decrypt 1MB of data sent by the server
+  (`transfer_no_resume`)
+
+The scenarios are benchmarked with different TLS versions, certificate key types and cipher suites.
+CPU counts are measured independently for the server side and for the client side. Hence, we end up
+with names like `transfer_no_resume_1.3_rsa_aes_client`.
+
+## Internals
+
+We have made an effort to heavily document the source code of the benchmarks. In addition to that,
+here are some high-level considerations that can help you hack on the crate.
+
+### Architecture
+
+An important goal of this benchmarking setup is that it should run with minimum noise on
+standard GitHub Actions runners. We achieve that by measuring CPU instructions using `cachegrind`,
+which runs fine on the cloud (contrary to hardware instruction counters). This is the same
+approach used by the [iai](https://crates.io/crates/iai) benchmarking crate, but we needed more
+flexibility and have therefore rolled our own setup.
+
+Using `cachegrind` has some architectural consequences because it operates at the process level
+(i.e. it can count CPU instructions for a whole process, but not for a single function). The
+most important consequences are:
+
+- Since we want to measure server and client instruction counts separately, the benchmark runner
+  spawns two child processes for each benchmark (one for the client, one for the server) and pipes
+  their stdio to each other for communication (i.e. stdio acts as the transport layer).
+- There is a no-op "benchmark" that measures the overhead of starting up the child process, so
+  we can subtract it from the instruction count of the real benchmarks and reduce noise.
+- Since we want to measure individual portions of code (e.g. data transfer after the handshake),
+  there is a mechanism to subtract the instructions that are part of a benchmark's setup.
+  Specifically, a benchmark can be configured to have another benchmark's instruction count
+  subtracted from it. We are currently using this to subtract the handshake instructions from the
+  data transfer benchmark.
+
+### Debugging
+
+If you need to debug the crate, here are a few tricks that might help:
+
+- For printf debugging, you should use `eprintln!`, because child processes use stdio as the
+  transport for the TLS connection (i.e. if you print something to stdout, you won't even see it
+  _and_ the other side of the connection will choke on it).
+- When using a proper debugger, remember that each side of the connection runs as a child process.
+  If necessary, you can tweak the code to ensure both sides of the connection run on the parent
+  process (e.g. by starting each side on its own thread and having them communicate through TCP).
+  This should require little effort, because the TLS transport layer is encapsulated and generic
+  over `Read` and `Write`.
+
+### Why measure CPU instructions
+
+This technique has been successfully used in tracking the Rust compiler's performance, and is
+known to work well when comparing two versions of the same code. It has incredibly low noise,
+and therefore makes for a very good metric for automatic PR checking (i.e. the automatic check
+will reliably identify significant performance changes).
+
+It is not possible to deduce the exact change in runtime based on the instruction count
+difference (e.g. a 5% increase in instructions does not necessarily result in a 5% increase in
+runtime). However, if there is a significant change in instruction count, you can be fairly
+confident there is a significant change in runtime too. This is very useful information to have
+when reviewing a PR.
+
+For more information, including the alternatives we considered, check out [this comment]
+(https://github.com/rustls/rustls/issues/1385#issuecomment-1668023152) in the issue tracker.

--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -1,0 +1,197 @@
+use std::collections::{HashMap, HashSet};
+
+use itertools::Itertools;
+
+use crate::cachegrind::InstructionCounts;
+use crate::util::KeyType;
+use crate::Side;
+
+/// Validates a benchmark collection, returning an error if the provided benchmarks are invalid
+///
+/// Benchmarks can be invalid because of the following reasons:
+///
+/// - Re-using an already defined benchmark name.
+/// - Referencing a non-existing benchmark in [`ReportingMode::AllInstructionsExceptSetup`].
+pub fn validate_benchmarks(benchmarks: &[Benchmark]) -> anyhow::Result<()> {
+    // Detect duplicate definitions
+    let duplicate_names: Vec<_> = benchmarks
+        .iter()
+        .map(|b| b.name.as_str())
+        .duplicates()
+        .collect();
+    if !duplicate_names.is_empty() {
+        anyhow::bail!(
+            "The following benchmarks are defined multiple times: {}",
+            duplicate_names.join(", ")
+        );
+    }
+
+    // Detect dangling benchmark references
+    let all_names: HashSet<_> = benchmarks
+        .iter()
+        .map(|b| b.name.as_str())
+        .collect();
+    let referenced_names: HashSet<_> = benchmarks
+        .iter()
+        .flat_map(|b| match &b.reporting_mode {
+            ReportingMode::AllInstructions => None,
+            ReportingMode::AllInstructionsExceptSetup(name) => Some(name.as_str()),
+        })
+        .collect();
+
+    let undefined_names: Vec<_> = referenced_names
+        .difference(&all_names)
+        .cloned()
+        .collect();
+    if !undefined_names.is_empty() {
+        anyhow::bail!("The following benchmark names are referenced, but have no corresponding benchmarks: {}",
+            undefined_names.join(", "));
+    }
+
+    Ok(())
+}
+
+/// Specifies how the results of a particular benchmark should be reported
+pub enum ReportingMode {
+    /// All instructions are reported
+    AllInstructions,
+    /// All instructions are reported, after subtracting the instructions of the setup code
+    ///
+    /// The instruction count of the setup code is obtained by running a benchmark containing only
+    /// that code. The string parameter corresponds to the name of that benchmark.
+    AllInstructionsExceptSetup(String),
+}
+
+/// Get the reported instruction counts for the provided benchmark
+pub fn get_reported_instr_count(
+    bench: &Benchmark,
+    results: &HashMap<&str, InstructionCounts>,
+) -> InstructionCounts {
+    match bench.reporting_mode() {
+        ReportingMode::AllInstructions => results[&bench.name()],
+        ReportingMode::AllInstructionsExceptSetup(setup_name) => {
+            let bench_results = results[&bench.name()];
+            let setup_results = results[setup_name.as_str()];
+            bench_results - setup_results
+        }
+    }
+}
+
+/// Specifies which functionality is being benchmarked
+#[derive(Copy, Clone)]
+pub enum BenchmarkKind {
+    /// Perform the handshake and exit
+    Handshake(ResumptionKind),
+    /// Perform the handshake and transfer 1MB of data
+    Transfer,
+}
+
+impl BenchmarkKind {
+    /// Returns the [`ResumptionKind`] used in the handshake part of the benchmark
+    pub fn resumption_kind(self) -> ResumptionKind {
+        match self {
+            BenchmarkKind::Handshake(kind) => kind,
+            BenchmarkKind::Transfer => ResumptionKind::No,
+        }
+    }
+}
+
+#[derive(PartialEq, Clone, Copy)]
+/// The kind of resumption used during the handshake
+pub enum ResumptionKind {
+    /// No resumption
+    No,
+    /// Session ID
+    SessionID,
+    /// Session tickets
+    Tickets,
+}
+
+impl ResumptionKind {
+    pub const ALL: &'static [ResumptionKind] = &[Self::No, Self::SessionID, Self::Tickets];
+
+    /// Returns a user-facing label that identifies the resumption kind
+    pub fn label(&self) -> &'static str {
+        match *self {
+            Self::No => "no_resume",
+            Self::SessionID => "session_id",
+            Self::Tickets => "tickets",
+        }
+    }
+}
+
+/// Parameters associated to a benchmark
+#[derive(Copy, Clone)]
+pub struct BenchmarkParams {
+    /// The type of key used to sign the TLS certificate
+    pub key_type: KeyType,
+    /// Cipher suite
+    pub ciphersuite: rustls::SupportedCipherSuite,
+    /// TLS version
+    pub version: &'static rustls::SupportedProtocolVersion,
+    /// A user-facing label that identifies these params
+    pub label: &'static str,
+}
+
+impl BenchmarkParams {
+    /// Create a new set of benchmark params
+    pub const fn new(
+        key_type: KeyType,
+        ciphersuite: rustls::SupportedCipherSuite,
+        version: &'static rustls::SupportedProtocolVersion,
+        label: &'static str,
+    ) -> Self {
+        Self {
+            key_type,
+            ciphersuite,
+            version,
+            label,
+        }
+    }
+}
+
+/// A benchmark specification
+pub struct Benchmark {
+    /// The name of the benchmark, as shown in the benchmark results
+    name: String,
+    /// The benchmark kind
+    pub kind: BenchmarkKind,
+    /// The benchmark's parameters
+    pub params: BenchmarkParams,
+    /// The way instruction counts should be reported for this benchmark
+    pub reporting_mode: ReportingMode,
+}
+
+impl Benchmark {
+    /// Create a new benchmark
+    pub fn new(name: String, kind: BenchmarkKind, params: BenchmarkParams) -> Self {
+        Self {
+            name,
+            kind,
+            params,
+            reporting_mode: ReportingMode::AllInstructions,
+        }
+    }
+
+    /// Configure this benchmark to subtract the instruction count of the referenced benchmark when
+    /// reporting results
+    pub fn exclude_setup_instructions(mut self, name: String) -> Self {
+        self.reporting_mode = ReportingMode::AllInstructionsExceptSetup(name);
+        self
+    }
+
+    /// Returns the benchmark's unique name
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the benchmark's unique name with the side appended to it
+    pub fn name_with_side(&self, side: Side) -> String {
+        format!("{}_{}", self.name, side.as_str())
+    }
+
+    /// Returns the benchmark's reporting mode
+    pub fn reporting_mode(&self) -> &ReportingMode {
+        &self.reporting_mode
+    }
+}

--- a/ci-bench/src/cachegrind.rs
+++ b/ci-bench/src/cachegrind.rs
@@ -1,0 +1,218 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::ops::Sub;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use anyhow::Context;
+
+use crate::benchmark::Benchmark;
+use crate::Side;
+
+/// A cachegrind-based benchmark runner
+pub struct CachegrindRunner {
+    /// The path to the ci-bench executable
+    ///
+    /// This is necessary because the cachegrind runner works by spawning child processes
+    executable: String,
+    /// The amount of instructions that are executed upon startup of the child process, before
+    /// actually running one of the benchmarks
+    ///
+    /// This count is subtracted from benchmark results, to reduce noise
+    overhead_instructions: u64,
+}
+
+impl CachegrindRunner {
+    /// Returns a new cachegrind-based benchmark runner
+    pub fn new(executable: String) -> anyhow::Result<Self> {
+        Self::ensure_cachegrind_available()?;
+
+        // We don't care about the side here, so let's use `Server` just to choose something
+        let overhead_instructions = Self::run_bench_side(
+            &executable,
+            u32::MAX,
+            Side::Server,
+            "calibration",
+            Stdio::piped(),
+            Stdio::piped(),
+        )?
+        .wait_and_get_instr_count()
+        .context("Unable to count overhead instructions")?;
+
+        Ok(CachegrindRunner {
+            executable,
+            overhead_instructions,
+        })
+    }
+
+    /// Runs the benchmark at the specified index and returns the instruction counts for each side
+    pub fn run_bench(
+        &self,
+        benchmark_index: u32,
+        bench: &Benchmark,
+    ) -> anyhow::Result<InstructionCounts> {
+        // The server and client are started as child processes, and communicate with each other
+        // through stdio.
+
+        let mut server = Self::run_bench_side(
+            &self.executable,
+            benchmark_index,
+            Side::Server,
+            &bench.name_with_side(Side::Server),
+            Stdio::piped(),
+            Stdio::piped(),
+        )
+        .context("server side bench crashed")?;
+
+        let client = Self::run_bench_side(
+            &self.executable,
+            benchmark_index,
+            Side::Client,
+            &bench.name_with_side(Side::Client),
+            Stdio::from(server.process.stdout.take().unwrap()),
+            Stdio::from(server.process.stdin.take().unwrap()),
+        )
+        .context("client side bench crashed")?;
+
+        let counts = InstructionCounts {
+            server: server.wait_and_get_instr_count()?,
+            client: client.wait_and_get_instr_count()?,
+        };
+
+        let overhead_counts = InstructionCounts {
+            server: self.overhead_instructions,
+            client: self.overhead_instructions,
+        };
+
+        Ok(counts - overhead_counts)
+    }
+
+    /// Returns an error if cachegrind is not available
+    fn ensure_cachegrind_available() -> anyhow::Result<()> {
+        let result = Command::new("valgrind")
+            .arg("--tool=cachegrind")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+
+        match result {
+            Err(e) => anyhow::bail!("Unexpected error while launching cachegrind. Error: {}", e),
+            Ok(status) => {
+                if status.success() {
+                    Ok(())
+                } else {
+                    anyhow::bail!("Failed to launch cachegrind. Error: {}. Please ensure that valgrind is installed and on the $PATH.", status)
+                }
+            }
+        }
+    }
+
+    /// See docs for [`Self::run_bench`]
+    fn run_bench_side(
+        executable: &str,
+        benchmark_index: u32,
+        side: Side,
+        name: &str,
+        stdin: Stdio,
+        stdout: Stdio,
+    ) -> anyhow::Result<BenchSubprocess> {
+        let output_file = PathBuf::from(format!("target/cachegrind/cachegrind.out.{}", name));
+        std::fs::create_dir_all(output_file.parent().unwrap())
+            .context("Failed to create cachegrind output directory")?;
+
+        // Run under setarch to disable ASLR, to reduce noise
+        let mut cmd = Command::new("setarch");
+        let child = cmd
+            .arg("-R")
+            .arg("valgrind")
+            .arg("--tool=cachegrind")
+            // Disable the cache simulation, since we are only interested in instruction counts
+            .arg("--cache-sim=no")
+            // Discard cachegrind's logs, which would otherwise be printed to stderr (we want to
+            // keep stderr free of noise, to see any errors from the child process)
+            .arg("--log-file=/dev/null")
+            // The file where the instruction counts will be stored
+            .arg(format!("--cachegrind-out-file={}", output_file.display()))
+            .arg(executable)
+            .arg("run-single")
+            .arg(benchmark_index.to_string())
+            .arg(side.as_str())
+            .stdin(stdin)
+            .stdout(stdout)
+            .stderr(Stdio::inherit())
+            .spawn()
+            .context("Failed to run benchmark in cachegrind")?;
+
+        Ok(BenchSubprocess {
+            process: child,
+            output_file,
+        })
+    }
+}
+
+/// A running subprocess for one of the sides of the benchmark (client or server)
+struct BenchSubprocess {
+    /// The benchmark's child process, running under cachegrind
+    process: Child,
+    /// Cachegrind's output file for this benchmark
+    output_file: PathBuf,
+}
+
+impl BenchSubprocess {
+    /// Waits for the process to finish and returns the measured instruction count
+    fn wait_and_get_instr_count(mut self) -> anyhow::Result<u64> {
+        let status = self
+            .process
+            .wait()
+            .context("Failed to run benchmark in cachegrind")?;
+        if !status.success() {
+            anyhow::bail!(
+                "Failed to run benchmark in cachegrind. Exit code: {:?}",
+                status.code()
+            );
+        }
+
+        let instruction_count = parse_cachegrind_output(&self.output_file)?;
+        std::fs::remove_file(&self.output_file).ok();
+
+        Ok(instruction_count)
+    }
+}
+
+/// Returns the instruction count, extracted from the cachegrind output file at the provided path
+fn parse_cachegrind_output(file: &Path) -> anyhow::Result<u64> {
+    let file_in = File::open(file).context("Unable to open cachegrind output file")?;
+
+    for line in BufReader::new(file_in).lines() {
+        let line = line.context("Error reading cachegrind output file")?;
+        if let Some(line) = line.strip_prefix("summary: ") {
+            let instr_count = line
+                .trim()
+                .parse()
+                .context("Unable to parse instruction counts from cachegrind output file")?;
+
+            return Ok(instr_count);
+        }
+    }
+
+    anyhow::bail!("`summary` section not found in cachegrind output file")
+}
+
+/// The instruction counts, for each side, after running a benchmark
+#[derive(Copy, Clone)]
+pub struct InstructionCounts {
+    pub client: u64,
+    pub server: u64,
+}
+
+impl Sub for InstructionCounts {
+    type Output = InstructionCounts;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        InstructionCounts {
+            client: self.client - rhs.client,
+            server: self.server - rhs.server,
+        }
+    }
+}

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -1,0 +1,632 @@
+use std::collections::HashMap;
+use std::fs;
+use std::hint::black_box;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Context;
+use clap::{Parser, Subcommand, ValueEnum};
+use itertools::Itertools;
+use rayon::iter::Either;
+use rayon::prelude::*;
+use rustls::client::Resumption;
+use rustls::crypto::ring::Ring;
+use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
+use rustls::{
+    ClientConfig, ClientConnection, ProtocolVersion, RootCertStore, ServerConfig, ServerConnection,
+    Ticketer,
+};
+
+use crate::benchmark::{
+    get_reported_instr_count, validate_benchmarks, Benchmark, BenchmarkKind, BenchmarkParams,
+    ResumptionKind,
+};
+use crate::cachegrind::CachegrindRunner;
+use crate::util::transport::{
+    read_handshake_message, read_plaintext_to_end_bounded, send_handshake_message,
+    write_all_plaintext_bounded,
+};
+use crate::util::KeyType;
+
+mod benchmark;
+mod cachegrind;
+mod util;
+
+/// The size in bytes of the plaintext sent in the transfer benchmark
+const TRANSFER_PLAINTEXT_SIZE: usize = 1024 * 1024;
+
+/// The amount of times a resumed handshake should be executed during benchmarking.
+///
+/// Handshakes with session resumption execute a very small amount of instructions (less than 200_000
+/// for some parameters), so a small difference in instructions accounts for a high difference in
+/// percentage (making the benchmark more sensitive to noise, because differences as low as 500
+/// instructions already raise a flag). Running the handshake multiple times gives additional weight
+/// to the instructions involved in the handshake, and less weight to noisy one-time setup code.
+///
+/// More specifically, great part of the noise in resumed handshakes comes from the usage of
+/// [`rustls::client::ClientSessionMemoryCache`] and [`rustls::server::ServerSessionMemoryCache`],
+/// which rely on a randomized `HashMap` under the hood (you can check for yourself by that
+/// `HashMap` by a `FxHashMap`, which brings the noise down to acceptable levels in a single run).
+const RESUMED_HANDSHAKE_RUNS: usize = 3;
+
+/// The threshold at which instruction count changes are considered relevant
+const CHANGE_THRESHOLD: f64 = 0.002; // 0.2%
+
+#[derive(Parser)]
+#[command(about)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Run all benchmarks and prints the measured CPU instruction counts in CSV format
+    RunAll,
+    /// Run a single benchmark at the provided index (used by the bench runner to start each benchmark in its own process)
+    RunSingle { index: u32, side: Side },
+    /// Compare the results from two previous benchmark runs and print a user-friendly markdown overview
+    Compare {
+        /// Path to a CSV file obtained from a previous `run-all` execution
+        baseline_input: PathBuf,
+        /// Path to a CSV file obtained from a previous `run-all` execution
+        candidate_input: PathBuf,
+    },
+}
+
+#[derive(Copy, Clone, ValueEnum)]
+pub enum Side {
+    Server,
+    Client,
+}
+
+impl Side {
+    /// Returns the string representation of the side
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Side::Client => "client",
+            Side::Server => "server",
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let benchmarks = all_benchmarks()?;
+
+    let cli = Cli::parse();
+    match cli.command {
+        Command::RunAll => {
+            let executable = std::env::args().next().unwrap();
+            let results = run_all(executable, &benchmarks)?;
+
+            // Output results in CSV (note: not using a library here to avoid extra dependencies)
+            for (name, instr_count) in results {
+                println!("{name},{instr_count}");
+            }
+        }
+        Command::RunSingle { index, side } => {
+            // `u32::MAX` is used as a signal to do nothing and return. By "running" an empty
+            // benchmark we can measure the startup overhead.
+            if index == u32::MAX {
+                return Ok(());
+            }
+
+            let bench = benchmarks
+                .get(index as usize)
+                .ok_or(anyhow::anyhow!("Benchmark not found: {index}"))?;
+
+            let mut stdin = io::stdin().lock();
+            let mut stdout = io::stdout().lock();
+
+            let handshake_buf = &mut [0u8; 262144];
+            let resumption_kind = black_box(bench.kind.resumption_kind());
+            let params = black_box(bench.params);
+            let io = StepperIO {
+                reader: &mut stdin,
+                writer: &mut stdout,
+                handshake_buf,
+            };
+            let result = match side {
+                Side::Server => run_bench(
+                    ServerSideStepper {
+                        io,
+                        config: ServerSideStepper::make_config(&params, resumption_kind),
+                    },
+                    bench.kind,
+                ),
+                Side::Client => run_bench(
+                    ClientSideStepper {
+                        io,
+                        resumption_kind,
+                        config: ClientSideStepper::make_config(&params, resumption_kind),
+                    },
+                    bench.kind,
+                ),
+            };
+
+            result
+                .with_context(|| format!("{} crashed for {} side", bench.name(), side.as_str()))?;
+        }
+        Command::Compare {
+            baseline_input,
+            candidate_input,
+        } => {
+            let baseline = read_results(baseline_input.as_ref())?;
+            let candidate = read_results(candidate_input.as_ref())?;
+            let result = compare_results(&baseline, &candidate);
+            print_report(result);
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns all benchmarks
+fn all_benchmarks() -> anyhow::Result<Vec<Benchmark>> {
+    let mut benchmarks = Vec::new();
+    for &param in ALL_BENCHMARK_PARAMS {
+        add_benchmark_group(&mut benchmarks, param);
+    }
+
+    validate_benchmarks(&benchmarks)?;
+    Ok(benchmarks)
+}
+
+/// The benchmark params to use for each group of benchmarks
+static ALL_BENCHMARK_PARAMS: &[BenchmarkParams] = &[
+    BenchmarkParams::new(
+        KeyType::Rsa,
+        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        &rustls::version::TLS12,
+        "1.2_rsa_aes",
+    ),
+    BenchmarkParams::new(
+        KeyType::Rsa,
+        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        &rustls::version::TLS13,
+        "1.3_rsa_aes",
+    ),
+    BenchmarkParams::new(
+        KeyType::Ecdsa,
+        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        &rustls::version::TLS13,
+        "1.3_ecdsa_aes",
+    ),
+    BenchmarkParams::new(
+        KeyType::Rsa,
+        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        &rustls::version::TLS13,
+        "1.3_rsa_chacha",
+    ),
+    BenchmarkParams::new(
+        KeyType::Ecdsa,
+        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        &rustls::version::TLS13,
+        "1.3_ecdsa_chacha",
+    ),
+];
+
+/// Adds a group of benchmarks for the specified parameters
+///
+/// The benchmarks in the group are:
+///
+/// - Handshake without resumption
+/// - Handshake with session id resumption
+/// - Handshake with ticket resumption
+/// - Transfer a 1MB data stream from the server to the client
+fn add_benchmark_group(benchmarks: &mut Vec<Benchmark>, params: BenchmarkParams) {
+    let params_label = params.label;
+
+    // Create handshake benchmarks for all resumption kinds
+    for &resumption_param in ResumptionKind::ALL {
+        let handshake_bench = Benchmark::new(
+            format!("handshake_{}_{params_label}", resumption_param.label()),
+            BenchmarkKind::Handshake(resumption_param),
+            params,
+        );
+
+        let handshake_bench = if resumption_param != ResumptionKind::No {
+            // Since resumed handshakes include a first non-resumed handshake, we need to subtract
+            // the non-resumed handshake's instructions
+            handshake_bench
+                .exclude_setup_instructions(format!("handshake_no_resume_{params_label}"))
+        } else {
+            handshake_bench
+        };
+
+        benchmarks.push(handshake_bench);
+    }
+
+    // Benchmark data transfer
+    benchmarks.push(
+        Benchmark::new(
+            format!("transfer_no_resume_{params_label}"),
+            BenchmarkKind::Transfer,
+            params,
+        )
+        .exclude_setup_instructions(format!("handshake_no_resume_{params_label}")),
+    );
+}
+
+/// Run all the provided benches under cachegrind to retrieve their instruction count
+pub fn run_all(executable: String, benches: &[Benchmark]) -> anyhow::Result<Vec<(String, u64)>> {
+    // Run the benchmarks in parallel
+    let cachegrind = CachegrindRunner::new(executable)?;
+    let results: Vec<_> = benches
+        .par_iter()
+        .enumerate()
+        .map(|(i, bench)| (bench, cachegrind.run_bench(i as u32, bench)))
+        .collect();
+
+    // Report possible errors
+    let (errors, results): (Vec<_>, HashMap<_, _>) =
+        results
+            .into_iter()
+            .partition_map(|(bench, result)| match result {
+                Err(_) => Either::Left(()),
+                Ok(instr_counts) => Either::Right((bench.name(), instr_counts)),
+            });
+    if !errors.is_empty() {
+        // Note: there is no need to explicitly report the names of each crashed benchmark, because
+        // names and other details are automatically printed to stderr by the child process upon
+        // crashing
+        anyhow::bail!("One or more benchmarks crashed");
+    }
+
+    // Gather results keeping the original order of the benchmarks
+    let mut measurements = Vec::new();
+    for bench in benches {
+        let instr_counts = get_reported_instr_count(bench, &results);
+        measurements.push((bench.name_with_side(Side::Server), instr_counts.server));
+        measurements.push((bench.name_with_side(Side::Client), instr_counts.client));
+    }
+
+    Ok(measurements)
+}
+
+/// Drives the different steps in a benchmark.
+///
+/// See [`run_bench`] for specific details on how it is used.
+trait BenchStepper {
+    type Endpoint;
+
+    fn handshake(&mut self) -> anyhow::Result<Self::Endpoint>;
+    fn sync_before_resumed_handshake(&mut self) -> anyhow::Result<()>;
+    fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()>;
+}
+
+/// Stepper fields necessary for IO
+struct StepperIO<'a> {
+    reader: &'a mut dyn Read,
+    writer: &'a mut dyn Write,
+    handshake_buf: &'a mut [u8],
+}
+
+/// A benchmark stepper for the client-side of the connection
+struct ClientSideStepper<'a> {
+    io: StepperIO<'a>,
+    resumption_kind: ResumptionKind,
+    config: Arc<ClientConfig<Ring>>,
+}
+
+impl ClientSideStepper<'_> {
+    fn make_config(params: &BenchmarkParams, resume: ResumptionKind) -> Arc<ClientConfig<Ring>> {
+        assert_eq!(params.ciphersuite.version(), params.version);
+        let mut root_store = RootCertStore::empty();
+        let mut rootbuf =
+            io::BufReader::new(fs::File::open(params.key_type.path_for("ca.cert")).unwrap());
+        root_store.add_parsable_certificates(rustls_pemfile::certs(&mut rootbuf).unwrap());
+
+        let mut cfg = ClientConfig::builder()
+            .with_cipher_suites(&[params.ciphersuite])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[params.version])
+            .unwrap()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+
+        if resume != ResumptionKind::No {
+            cfg.resumption = Resumption::in_memory_sessions(128);
+        } else {
+            cfg.resumption = Resumption::disabled();
+        }
+
+        Arc::new(cfg)
+    }
+}
+
+impl BenchStepper for ClientSideStepper<'_> {
+    type Endpoint = ClientConnection;
+
+    fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
+        let server_name = "localhost".try_into().unwrap();
+        let mut client = ClientConnection::new(self.config.clone(), server_name).unwrap();
+        client.set_buffer_limit(None);
+
+        loop {
+            send_handshake_message(&mut client, self.io.writer, self.io.handshake_buf)?;
+            if !client.is_handshaking() && !client.wants_write() {
+                break;
+            }
+            read_handshake_message(&mut client, self.io.reader, self.io.handshake_buf)?;
+        }
+
+        // Session ids and tickets are no longer part of the handshake in TLS 1.3, so we need to
+        // explicitly receive them from the server
+        if self.resumption_kind != ResumptionKind::No
+            && client.protocol_version().unwrap() == ProtocolVersion::TLSv1_3
+        {
+            read_handshake_message(&mut client, self.io.reader, self.io.handshake_buf)?;
+        }
+
+        Ok(client)
+    }
+
+    fn sync_before_resumed_handshake(&mut self) -> anyhow::Result<()> {
+        // The client syncs by receiving a single byte (we assert that it matches the `42` byte sent
+        // by the server, just to be sure)
+        let buf = &mut [0];
+        self.io.reader.read_exact(buf)?;
+        assert_eq!(buf[0], 42);
+        Ok(())
+    }
+
+    fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()> {
+        let total_plaintext_read = read_plaintext_to_end_bounded(endpoint, self.io.reader)?;
+        assert_eq!(total_plaintext_read, TRANSFER_PLAINTEXT_SIZE);
+        Ok(())
+    }
+}
+
+/// A benchmark stepper for the server-side of the connection
+struct ServerSideStepper<'a> {
+    io: StepperIO<'a>,
+    config: Arc<ServerConfig<Ring>>,
+}
+
+impl ServerSideStepper<'_> {
+    fn make_config(params: &BenchmarkParams, resume: ResumptionKind) -> Arc<ServerConfig<Ring>> {
+        assert_eq!(params.ciphersuite.version(), params.version);
+
+        let mut cfg = ServerConfig::builder()
+            .with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[params.version])
+            .unwrap()
+            .with_client_cert_verifier(WebPkiClientVerifier::no_client_auth())
+            .with_single_cert(params.key_type.get_chain(), params.key_type.get_key())
+            .expect("bad certs/private key?");
+
+        if resume == ResumptionKind::SessionID {
+            cfg.session_storage = ServerSessionMemoryCache::new(128);
+        } else if resume == ResumptionKind::Tickets {
+            cfg.ticketer = Ticketer::new().unwrap();
+        } else {
+            cfg.session_storage = Arc::new(NoServerSessionStorage {});
+        }
+
+        Arc::new(cfg)
+    }
+}
+
+impl BenchStepper for ServerSideStepper<'_> {
+    type Endpoint = ServerConnection;
+
+    fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
+        let mut server = ServerConnection::new(self.config.clone()).unwrap();
+        server.set_buffer_limit(None);
+
+        while server.is_handshaking() {
+            read_handshake_message(&mut server, self.io.reader, self.io.handshake_buf)?;
+            send_handshake_message(&mut server, self.io.writer, self.io.handshake_buf)?;
+        }
+
+        Ok(server)
+    }
+
+    fn sync_before_resumed_handshake(&mut self) -> anyhow::Result<()> {
+        // The server syncs by sending a single byte
+        self.io.writer.write_all(&[42])?;
+        self.io.writer.flush()?;
+        Ok(())
+    }
+
+    fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()> {
+        write_all_plaintext_bounded(endpoint, self.io.writer, TRANSFER_PLAINTEXT_SIZE)?;
+        Ok(())
+    }
+}
+
+/// Runs the benchmark using the provided stepper
+fn run_bench<T: BenchStepper>(mut stepper: T, kind: BenchmarkKind) -> anyhow::Result<()> {
+    let mut endpoint = stepper.handshake()?;
+
+    match kind {
+        BenchmarkKind::Handshake(ResumptionKind::No) => {
+            // Nothing else to do here, since the handshake already happened
+            black_box(endpoint);
+        }
+        BenchmarkKind::Handshake(_) => {
+            // The handshake performed above was non-resumed, because the client didn't have a
+            // session ID / ticket; from now on we can perform resumed handshakes. We do it multiple
+            // times, for reasons explained in the comments to `RESUMED_HANDSHAKE_RUNS`.
+            for _ in 0..RESUMED_HANDSHAKE_RUNS {
+                // Wait for the endpoints to sync (i.e. the server must have discarded the previous
+                // connection and be ready for a new handshake, otherwise the client will start a
+                // handshake before the server is ready and the bytes will be fed to the old
+                // connection!)
+                stepper.sync_before_resumed_handshake()?;
+                stepper.handshake()?;
+            }
+        }
+        BenchmarkKind::Transfer => {
+            stepper.transmit_data(&mut endpoint)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// The results of a comparison between two `run-all` executions
+struct CompareResult {
+    diffs: Vec<Diff>,
+    /// Benchmark scenarios present in the candidate but missing in the baseline
+    missing_in_baseline: Vec<String>,
+}
+
+/// Contains information about instruction counts and their difference for a specific scenario
+struct Diff {
+    scenario: String,
+    baseline: u64,
+    candidate: u64,
+    diff: i64,
+    diff_ratio: f64,
+}
+
+/// Reads the (benchmark, instruction count) pairs from previous CSV output
+fn read_results(path: &Path) -> anyhow::Result<HashMap<String, u64>> {
+    let file = fs::File::open(path).context("CSV file for comparison not found")?;
+
+    let mut measurements = HashMap::new();
+    for line in BufReader::new(file).lines() {
+        let line = line.context("Unable to read results from CSV file")?;
+        let line = line.trim();
+        let mut parts = line.split(',');
+        measurements.insert(
+            parts
+                .next()
+                .ok_or(anyhow::anyhow!("CSV is wrongly formatted"))?
+                .to_string(),
+            parts
+                .next()
+                .ok_or(anyhow::anyhow!("CSV is wrongly formatted"))?
+                .parse()
+                .context("Unable to parse instruction count from CSV")?,
+        );
+    }
+
+    Ok(measurements)
+}
+
+/// Returns an internal representation of the comparison between the baseline and the candidate
+/// measurements
+fn compare_results(
+    baseline: &HashMap<String, u64>,
+    candidate: &HashMap<String, u64>,
+) -> CompareResult {
+    let mut diffs = Vec::new();
+    let mut missing = Vec::new();
+    for (scenario, &instr_count) in candidate {
+        let Some(&baseline_instr_count) = baseline.get(scenario) else {
+            missing.push(scenario.clone());
+            continue;
+        };
+
+        let diff = instr_count as i64 - baseline_instr_count as i64;
+        let diff_ratio = diff as f64 / baseline_instr_count as f64;
+        diffs.push(Diff {
+            scenario: scenario.clone(),
+            baseline: baseline_instr_count,
+            candidate: instr_count,
+            diff,
+            diff_ratio,
+        });
+    }
+
+    CompareResult {
+        diffs,
+        missing_in_baseline: missing,
+    }
+}
+
+/// Prints a report of the comparison to stdout, using GitHub-flavored markdown
+fn print_report(mut result: CompareResult) {
+    result.diffs.sort_by(|diff1, diff2| {
+        diff2
+            .diff_ratio
+            .abs()
+            .total_cmp(&diff1.diff_ratio.abs())
+    });
+
+    println!("# Benchmark results");
+
+    if !result.missing_in_baseline.is_empty() {
+        println!("### ⚠️ Warning: missing benchmarks");
+        println!();
+        println!("The following benchmark scenarios are present in the candidate but not in the baseline:");
+        println!();
+        for scenario in &result.missing_in_baseline {
+            println!("* {scenario}");
+        }
+    }
+
+    if result.diffs.is_empty() {
+        println!("### ⚠️ Warning: missing benchmarks");
+        println!();
+        println!("There are no benchmarks to report");
+        return;
+    }
+
+    let (noteworthy, negligible) = split_on_threshold(&result.diffs);
+
+    println!("### Noteworthy instruction count differences");
+    if noteworthy.is_empty() {
+        println!(
+            "_There are no noteworthy instruction count differences (i.e. above {}%)_",
+            CHANGE_THRESHOLD * 100.0
+        );
+    } else {
+        table(noteworthy, true);
+    }
+
+    println!("### Other instruction count differences");
+    if negligible.is_empty() {
+        println!("_There are no other instruction count differences_");
+    } else {
+        println!("<details>");
+        println!("<summary>Click to expand</summary>\n");
+        table(negligible, false);
+        println!("</details>\n")
+    }
+}
+
+/// Splits the diffs into two slices, the first one containing the diffs that exceed the threshold,
+/// the second one containing the rest.
+///
+/// Assumes that the diff slice is sorted by `diff_ratio` in descending order.
+fn split_on_threshold(diffs: &[Diff]) -> (&[Diff], &[Diff]) {
+    match diffs
+        .iter()
+        .position(|diff| diff.diff_ratio.abs() < CHANGE_THRESHOLD)
+    {
+        None => (diffs, &[]),
+        Some(first_below_threshold) => (
+            &diffs[..first_below_threshold],
+            &diffs[first_below_threshold..],
+        ),
+    }
+}
+
+/// Renders the diffs as a markdown table
+fn table(diffs: &[Diff], emoji_feedback: bool) {
+    println!("| Scenario | Baseline | Candidate | Diff |");
+    println!("| --- | ---: | ---: | ---: |");
+    for diff in diffs {
+        let emoji = match emoji_feedback {
+            true if diff.diff > 0 => "⚠️ ",
+            true if diff.diff < 0 => "✅ ",
+            _ => "",
+        };
+
+        println!(
+            "| {} | {} | {} | {}{} ({:.2}%) |",
+            diff.scenario,
+            diff.baseline,
+            diff.candidate,
+            emoji,
+            diff.diff,
+            diff.diff_ratio * 100.0
+        )
+    }
+}

--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -1,0 +1,195 @@
+use std::{fs, io};
+
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub enum KeyType {
+    Rsa,
+    Ecdsa,
+}
+
+impl KeyType {
+    pub(crate) fn path_for(&self, part: &str) -> String {
+        match self {
+            Self::Rsa => format!("../test-ca/rsa/{}", part),
+            Self::Ecdsa => format!("../test-ca/ecdsa/{}", part),
+        }
+    }
+
+    pub(crate) fn get_chain(&self) -> Vec<rustls::Certificate> {
+        rustls_pemfile::certs(&mut io::BufReader::new(
+            fs::File::open(self.path_for("end.fullchain")).unwrap(),
+        ))
+        .unwrap()
+        .iter()
+        .map(|v| rustls::Certificate(v.clone()))
+        .collect()
+    }
+
+    pub(crate) fn get_key(&self) -> rustls::PrivateKey {
+        rustls::PrivateKey(
+            rustls_pemfile::pkcs8_private_keys(&mut io::BufReader::new(
+                fs::File::open(self.path_for("end.key")).unwrap(),
+            ))
+            .unwrap()[0]
+                .clone(),
+        )
+    }
+}
+
+pub mod transport {
+    //! This module implements custom functions to interact between rustls clients and a servers.
+    //!
+    //! The goal of these functions is to ensure messages are exchanged in chunks of a fixed size, to make
+    //! instruction counts more deterministic. This is particularly important for the receiver of the
+    //! data. Without it, the amount of bytes received in a single `read` call can wildly differ among
+    //! benchmark runs, which in turn influences the resizing of rustls' internal buffers, and therefore
+    //! affects the instruction count (resulting in consistent noise above 2% for the client-side of the
+    //! data transfer benchmarks, which is unacceptable).
+    //!
+    //! Note that this approach introduces extra copies, because we are using an intermediate buffer,
+    //! but that doesn't matter (we are measuring performance differences, and overhead is automatically
+    //! ignored as long as it remains constant).
+
+    use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+    use rustls::{ClientConnection, ConnectionCommon, ServerConnection, SideData};
+    use std::io::{Read, Write};
+
+    /// Sends one side's handshake data to the other side in one go.
+    ///
+    /// Because it is not possible for the receiver to know beforehand how many bytes are contained in
+    /// the message, the transmission consists of a leading big-endian u32 specifying the message's
+    /// length, followed by the message itself.
+    ///
+    /// The receiving end should use [`read_handshake_message`] to process the transmission.
+    pub fn send_handshake_message<T: SideData>(
+        conn: &mut ConnectionCommon<T>,
+        writer: &mut dyn Write,
+        buf: &mut [u8],
+    ) -> anyhow::Result<()> {
+        // Write all bytes the connection wants to send to an intermediate buffer
+        let mut written = 0;
+        while conn.wants_write() {
+            if written >= buf.len() {
+                anyhow::bail!(
+                    "Not enough space in buffer for outgoing message (buf len = {})",
+                    buf.len()
+                );
+            }
+
+            written += conn.write_tls(&mut &mut buf[written..])?;
+        }
+
+        if written == 0 {
+            return Ok(());
+        }
+
+        // Write the whole buffer in one go, preceded by its length
+        writer.write_u32::<BigEndian>(written as u32)?;
+        writer.write_all(&buf[..written])?;
+        writer.flush()?;
+
+        Ok(())
+    }
+
+    /// Receives one side's handshake data to the other side in one go.
+    ///
+    /// Used in combination with [`send_handshake_message`] (see that function's documentation for
+    /// more details).
+    pub fn read_handshake_message<T: SideData>(
+        conn: &mut ConnectionCommon<T>,
+        reader: &mut dyn Read,
+        buf: &mut [u8],
+    ) -> anyhow::Result<usize> {
+        // Read the message to an intermediate buffer
+        let length = reader.read_u32::<BigEndian>()? as usize;
+        if length >= buf.len() {
+            anyhow::bail!(
+            "Not enough space in buffer for incoming message (msg len = {length}, buf len = {})",
+            buf.len()
+        );
+        }
+        reader.read_exact(&mut buf[..length])?;
+
+        // Feed the data to rustls
+        let in_memory_reader = &mut &buf[..length];
+        while conn.read_tls(in_memory_reader)? != 0 {
+            conn.process_new_packets()?;
+        }
+
+        Ok(length)
+    }
+
+    /// Reads plaintext until the reader reaches EOF, using a bounded amount of memory.
+    ///
+    /// Returns the amount of plaintext bytes received.
+    pub fn read_plaintext_to_end_bounded(
+        client: &mut ClientConnection,
+        reader: &mut dyn Read,
+    ) -> anyhow::Result<usize> {
+        let mut chunk_buf = [0u8; 262_144];
+        let mut plaintext_buf = [0u8; 262_144];
+        let mut total_plaintext_bytes_read = 0;
+
+        loop {
+            // Read until the whole chunk is received
+            let mut chunk_buf_end = 0;
+            while chunk_buf_end != chunk_buf.len() {
+                let read = reader.read(&mut chunk_buf[chunk_buf_end..])?;
+                if read == 0 {
+                    // Stream closed
+                    break;
+                }
+
+                chunk_buf_end += read;
+            }
+
+            if chunk_buf_end == 0 {
+                // Stream closed
+                break;
+            }
+
+            // Load the buffer's bytes into rustls
+            let mut chunk_buf_offset = 0;
+            while chunk_buf_offset < chunk_buf_end {
+                let read = client.read_tls(&mut &chunk_buf[chunk_buf_offset..chunk_buf_end])?;
+                chunk_buf_offset += read;
+
+                // Process packets to free space in the message buffer
+                let state = client.process_new_packets()?;
+                let available_plaintext_bytes = state.plaintext_bytes_to_read();
+                let mut plaintext_bytes_read = 0;
+                while plaintext_bytes_read < available_plaintext_bytes {
+                    plaintext_bytes_read += client
+                        .reader()
+                        .read(&mut plaintext_buf)?;
+                }
+
+                total_plaintext_bytes_read += plaintext_bytes_read;
+            }
+        }
+
+        Ok(total_plaintext_bytes_read)
+    }
+
+    /// Writes a plaintext of size `plaintext_size`, using a bounded amount of memory
+    pub fn write_all_plaintext_bounded(
+        server: &mut ServerConnection,
+        writer: &mut dyn Write,
+        plaintext_size: usize,
+    ) -> anyhow::Result<()> {
+        let send_buf = [0u8; 262_144];
+        assert_eq!(plaintext_size % send_buf.len(), 0);
+        let iterations = plaintext_size / send_buf.len();
+
+        for _ in 0..iterations {
+            server.writer().write_all(&send_buf)?;
+
+            // Empty the server's buffer, so we can re-fill it in the next iteration
+            while server.wants_write() {
+                server.write_tls(writer)?;
+                writer.flush()?;
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR is a first step towards closing #1385. It implements a basic benchmarking setup suitable for CI, but doesn't hook it up yet to GitHub actions. The code is contained in its own crate (`ci-bench`).

Relevant features (check out the [readme](https://github.com/aochagavia/rustls/blob/ci-bench/ci-bench/README.md) for details):

1. Count CPU instructions for ~20 scenarios.
2. Separately measure server and client side CPU instructions.
3. Compare results between a baseline and a candidate, and generate a user-friendly overview in markdown (see the first comment to this PR as an example).

Non-features:

1. Aggregate statistics to better identify where a change in CPU counts comes from ([suggested](https://github.com/rustls/rustls/issues/1385#issuecomment-1678684307) by @djc). I'd rather get this out of the door in its current form, so we have something to iterate upon, and tweak it later if necessary.
2. GitHub Actions integration. I'd rather postpone this to focus on the benchmarking setup itself.
4. Benchmarks for memory usage. I still need to think about a reasonable setup for this one.

### Open question: significance threshold

Which instruction count diffs should be marked as significant (i.e. requiring attention of a reviewer)? I'm leaning towards a threshold of 0.2% because __it is the lowest change that can be confirmed or disproved by time-based benchmarks__.

If the instruction counts for a PR are suspect, we will want to confirm there is truly a performance regression through time-based benchmarks (remember that the change in executed CPU instructions is not necessarily in the same proportion as the change in wall time). Assuming a worst-case scenario where the wall time is affected by 5x the change in CPU instructions, a 0.2% change in instructions would amount to a 1% change in runtime. Time-based benchmarks take around 800 µs on my machine, and a difference of 1% (~8 µs) is just high enough to be detected through paired benchmarking.

There is a chance that the threshold is too low, and might result in noise (i.e. changes in instruction counts that cannot be reliably confirmed by time-based benchmarks). Still, as @djc [suggested](https://github.com/rustls/rustls/issues/1385#issuecomment-1671549976), it makes sense to start with a low threshold in order to gain experience. We can always tweak it later if it gets too annoying.

### Sidenote on the benchmarking code

The benchmarks themselves were adapted from [here](https://github.com/rustls/rustls/blob/6bdaf04e7af97821485da115b5436913fedea874/rustls/examples/internal/bench.rs). It would be nice if you can double check they are correct, because I'm not familiar enough with rustls to do so with confidence.