### PR TITLE
Hook up icount benchmarks to CI

### DIFF
--- a/.github/workflows/icount-bench.yml
+++ b/.github/workflows/icount-bench.yml
@@ -1,0 +1,34 @@
+name: icount bench
+on: [pull_request]
+
+jobs:
+  icount-benchmarks:
+    name: Run icount benchmarks
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install valgrind
+        run: sudo apt install -y valgrind
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Checkout ${{ github.base_ref }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+
+      - name: Run icount benchmarks for ${{ github.base_ref }}
+        run: cd ci-bench && cargo run --release -- run-all > ${{ runner.temp }}/base.csv
+
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        with:
+          clean: false
+          persist-credentials: false
+
+      - name: Run icount benchmarks for PR
+        run: cd ci-bench && cargo run --release -- run-all > ${{ runner.temp }}/pr.csv
+
+      - name: Compare results
+        run: cd ci-bench && cargo run --release -- compare ${{ runner.temp }}/base.csv ${{ runner.temp }}/pr.csv > $GITHUB_STEP_SUMMARY

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -48,7 +48,7 @@ const TRANSFER_PLAINTEXT_SIZE: usize = 1024 * 1024;
 /// [`rustls::client::ClientSessionMemoryCache`] and [`rustls::server::ServerSessionMemoryCache`],
 /// which rely on a randomized `HashMap` under the hood (you can check for yourself by that
 /// `HashMap` by a `FxHashMap`, which brings the noise down to acceptable levels in a single run).
-const RESUMED_HANDSHAKE_RUNS: usize = 3;
+const RESUMED_HANDSHAKE_RUNS: usize = 30;
 
 /// The threshold at which instruction count changes are considered relevant
 const CHANGE_THRESHOLD: f64 = 0.002; // 0.2%


### PR DESCRIPTION
This PR adds a GitHub actions job that does the following:

- Benchmark the PR's target branch and store the results in a temp file.
- Benchmark the PR itself and store the results in a temp file.
- Compare the two runs and set the job summary to display the pretty-printed results.
- Let the job fail if there is a noteworthy difference in instruction counts, hinting you should look at the job summary to see the details.

You can already see it in action by looking at the new job triggered by this very PR 😉. It is failing, because the icounts have increased a lot (I discovered we need to run the resumed handshakes about 30x to filter out noise, instead of 3x).

Relevant context:

- It's not possible to post the benchmark results as a comment to the PR directly from the GitHub Actions job. This happens because the job runner has read-only access to the issues when the PR has been created from a fork (see the [docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)). Codecov manages to do this by running as a separate application, with its own permissions.
- I'm using the term "noteworthy" instead of "significant" to avoid giving the impression we are doing anything fancy with statistics here.