### PR TITLE
Show detailed icount diff for scenarios with noteworthy diffs

### DIFF
--- a/.github/workflows/icount-bench.yml
+++ b/.github/workflows/icount-bench.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
 
       - name: Run icount benchmarks for ${{ github.base_ref }}
-        run: cd ci-bench && cargo run --release -- run-all > ${{ runner.temp }}/base.csv
+        run: cd ci-bench && cargo run --release -- run-all --output-dir ${{ runner.temp }}/base
 
       - name: Checkout PR
         uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run icount benchmarks for PR
-        run: cd ci-bench && cargo run --release -- run-all > ${{ runner.temp }}/pr.csv
+        run: cd ci-bench && cargo run --release -- run-all --output-dir ${{ runner.temp }}/pr
 
       - name: Compare results
-        run: cd ci-bench && cargo run --release -- compare ${{ runner.temp }}/base.csv ${{ runner.temp }}/pr.csv > $GITHUB_STEP_SUMMARY
+        run: cd ci-bench && cargo run --release -- compare ${{ runner.temp }}/base ${{ runner.temp }}/pr > $GITHUB_STEP_SUMMARY

--- a/ci-bench/README.md
+++ b/ci-bench/README.md
@@ -12,8 +12,9 @@ important bits.
 
 _Note: this step requires having `valgrind` in your path._
 
-Use `cargo run --release -- run-all > out.csv` to generate a CSV with the instruction counts for
-the different scenarios we support. The result should look like the following:
+Use `cargo run --release -- run-all --output-dir foo` to generate the results inside the `foo`
+directory. Within that directory, you will find an `icounts.csv` file with the instruction counts
+for the different scenarios we support. It should look like the following:
 
 ```csv
 handshake_no_resume_1.2_rsa_aes_server,11327015
@@ -31,12 +32,14 @@ handshake_no_resume_1.3_rsa_aes_client,4212770
 ...
 ```
 
+In the `cachegrind` subdirectory you will find output files emitted by the `cachegrind` tool, which
+are useful to report detailed instruction count differences when comparing two benchmark runs.
+
 ### Comparing results
 
-Use `cargo run --release -- compare out1.csv out2.csv`. It will output a report using
-GitHub-flavored markdown (used by the CI itself to give feedback about PRs). We currently
-consider differences of 0.2% to be significant, but might tweak it in the future after we gain
-experience with the benchmarking setup.
+Use `cargo run --release -- compare foo bar`. It will output a report using GitHub-flavored markdown
+(used by the CI itself to give feedback about PRs). We currently consider differences of 0.2% to be
+significant, but might tweak it in the future after we gain experience with the benchmarking setup.
 
 ### Supported scenarios
 

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -56,6 +56,9 @@ const RESUMED_HANDSHAKE_RUNS: usize = 30;
 /// The threshold at which instruction count changes are considered relevant
 const CHANGE_THRESHOLD: f64 = 0.002; // 0.2%
 
