### PR TITLE
v0.20.10 release prep

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 cargo-fuzz = true
 
 [dependencies]
-webpki = "0.22"
+webpki = { package = "rustls-webpki", version = "0.100.2", features = ["alloc", "std"] }
 
 [dependencies.rustls]
 path = "../rustls"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -20,7 +20,7 @@ rustversion = { version = "1.0.6", optional = true }
 log = { version = "0.4.4", optional = true }
 ring = "0.16.20"
 sct = "0.7.0"
-webpki = { version = "0.22.0", features = ["alloc", "std"] }
+webpki = { package = "rustls-webpki", version = "0.100.2", features = ["alloc", "std"] }
 
 [features]
 default = ["logging", "tls12"]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.20.9"
+version = "0.20.10"
 edition = "2018"
 rust-version = "1.60"
 license = "Apache-2.0/ISC/MIT"

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -108,7 +108,7 @@ impl CertifiedKey {
             // that the certificate is valid for, if the certificate is
             // valid.
             if end_entity_cert
-                .verify_is_valid_for_dns_name(name)
+                .verify_is_valid_for_subject_name(webpki::SubjectNameRef::DnsName(name))
                 .is_err()
             {
                 return Err(Error::General(

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -371,7 +371,7 @@ impl ServerCertVerifier for WebPkiVerifier {
             trace!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
         }
 
-        cert.verify_is_valid_for_dns_name(dns_name.0.as_ref())
+        cert.verify_is_valid_for_subject_name(webpki::SubjectNameRef::DnsName(dns_name.0.as_ref()))
             .map_err(pki_error)
             .map(|_| ServerCertVerified::assertion())
     }


### PR DESCRIPTION
## Description

This branch prepares a 0.20.10 release, switching to the Rustls project maintained webpki fork. This resolves RUSTSEC-2023-0052 by switching to a our fork, with the patch for RUSTSEC-2023-0053.

This may not be strictly semver compatible: Rustls 0.20.x exposes Webpki types in its API.

- [x] `cargo update`.
- [x] `cargo outdated`.
- [x] `cargo test --all-features`.
- [x] Update `version` in `Cargo.toml`.
- [x] `cargo publish --dry-run -p rustls`
- [x] PR desc updated with release headlines

### Proposed release notes headlines:

 **Note**: This update is not strictly semver compatible, since [`RootCertStore::add`](https://docs.rs/rustls/0.20.9/rustls/struct.RootCertStore.html#method.add) returns `webpki::Error`.

* Switches `webpki` to `rustls/webpki`. This resolves RUSTSEC-2023-0052: When the `webpki` crate is given a pathological certificate chain to validate, it will spend CPU time exponential with the number of candidate certificates at each step of path building. Both TLS clients and TLS servers that accept client certificate are affected. The updated `rustls/webpki` crate now gives each path building operation a budget of 100 signature verifications.

### deps: update webpki v0.22 -> rustls-webpk v0.100.2

This resolves RUSTSEC-2023-0052 by switching to a Rustls project maintained fork, with the patch for RUSTSEC-2023-0053.

### Cargo: bump version 0.20.9 -> 0.20.10.
Prepares for 0.20.10 release.
