### PR TITLE
SECURITY.md: use github vuln reporting tool

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Therefore 0.20.x and 0.21.x will be updated, while 0.19.x will not be.
 
 ## Reporting a Vulnerability
 
-Please report security bugs by email to rustls-security@googlegroups.com.
+Please report security bugs [via github](https://github.com/rustls/rustls/security/advisories/new).
 We'll then:
 
 - Prepare a fix and regression tests.


### PR DESCRIPTION
We have a mailing list for this. But, the first time that was used for real, it didn't go very well:

- the report and a follow-up went into spam. A private google group delivering to gmail -- you'd think this would work well, but  it did not.
- there was only me in the group.

Github now has a "private vulnerability reporting" feature that should be better for getting reports to the right people quickly. Let's try that?