### PR TITLE
Support aws-lc-rs as an optional dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
       - name: cargo build (debug; default features)
         run: cargo build --locked
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,23 +88,29 @@ jobs:
 
       - name: cargo build (debug; default features)
         run: cargo build --locked
+        working-directory: rustls
 
       - name: cargo test (debug; default features)
         run: cargo test --locked
+        working-directory: rustls
         env:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; no default features)
         run: cargo test --locked --no-default-features
+        working-directory: rustls
 
       - name: cargo test (debug; no default features; tls12)
         run: cargo test --locked --no-default-features --features tls12
+        working-directory: rustls
 
       - name: cargo test (debug; no default features; aws-lc-rs,tls12)
         run: cargo test --no-default-features --features aws_lc_rs,tls12
+        working-directory: rustls
 
       - name: cargo test (release; no run)
         run: cargo test --locked --release --no-run
+        working-directory: rustls
 
   bogo:
     name: BoGo test suite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,11 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+      - name: cargo test (debug; aws-lc-rs)
+        run: cargo test --no-default-features --features aws_lc_rs,tls12,quic,read_buf,logging
+        env:
+          RUST_BACKTRACE: 1
+
       - name: cargo build (debug; rustls-provider-example)
         run: cargo build --locked -p rustls-provider-example
 
@@ -95,6 +100,9 @@ jobs:
       - name: cargo test (debug; no default features; tls12)
         run: cargo test --locked --no-default-features --features tls12
 
+      - name: cargo test (debug; no default features; aws-lc-rs,tls12)
+        run: cargo test --no-default-features --features aws_lc_rs,tls12
+
       - name: cargo test (release; no run)
         run: cargo test --locked --release --no-run
 
@@ -116,9 +124,17 @@ jobs:
           go-version: "1.20"
           cache: false
 
-      - name: Run test suite
+      - name: Run test suite (ring)
         working-directory: bogo
         run: ./runme
+        env:
+          BOGO_SHIM_PROVIDER: ring
+
+      - name: Run test suite (aws-lc-rs)
+        working-directory: bogo
+        run: ./runme
+        env:
+          BOGO_SHIM_PROVIDER: aws-lc-rs
 
 
   fuzz:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb76b0a64f839f9e2be9871ea670a197a3e1d4b9634d741ec1456102a4fbaba"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de27c152edd365909b8fe952bce7617c910bd413b5b4bb9b0238d37e412f7e2a"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "dunce",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +164,29 @@ name = "bencher"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
+
+[[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -189,6 +237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +287,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +336,15 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -410,6 +487,12 @@ dependencies = [
  "serde",
  "strsim",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
@@ -556,6 +639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +743,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -776,10 +874,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libm"
@@ -846,6 +960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +984,22 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -969,6 +1105,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pem"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1202,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1246,6 +1404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1447,7 @@ dependencies = [
 name = "rustls"
 version = "0.22.0-alpha.4"
 dependencies = [
+ "aws-lc-rs",
  "base64",
  "bencher",
  "env_logger",
@@ -1398,6 +1563,7 @@ version = "0.102.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34d9ed3a8267782ba32d257ff5b197b63eef19a467dbd1be011caaae35ee416e"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.5",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -1461,6 +1627,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signature"
@@ -1830,6 +2002,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42157929d7ca9c353222a4d1763c52ef86d25d0fd2eca66076df5975fd4e25ed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/bogo/runme
+++ b/bogo/runme
@@ -5,9 +5,20 @@
 
 set -xe
 
-if [ "x$USE_EXISTING_BOGO_SHIM" = "x" ] ; then
-  cargo build --example bogo_shim --features quic
-fi
+case ${BOGO_SHIM_PROVIDER:-ring} in
+  ring)
+      cargo build --example bogo_shim --features quic
+      ;;
+  aws-lc-rs)
+      cargo build --example bogo_shim --no-default-features --features quic,aws_lc_rs,tls12,logging
+      ;;
+  existing)
+      ;;
+  *)
+      echo "unsupported BOGO_SHIM_PROVIDER: supported are (ring|aws-lc-rs|existing)"
+      exit 1
+      ;;
+esac
 
 if [ ! -e bogo/ssl/test/runner/runner.test ] ; then
   ./fetch-and-build

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -14,5 +14,5 @@ fxhash = "0.2.1"
 itertools = "0.11.0"
 pki-types = { package = "rustls-pki-types", version = "0.2" }
 rayon = "1.7.0"
-rustls = { path = "../rustls" }
+rustls = { path = "../rustls", features = ["ring", "aws_lc_rs"] }
 rustls-pemfile = "2.0.0-alpha.1"

--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use fxhash::{FxHashMap, FxHashSet};
 use itertools::Itertools;
 
@@ -120,8 +122,12 @@ impl ResumptionKind {
 }
 
 /// Parameters associated to a benchmark
