### PR TITLE
Arc-wrap ClientConfig `RootCertStore` and remove expensiveness warnings

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -16,7 +16,7 @@ impl<C: CryptoProvider> ConfigBuilder<ClientConfig<C>, WantsVerifier<C>> {
     /// Choose how to verify server certificates.
     pub fn with_root_certificates(
         self,
-        root_store: webpki::RootCertStore,
+        root_store: impl Into<Arc<webpki::RootCertStore>>,
     ) -> ConfigBuilder<ClientConfig<C>, WantsClientCert<C>> {
         ConfigBuilder {
             state: WantsClientCert {

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -107,11 +107,12 @@ pub trait ResolvesClientCert: Send + Sync {
     fn has_certs(&self) -> bool;
 }
 
-/// Common configuration for (typically) all connections made by
-/// a program.
+/// Common configuration for (typically) all connections made by a program.
 ///
-/// Making one of these can be expensive, and should be
-/// once per process rather than once per connection.
+/// Making one of these is cheap, though one of the inputs may be expensive: gathering trust roots
+/// from the operating system to add to the [`RootCertStore`] passed to `with_root_certificates()`
+/// (the rustls-native-certs crate is often used for this) may take on the order of a few hundred
+/// milliseconds.
 ///
 /// These must be created via the [`ClientConfig::builder()`] function.
 ///
@@ -122,6 +123,8 @@ pub trait ResolvesClientCert: Send + Sync {
 ///    ids or tickets, with a max of eight tickets per server.
 /// * [`ClientConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ClientConfig::key_log`]: key material is not logged.
+///
+/// [`RootCertStore`]: crate::RootCertStore
 pub struct ClientConfig<C: CryptoProvider> {
     /// List of ciphersuites, in preference order.
     pub(super) cipher_suites: Vec<SupportedCipherSuite>,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -185,8 +185,9 @@ impl<'a> ClientHello<'a> {
 
 /// Common configuration for a set of server sessions.
 ///
-/// Making one of these can be expensive, and should be
-/// once per process rather than once per connection.
+/// Making one of these is cheap, though one of the inputs may be expensive: gathering trust roots
+/// from the operating system to add to the [`RootCertStore`] passed to a `ClientCertVerifier`
+/// builder may take on the order of a few hundred milliseconds.
 ///
 /// These must be created via the [`ServerConfig::builder()`] function.
 ///
@@ -197,6 +198,8 @@ impl<'a> ClientHello<'a> {
 /// * [`ServerConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ServerConfig::key_log`]: key material is not logged.
 /// * [`ServerConfig::send_tls13_tickets`]: 4 tickets are sent.
+///
+/// [`RootCertStore`]: crate::RootCertStore
 pub struct ServerConfig<C: CryptoProvider> {
     /// List of ciphersuites, in preference order.
     pub(super) cipher_suites: Vec<SupportedCipherSuite>,

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -144,7 +144,7 @@ impl ServerCertVerifier for WebPkiServerVerifier {
 /// Default `ServerCertVerifier`, see the trait impl for more information.
 #[allow(unreachable_pub)]
 pub struct WebPkiServerVerifier {
-    roots: RootCertStore,
+    roots: Arc<RootCertStore>,
 }
 
 #[allow(unreachable_pub)]
@@ -152,8 +152,10 @@ impl WebPkiServerVerifier {
     /// Constructs a new `WebPkiServerVerifier`.
     ///
     /// `roots` is the set of trust anchors to trust for issuing server certs.
-    pub fn new(roots: RootCertStore) -> Self {
-        Self { roots }
+    pub fn new(roots: impl Into<Arc<RootCertStore>>) -> Self {
+        Self {
+            roots: roots.into(),
+        }
     }
 
     /// Which signature verification schemes the `webpki` crate supports.


### PR DESCRIPTION
From #1403:

> We should add some nuance to this, explaining for instance that loading a bundle of roots from disk may be slow, so ClientConfigs/ServerConfigs that use that method should be reused to the extent possible. And perhaps going into even more detail, that the slowness specifically lives in [`ConfigBuilder::with_root_certificates`](https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html#method.with_root_certificates) (and the steps that come before that, to load the RootCertStore).

I ended up just removing the remarks for now, after changing `with_root_certificates()` for the `ClientConfig` builder to take an `Arc<RootCertStore>` (the `ServerConfig` builder started taking an `Arc`-wrapped `RootCertStore` in #1368). IMO it would be best to document the performance implications where they occur, which in this case means `rustls_native_certs::load_native_certs()`. Its documentation currently reads:

> This function can be expensive: on some platforms it involves loading and parsing a ~300KB disk file. It’s therefore prudent to call this sparingly.

I also believe the use of `Arc` wrappers itself will help signal that (re)creating something of that type is performance-sensitive, so I feel there's not much value in further discussion directly on the config types (which, at worst, cost a few allocations for clones, many of which are actually refcount bumps from other `Arc`s).

Fixes #1403. Motivated by discussion in https://github.com/bluejekyll/trust-dns/issues/1990 (trust-dns-resolver currently stores a `Lazy<Arc<ClientConfig>>` wrapping webpki-roots -- which doesn't seem great).