### PR TITLE
ci: add server_acceptor build check to connect-tests.

### DIFF
--- a/.github/workflows/connect-tests.yml
+++ b/.github/workflows/connect-tests.yml
@@ -49,3 +49,7 @@ jobs:
       - run: cargo run --bin limitedclient
 
       - run: cargo run --bin simple_0rtt_client
+
+      # Test the server_acceptor binary builds - we invoke with --help since it
+      # will run a server process that doesn't exit when invoked with no args
+      - run: cargo run --bin server_acceptor -- --help


### PR DESCRIPTION
This ensures the example binary continues to build, similar to how we handle the other examples.