+/// The name of the file where the instruction counts are stored after a `run-all` run
+const ICOUNTS_FILENAME: &str = "icounts.csv";
+
 #[derive(Parser)]
 #[command(about)]
 pub struct Cli {
@@ -66,15 +69,18 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Command {
     /// Run all benchmarks and prints the measured CPU instruction counts in CSV format
-    RunAll,
+    RunAll {
+        #[arg(short, long)]
+        output_dir: Option<PathBuf>,
+    },
     /// Run a single benchmark at the provided index (used by the bench runner to start each benchmark in its own process)
     RunSingle { index: u32, side: Side },
     /// Compare the results from two previous benchmark runs and print a user-friendly markdown overview
     Compare {
-        /// Path to a CSV file obtained from a previous `run-all` execution
-        baseline_input: PathBuf,
-        /// Path to a CSV file obtained from a previous `run-all` execution
-        candidate_input: PathBuf,
+        /// Path to the directory with the results of a previous `run-all` execution
+        baseline_dir: PathBuf,
+        /// Path to the directory with the results of a previous `run-all` execution
+        candidate_dir: PathBuf,
     },
 }
 
@@ -99,13 +105,16 @@ fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
     match cli.command {
-        Command::RunAll => {
+        Command::RunAll { output_dir } => {
             let executable = std::env::args().next().unwrap();
-            let results = run_all(executable, &benchmarks)?;
+            let output_dir = output_dir.unwrap_or("target/ci-bench".into());
+            let results = run_all(executable, output_dir.clone(), &benchmarks)?;
 
             // Output results in CSV (note: not using a library here to avoid extra dependencies)
+            let mut csv_file = File::create(output_dir.join(ICOUNTS_FILENAME))
+                .context("cannot create output csv file")?;
             for (name, instr_count) in results {
-                println!("{name},{instr_count}");
+                writeln!(csv_file, "{name},{instr_count}")?;
             }
         }
         Command::RunSingle { index, side } => {
@@ -167,12 +176,12 @@ fn main() -> anyhow::Result<()> {
             mem::forget(stdout);
         }
         Command::Compare {
-            baseline_input,
-            candidate_input,
+            baseline_dir,
+            candidate_dir,
         } => {
-            let baseline = read_results(baseline_input.as_ref())?;
-            let candidate = read_results(candidate_input.as_ref())?;
-            let result = compare_results(&baseline, &candidate);
+            let baseline = read_results(&baseline_dir.join(ICOUNTS_FILENAME))?;
+            let candidate = read_results(&candidate_dir.join(ICOUNTS_FILENAME))?;
+            let result = compare_results(&baseline_dir, &candidate_dir, &baseline, &candidate)?;
             print_report(&result);
 
             if !result.noteworthy.is_empty() {
@@ -275,9 +284,13 @@ fn add_benchmark_group(benchmarks: &mut Vec<Benchmark>, params: BenchmarkParams)
 }
 
 /// Run all the provided benches under cachegrind to retrieve their instruction count
-pub fn run_all(executable: String, benches: &[Benchmark]) -> anyhow::Result<Vec<(String, u64)>> {
+pub fn run_all(
+    executable: String,
+    output_dir: PathBuf,
+    benches: &[Benchmark],
+) -> anyhow::Result<Vec<(String, u64)>> {
     // Run the benchmarks in parallel
-    let cachegrind = CachegrindRunner::new(executable)?;
+    let cachegrind = CachegrindRunner::new(executable, output_dir)?;
     let results: Vec<_> = benches
         .par_iter()
         .enumerate()
@@ -495,8 +508,10 @@ fn run_bench<T: BenchStepper>(mut stepper: T, kind: BenchmarkKind) -> anyhow::Re
 
 /// The results of a comparison between two `run-all` executions
 struct CompareResult {
-    /// Results that probably indicate a real change in performance and should be highlighted
-    noteworthy: Vec<Diff>,
+    /// Results that probably indicate a real change in performance and should be highlighted.
+    ///
+    /// The string is a detailed diff between the instruction counts obtained from cachegrind.
+    noteworthy: Vec<(Diff, String)>,
     /// Results within the noise threshold
     negligible: Vec<Diff>,
     /// Benchmark scenarios present in the candidate but missing in the baseline
@@ -515,7 +530,10 @@ struct Diff {
 
 /// Reads the (benchmark, instruction count) pairs from previous CSV output
 fn read_results(path: &Path) -> anyhow::Result<HashMap<String, u64>> {
-    let file = fs::File::open(path).context("CSV file for comparison not found")?;
+    let file = File::open(path).context(format!(
+        "CSV file for comparison not found: {}",
+        path.display()
+    ))?;
 
     let mut measurements = HashMap::new();
     for line in BufReader::new(file).lines() {
@@ -541,9 +559,11 @@ fn read_results(path: &Path) -> anyhow::Result<HashMap<String, u64>> {
 /// Returns an internal representation of the comparison between the baseline and the candidate
 /// measurements
 fn compare_results(
+    baseline_dir: &Path,
+    candidate_dir: &Path,
     baseline: &HashMap<String, u64>,
     candidate: &HashMap<String, u64>,
-) -> CompareResult {
+) -> anyhow::Result<CompareResult> {
     let mut diffs = Vec::new();
     let mut missing = Vec::new();
     for (scenario, &instr_count) in candidate {
@@ -571,11 +591,18 @@ fn compare_results(
     });
 
     let (noteworthy, negligible) = split_on_threshold(&diffs);
-    CompareResult {
-        noteworthy,
+
+    let mut noteworthy_with_details = Vec::new();
+    for diff in noteworthy {
+        let detailed_diff = cachegrind::diff(baseline_dir, candidate_dir, &diff.scenario)?;
+        noteworthy_with_details.push((diff, detailed_diff));
+    }
+
+    Ok(CompareResult {
+        noteworthy: noteworthy_with_details,
         negligible,
         missing_in_baseline: missing,
-    }
+    })
 }
 
 /// Prints a report of the comparison to stdout, using GitHub-flavored markdown
@@ -592,23 +619,38 @@ fn print_report(result: &CompareResult) {
         }
     }
 
-    println!("### Noteworthy instruction count differences");
+    println!("## Noteworthy instruction count differences");
     if result.noteworthy.is_empty() {
         println!(
             "_There are no noteworthy instruction count differences (i.e. above {}%)_",
             CHANGE_THRESHOLD * 100.0
         );
     } else {
-        table(&result.noteworthy, true);
+        table(
+            result
+                .noteworthy
+                .iter()
+                .map(|(diff, _)| diff),
+            true,
+        );
+        println!("<details>");
+        println!("<summary>Details per scenario</summary>\n");
+        for (diff, detailed_diff) in &result.noteworthy {
+            println!("#### {}", diff.scenario);
+            println!("```");
+            println!("{detailed_diff}");
+            println!("```");
+        }
+        println!("</details>\n")
     }
 
-    println!("### Other instruction count differences");
+    println!("## Other instruction count differences");
     if result.negligible.is_empty() {
         println!("_There are no other instruction count differences_");
     } else {
         println!("<details>");
         println!("<summary>Click to expand</summary>\n");
-        table(&result.negligible, false);
+        table(result.negligible.iter(), false);
         println!("</details>\n")
     }
 }
@@ -631,7 +673,7 @@ fn split_on_threshold(diffs: &[Diff]) -> (Vec<Diff>, Vec<Diff>) {
 }
 
 /// Renders the diffs as a markdown table
-fn table(diffs: &[Diff], emoji_feedback: bool) {
+fn table<'a>(diffs: impl Iterator<Item = &'a Diff>, emoji_feedback: bool) {
     println!("| Scenario | Baseline | Candidate | Diff |");
     println!("| --- | ---: | ---: | ---: |");
     for diff in diffs {


### PR DESCRIPTION
__Note__: the CI job will fail because the CLI and its output have changed between main and this branch.

For an example of the output consider the following patch:

```patch
diff --git a/rustls/src/msgs/handshake.rs b/rustls/src/msgs/handshake.rs
index 824dbf54..3fdc2c6c 100644
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -853,7 +853,7 @@ impl ClientHelloPayload {
     /// Returns true if there is more than one extension of a given
     /// type.
     pub fn has_duplicate_extension(&self) -> bool {
-        let mut seen = collections::HashSet::new();
+        let mut seen = collections::HashSet::with_capacity(2_000);
 
         for ext in &self.extensions {
             let typ = ext.get_type().get_u16();
```

Below follows the output after comparing against the main branch (notice the new "Details per scenario" section). You can observe that less instructions are spent hashing (because the `HashSet` no longer needs to resize + rehash) and much more instructions are spent initializing memory.

# Benchmark results
## Noteworthy instruction count differences
| Scenario | Baseline | Candidate | Diff |
| --- | ---: | ---: | ---: |
| handshake_session_id_1.2_rsa_aes_server | 4452009 | 4519417 | ⚠️ 67408 (1.51%) |
| handshake_tickets_1.2_rsa_aes_server | 4911784 | 4975713 | ⚠️ 63929 (1.30%) |
| handshake_tickets_1.3_ecdsa_aes_server | 36152062 | 36248974 | ⚠️ 96912 (0.27%) |
| handshake_tickets_1.3_ecdsa_chacha_server | 36100101 | 36196796 | ⚠️ 96695 (0.27%) |
| handshake_tickets_1.3_rsa_chacha_server | 36099925 | 36174228 | ⚠️ 74303 (0.21%) |
| handshake_tickets_1.3_rsa_aes_server | 36151940 | 36226085 | ⚠️ 74145 (0.21%) |
<details>
<summary>Details per scenario</summary>

#### handshake_session_id_1.2_rsa_aes_server
```
Ir              
--------------------------------------------------------------------------------
71,755 (100.0%)  PROGRAM TOTALS

--------------------------------------------------------------------------------
Ir                file:function
--------------------------------------------------------------------------------
127,007 (177.0%)  ./string/../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:__memset_avx2_unaligned_erms
-26,660 (-37.2%)  ???:core::hash::BuildHasher::hash_one
-22,076 (-30.8%)  ???:hashbrown::raw::RawTable<T,A>::reserve_rehash
-10,230 (-14.3%)  ???:<core::hash::sip::Hasher<S> as core::hash::Hasher>::write
  6,054 ( 8.44%)  ./malloc/./malloc/malloc.c:_int_malloc
 -2,635 (-3.67%)  ./malloc/./malloc/malloc.c:malloc
  2,544 ( 3.55%)  ./malloc/./malloc/malloc.c:malloc_consolidate
  2,542 ( 3.54%)  ???:hashbrown::raw::RawTable<T,A>::with_capacity_in
 -2,456 (-3.42%)  ./malloc/./malloc/malloc.c:_int_free
 -1,608 (-2.24%)  ???:hashbrown::raw::RawTable<T,A>::insert
 -1,302 (-1.81%)  ./malloc/./malloc/malloc.c:free
  1,012 ( 1.41%)  ./malloc/./malloc/malloc.c:unlink_chunk.constprop.0
   -434 (-0.60%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys/unix/alloc.rs:__rdl_alloc
    238 ( 0.33%)  ./string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms
   -186 (-0.26%)  ./malloc/./malloc/arena.c:free
   -124 (-0.17%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/alloc.rs:__rdl_alloc
    112 ( 0.16%)  ./malloc/./malloc/arena.c:malloc

```
#### handshake_tickets_1.2_rsa_aes_server
```
Ir              
--------------------------------------------------------------------------------
68,276 (100.0%)  PROGRAM TOTALS

--------------------------------------------------------------------------------
Ir                file:function
--------------------------------------------------------------------------------
127,007 (186.0%)  ./string/../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:__memset_avx2_unaligned_erms
-26,660 (-39.0%)  ???:core::hash::BuildHasher::hash_one
-22,076 (-32.3%)  ???:hashbrown::raw::RawTable<T,A>::reserve_rehash
-10,230 (-15.0%)  ???:<core::hash::sip::Hasher<S> as core::hash::Hasher>::write
  4,642 ( 6.80%)  ./malloc/./malloc/malloc.c:_int_malloc
 -4,013 (-5.88%)  ./malloc/./malloc/malloc.c:_int_free
 -2,635 (-3.86%)  ./malloc/./malloc/malloc.c:malloc
  2,542 ( 3.72%)  ???:hashbrown::raw::RawTable<T,A>::with_capacity_in
  2,523 ( 3.70%)  ./malloc/./malloc/malloc.c:malloc_consolidate
 -1,600 (-2.34%)  ???:hashbrown::raw::RawTable<T,A>::insert
 -1,302 (-1.91%)  ./malloc/./malloc/malloc.c:free
  1,041 ( 1.52%)  ./malloc/./malloc/malloc.c:unlink_chunk.constprop.0
    442 ( 0.65%)  ./string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms
   -434 (-0.64%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys/unix/alloc.rs:__rdl_alloc
   -214 (-0.31%)  ???:rustls::msgs::handshake::ClientHelloPayload::has_duplicate_extension
   -186 (-0.27%)  ./malloc/./malloc/arena.c:free
   -124 (-0.18%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/alloc.rs:__rdl_alloc
    -72 (-0.11%)  ???:<core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
    -72 (-0.11%)  ???:<hashbrown::raw::RawTable<T,A> as core::ops::drop::Drop>::drop

```
#### handshake_tickets_1.3_ecdsa_aes_server
```
Ir              
--------------------------------------------------------------------------------
99,976 (100.0%)  PROGRAM TOTALS

--------------------------------------------------------------------------------
Ir                file:function
--------------------------------------------------------------------------------
127,019 (127.0%)  ./string/../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:__memset_avx2_unaligned_erms
-26,660 (-26.7%)  ???:core::hash::BuildHasher::hash_one
-22,076 (-22.1%)  ???:hashbrown::raw::RawTable<T,A>::reserve_rehash
 19,849 (19.85%)  ./malloc/./malloc/malloc.c:_int_malloc
 13,413 (13.42%)  ./malloc/./malloc/malloc.c:malloc_consolidate
-10,230 (-10.2%)  ???:<core::hash::sip::Hasher<S> as core::hash::Hasher>::write
  7,207 ( 7.21%)  ./malloc/./malloc/malloc.c:unlink_chunk.constprop.0
 -3,759 (-3.76%)  ./malloc/./malloc/malloc.c:_int_free
 -2,635 (-2.64%)  ./malloc/./malloc/malloc.c:malloc
  2,542 ( 2.54%)  ???:hashbrown::raw::RawTable<T,A>::with_capacity_in
 -1,624 (-1.62%)  ???:hashbrown::raw::RawTable<T,A>::insert
 -1,312 (-1.31%)  ./string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms
 -1,302 (-1.30%)  ./malloc/./malloc/malloc.c:free
   -434 (-0.43%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys/unix/alloc.rs:__rdl_alloc
    376 ( 0.38%)  ./malloc/./malloc/malloc.c:_int_realloc
   -188 (-0.19%)  ???:rustls::msgs::handshake::ClientHelloPayload::has_duplicate_extension
   -186 (-0.19%)  ./malloc/./malloc/arena.c:free
    136 ( 0.14%)  ./malloc/./malloc/malloc.c:alloc_perturb
   -126 (-0.13%)  ???:???
   -124 (-0.12%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/alloc.rs:__rdl_alloc

```
#### handshake_tickets_1.3_ecdsa_chacha_server
```
Ir              
--------------------------------------------------------------------------------
99,569 (100.0%)  PROGRAM TOTALS

--------------------------------------------------------------------------------
Ir                file:function
--------------------------------------------------------------------------------
127,010 (127.6%)  ./string/../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:__memset_avx2_unaligned_erms
-26,660 (-26.8%)  ???:core::hash::BuildHasher::hash_one
-22,072 (-22.2%)  ???:hashbrown::raw::RawTable<T,A>::reserve_rehash
 19,849 (19.93%)  ./malloc/./malloc/malloc.c:_int_malloc
 13,413 (13.47%)  ./malloc/./malloc/malloc.c:malloc_consolidate
-10,230 (-10.3%)  ???:<core::hash::sip::Hasher<S> as core::hash::Hasher>::write
  7,207 ( 7.24%)  ./malloc/./malloc/malloc.c:unlink_chunk.constprop.0
 -3,759 (-3.78%)  ./malloc/./malloc/malloc.c:_int_free
 -2,635 (-2.65%)  ./malloc/./malloc/malloc.c:malloc
  2,542 ( 2.55%)  ???:hashbrown::raw::RawTable<T,A>::with_capacity_in
 -1,576 (-1.58%)  ???:hashbrown::raw::RawTable<T,A>::insert
 -1,346 (-1.35%)  ./string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms
 -1,302 (-1.31%)  ./malloc/./malloc/malloc.c:free
   -434 (-0.44%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys/unix/alloc.rs:__rdl_alloc
    376 ( 0.38%)  ./malloc/./malloc/malloc.c:_int_realloc
   -266 (-0.27%)  ???:rustls::msgs::handshake::ClientHelloPayload::has_duplicate_extension
   -198 (-0.20%)  /home/aochagavia/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/pregenerated/chacha20_poly1305_x86_64-elf.S:GFp_chacha20_poly1305_seal
   -186 (-0.19%)  ./malloc/./malloc/arena.c:free
    136 ( 0.14%)  ./malloc/./malloc/malloc.c:alloc_perturb
   -126 (-0.13%)  ???:???
   -124 (-0.12%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/alloc.rs:__rdl_alloc

```
#### handshake_tickets_1.3_rsa_chacha_server
```
Ir              
--------------------------------------------------------------------------------
77,668 (100.0%)  PROGRAM TOTALS

--------------------------------------------------------------------------------
Ir                file:function
--------------------------------------------------------------------------------
127,007 (163.5%)  ./string/../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:__memset_avx2_unaligned_erms
-26,660 (-34.3%)  ???:core::hash::BuildHasher::hash_one
-22,072 (-28.4%)  ???:hashbrown::raw::RawTable<T,A>::reserve_rehash
-10,230 (-13.2%)  ???:<core::hash::sip::Hasher<S> as core::hash::Hasher>::write
  9,467 (12.19%)  ./malloc/./malloc/malloc.c:_int_malloc
  6,358 ( 8.19%)  ./malloc/./malloc/malloc.c:malloc_consolidate
 -3,290 (-4.24%)  ./malloc/./malloc/malloc.c:_int_free
 -2,635 (-3.39%)  ./malloc/./malloc/malloc.c:malloc
  2,542 ( 3.27%)  ???:hashbrown::raw::RawTable<T,A>::with_capacity_in
 -1,576 (-2.03%)  ???:hashbrown::raw::RawTable<T,A>::insert
 -1,302 (-1.68%)  ./malloc/./malloc/malloc.c:free
  1,035 ( 1.33%)  ./malloc/./malloc/malloc.c:unlink_chunk.constprop.0
   -434 (-0.56%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys/unix/alloc.rs:__rdl_alloc
   -220 (-0.28%)  ./string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms
    204 ( 0.26%)  ./malloc/./malloc/malloc.c:alloc_perturb
   -186 (-0.24%)  ./malloc/./malloc/arena.c:free
   -124 (-0.16%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/alloc.rs:__rdl_alloc

```
#### handshake_tickets_1.3_rsa_aes_server
```
Ir              
--------------------------------------------------------------------------------
77,424 (100.0%)  PROGRAM TOTALS

--------------------------------------------------------------------------------
Ir                file:function
--------------------------------------------------------------------------------
127,007 (164.0%)  ./string/../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:__memset_avx2_unaligned_erms
-26,660 (-34.4%)  ???:core::hash::BuildHasher::hash_one
-22,072 (-28.5%)  ???:hashbrown::raw::RawTable<T,A>::reserve_rehash
-10,230 (-13.2%)  ???:<core::hash::sip::Hasher<S> as core::hash::Hasher>::write
  9,467 (12.23%)  ./malloc/./malloc/malloc.c:_int_malloc
  6,358 ( 8.21%)  ./malloc/./malloc/malloc.c:malloc_consolidate
 -3,290 (-4.25%)  ./malloc/./malloc/malloc.c:_int_free
 -2,635 (-3.40%)  ./malloc/./malloc/malloc.c:malloc
  2,542 ( 3.28%)  ???:hashbrown::raw::RawTable<T,A>::with_capacity_in
 -1,640 (-2.12%)  ???:hashbrown::raw::RawTable<T,A>::insert
 -1,302 (-1.68%)  ./malloc/./malloc/malloc.c:free
  1,035 ( 1.34%)  ./malloc/./malloc/malloc.c:unlink_chunk.constprop.0
   -434 (-0.56%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/sys/unix/alloc.rs:__rdl_alloc
   -220 (-0.28%)  ./string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms
   -214 (-0.28%)  ???:rustls::msgs::handshake::ClientHelloPayload::has_duplicate_extension
    204 ( 0.26%)  ./malloc/./malloc/malloc.c:alloc_perturb
   -186 (-0.24%)  ./malloc/./malloc/arena.c:free
   -124 (-0.16%)  /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/alloc.rs:__rdl_alloc

```
</details>

## Other instruction count differences
<details>
<summary>Click to expand</summary>

| Scenario | Baseline | Candidate | Diff |
| --- | ---: | ---: | ---: |
| handshake_session_id_1.3_rsa_chacha_server | 35836352 | 35906755 | 70403 (0.20%) |
| handshake_session_id_1.3_rsa_aes_server | 35914322 | 35984837 | 70515 (0.20%) |
| handshake_no_resume_1.3_ecdsa_aes_server | 1829798 | 1832806 | 3008 (0.16%) |
| handshake_session_id_1.3_ecdsa_chacha_server | 35848874 | 35905634 | 56760 (0.16%) |
| handshake_session_id_1.3_ecdsa_aes_server | 35927026 | 35983619 | 56593 (0.16%) |
| handshake_no_resume_1.3_ecdsa_chacha_server | 1832773 | 1835591 | 2818 (0.15%) |
| transfer_no_resume_1.3_ecdsa_aes_server | 4848972 | 4845833 | -3139 (-0.06%) |
| handshake_no_resume_1.2_rsa_aes_server | 11865248 | 11869539 | 4291 (0.04%) |
| transfer_no_resume_1.3_rsa_aes_server | 4846325 | 4848074 | 1749 (0.04%) |
| transfer_no_resume_1.3_ecdsa_chacha_server | 8282156 | 8279254 | -2902 (-0.04%) |
| handshake_no_resume_1.3_rsa_chacha_server | 12076284 | 12079593 | 3309 (0.03%) |
| handshake_no_resume_1.3_rsa_aes_server | 12066398 | 12069621 | 3223 (0.03%) |
| transfer_no_resume_1.3_rsa_chacha_server | 8279740 | 8281430 | 1690 (0.02%) |
| transfer_no_resume_1.3_rsa_chacha_client | 9665985 | 9666277 | 292 (0.00%) |
| handshake_no_resume_1.2_rsa_aes_client | 4365825 | 4365706 | -119 (-0.00%) |
| transfer_no_resume_1.2_rsa_aes_server | 4838990 | 4839097 | 107 (0.00%) |
| handshake_tickets_1.2_rsa_aes_client | 4731637 | 4731706 | 69 (0.00%) |
| handshake_session_id_1.2_rsa_aes_client | 4425171 | 4425230 | 59 (0.00%) |
| handshake_no_resume_1.3_ecdsa_chacha_client | 14263732 | 14263546 | -186 (-0.00%) |
| handshake_no_resume_1.3_rsa_chacha_client | 4479671 | 4479619 | -52 (-0.00%) |
| transfer_no_resume_1.2_rsa_aes_client | 6185665 | 6185728 | 63 (0.00%) |
| handshake_no_resume_1.3_rsa_aes_client | 4469722 | 4469678 | -44 (-0.00%) |
| handshake_session_id_1.3_ecdsa_chacha_client | 34045550 | 34045820 | 270 (0.00%) |
| handshake_tickets_1.3_ecdsa_aes_client | 34234168 | 34234434 | 266 (0.00%) |
| handshake_no_resume_1.3_ecdsa_aes_client | 14260721 | 14260642 | -79 (-0.00%) |
| transfer_no_resume_1.3_rsa_aes_client | 6202712 | 6202680 | -32 (-0.00%) |
| handshake_session_id_1.3_ecdsa_aes_client | 34098641 | 34098487 | -154 (-0.00%) |
| transfer_no_resume_1.3_ecdsa_aes_client | 6201837 | 6201857 | 20 (0.00%) |
| handshake_tickets_1.3_rsa_aes_client | 34469303 | 34469267 | -36 (-0.00%) |
| handshake_session_id_1.3_rsa_aes_client | 34316876 | 34316842 | -34 (-0.00%) |
| handshake_tickets_1.3_ecdsa_chacha_client | 34193306 | 34193339 | 33 (0.00%) |
| handshake_session_id_1.3_rsa_chacha_client | 34264156 | 34264189 | 33 (0.00%) |
| transfer_no_resume_1.3_ecdsa_chacha_client | 9664921 | 9664917 | -4 (-0.00%) |
| handshake_tickets_1.3_rsa_chacha_client | 34428715 | 34428711 | -4 (-0.00%) |
</details>