### PR TITLE
Rustls 0.20.9 release prep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.57 # MSRV
+          - "1.60" # MSRV
         os: [ubuntu-20.04]
         # but only stable on macos/windows (slower platforms)
         include:

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.20.8"
+version = "0.20.9"
 edition = "2018"
 rust-version = "1.60"
 license = "Apache-2.0/ISC/MIT"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls"
 version = "0.20.8"
 edition = "2018"
-rust-version = "1.57"
+rust-version = "1.60"
 license = "Apache-2.0/ISC/MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -27,7 +27,7 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
                 versions: self.state.versions,
                 root_store,
             },
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 
@@ -44,7 +44,7 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
                 versions: self.state.versions,
                 verifier,
             },
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -173,7 +173,7 @@ impl ClientConfig {
     pub fn builder() -> ConfigBuilder<Self, WantsCipherSuites> {
         ConfigBuilder {
             state: WantsCipherSuites(()),
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -709,6 +709,27 @@ impl ExpectServerHelloOrHelloRetryRequest {
                 .illegal_param("server requested hrr with no changes"));
         }
 
+        // Or does not echo the session_id from our ClientHello:
+        //
+        // > the HelloRetryRequest has the same format as a ServerHello message,
+        // > and the legacy_version, legacy_session_id_echo, cipher_suite, and
+        // > legacy_compression_method fields have the same meaning
+        // <https://www.rfc-editor.org/rfc/rfc8446#section-4.1.4>
+        //
+        // and
+        //
+        // > A client which receives a legacy_session_id_echo field that does not
+        // > match what it sent in the ClientHello MUST abort the handshake with an
+        // > "illegal_parameter" alert.
+        // <https://www.rfc-editor.org/rfc/rfc8446#section-4.1.3>
+        if hrr.session_id != self.next.session_id {
+            cx.common
+                .send_fatal_alert(AlertDescription::IllegalParameter);
+            return Err(Error::PeerMisbehavedError(
+                "server did not echo the session_id from client hello".to_string(),
+            ));
+        }
+
         // Or asks us to talk a protocol we didn't offer, or doesn't support HRR at all.
         match hrr.get_supported_versions() {
             Some(ProtocolVersion::TLSv1_3) => {

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -25,7 +25,7 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
                 versions: self.state.versions,
                 verifier: client_cert_verifier,
             },
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -305,7 +305,7 @@ impl ServerConfig {
     pub fn builder() -> ConfigBuilder<Self, WantsCipherSuites> {
         ConfigBuilder {
             state: WantsCipherSuites(()),
-            side: PhantomData::default(),
+            side: PhantomData,
         }
     }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -216,6 +216,7 @@ mod client_hello {
                         emit_hello_retry_request(
                             &mut self.transcript,
                             self.suite,
+                            client_hello.session_id,
                             cx.common,
                             group.name,
                         );
@@ -568,12 +569,13 @@ mod client_hello {
     fn emit_hello_retry_request(
         transcript: &mut HandshakeHash,
         suite: &'static Tls13CipherSuite,
+        session_id: SessionID,
         common: &mut CommonState,
         group: NamedGroup,
     ) {
         let mut req = HelloRetryRequest {
             legacy_version: ProtocolVersion::TLSv1_2,
-            session_id: SessionID::empty(),
+            session_id,
             cipher_suite: suite.common.suite,
             extensions: Vec::new(),
         };

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3713,6 +3713,64 @@ fn test_client_sends_helloretryrequest() {
 }
 
 #[test]
+fn test_server_requests_retry_with_echoed_session_id() {
+    use rustls::internal::msgs::handshake::SessionID;
+    let expected_session_id = SessionID::random().unwrap();
+
+    let assert_client_sends_hello_with_secp384 = |msg: &mut Message| -> Altered {
+        if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
+            if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
+                let keyshares = ch
+                    .get_keyshare_extension()
+                    .expect("missing key share extension");
+                assert_eq!(keyshares.len(), 1);
+                assert_eq!(keyshares[0].group, rustls::NamedGroup::secp384r1);
+
+                ch.session_id = expected_session_id;
+                *encoded = Payload::new(parsed.get_encoding());
+            }
+        }
+        Altered::InPlace
+    };
+
+    let assert_server_requests_retry_and_echoes_session_id = |msg: &mut Message| -> Altered {
+        if let MessagePayload::Handshake { parsed, .. } = &mut msg.payload {
+            if let HandshakePayload::HelloRetryRequest(hrr) = &mut parsed.payload {
+                let group = hrr.get_requested_key_share_group();
+                assert_eq!(group, Some(rustls::NamedGroup::X25519));
+
+                assert_eq!(hrr.session_id, expected_session_id);
+            }
+        }
+        Altered::InPlace
+    };
+
+    // client prefers a secp384r1 key share, server only accepts x25519
+    let client_config = make_client_config_with_kx_groups(
+        KeyType::Rsa,
+        &[&rustls::kx_group::SECP384R1, &rustls::kx_group::X25519],
+    );
+
+    let server_config =
+        make_server_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
+
+    let (client, server) = make_pair_for_configs(client_config, server_config);
+    let (mut client, mut server) = (client.into(), server.into());
+    transfer_altered(
+        &mut client,
+        assert_client_sends_hello_with_secp384,
+        &mut server,
+    );
+    server.process_new_packets().unwrap();
+    transfer_altered(
+        &mut server,
+        assert_server_requests_retry_and_echoes_session_id,
+        &mut client,
+    );
+    client.process_new_packets().unwrap();
+}
+
+#[test]
 fn test_client_attempts_to_use_unsupported_kx_group() {
     // common to both client configs
     let shared_storage = Arc::new(ClientStorage::new());


### PR DESCRIPTION
## Description

This branch backports https://github.com/rustls/rustls/pull/1374 onto the `rel-0.20` release branch (created from `v/0.20.8` tag) and prepares the 0.20.9 release.

Updates https://github.com/rustls/rustls/issues/1424

- [x] `cargo update`.
- [x] `cargo outdated`.
- [x] `cargo test --all-features`.
- [x] Update `version` in `Cargo.toml`.
- [x] `cargo publish --dry-run -p rustls`
- [x] PR desc updated with release headlines

### Proposed release notes headlines:

- Fixes interoperability bug where Rustls servers would not properly echo the `session_id` in `HelloRetryRequest` messages as was done for `ServerHello` messages.

### Echo `session_id` in HRR

On the server, we should've been echoing the `session_id` in HelloRetryRequest messages (we already did for ServerHellos).

On the client, there's a requirement that we detect this and fail the connection with an `illegal_parameter` alert.

fixes https://github.com/rustls/rustls/issues/1373

### Remove calls to PhantomData::default

Resolves `clippy` errors.

### Cargo: bump MSRV 1.57 -> 1.60.

Resolves MSRV breakage from `log`, matches current release stream MSRV.

### Cargo: bump version v0.20.8 -> v0.20.9.

Prepare for a v0.20.9 release.