### PR TITLE
use caches instead for session cache

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -16,6 +16,7 @@ build = "build.rs"
 rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
+caches = { version = "0.2.4", features = ["core"], default-features = false, git = "https://github.com/stevefan1999-personal/caches-rs" }
 log = { version = "0.4.4", optional = true }
 ring = "0.16.20"
 subtle = "2.5.0"

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -2,7 +2,7 @@ use crate::client;
 use crate::enums::SignatureScheme;
 use crate::error::Error;
 use crate::key;
-use crate::limited_cache;
+use crate::limited_cache::CacheExt;
 use crate::msgs::persist;
 use crate::sign;
 use crate::NamedGroup;
@@ -10,6 +10,7 @@ use crate::ServerName;
 
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
+use caches::Cache;
 use std::sync::Mutex;
 
 /// An implementer of `ClientSessionStore` which does nothing.
@@ -66,7 +67,7 @@ impl Default for ServerData {
 ///
 /// It enforces a limit on the number of entries to bound memory usage.
 pub struct ClientSessionMemoryCache {
-    servers: Mutex<limited_cache::LimitedCache<ServerName, ServerData>>,
+    servers: Mutex<caches::AdaptiveCache<ServerName, ServerData>>,
 }
 
 impl ClientSessionMemoryCache {
@@ -76,7 +77,7 @@ impl ClientSessionMemoryCache {
         let max_servers =
             size.saturating_add(MAX_TLS13_TICKETS_PER_SERVER - 1) / MAX_TLS13_TICKETS_PER_SERVER;
         Self {
-            servers: Mutex::new(limited_cache::LimitedCache::new(max_servers)),
+            servers: Mutex::new(caches::AdaptiveCache::new(max_servers).unwrap()),
         }
     }
 }


### PR DESCRIPTION
This PR almost removes the entirety of `limited_cache.rs`, because I spotted that it is just a LRU in a nutshell. This let us use more cache replacement policies, for example, the [Adaptive Replacement Cache](https://en.wikipedia.org/wiki/Adaptive_replacement_cache) as an experiment.  

The `caches` crate offers `no_std` mode and it is taken care of. But there are few problems:

1.  [Hidden KeyRef type complicates key lookup · Issue #2 · al8n/caches-rs (github.com)](https://github.com/al8n/caches-rs/issues/2)
2.  [Buggy behavior on ARC · Issue #9 · al8n/caches-rs (github.com)](https://github.com/al8n/caches-rs/issues/9)

I have worked around the issue and made subsequent PRs for this. It is now await feedback and will replace the current git crate repo it to point to the main crates.io once the PRs are accepted and published.

Also it seems like the initial cache size is off by one, so I "fixed" it in the tests. It turns out the original LRU cache implementation seems to have an open interval.