### PR TITLE
examples: configure `KeyLogFile` for all examples.

### DIFF
--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -228,16 +228,19 @@ impl TestPki {
         // Build a server config using the fresh verifier. If necessary, this could be customized
         // based on the ClientHello (e.g. selecting a different certificate, or customizing
         // supported algorithms/protocol versions).
-        Arc::new(
-            ServerConfig::builder()
-                .with_safe_defaults()
-                .with_client_cert_verifier(verifier)
-                .with_single_cert(
-                    vec![Certificate(self.server_cert_der.clone())],
-                    PrivateKey(self.server_key_der.clone()),
-                )
-                .unwrap(),
-        )
+        let mut server_config = ServerConfig::builder()
+            .with_safe_defaults()
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(
+                vec![Certificate(self.server_cert_der.clone())],
+                PrivateKey(self.server_key_der.clone()),
+            )
+            .unwrap();
+
+        // Allow using SSLKEYLOGFILE.
+        server_config.key_log = Arc::new(rustls::KeyLogFile::new());
+
+        Arc::new(server_config)
     }
 
     /// Issue a certificate revocation list (CRL) for the revoked `serials` provided (may be empty).

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -77,6 +77,9 @@ fn main() {
         .with_root_certificates(root_store)
         .with_no_client_auth();
 
+    // Allow using SSLKEYLOGFILE.
+    config.key_log = Arc::new(rustls::KeyLogFile::new());
+
     // Enable early data.
     config.enable_early_data = true;
     let config = Arc::new(config);

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -28,10 +28,13 @@ fn main() {
                 )
             }),
     );
-    let config = rustls::ClientConfig::<Ring>::builder()
+    let mut config = rustls::ClientConfig::<Ring>::builder()
         .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
+
+    // Allow using SSLKEYLOGFILE.
+    config.key_log = Arc::new(rustls::KeyLogFile::new());
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();


### PR DESCRIPTION
The example programs distributed with Rustls are often used to demonstrate TLS features, or debug issues, that require being able to view plaintext data captured in a pcap (e.g. with Wireshark). As one concrete example a modified `simple_0rtt_client.rs`, was used to help debug https://github.com/rustls/rustls/issues/1406.

To make this convenient this commit updates the examples (minus the MIO examples that already did so ) to configure Rustls with a `KeyLogFile` implementation of the `KeyLog` trait. Users can then specify the `SSLKEYLOGFILE` environment variable to log the required session secrets for use with their pcap tool of choice.