### PR TITLE
Correct `cargo test` for all feature combinations

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -41,7 +41,7 @@ base64 = "0.21"
 [[example]]
 name = "bogo_shim"
 path = "examples/internal/bogo_shim.rs"
-required-features = ["dangerous_configuration", "quic"]
+required-features = ["dangerous_configuration", "quic", "tls12"]
 
 [[example]]
 name = "bench"

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4776,7 +4776,7 @@ fn test_no_warning_logging_during_successful_sessions() {
 }
 
 /// Test that secrets can be extracted and used for encryption/decryption.
-#[cfg(feature = "secret_extraction")]
+#[cfg(all(feature = "secret_extraction", feature = "tls12"))]
 #[test]
 fn test_secret_extraction_enabled() {
     // Normally, secret extraction would be used to configure kTLS (TLS offload
@@ -4851,7 +4851,7 @@ fn test_secret_extraction_enabled() {
 
 /// Test that secrets cannot be extracted unless explicitly enabled, and until
 /// the handshake is done.
-#[cfg(feature = "secret_extraction")]
+#[cfg(all(feature = "secret_extraction", feature = "tls12"))]
 #[test]
 fn test_secret_extraction_disabled_or_too_early() {
     let suite = rustls::cipher_suite::TLS13_AES_128_GCM_SHA256;


### PR DESCRIPTION
It seems ideal if `cargo build` and `cargo test` work without errors for any combination of crate features.

`cargo hack --feature-powerset --keep-going test` shows a few existing issues that this commit addresses:

- `bogo_shim`: requires the `tls12` feature
- `test_secret_extraction_enabled` and `test_secret_extraction_disabled_or_too_early` require the `tls12` feature.

nb. probably not plausible to check this in CI, because it takes 15 minutes of CPU time at the moment and increases superlinearly with number of features.