### PR TITLE
ci: fix job name for `cargo test`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-      - name: cargo build (debug; no default features)
+      - name: cargo test (debug; no default features)
         run: cargo test --no-default-features
 
       - name: cargo test (debug; no default features; tls12)


### PR DESCRIPTION
There was a mismatch between the job name and what it did.