### PR TITLE
CI bench fix: create cg_diff tmp file at the cwd

### DIFF
--- a/.github/workflows/icount-bench.yml
+++ b/.github/workflows/icount-bench.yml
@@ -7,7 +7,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install valgrind
-        run: sudo apt install -y valgrind
+        run: |
+          sudo apt install -y valgrind
+          valgrind --version
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/ci-bench/src/cachegrind.rs
+++ b/ci-bench/src/cachegrind.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::ops::Sub;
 use std::path::{Path, PathBuf};
@@ -236,7 +236,7 @@ pub fn diff(baseline: &Path, candidate: &Path, scenario: &str) -> anyhow::Result
     // cg_annotate. Many systems are running older versions, though, so we are sticking with cg_diff
     // for the time being.
 
-    let tmp_path = Path::new("target/ci-bench-tmp");
+    let tmp_path = Path::new("ci-bench-tmp");
     let tmp = File::create(tmp_path).context("cannot create temp file for cg_diff")?;
 
     // cg_diff generates a diff between two cachegrind output files in a custom format that is not
@@ -292,6 +292,8 @@ pub fn diff(baseline: &Path, candidate: &Path, scenario: &str) -> anyhow::Result
         diff.push_str(line);
         diff.push('\n');
     }
+
+    fs::remove_file(tmp_path).ok();
 
     Ok(diff)
 }


### PR DESCRIPTION
The CI benchmarks are currently failing, because a temp file was previously created under `target` (and the `target` dir doesn't exist under `ci-bench` when running in the CI).

I've validated that this is working in a PR to my own fork: https://github.com/aochagavia/rustls/pull/2 (the error only happened when significant differences were found between the baseline and the candidate).

I also added a commit to show the valgrind version after installing it, since it might come in handy later for debugging. It's unrelated to the fix, but it felt overkill to create a separate PR for it (I can still split it off, if you think it's important).