### PR TITLE
rel-0.21: Echo `session_id` in HRR

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 edition = "2021"
 rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -755,6 +755,28 @@ impl ExpectServerHelloOrHelloRetryRequest {
             });
         }
 
+        // Or does not echo the session_id from our ClientHello:
+        //
+        // > the HelloRetryRequest has the same format as a ServerHello message,
+        // > and the legacy_version, legacy_session_id_echo, cipher_suite, and
+        // > legacy_compression_method fields have the same meaning
+        // <https://www.rfc-editor.org/rfc/rfc8446#section-4.1.4>
+        //
+        // and
+        //
+        // > A client which receives a legacy_session_id_echo field that does not
+        // > match what it sent in the ClientHello MUST abort the handshake with an
+        // > "illegal_parameter" alert.
+        // <https://www.rfc-editor.org/rfc/rfc8446#section-4.1.3>
+        if hrr.session_id != self.next.input.session_id {
+            return Err({
+                cx.common.send_fatal_alert(
+                    AlertDescription::IllegalParameter,
+                    PeerMisbehaved::IllegalHelloRetryRequestWithWrongSessionId,
+                )
+            });
+        }
+
         // Or asks us to talk a protocol we didn't offer, or doesn't support HRR at all.
         match hrr.get_supported_versions() {
             Some(ProtocolVersion::TLSv1_3) => {

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -183,6 +183,7 @@ pub enum PeerMisbehaved {
     IllegalHelloRetryRequestWithUnofferedCipherSuite,
     IllegalHelloRetryRequestWithUnofferedNamedGroup,
     IllegalHelloRetryRequestWithUnsupportedVersion,
+    IllegalHelloRetryRequestWithWrongSessionId,
     IllegalMiddleboxChangeCipherSpec,
     IllegalTlsInnerPlaintext,
     IncorrectBinder,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -235,6 +235,7 @@ mod client_hello {
                         emit_hello_retry_request(
                             &mut self.transcript,
                             self.suite,
+                            client_hello.session_id,
                             cx.common,
                             group.name,
                         );
@@ -570,12 +571,13 @@ mod client_hello {
     fn emit_hello_retry_request(
         transcript: &mut HandshakeHash,
         suite: &'static Tls13CipherSuite,
+        session_id: SessionId,
         common: &mut CommonState,
         group: NamedGroup,
     ) {
         let mut req = HelloRetryRequest {
             legacy_version: ProtocolVersion::TLSv1_2,
-            session_id: SessionId::empty(),
+            session_id,
             cipher_suite: suite.common.suite,
             extensions: Vec::new(),
         };


### PR DESCRIPTION
## Description

This branch backports https://github.com/rustls/rustls/pull/1374 onto the `rel-0.21` release branch.

Updates https://github.com/rustls/rustls/issues/1424

- [x] `cargo update`.
- [x] `cargo outdated`.
- [x] `cargo test --all-features`.
- [x] Update `version` in `Cargo.toml`.
- [x] `cargo publish --dry-run -p rustls`
- [x] PR desc updated with release headlines

### Proposed release notes headlines:

- Fixes interoperability bug where Rustls servers would not properly echo the `session_id` in `HelloRetryRequest` messages as was done for `ServerHello` messages.
- `WebPkiVerifier` now stores an `Arc<RootCertStore>`.
- Documentation for the computational expense required to build client and server configurations has been clarified to emphasize this is cheap with the exception of gathering certificates from a platform trust root store.

### Echo `session_id` in HRR

On the server, we should've been echoing the `session_id` in HelloRetryRequest messages (we already did for ServerHellos).

On the client, there's a requirement that we detect this and fail the connection with an `illegal_parameter` alert.

fixes https://github.com/rustls/rustls/issues/1373


### Cargo: bump version v0.21.6 -> v0.21.7.

Prepare for a v0.21.7 release.