-#[derive(Copy, Clone)]
+#[derive(Clone, Debug)]
 pub struct BenchmarkParams {
+    /// Which `CryptoProvider` to test
+    pub provider: &'static dyn rustls::crypto::CryptoProvider,
+    /// How to make a suitable [`rustls::server::ProducesTickets`].
+    pub ticketer: &'static fn() -> Arc<dyn rustls::server::ProducesTickets>,
     /// The type of key used to sign the TLS certificate
     pub key_type: KeyType,
     /// Cipher suite
@@ -129,18 +135,22 @@ pub struct BenchmarkParams {
     /// TLS version
     pub version: &'static rustls::SupportedProtocolVersion,
     /// A user-facing label that identifies these params
-    pub label: &'static str,
+    pub label: String,
 }
 
 impl BenchmarkParams {
     /// Create a new set of benchmark params
     pub const fn new(
+        provider: &'static dyn rustls::crypto::CryptoProvider,
+        ticketer: &'static fn() -> Arc<dyn rustls::server::ProducesTickets>,
         key_type: KeyType,
         ciphersuite: rustls::SupportedCipherSuite,
         version: &'static rustls::SupportedProtocolVersion,
-        label: &'static str,
+        label: String,
     ) -> Self {
         Self {
+            provider,
+            ticketer,
             key_type,
             ciphersuite,
             version,

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -14,7 +14,7 @@ use itertools::Itertools;
 use rayon::iter::Either;
 use rayon::prelude::*;
 use rustls::client::Resumption;
-use rustls::crypto::ring::Ticketer;
+use rustls::crypto::ring::{cipher_suite, Ticketer};
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::{
     ClientConfig, ClientConnection, ProtocolVersion, RootCertStore, ServerConfig, ServerConnection,
@@ -210,31 +210,31 @@ fn all_benchmarks() -> anyhow::Result<Vec<Benchmark>> {
 static ALL_BENCHMARK_PARAMS: &[BenchmarkParams] = &[
     BenchmarkParams::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         &rustls::version::TLS12,
         "1.2_rsa_aes",
     ),
     BenchmarkParams::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
         &rustls::version::TLS13,
         "1.3_rsa_aes",
     ),
     BenchmarkParams::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
         &rustls::version::TLS13,
         "1.3_ecdsa_aes",
     ),
     BenchmarkParams::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS13,
         "1.3_rsa_chacha",
     ),
     BenchmarkParams::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS13,
         "1.3_ecdsa_chacha",
     ),

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -15,7 +15,7 @@ fn main() {
     );
 
     let config = rustls::ClientConfig::builder()
-        .with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
+        .with_cipher_suites(&[rustls::crypto::ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
         .with_kx_groups(&[rustls::crypto::ring::kx_group::X25519])
         .with_protocol_versions(&[&rustls::version::TLS13])
         .unwrap()

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -2,7 +2,7 @@ use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls_provider_example::{certificate_verifier, PROVIDER};
+use rustls_provider_example::PROVIDER;
 
 fn main() {
     env_logger::init();
@@ -16,8 +16,7 @@ fn main() {
 
     let config = rustls::ClientConfig::builder_with_provider(PROVIDER)
         .with_safe_defaults()
-        .dangerous()
-        .with_custom_certificate_verifier(certificate_verifier(root_store))
+        .with_root_certificates(root_store)
         .with_no_client_auth();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -36,6 +36,10 @@ impl rustls::crypto::CryptoProvider for Provider {
     ) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
         unimplemented!()
     }
+
+    fn signature_verification_algorithms(&self) -> rustls::WebPkiSupportedAlgorithms {
+        verify::ALGORITHMS
+    }
 }
 
 static ALL_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[
@@ -67,12 +71,3 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherS
         prf_provider: &rustls::crypto::tls12::PrfUsingHmac(&hmac::Sha256Hmac),
         aead_alg: &aead::Chacha20Poly1305,
     });
-
-pub fn certificate_verifier(
-    roots: rustls::RootCertStore,
-) -> Arc<dyn rustls::client::danger::ServerCertVerifier> {
-    rustls::client::WebPkiServerVerifier::builder(roots.into())
-        .with_signature_verification_algorithms(verify::ALGORITHMS)
-        .build()
-        .unwrap()
-}

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -1,3 +1,4 @@
+use pki_types::PrivateKeyDer;
 use std::sync::Arc;
 
 mod aead;
@@ -25,6 +26,15 @@ impl rustls::crypto::CryptoProvider for Provider {
 
     fn default_kx_groups(&self) -> &'static [&'static dyn rustls::crypto::SupportedKxGroup] {
         kx::ALL_KX_GROUPS
+    }
+
+    /// XXX: currently this example is client-only, which avoids the need for it to support
+    /// authentication key handling.
+    fn load_private_key(
+        &self,
+        _key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
+        unimplemented!()
     }
 }
 

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -35,7 +35,7 @@ static ALL_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[
 
 pub static TLS13_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
     rustls::SupportedCipherSuite::Tls13(&rustls::Tls13CipherSuite {
-        common: rustls::cipher_suite::CipherSuiteCommon {
+        common: rustls::CipherSuiteCommon {
             suite: rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
             hash_provider: &hash::Sha256,
         },
@@ -45,7 +45,7 @@ pub static TLS13_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
 
 pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
     rustls::SupportedCipherSuite::Tls12(&rustls::Tls12CipherSuite {
-        common: rustls::cipher_suite::CipherSuiteCommon {
+        common: rustls::CipherSuiteCommon {
             suite: rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
             hash_provider: &hash::Sha256,
         },

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -44,7 +44,7 @@ base64 = "0.21"
 [[example]]
 name = "bogo_shim"
 path = "examples/internal/bogo_shim.rs"
-required-features = ["quic", "tls12", "ring"]
+required-features = ["quic", "tls12"]
 
 [[example]]
 name = "bench"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -16,6 +16,7 @@ build = "build.rs"
 rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
+aws-lc-rs = { version = "1", optional = true }
 log = { version = "0.4.4", optional = true }
 ring = { version = "0.17", optional = true }
 subtle = { version = "2.5.0", default-features = false }
@@ -26,6 +27,7 @@ zeroize = "1.6.0"
 [features]
 default = ["logging", "ring", "tls12"]
 logging = ["log"]
+aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 ring = ["dep:ring", "webpki/ring"]
 quic = []
 tls12 = []

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use pki_types::{CertificateDer, PrivateKeyDer};
 
 use rustls::client::Resumption;
-use rustls::crypto::ring::Ticketer;
+use rustls::crypto::ring::{cipher_suite, Ticketer};
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::RootCertStore;
 use rustls::{ClientConfig, ClientConnection};
@@ -175,68 +175,68 @@ static ALL_BENCHMARKS: &[BenchmarkParam] = &[
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
         &rustls::version::TLS12,
     ),
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS13,
     ),
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
+        cipher_suite::TLS13_AES_256_GCM_SHA384,
         &rustls::version::TLS13,
     ),
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
         &rustls::version::TLS13,
     ),
     BenchmarkParam::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
         &rustls::version::TLS13,
     ),
     BenchmarkParam::new(
         KeyType::Ed25519,
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
         &rustls::version::TLS13,
     ),
 ];

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -5,7 +5,6 @@ use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::error::Error;
 use crate::key_log::NoKeyLog;
 use crate::suites::SupportedCipherSuite;
-#[cfg(feature = "ring")]
 use crate::webpki;
 use crate::{verify, versions};
 
@@ -15,11 +14,9 @@ use pki_types::{CertificateDer, PrivateKeyDer};
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-#[cfg(any(feature = "dangerous_configuration", feature = "ring"))]
 use core::marker::PhantomData;
 
 impl ConfigBuilder<ClientConfig, WantsVerifier> {
-    #[cfg(feature = "ring")]
     /// Choose how to verify server certificates.
     pub fn with_root_certificates(
         self,
@@ -33,6 +30,9 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
                 versions: self.state.versions,
                 verifier: Arc::new(webpki::WebPkiServerVerifier::new_without_revocation(
                     root_store,
+                    self.state
+                        .provider
+                        .signature_verification_algorithms(),
                 )),
             },
             side: PhantomData,

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -122,7 +122,8 @@ pub trait ResolvesClientCert: Send + Sync {
 /// (the rustls-native-certs crate is often used for this) may take on the order of a few hundred
 /// milliseconds.
 ///
-/// These must be created via the [`ClientConfig::builder()`] function.
+/// These must be created via the [`ClientConfig::builder()`] or [`ClientConfig::builder_with_provider()`]
+/// function.
 ///
 /// # Defaults
 ///
@@ -248,16 +249,15 @@ impl fmt::Debug for ClientConfig {
 
 impl ClientConfig {
     #[cfg(feature = "ring")]
-    /// Create a builder to build up the client configuration with the default
-    /// [`CryptoProvider`].
+    /// Create a builder for a client configuration with the default
+    /// [`CryptoProvider`]: [`crate::crypto::ring::RING`].
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
     pub fn builder() -> ConfigBuilder<Self, WantsCipherSuites> {
         Self::builder_with_provider(crate::crypto::ring::RING)
     }
 
-    /// Create builder to build up the client configuration with a specific
-    /// `CryptoProvider`.
+    /// Create a builder for a client configuration with a specific [`CryptoProvider`].
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
     pub fn builder_with_provider(

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -201,16 +201,16 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
     }
 }
 
-#[cfg(all(test, feature = "ring"))]
+#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
 mod tests {
     use super::NoClientSessionStorage;
     use crate::client::ClientSessionStore;
-    use crate::crypto::ring::cipher_suite;
     use crate::msgs::enums::NamedGroup;
     #[cfg(feature = "tls12")]
     use crate::msgs::handshake::SessionId;
     use crate::msgs::persist::Tls13ClientSessionValue;
     use crate::suites::SupportedCipherSuite;
+    use crate::test_provider::cipher_suite;
 
     use pki_types::UnixTime;
 

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -1,19 +1,16 @@
 use crate::client;
 use crate::enums::SignatureScheme;
+use crate::error::Error;
 use crate::limited_cache;
 use crate::msgs::persist;
 use crate::sign;
 use crate::NamedGroup;
 use crate::ServerName;
-#[cfg(feature = "ring")]
-use crate::{crypto::ring, error::Error};
 
-#[cfg(feature = "ring")]
-use pki_types::{CertificateDer, PrivateKeyDer};
+use pki_types::CertificateDer;
 
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
-#[cfg(feature = "ring")]
 use alloc::vec::Vec;
 use std::sync::Mutex;
 
@@ -182,14 +179,11 @@ impl client::ResolvesClientCert for FailResolveClientCert {
 pub(super) struct AlwaysResolvesClientCert(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesClientCert {
-    #[cfg(feature = "ring")]
     pub(super) fn new(
+        private_key: Arc<dyn sign::SigningKey>,
         chain: Vec<CertificateDer<'static>>,
-        priv_key: &PrivateKeyDer<'_>,
     ) -> Result<Self, Error> {
-        let key = ring::sign::any_supported_type(priv_key)
-            .map_err(|_| Error::General("invalid private key".into()))?;
-        Ok(Self(Arc::new(sign::CertifiedKey::new(chain, key))))
+        Ok(Self(Arc::new(sign::CertifiedKey::new(chain, private_key))))
     }
 }
 

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -211,6 +211,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
 mod tests {
     use super::NoClientSessionStorage;
     use crate::client::ClientSessionStore;
+    use crate::crypto::ring::cipher_suite;
     use crate::msgs::enums::NamedGroup;
     #[cfg(feature = "tls12")]
     use crate::msgs::handshake::SessionId;
@@ -234,7 +235,7 @@ mod tests {
         {
             use crate::msgs::persist::Tls12ClientSessionValue;
             let SupportedCipherSuite::Tls12(tls12_suite) =
-                crate::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
             else {
                 unreachable!()
             };
@@ -257,7 +258,7 @@ mod tests {
         }
 
         #[cfg_attr(not(feature = "tls12"), allow(clippy::infallible_destructuring_match))]
-        let tls13_suite = match crate::cipher_suite::TLS13_AES_256_GCM_SHA384 {
+        let tls13_suite = match cipher_suite::TLS13_AES_256_GCM_SHA384 {
             SupportedCipherSuite::Tls13(inner) => inner,
             #[cfg(feature = "tls12")]
             _ => unreachable!(),

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -1,5 +1,6 @@
 use crate::sign::SigningKey;
 use crate::suites;
+use crate::webpki::WebPkiSupportedAlgorithms;
 use crate::{Error, NamedGroup};
 
 use alloc::boxed::Box;
@@ -54,6 +55,11 @@ pub trait CryptoProvider: Send + Sync + Debug + 'static {
         &self,
         key_der: PrivateKeyDer<'static>,
     ) -> Result<Arc<dyn SigningKey>, Error>;
+
+    /// Return the signature verification algorithms for use with webpki.
+    ///
+    /// These are used for both certificate chain verification and handshake signature verification.
+    fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms;
 }
 
 /// A supported key exchange group.

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -1,10 +1,13 @@
+use crate::sign::SigningKey;
 use crate::suites;
 use crate::{Error, NamedGroup};
 
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
+use pki_types::PrivateKeyDer;
 use zeroize::Zeroize;
 
 /// *ring* based CryptoProvider.
@@ -43,6 +46,14 @@ pub trait CryptoProvider: Send + Sync + Debug + 'static {
 
     /// Return a safe set of supported key exchange groups to be used as the defaults.
     fn default_kx_groups(&self) -> &'static [&'static dyn SupportedKxGroup];
+
+    /// Decode and validate a private signing key from `key_der`.
+    ///
+    /// Return an error if the key type encoding is not supported, or if the key fails validation.
+    fn load_private_key(
+        &self,
+        key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn SigningKey>, Error>;
 }
 
 /// A supported key exchange group.

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -15,6 +15,10 @@ use zeroize::Zeroize;
 #[cfg(feature = "ring")]
 pub mod ring;
 
+/// aws-lc-rs-based CryptoProvider.
+#[cfg(feature = "aws_lc_rs")]
+pub mod aws_lc_rs;
+
 /// TLS message encryption/decryption interfaces.
 pub mod cipher;
 

--- a/rustls/src/crypto/ring/hash.rs
+++ b/rustls/src/crypto/ring/hash.rs
@@ -1,21 +1,21 @@
+use super::ring_like::digest;
 use crate::crypto;
 use crate::msgs::enums::HashAlgorithm;
-use ring;
 
 use alloc::boxed::Box;
 
-pub(crate) static SHA256: Hash = Hash(&ring::digest::SHA256, HashAlgorithm::SHA256);
-pub(crate) static SHA384: Hash = Hash(&ring::digest::SHA384, HashAlgorithm::SHA384);
+pub(crate) static SHA256: Hash = Hash(&digest::SHA256, HashAlgorithm::SHA256);
+pub(crate) static SHA384: Hash = Hash(&digest::SHA384, HashAlgorithm::SHA384);
 
-pub(crate) struct Hash(&'static ring::digest::Algorithm, HashAlgorithm);
+pub(crate) struct Hash(&'static digest::Algorithm, HashAlgorithm);
 
 impl crypto::hash::Hash for Hash {
     fn start(&self) -> Box<dyn crypto::hash::Context> {
-        Box::new(Context(ring::digest::Context::new(self.0)))
+        Box::new(Context(digest::Context::new(self.0)))
     }
 
     fn hash(&self, bytes: &[u8]) -> crypto::hash::Output {
-        let mut ctx = ring::digest::Context::new(self.0);
+        let mut ctx = digest::Context::new(self.0);
         ctx.update(bytes);
         convert(ctx.finish())
     }
@@ -29,7 +29,7 @@ impl crypto::hash::Hash for Hash {
     }
 }
 
-struct Context(ring::digest::Context);
+struct Context(digest::Context);
 
 impl crypto::hash::Context for Context {
     fn fork_finish(&self) -> crypto::hash::Output {
@@ -49,6 +49,6 @@ impl crypto::hash::Context for Context {
     }
 }
 
-fn convert(val: ring::digest::Digest) -> crypto::hash::Output {
+fn convert(val: digest::Digest) -> crypto::hash::Output {
     crypto::hash::Output::new(val.as_ref())
 }

--- a/rustls/src/crypto/ring/hash.rs
+++ b/rustls/src/crypto/ring/hash.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::duplicate_mod)]
+
 use super::ring_like::digest;
 use crate::crypto;
 use crate::msgs::enums::HashAlgorithm;
@@ -21,7 +23,7 @@ impl crypto::hash::Hash for Hash {
     }
 
     fn output_len(&self) -> usize {
-        self.0.output_len()
+        super::ring_shim::digest_output_len(self.0)
     }
 
     fn algorithm(&self) -> HashAlgorithm {

--- a/rustls/src/crypto/ring/hmac.rs
+++ b/rustls/src/crypto/ring/hmac.rs
@@ -1,18 +1,18 @@
+use super::ring_like;
 use crate::crypto;
-use ring;
 
 use alloc::boxed::Box;
 
-pub(crate) static HMAC_SHA256: Hmac = Hmac(&ring::hmac::HMAC_SHA256);
-pub(crate) static HMAC_SHA384: Hmac = Hmac(&ring::hmac::HMAC_SHA384);
+pub(crate) static HMAC_SHA256: Hmac = Hmac(&ring_like::hmac::HMAC_SHA256);
+pub(crate) static HMAC_SHA384: Hmac = Hmac(&ring_like::hmac::HMAC_SHA384);
 #[cfg(all(test, feature = "tls12"))]
-pub(crate) static HMAC_SHA512: Hmac = Hmac(&ring::hmac::HMAC_SHA512);
+pub(crate) static HMAC_SHA512: Hmac = Hmac(&ring_like::hmac::HMAC_SHA512);
 
-pub(crate) struct Hmac(&'static ring::hmac::Algorithm);
+pub(crate) struct Hmac(&'static ring_like::hmac::Algorithm);
 
 impl crypto::hmac::Hmac for Hmac {
     fn with_key(&self, key: &[u8]) -> Box<dyn crypto::hmac::Key> {
-        Box::new(Key(ring::hmac::Key::new(*self.0, key)))
+        Box::new(Key(ring_like::hmac::Key::new(*self.0, key)))
     }
 
     fn hash_output_len(&self) -> usize {
@@ -20,11 +20,11 @@ impl crypto::hmac::Hmac for Hmac {
     }
 }
 
-struct Key(ring::hmac::Key);
+struct Key(ring_like::hmac::Key);
 
 impl crypto::hmac::Key for Key {
     fn sign_concat(&self, first: &[u8], middle: &[&[u8]], last: &[u8]) -> crypto::hmac::Tag {
-        let mut ctx = ring::hmac::Context::with_key(&self.0);
+        let mut ctx = ring_like::hmac::Context::with_key(&self.0);
         ctx.update(first);
         for d in middle {
             ctx.update(d);

--- a/rustls/src/crypto/ring/hmac.rs
+++ b/rustls/src/crypto/ring/hmac.rs
@@ -7,7 +7,8 @@ use alloc::boxed::Box;
 
 pub(crate) static HMAC_SHA256: Hmac = Hmac(&ring_like::hmac::HMAC_SHA256);
 pub(crate) static HMAC_SHA384: Hmac = Hmac(&ring_like::hmac::HMAC_SHA384);
-#[cfg(all(test, feature = "tls12"))]
+#[cfg(test)]
+#[allow(dead_code)] // only for TLS1.2 prf test
 pub(crate) static HMAC_SHA512: Hmac = Hmac(&ring_like::hmac::HMAC_SHA512);
 
 pub(crate) struct Hmac(&'static ring_like::hmac::Algorithm);

--- a/rustls/src/crypto/ring/hmac.rs
+++ b/rustls/src/crypto/ring/hmac.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::duplicate_mod)]
+
 use super::ring_like;
 use crate::crypto;
 
@@ -16,7 +18,7 @@ impl crypto::hmac::Hmac for Hmac {
     }
 
     fn hash_output_len(&self) -> usize {
-        self.0.digest_algorithm().output_len()
+        super::ring_shim::digest_output_len(self.0.digest_algorithm())
     }
 }
 
@@ -34,9 +36,6 @@ impl crypto::hmac::Key for Key {
     }
 
     fn tag_len(&self) -> usize {
-        self.0
-            .algorithm()
-            .digest_algorithm()
-            .output_len()
+        super::ring_shim::digest_output_len(self.0.algorithm().digest_algorithm())
     }
 }

--- a/rustls/src/crypto/ring/kx.rs
+++ b/rustls/src/crypto/ring/kx.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::duplicate_mod)]
+
 use crate::crypto::{ActiveKeyExchange, SharedSecret, SupportedKxGroup};
 use crate::error::{Error, PeerMisbehaved};
 use crate::msgs::enums::NamedGroup;
@@ -85,10 +87,8 @@ impl ActiveKeyExchange for KeyExchange {
     /// Completes the key exchange, given the peer's public key.
     fn complete(self: Box<Self>, peer: &[u8]) -> Result<SharedSecret, Error> {
         let peer_key = agreement::UnparsedPublicKey::new(self.agreement_algorithm, peer);
-        agreement::agree_ephemeral(self.priv_key, &peer_key, |secret| {
-            SharedSecret::from(secret)
-        })
-        .map_err(|_| PeerMisbehaved::InvalidKeyShare.into())
+        super::ring_shim::agree_ephemeral(self.priv_key, &peer_key)
+            .map_err(|_| PeerMisbehaved::InvalidKeyShare.into())
     }
 
     /// Return the group being used.

--- a/rustls/src/crypto/ring/kx.rs
+++ b/rustls/src/crypto/ring/kx.rs
@@ -3,8 +3,8 @@ use crate::error::{Error, PeerMisbehaved};
 use crate::msgs::enums::NamedGroup;
 use crate::rand::GetRandomFailed;
 
-use ring::agreement;
-use ring::rand::SystemRandom;
+use super::ring_like::agreement;
+use super::ring_like::rand::SystemRandom;
 
 use alloc::boxed::Box;
 use core::fmt;

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -1,6 +1,13 @@
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::rand::GetRandomFailed;
+use crate::sign::SigningKey;
 use crate::suites::SupportedCipherSuite;
+use crate::Error;
+
+use pki_types::PrivateKeyDer;
+
+use alloc::borrow::ToOwned;
+use alloc::sync::Arc;
 
 pub(crate) use ring as ring_like;
 use ring_like::rand::{SecureRandom, SystemRandom};
@@ -38,9 +45,16 @@ impl CryptoProvider for Ring {
         DEFAULT_CIPHER_SUITES
     }
 
-    /// Return all supported key exchange groups.
     fn default_kx_groups(&self) -> &'static [&'static dyn SupportedKxGroup] {
         ALL_KX_GROUPS
+    }
+
+    fn load_private_key(
+        &self,
+        key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn SigningKey>, Error> {
+        sign::any_supported_type(&key_der)
+            .map_err(|_| Error::General("invalid private key".to_owned()))
     }
 }
 

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -1,10 +1,13 @@
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
+use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
 use crate::suites::SupportedCipherSuite;
+use crate::webpki::WebPkiSupportedAlgorithms;
 use crate::Error;
 
 use pki_types::PrivateKeyDer;
+use webpki::ring as webpki_algs;
 
 use alloc::borrow::ToOwned;
 use alloc::sync::Arc;
@@ -97,6 +100,67 @@ pub mod cipher_suite {
         TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
     };
 }
+
+/// A `WebPkiSupportedAlgorithms` value that reflects webpki's capabilities when
+/// compiled against *ring*.
+pub(crate) static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+    all: &[
+        webpki_algs::ECDSA_P256_SHA256,
+        webpki_algs::ECDSA_P256_SHA384,
+        webpki_algs::ECDSA_P384_SHA256,
+        webpki_algs::ECDSA_P384_SHA384,
+        webpki_algs::ED25519,
+        webpki_algs::RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
+        webpki_algs::RSA_PSS_2048_8192_SHA384_LEGACY_KEY,
+        webpki_algs::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
+        webpki_algs::RSA_PKCS1_2048_8192_SHA256,
+        webpki_algs::RSA_PKCS1_2048_8192_SHA384,
+        webpki_algs::RSA_PKCS1_2048_8192_SHA512,
+        webpki_algs::RSA_PKCS1_3072_8192_SHA384,
+    ],
+    mapping: &[
+        // nb. for TLS1.2 the curve is not fixed by SignatureScheme. for TLS1.3 it is.
+        (
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            &[
+                webpki_algs::ECDSA_P384_SHA384,
+                webpki_algs::ECDSA_P256_SHA384,
+            ],
+        ),
+        (
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            &[
+                webpki_algs::ECDSA_P256_SHA256,
+                webpki_algs::ECDSA_P384_SHA256,
+            ],
+        ),
+        (SignatureScheme::ED25519, &[webpki_algs::ED25519]),
+        (
+            SignatureScheme::RSA_PSS_SHA512,
+            &[webpki_algs::RSA_PSS_2048_8192_SHA512_LEGACY_KEY],
+        ),
+        (
+            SignatureScheme::RSA_PSS_SHA384,
+            &[webpki_algs::RSA_PSS_2048_8192_SHA384_LEGACY_KEY],
+        ),
+        (
+            SignatureScheme::RSA_PSS_SHA256,
+            &[webpki_algs::RSA_PSS_2048_8192_SHA256_LEGACY_KEY],
+        ),
+        (
+            SignatureScheme::RSA_PKCS1_SHA512,
+            &[webpki_algs::RSA_PKCS1_2048_8192_SHA512],
+        ),
+        (
+            SignatureScheme::RSA_PKCS1_SHA384,
+            &[webpki_algs::RSA_PKCS1_2048_8192_SHA384],
+        ),
+        (
+            SignatureScheme::RSA_PKCS1_SHA256,
+            &[webpki_algs::RSA_PKCS1_2048_8192_SHA256],
+        ),
+    ],
+};
 
 /// All defined key exchange groups supported by *ring* appear in this module.
 ///

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -59,6 +59,10 @@ impl CryptoProvider for Ring {
         sign::any_supported_type(&key_der)
             .map_err(|_| Error::General("invalid private key".to_owned()))
     }
+
+    fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
+        SUPPORTED_SIG_ALGS
+    }
 }
 
 /// The cipher suite configuration that an application should use by default.
@@ -103,7 +107,7 @@ pub mod cipher_suite {
 
 /// A `WebPkiSupportedAlgorithms` value that reflects webpki's capabilities when
 /// compiled against *ring*.
-pub(crate) static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[
         webpki_algs::ECDSA_P256_SHA256,
         webpki_algs::ECDSA_P256_SHA384,

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -2,7 +2,11 @@ use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::rand::GetRandomFailed;
 use crate::suites::SupportedCipherSuite;
 
-use ring::rand::{SecureRandom, SystemRandom};
+pub(crate) use ring as ring_like;
+use ring_like::rand::{SecureRandom, SystemRandom};
+
+/// Using software keys for authentication.
+pub mod sign;
 
 pub(crate) mod hash;
 pub(crate) mod hmac;
@@ -13,9 +17,6 @@ pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
 pub(crate) mod tls12;
 pub(crate) mod tls13;
-
-/// Using software keys for authentication.
-pub mod sign;
 
 /// A `CryptoProvider` backed by the [*ring*] crate.
 ///

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -71,6 +71,19 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
+/// All defined cipher suites supported by *ring* appear in this module.
+pub mod cipher_suite {
+    #[cfg(feature = "tls12")]
+    pub use super::tls12::{
+        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+    };
+    pub use super::tls13::{
+        TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
+    };
+}
+
 /// All defined key exchange groups supported by *ring* appear in this module.
 ///
 /// [`ALL_KX_GROUPS`] is provided as an array of all of these values.

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -7,7 +7,7 @@ use crate::tls13::Tls13CipherSuite;
 
 use alloc::boxed::Box;
 
-use ring::aead;
+use super::ring_like::aead;
 
 pub(crate) struct HeaderProtectionKey(aead::quic::HeaderProtectionKey);
 

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::duplicate_mod)]
+
 use crate::crypto::cipher::{Iv, Nonce};
 use crate::crypto::tls13;
 use crate::error::Error;

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -3,10 +3,10 @@ use crate::error::Error;
 use crate::sign::{Signer, SigningKey};
 use crate::x509::{asn1_wrap, wrap_in_sequence};
 
+use super::ring_like::io::der;
+use super::ring_like::rand::{SecureRandom, SystemRandom};
+use super::ring_like::signature::{self, EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair};
 use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
-use ring::io::der;
-use ring::rand::{SecureRandom, SystemRandom};
-use ring::signature::{self, EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair};
 
 use alloc::boxed::Box;
 use alloc::string::ToString;
@@ -143,7 +143,7 @@ impl Signer for RsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error> {
         let mut sig = vec![0; self.key.public().modulus_len()];
 
-        let rng = ring::rand::SystemRandom::new();
+        let rng = SystemRandom::new();
         self.key
             .sign(self.encoding, &rng, message, &mut sig)
             .map(|_| sig)
@@ -266,7 +266,7 @@ struct EcdsaSigner {
 
 impl Signer for EcdsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error> {
-        let rng = ring::rand::SystemRandom::new();
+        let rng = super::ring_like::rand::SystemRandom::new();
         self.key
             .sign(&rng, message)
             .map_err(|_| Error::General("signing failed".into()))

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::duplicate_mod)]
+
 use crate::enums::{SignatureAlgorithm, SignatureScheme};
 use crate::error::Error;
 use crate::sign::{Signer, SigningKey};
@@ -141,7 +143,7 @@ impl RsaSigner {
 
 impl Signer for RsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error> {
-        let mut sig = vec![0; self.key.public().modulus_len()];
+        let mut sig = vec![0; super::ring_shim::rsa_key_pair_public_modulus_len(&self.key)];
 
         let rng = SystemRandom::new();
         self.key
@@ -186,7 +188,7 @@ impl EcdsaSigningKey {
                 Self::convert_sec1_to_pkcs8(scheme, sigalg, sec1.secret_sec1_der(), &rng)?
             }
             PrivateKeyDer::Pkcs8(pkcs8) => {
-                EcdsaKeyPair::from_pkcs8(sigalg, pkcs8.secret_pkcs8_der(), &rng).map_err(|_| ())?
+                super::ring_shim::ecdsa_key_pair_from_pkcs8(sigalg, pkcs8.secret_pkcs8_der(), &rng)?
             }
             _ => return Err(()),
         };
@@ -218,7 +220,7 @@ impl EcdsaSigningKey {
         pkcs8_inner.extend_from_slice(pkcs8_prefix);
         pkcs8_inner.extend_from_slice(&sec1_wrap);
 
-        EcdsaKeyPair::from_pkcs8(sigalg, &wrap_in_sequence(&pkcs8_inner), rng).map_err(|_| ())
+        super::ring_shim::ecdsa_key_pair_from_pkcs8(sigalg, &wrap_in_sequence(&pkcs8_inner), rng)
     }
 }
 

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::duplicate_mod)]
+
 use crate::error::Error;
 use crate::rand::GetRandomFailed;
 use crate::server::ProducesTickets;

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::duplicate_mod)]
+
 use crate::crypto::cipher::{
     make_tls12_aad, AeadKey, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter, Nonce,
     Tls12AeadAlgorithm, UnsupportedOperationError, NONCE_LEN,

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -14,7 +14,7 @@ use crate::tls12::Tls12CipherSuite;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use ring::aead;
+use super::ring_like::aead;
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256.
 pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::duplicate_mod)]
+
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -14,8 +14,8 @@ use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls13::Tls13CipherSuite;
 
-use ring::hkdf::KeyType;
-use ring::{aead, hkdf, hmac};
+use super::ring_like::hkdf::KeyType;
+use super::ring_like::{aead, hkdf, hmac};
 
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256
 pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
@@ -27,13 +27,13 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
         hash_provider: &super::hash::SHA256,
     },
     hkdf_provider: &RingHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
-    aead_alg: &Chacha20Poly1305Aead(AeadAlgorithm(&ring::aead::CHACHA20_POLY1305)),
+    aead_alg: &Chacha20Poly1305Aead(AeadAlgorithm(&aead::CHACHA20_POLY1305)),
     #[cfg(feature = "quic")]
     confidentiality_limit: u64::MAX,
     #[cfg(feature = "quic")]
     integrity_limit: 1 << 36,
     #[cfg(feature = "quic")]
-    quic: &super::quic::KeyBuilder(&ring::aead::CHACHA20_POLY1305, &ring::aead::quic::CHACHA20),
+    quic: &super::quic::KeyBuilder(&aead::CHACHA20_POLY1305, &aead::quic::CHACHA20),
 };
 
 /// The TLS1.3 ciphersuite TLS_AES_256_GCM_SHA384
@@ -44,13 +44,13 @@ pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
             hash_provider: &super::hash::SHA384,
         },
         hkdf_provider: &RingHkdf(hkdf::HKDF_SHA384, hmac::HMAC_SHA384),
-        aead_alg: &Aes256GcmAead(AeadAlgorithm(&ring::aead::AES_256_GCM)),
+        aead_alg: &Aes256GcmAead(AeadAlgorithm(&aead::AES_256_GCM)),
         #[cfg(feature = "quic")]
         confidentiality_limit: 1 << 23,
         #[cfg(feature = "quic")]
         integrity_limit: 1 << 52,
         #[cfg(feature = "quic")]
-        quic: &super::quic::KeyBuilder(&ring::aead::AES_256_GCM, &aead::quic::AES_256),
+        quic: &super::quic::KeyBuilder(&aead::AES_256_GCM, &aead::quic::AES_256),
     });
 
 /// The TLS1.3 ciphersuite TLS_AES_128_GCM_SHA256
@@ -63,13 +63,13 @@ pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13C
         hash_provider: &super::hash::SHA256,
     },
     hkdf_provider: &RingHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
-    aead_alg: &Aes128GcmAead(AeadAlgorithm(&ring::aead::AES_128_GCM)),
+    aead_alg: &Aes128GcmAead(AeadAlgorithm(&aead::AES_128_GCM)),
     #[cfg(feature = "quic")]
     confidentiality_limit: 1 << 23,
     #[cfg(feature = "quic")]
     integrity_limit: 1 << 52,
     #[cfg(feature = "quic")]
-    quic: &super::quic::KeyBuilder(&ring::aead::AES_128_GCM, &aead::quic::AES_128),
+    quic: &super::quic::KeyBuilder(&aead::AES_128_GCM, &aead::quic::AES_128),
 };
 
 struct Chacha20Poly1305Aead(AeadAlgorithm);
@@ -145,7 +145,7 @@ impl Tls13AeadAlgorithm for Aes128GcmAead {
 }
 
 // common encrypter/decrypter/key_len items for above Tls13AeadAlgorithm impls
-struct AeadAlgorithm(&'static ring::aead::Algorithm);
+struct AeadAlgorithm(&'static aead::Algorithm);
 
 impl AeadAlgorithm {
     fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
@@ -170,12 +170,12 @@ impl AeadAlgorithm {
 }
 
 struct Tls13MessageEncrypter {
-    enc_key: ring::aead::LessSafeKey,
+    enc_key: aead::LessSafeKey,
     iv: Iv,
 }
 
 struct Tls13MessageDecrypter {
-    dec_key: ring::aead::LessSafeKey,
+    dec_key: aead::LessSafeKey,
     iv: Iv,
 }
 

--- a/rustls/src/crypto/tls12.rs
+++ b/rustls/src/crypto/tls12.rs
@@ -76,10 +76,10 @@ pub(crate) fn prf(out: &mut [u8], hmac_key: &dyn hmac::Key, label: &[u8], seed: 
     }
 }
 
-#[cfg(all(test, feature = "ring"))]
+#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
 mod tests {
     use crate::crypto::hmac::Hmac;
-    use crate::crypto::ring;
+    use crate::test_provider::hmac;
 
     // Below known answer tests come from https://mailarchive.ietf.org/arch/msg/tls/fzVCzk-z3FShgGJ6DOXqM1ydxms/
 
@@ -93,7 +93,7 @@ mod tests {
 
         super::prf(
             &mut output,
-            &*ring::hmac::HMAC_SHA256.with_key(secret),
+            &*hmac::HMAC_SHA256.with_key(secret),
             label,
             seed,
         );
@@ -111,7 +111,7 @@ mod tests {
 
         super::prf(
             &mut output,
-            &*ring::hmac::HMAC_SHA512.with_key(secret),
+            &*hmac::HMAC_SHA512.with_key(secret),
             label,
             seed,
         );
@@ -129,7 +129,7 @@ mod tests {
 
         super::prf(
             &mut output,
-            &*ring::hmac::HMAC_SHA384.with_key(secret),
+            &*hmac::HMAC_SHA384.with_key(secret),
             label,
             seed,
         );
@@ -138,12 +138,12 @@ mod tests {
     }
 }
 
-#[cfg(bench)]
+#[cfg(all(bench, any(feature = "ring", feature = "aws_lc_rs")))]
 mod benchmarks {
     #[bench]
     fn bench_sha256(b: &mut test::Bencher) {
         use crate::crypto::hmac::Hmac;
-        use crate::crypto::ring;
+        use crate::test_provider::hmac;
 
         let label = &b"extended master secret"[..];
         let seed = [0u8; 32];
@@ -151,12 +151,7 @@ mod benchmarks {
 
         b.iter(|| {
             let mut out = [0u8; 48];
-            super::prf(
-                &mut out,
-                &*ring::hmac::HMAC_SHA256.with_key(key),
-                &label,
-                &seed,
-            );
+            super::prf(&mut out, &*hmac::HMAC_SHA256.with_key(key), &label, &seed);
             test::black_box(out);
         });
     }

--- a/rustls/src/crypto/tls13.rs
+++ b/rustls/src/crypto/tls13.rs
@@ -239,10 +239,10 @@ impl AsRef<[u8]> for OkmBlock {
 #[derive(Debug)]
 pub struct OutputLengthError;
 
-#[cfg(all(test, feature = "ring"))]
+#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
 mod tests {
     use super::{expand, Hkdf, HkdfUsingHmac};
-    use crate::crypto::ring;
+    use crate::test_provider::hmac;
 
     struct ByteArray<const N: usize>([u8; N]);
 
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn test_case_1() {
-        let hkdf = HkdfUsingHmac(&ring::hmac::HMAC_SHA256);
+        let hkdf = HkdfUsingHmac(&hmac::HMAC_SHA256);
         let ikm = &[0x0b; 22];
         let salt = &[
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_case_2() {
-        let hkdf = HkdfUsingHmac(&ring::hmac::HMAC_SHA256);
+        let hkdf = HkdfUsingHmac(&hmac::HMAC_SHA256);
         let ikm: Vec<u8> = (0x00u8..=0x4f).collect();
         let salt: Vec<u8> = (0x60u8..=0xaf).collect();
         let info: Vec<u8> = (0xb0u8..=0xff).collect();
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_case_3() {
-        let hkdf = HkdfUsingHmac(&ring::hmac::HMAC_SHA256);
+        let hkdf = HkdfUsingHmac(&hmac::HMAC_SHA256);
         let ikm = &[0x0b; 22];
         let salt = &[];
         let info = &[];
@@ -339,7 +339,7 @@ mod tests {
         //
         // >>> hkdf.HKDF(algorithm=hashes.SHA384(), length=96, salt=None, info=b"hello").derive(b"\x0b" * 40)
 
-        let hkdf = HkdfUsingHmac(&ring::hmac::HMAC_SHA384);
+        let hkdf = HkdfUsingHmac(&hmac::HMAC_SHA384);
         let ikm = &[0x0b; 40];
         let info = &[&b"hel"[..], &b"lo"[..]];
 
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_output_length_bounds() {
-        let hkdf = HkdfUsingHmac(&ring::hmac::HMAC_SHA256);
+        let hkdf = HkdfUsingHmac(&hmac::HMAC_SHA256);
         let ikm = &[];
         let info = &[];
 

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -41,7 +41,7 @@ impl HandshakeHashBuffer {
     }
 
     /// Hash or buffer a byte slice.
-    #[cfg(all(test, feature = "ring"))]
+    #[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
     fn update_raw(&mut self, buf: &[u8]) {
         self.buffer.extend_from_slice(buf);
     }
@@ -166,17 +166,17 @@ impl HandshakeHash {
     }
 }
 
-#[cfg(all(test, feature = "ring"))]
+#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
 mod tests {
     use super::HandshakeHashBuffer;
-    use crate::crypto::ring;
+    use crate::test_provider::hash::SHA256;
 
     #[test]
     fn hashes_correctly() {
         let mut hhb = HandshakeHashBuffer::new();
         hhb.update_raw(b"hello");
         assert_eq!(hhb.buffer.len(), 5);
-        let mut hh = hhb.start_hash(&ring::hash::SHA256);
+        let mut hh = hhb.start_hash(&SHA256);
         assert!(hh.client_auth.is_none());
         hh.update_raw(b"world");
         let h = hh.get_current_hash();
@@ -194,7 +194,7 @@ mod tests {
         hhb.set_client_auth_enabled();
         hhb.update_raw(b"hello");
         assert_eq!(hhb.buffer.len(), 5);
-        let mut hh = hhb.start_hash(&ring::hash::SHA256);
+        let mut hh = hhb.start_hash(&SHA256);
         assert_eq!(
             hh.client_auth
                 .as_ref()
@@ -224,7 +224,7 @@ mod tests {
         hhb.set_client_auth_enabled();
         hhb.update_raw(b"hello");
         assert_eq!(hhb.buffer.len(), 5);
-        let mut hh = hhb.start_hash(&ring::hash::SHA256);
+        let mut hh = hhb.start_hash(&SHA256);
         assert_eq!(
             hh.client_auth
                 .as_ref()

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -517,12 +517,8 @@ pub mod version {
     pub use crate::versions::TLS13;
 }
 
-/// Message signing interfaces and implementations.
+/// Message signing interfaces.
 pub mod sign {
-    #[cfg(feature = "ring")]
-    pub use crate::crypto::ring::sign::{
-        any_ecdsa_type, any_eddsa_type, any_supported_type, RsaSigningKey,
-    };
     pub use crate::crypto::signer::{CertifiedKey, Signer, SigningKey};
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -426,7 +426,9 @@ pub use crate::key_log_file::KeyLogFile;
 pub use crate::msgs::enums::NamedGroup;
 pub use crate::msgs::handshake::DistinguishedName;
 pub use crate::stream::{Stream, StreamOwned};
-pub use crate::suites::{ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite};
+pub use crate::suites::{
+    CipherSuiteCommon, ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite,
+};
 pub use crate::ticketer::TicketSwitcher;
 #[cfg(feature = "tls12")]
 pub use crate::tls12::Tls12CipherSuite;
@@ -505,23 +507,6 @@ pub mod server {
 }
 
 pub use server::{ServerConfig, ServerConnection};
-
-/// All defined ciphersuites appear in this module.
-///
-/// [`crypto::ring::ALL_CIPHER_SUITES`] is provided as an array of all of these values.
-pub mod cipher_suite {
-    #[cfg(all(feature = "tls12", feature = "ring"))]
-    pub use crate::crypto::ring::tls12::{
-        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-    };
-    #[cfg(feature = "ring")]
-    pub use crate::crypto::ring::tls13::{
-        TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
-    };
-    pub use crate::suites::CipherSuiteCommon;
-}
 
 /// All defined protocol versions appear in this module.
 ///

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -256,6 +256,20 @@
 //!   which is used for cryptography.
 //!   Without this feature, these items must be provided externally to the core
 //!   rustls crate.
+//!
+//! - `aws_lc_rs`: this makes the rustls crate depend on the aws-lc-rs crate,
+//!   which can be used for cryptography as an alternative to *ring*.
+//!   Use `rustls::crypto::aws_lc_rs::AWS_LC_RS` as a `CryptoProvider` when making a
+//!   `ClientConfig` or `ServerConfig` to use aws-lc-rs -- eg:
+//!
+//!   ```
+//!   # #[cfg(feature = "aws_lc_rs")] {
+//!   rustls::ClientConfig::builder_with_provider(rustls::crypto::aws_lc_rs::AWS_LC_RS);
+//!   # }
+//!   ```
+//!
+//!   Note that aws-lc-rs has additional build-time dependencies like cmake.
+//!   See [the documentation](https://aws.github.io/aws-lc-rs/requirements/index.html) for details.
 
 // Require docs for public APIs, deny unsafe code, etc.
 #![forbid(unsafe_code, unused_must_use)]
@@ -406,6 +420,13 @@ pub mod internal {
         pub use crate::record_layer::RecordLayer;
     }
 }
+
+// Have a (non-public) "test provider" mod which supplies
+// tests that need part of a *ring*-compatible provider module.
+#[cfg(all(any(test, bench), not(feature = "ring"), feature = "aws_lc_rs"))]
+use crate::crypto::{aws_lc_rs as test_provider, aws_lc_rs::AWS_LC_RS as TEST_PROVIDER};
+#[cfg(all(any(test, bench), feature = "ring"))]
+use crate::crypto::{ring as test_provider, ring::RING as TEST_PROVIDER};
 
 // The public interface is:
 pub use crate::builder::{

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -196,7 +196,8 @@ impl<'a> ClientHello<'a> {
 /// from the operating system to add to the [`RootCertStore`] passed to a `ClientCertVerifier`
 /// builder may take on the order of a few hundred milliseconds.
 ///
-/// These must be created via the [`ServerConfig::builder()`] function.
+/// These must be created via the [`ServerConfig::builder()`] or [`ServerConfig::builder_with_provider()`]
+/// function.
 ///
 /// # Defaults
 ///
@@ -354,16 +355,15 @@ impl fmt::Debug for ServerConfig {
 
 impl ServerConfig {
     #[cfg(feature = "ring")]
-    /// Create builder to build up the server configuration with the default
-    /// `CryptoProvider`.
+    /// Create a builder for a server configuration with the default
+    /// [`CryptoProvider`]: [`crate::crypto::ring::RING`].
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
     pub fn builder() -> ConfigBuilder<Self, WantsCipherSuites> {
         Self::builder_with_provider(crate::crypto::ring::RING)
     }
 
-    /// Create builder to build up the server configuration with a specific
-    /// `CryptoProvider`.
+    /// Create a builder for a server configuration with a specific [`CryptoProvider`].
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
     pub fn builder_with_provider(

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -212,10 +212,11 @@ pub enum ConnectionTrafficSecrets {
 }
 
 #[cfg(all(test, feature = "ring"))]
+#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
 mod tests {
-    use super::crypto::ring::tls13::*;
     use super::*;
     use crate::enums::CipherSuite;
+    use crate::test_provider::tls13::*;
 
     #[test]
     fn test_client_pref() {

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -307,12 +307,12 @@ pub(crate) fn decode_ecdh_params<T: Codec>(
 
 pub(crate) const DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01];
 
-#[cfg(all(test, feature = "ring"))]
+#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
 mod tests {
     use super::*;
     use crate::common_state::{CommonState, Side};
-    use crate::crypto::ring::kx_group::X25519;
     use crate::msgs::handshake::{ClientEcdhParams, ServerEcdhParams};
+    use crate::test_provider::kx_group::X25519;
 
     #[test]
     fn server_ecdhe_remaining_bytes() {

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -833,11 +833,11 @@ where
 #[cfg(all(test, feature = "ring"))]
 mod tests {
     use super::{derive_traffic_iv, derive_traffic_key, KeySchedule, SecretKind};
+    use crate::crypto::ring::ring_like::aead;
     use crate::crypto::ring::tls13::{
         TLS13_AES_128_GCM_SHA256_INTERNAL, TLS13_CHACHA20_POLY1305_SHA256_INTERNAL,
     };
     use crate::KeyLog;
-    use ring::aead;
 
     #[test]
     fn test_vectors() {

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -9,6 +9,7 @@
 use core::time::Duration;
 use std::time::Instant;
 
+use crate::crypto::ring;
 use crate::verify::ServerCertVerifier;
 use crate::webpki::{RootCertStore, WebPkiServerVerifier};
 
@@ -208,7 +209,10 @@ impl Context {
     }
 
     fn bench(&self, count: usize) {
-        let verifier = WebPkiServerVerifier::new_without_revocation(self.roots.clone());
+        let verifier = WebPkiServerVerifier::new_without_revocation(
+            self.roots.clone(),
+            ring::RING.signature_verification_algorithms(),
+        );
         const OCSP_RESPONSE: &[u8] = &[];
         let mut times = Vec::new();
 

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -164,7 +164,7 @@ impl ClientCertVerifierBuilder {
 
         #[cfg(feature = "ring")]
         if self.supported_algs.is_none() {
-            self.supported_algs = Some(super::verify::SUPPORTED_SIG_ALGS);
+            self.supported_algs = Some(crate::crypto::ring::SUPPORTED_SIG_ALGS);
         }
 
         let supported_algs = self

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -186,17 +186,20 @@ impl ClientCertVerifierBuilder {
 ///
 /// To require all clients present a client certificate issued by a trusted CA:
 /// ```no_run
+/// # #[cfg(feature = "ring")] {
 /// # use rustls::RootCertStore;
 /// # use rustls::server::WebPkiClientVerifier;
 /// # let roots = RootCertStore::empty();
 /// let client_verifier = WebPkiClientVerifier::builder(roots.into())
 ///   .build()
 ///   .unwrap();
+/// # }
 /// ```
 ///
 /// Or, to allow clients presenting a client certificate authenticated by a trusted CA, or
 /// anonymous clients that present no client certificate:
 /// ```no_run
+/// # #[cfg(feature = "ring")] {
 /// # use rustls::RootCertStore;
 /// # use rustls::server::WebPkiClientVerifier;
 /// # let roots = RootCertStore::empty();
@@ -204,6 +207,7 @@ impl ClientCertVerifierBuilder {
 ///   .allow_unauthenticated()
 ///   .build()
 ///   .unwrap();
+/// # }
 /// ```
 ///
 /// If you wish to disable advertising client authentication:
@@ -217,6 +221,7 @@ impl ClientCertVerifierBuilder {
 /// You can also configure the client verifier to check for certificate revocation with
 /// client certificate revocation lists (CRLs):
 /// ```no_run
+/// # #[cfg(feature = "ring")] {
 /// # use rustls::RootCertStore;
 /// # use rustls::server::{WebPkiClientVerifier};
 /// # let roots = RootCertStore::empty();
@@ -225,6 +230,7 @@ impl ClientCertVerifierBuilder {
 ///   .with_crls(crls)
 ///   .build()
 ///   .unwrap();
+/// # }
 /// ```
 ///
 /// [^1]: <https://github.com/rustls/webpki>

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -132,17 +132,6 @@ impl ClientCertVerifierBuilder {
         self
     }
 
-    /// Sets which signature verification algorithms are enabled.
-    ///
-    /// If this is called multiple times, the last call wins.
-    pub fn with_signature_verification_algorithms(
-        mut self,
-        supported_algs: WebPkiSupportedAlgorithms,
-    ) -> Self {
-        self.supported_algs = supported_algs;
-        self
-    }
-
     /// Build a client certificate verifier. The built verifier will be used for the server to offer
     /// client certificate authentication, to control how offered client certificates are validated,
     /// and to determine what to do with anonymous clients that do not respond to the client

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -34,11 +34,6 @@ pub enum VerifierBuilderError {
     NoRootAnchors,
     /// A provided CRL could not be parsed.
     InvalidCrl(CertRevocationListError),
-    /// No supported signature verification algorithms were provided.
-    ///
-    /// Call `with_signature_verification_algorithms` on the builder, or compile
-    /// with the `ring` feature.
-    NoSupportedAlgorithms,
 }
 
 impl From<CertRevocationListError> for VerifierBuilderError {
@@ -52,9 +47,6 @@ impl fmt::Display for VerifierBuilderError {
         match self {
             Self::NoRootAnchors => write!(f, "no root trust anchors were provided"),
             Self::InvalidCrl(e) => write!(f, "provided CRL could not be parsed: {:?}", e),
-            Self::NoSupportedAlgorithms => {
-                write!(f, "no signature verification algorithms were provided")
-            }
         }
     }
 }

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -81,17 +81,6 @@ impl ServerCertVerifierBuilder {
         self
     }
 
-    /// Sets which signature verification algorithms are enabled.
-    ///
-    /// If this is called multiple times, the last call wins.
-    pub fn with_signature_verification_algorithms(
-        mut self,
-        supported_algs: WebPkiSupportedAlgorithms,
-    ) -> Self {
-        self.supported_algs = supported_algs;
-        self
-    }
-
     /// Build a server certificate verifier, allowing control over the root certificates to use as
     /// trust anchors, and to control how server certificate revocation checking is performed.
     ///

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -6,11 +6,11 @@ use alloc::vec::Vec;
 use pki_types::{CertificateDer, CertificateRevocationListDer, UnixTime};
 use webpki::{CertRevocationList, RevocationCheckDepth, UnknownStatusPolicy};
 
+#[cfg(feature = "ring")]
+use crate::crypto::ring::SUPPORTED_SIG_ALGS;
 use crate::verify::{
     DigitallySignedStruct, HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
 };
-#[cfg(feature = "ring")]
-use crate::webpki::verify::SUPPORTED_SIG_ALGS;
 use crate::webpki::verify::{
     verify_server_cert_signed_by_trust_anchor_impl, verify_signed_struct, verify_tls13,
     ParsedCertificate,

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -246,7 +246,7 @@ mod tests {
     fn webpki_supported_algorithms_is_debug() {
         assert_eq!(
             "WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }",
-            format!("{:?}", crate::crypto::ring::SUPPORTED_SIG_ALGS)
+            format!("{:?}", crate::crypto::ring::RING.signature_verification_algorithms())
         );
     }
 }

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -2,8 +2,6 @@ use alloc::vec::Vec;
 use core::fmt;
 
 use pki_types::{CertificateDer, SignatureVerificationAlgorithm, UnixTime};
-#[cfg(feature = "ring")]
-use webpki::ring as webpki_algs;
 
 use super::anchors::RootCertStore;
 use super::pki_error;
@@ -144,68 +142,6 @@ impl<'a> TryFrom<&'a CertificateDer<'a>> for ParsedCertificate<'a> {
     }
 }
 
-/// A `WebPkiSupportedAlgorithms` value that reflects webpki's capabilities when
-/// compiled against *ring*.
-#[cfg(feature = "ring")]
-pub(crate) static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
-    all: &[
-        webpki_algs::ECDSA_P256_SHA256,
-        webpki_algs::ECDSA_P256_SHA384,
-        webpki_algs::ECDSA_P384_SHA256,
-        webpki_algs::ECDSA_P384_SHA384,
-        webpki_algs::ED25519,
-        webpki_algs::RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
-        webpki_algs::RSA_PSS_2048_8192_SHA384_LEGACY_KEY,
-        webpki_algs::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
-        webpki_algs::RSA_PKCS1_2048_8192_SHA256,
-        webpki_algs::RSA_PKCS1_2048_8192_SHA384,
-        webpki_algs::RSA_PKCS1_2048_8192_SHA512,
-        webpki_algs::RSA_PKCS1_3072_8192_SHA384,
-    ],
-    mapping: &[
-        // nb. for TLS1.2 the curve is not fixed by SignatureScheme. for TLS1.3 it is.
-        (
-            SignatureScheme::ECDSA_NISTP384_SHA384,
-            &[
-                webpki_algs::ECDSA_P384_SHA384,
-                webpki_algs::ECDSA_P256_SHA384,
-            ],
-        ),
-        (
-            SignatureScheme::ECDSA_NISTP256_SHA256,
-            &[
-                webpki_algs::ECDSA_P256_SHA256,
-                webpki_algs::ECDSA_P384_SHA256,
-            ],
-        ),
-        (SignatureScheme::ED25519, &[webpki_algs::ED25519]),
-        (
-            SignatureScheme::RSA_PSS_SHA512,
-            &[webpki_algs::RSA_PSS_2048_8192_SHA512_LEGACY_KEY],
-        ),
-        (
-            SignatureScheme::RSA_PSS_SHA384,
-            &[webpki_algs::RSA_PSS_2048_8192_SHA384_LEGACY_KEY],
-        ),
-        (
-            SignatureScheme::RSA_PSS_SHA256,
-            &[webpki_algs::RSA_PSS_2048_8192_SHA256_LEGACY_KEY],
-        ),
-        (
-            SignatureScheme::RSA_PKCS1_SHA512,
-            &[webpki_algs::RSA_PKCS1_2048_8192_SHA512],
-        ),
-        (
-            SignatureScheme::RSA_PKCS1_SHA384,
-            &[webpki_algs::RSA_PKCS1_2048_8192_SHA384],
-        ),
-        (
-            SignatureScheme::RSA_PKCS1_SHA256,
-            &[webpki_algs::RSA_PKCS1_2048_8192_SHA256],
-        ),
-    ],
-};
-
 fn verify_sig_using_any_alg(
     cert: &webpki::EndEntityCert,
     algs: &[&'static dyn SignatureVerificationAlgorithm],
@@ -310,7 +246,7 @@ mod tests {
     fn webpki_supported_algorithms_is_debug() {
         assert_eq!(
             "WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }",
-            format!("{:?}", SUPPORTED_SIG_ALGS)
+            format!("{:?}", crate::crypto::ring::SUPPORTED_SIG_ALGS)
         );
     }
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -14,6 +14,7 @@ use pki_types::{CertificateDer, PrivateKeyDer, UnixTime};
 use rustls::client::{
     verify_server_cert_signed_by_trust_anchor, ResolvesClientCert, Resumption, WebPkiServerVerifier,
 };
+use rustls::crypto::ring::sign::RsaSigningKey;
 use rustls::crypto::ring::{cipher_suite, ALL_CIPHER_SUITES};
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
@@ -2524,7 +2525,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
 fn sni_resolver_works() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
     resolver
         .add(
@@ -2562,7 +2563,7 @@ fn sni_resolver_works() {
 fn sni_resolver_rejects_wrong_names() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
@@ -2592,7 +2593,7 @@ fn sni_resolver_rejects_wrong_names() {
 fn sni_resolver_lower_cases_configured_names() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
@@ -2619,7 +2620,7 @@ fn sni_resolver_lower_cases_queried_names() {
     // actually, the handshake parser does this, but the effect is the same.
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
@@ -2645,7 +2646,7 @@ fn sni_resolver_lower_cases_queried_names() {
 fn sni_resolver_rejects_bad_certs() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5489,6 +5489,11 @@ impl rustls::crypto::CryptoProvider for FaultyRandomProvider {
     ) -> Result<Arc<dyn rustls::sign::SigningKey>, Error> {
         self.parent.load_private_key(key_der)
     }
+
+    fn signature_verification_algorithms(&self) -> rustls::WebPkiSupportedAlgorithms {
+        self.parent
+            .signature_verification_algorithms()
+    }
 }
 
 #[test]

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use pki_types::{CertificateDer, UnixTime};
+use pki_types::{CertificateDer, PrivateKeyDer, UnixTime};
 use rustls::client::{
     verify_server_cert_signed_by_trust_anchor, ResolvesClientCert, Resumption, WebPkiServerVerifier,
 };
@@ -5481,6 +5481,13 @@ impl rustls::crypto::CryptoProvider for FaultyRandomProvider {
 
     fn default_kx_groups(&self) -> &'static [&'static (dyn rustls::crypto::SupportedKxGroup)] {
         self.parent.default_kx_groups()
+    }
+
+    fn load_private_key(
+        &self,
+        key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn rustls::sign::SigningKey>, Error> {
+        self.parent.load_private_key(key_der)
     }
 }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -14,7 +14,7 @@ use pki_types::{CertificateDer, UnixTime};
 use rustls::client::{
     verify_server_cert_signed_by_trust_anchor, ResolvesClientCert, Resumption, WebPkiServerVerifier,
 };
-use rustls::crypto::ring::ALL_CIPHER_SUITES;
+use rustls::crypto::ring::{cipher_suite, ALL_CIPHER_SUITES};
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::enums::AlertLevel;
@@ -248,7 +248,7 @@ fn config_builder_for_client_rejects_empty_cipher_suites() {
 fn config_builder_for_client_rejects_incompatible_cipher_suites() {
     assert_eq!(
         ClientConfig::builder()
-            .with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
+            .with_cipher_suites(&[cipher_suite::TLS13_AES_256_GCM_SHA384])
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS12])
             .err(),
@@ -285,7 +285,7 @@ fn config_builder_for_server_rejects_empty_cipher_suites() {
 fn config_builder_for_server_rejects_incompatible_cipher_suites() {
     assert_eq!(
         ServerConfig::builder()
-            .with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
+            .with_cipher_suites(&[cipher_suite::TLS13_AES_256_GCM_SHA384])
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS12])
             .err(),
@@ -451,7 +451,7 @@ fn test_config_builders_debug() {
         "ConfigBuilder<ServerConfig, _> { state: WantsCipherSuites(Ring) }",
         format!("{:?}", b)
     );
-    let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
+    let b = b.with_cipher_suites(&[cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
     assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], provider: Ring } }", format!("{:?}", b));
     let b = b.with_kx_groups(&[rustls::crypto::ring::kx_group::X25519]);
     assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], provider: Ring } }", format!("{:?}", b));
@@ -466,7 +466,7 @@ fn test_config_builders_debug() {
         "ConfigBuilder<ClientConfig, _> { state: WantsCipherSuites(Ring) }",
         format!("{:?}", b)
     );
-    let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
+    let b = b.with_cipher_suites(&[cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
     assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], provider: Ring } }", format!("{:?}", b));
     let b = b.with_kx_groups(&[rustls::crypto::ring::kx_group::X25519]);
     assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], provider: Ring } }", format!("{:?}", b));
@@ -2307,7 +2307,7 @@ fn make_disjoint_suite_configs() -> (ClientConfig, ServerConfig) {
     let server_config = finish_server_config(
         kt,
         ServerConfig::builder()
-            .with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
+            .with_cipher_suites(&[cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
             .with_safe_default_kx_groups()
             .with_safe_default_protocol_versions()
             .unwrap(),
@@ -2316,7 +2316,7 @@ fn make_disjoint_suite_configs() -> (ClientConfig, ServerConfig) {
     let client_config = finish_client_config(
         kt,
         ClientConfig::builder()
-            .with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
+            .with_cipher_suites(&[cipher_suite::TLS13_AES_256_GCM_SHA384])
             .with_safe_default_kx_groups()
             .with_safe_default_protocol_versions()
             .unwrap(),
@@ -4173,7 +4173,7 @@ mod test_quic {
 
     #[test]
     fn packet_key_api() {
-        use rustls::cipher_suite::TLS13_AES_128_GCM_SHA256;
+        use cipher_suite::TLS13_AES_128_GCM_SHA256;
         use rustls::quic::{Keys, Version};
         use rustls::Side;
 
@@ -5213,12 +5213,12 @@ fn test_secret_extraction_enabled() {
     // Chacha20Poly1305), so that's 2*3 = 6 combinations to test.
     let kt = KeyType::Rsa;
     for suite in [
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
-        rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
-        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_256_GCM_SHA384,
+        cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
     ] {
         let version = suite.version();
         println!("Testing suite {:?}", suite.suite().as_str());
@@ -5284,7 +5284,7 @@ fn test_secret_extraction_enabled() {
 #[cfg(feature = "tls12")]
 #[test]
 fn test_secret_extraction_disabled_or_too_early() {
-    let suite = rustls::cipher_suite::TLS13_AES_128_GCM_SHA256;
+    let suite = cipher_suite::TLS13_AES_128_GCM_SHA256;
     let kt = KeyType::Rsa;
 
     for (server_enable, client_enable) in [(true, false), (false, true)] {
@@ -5340,7 +5340,7 @@ fn test_secret_extraction_disabled_or_too_early() {
 
 #[test]
 fn test_received_plaintext_backpressure() {
-    let suite = rustls::cipher_suite::TLS13_AES_128_GCM_SHA256;
+    let suite = cipher_suite::TLS13_AES_128_GCM_SHA256;
     let kt = KeyType::Rsa;
 
     let server_config = Arc::new(

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -8,7 +8,6 @@ use crate::common::{
     make_pair_for_arc_configs, make_server_config, ErrorFromPeer, ALL_KEY_TYPES,
 };
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-use rustls::client::WebPkiServerVerifier;
 use rustls::DigitallySignedStruct;
 use rustls::{AlertDescription, Error, InvalidMessage, SignatureScheme};
 
@@ -264,7 +263,13 @@ impl Default for MockServerVerifier {
             cert_rejection_error: None,
             tls12_signature_error: None,
             tls13_signature_error: None,
-            signature_schemes: WebPkiServerVerifier::default_supported_verify_schemes(),
+            signature_schemes: vec![
+                SignatureScheme::RSA_PSS_SHA256,
+                SignatureScheme::RSA_PKCS1_SHA256,
+                SignatureScheme::ED25519,
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::ECDSA_NISTP384_SHA384,
+            ],
         }
     }
 }


### PR DESCRIPTION
The end goal of this is to let people opt-in to using aws-lc-rs in FIPS mode. The next step in that direction is to support and test aws-lc-rs in non-FIPS mode, which is this PR.