### PR TITLE
Use dynamic dispatch for `CryptoProvider`

### DIFF
--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -14,7 +14,6 @@ use itertools::Itertools;
 use rayon::iter::Either;
 use rayon::prelude::*;
 use rustls::client::Resumption;
-use rustls::crypto::ring::Ring;
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::{
     ClientConfig, ClientConnection, ProtocolVersion, RootCertStore, ServerConfig, ServerConnection,
@@ -345,11 +344,11 @@ struct StepperIO<'a> {
 struct ClientSideStepper<'a> {
     io: StepperIO<'a>,
     resumption_kind: ResumptionKind,
-    config: Arc<ClientConfig<Ring>>,
+    config: Arc<ClientConfig>,
 }
 
 impl ClientSideStepper<'_> {
-    fn make_config(params: &BenchmarkParams, resume: ResumptionKind) -> Arc<ClientConfig<Ring>> {
+    fn make_config(params: &BenchmarkParams, resume: ResumptionKind) -> Arc<ClientConfig> {
         assert_eq!(params.ciphersuite.version(), params.version);
         let mut root_store = RootCertStore::empty();
         let mut rootbuf =
@@ -422,11 +421,11 @@ impl BenchStepper for ClientSideStepper<'_> {
 /// A benchmark stepper for the server-side of the connection
 struct ServerSideStepper<'a> {
     io: StepperIO<'a>,
-    config: Arc<ServerConfig<Ring>>,
+    config: Arc<ServerConfig>,
 }
 
 impl ServerSideStepper<'_> {
-    fn make_config(params: &BenchmarkParams, resume: ResumptionKind) -> Arc<ServerConfig<Ring>> {
+    fn make_config(params: &BenchmarkParams, resume: ResumptionKind) -> Arc<ServerConfig> {
         assert_eq!(params.ciphersuite.version(), params.version);
 
         let mut cfg = ServerConfig::builder()

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -18,7 +18,7 @@ fn main() {
 
     let config = rustls::ClientConfig::<Ring>::builder()
         .with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
-        .with_kx_groups(&[&rustls::kx_group::X25519])
+        .with_kx_groups(&[rustls::kx_group::X25519])
         .with_protocol_versions(&[&rustls::version::TLS13])
         .unwrap()
         .with_root_certificates(root_store)

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -6,8 +6,6 @@ use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls::crypto::ring::Ring;
-
 fn main() {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(
@@ -16,7 +14,7 @@ fn main() {
             .cloned(),
     );
 
-    let config = rustls::ClientConfig::<Ring>::builder()
+    let config = rustls::ClientConfig::builder()
         .with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
         .with_kx_groups(&[rustls::kx_group::X25519])
         .with_protocol_versions(&[&rustls::version::TLS13])

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -2,11 +2,9 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls::crypto::ring::Ring;
-use rustls::crypto::CryptoProvider;
 use rustls::RootCertStore;
 
-fn start_connection(config: &Arc<rustls::ClientConfig<impl CryptoProvider>>, domain_name: &str) {
+fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
     let server_name = domain_name
         .try_into()
         .expect("invalid DNS name");
@@ -65,7 +63,7 @@ fn main() {
             .cloned(),
     );
 
-    let mut config = rustls::ClientConfig::<Ring>::builder()
+    let mut config = rustls::ClientConfig::builder()
         .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -12,7 +12,6 @@ use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls::crypto::ring::Ring;
 use rustls::RootCertStore;
 
 fn main() {
@@ -22,7 +21,7 @@ fn main() {
             .iter()
             .cloned(),
     );
-    let mut config = rustls::ClientConfig::<Ring>::builder()
+    let mut config = rustls::ClientConfig::builder()
         .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -8,8 +8,6 @@ use mio::net::TcpStream;
 use pki_types::{CertificateDer, PrivateKeyDer};
 use serde::Deserialize;
 
-use rustls::crypto::ring::Ring;
-use rustls::crypto::CryptoProvider;
 use rustls::RootCertStore;
 
 const CLIENT: mio::Token = mio::Token(0);
@@ -27,7 +25,7 @@ impl TlsClient {
     fn new(
         sock: TcpStream,
         server_name: rustls::ServerName,
-        cfg: Arc<rustls::ClientConfig<impl CryptoProvider>>,
+        cfg: Arc<rustls::ClientConfig>,
     ) -> Self {
         Self {
             socket: sock,
@@ -356,7 +354,7 @@ mod danger {
 }
 
 #[cfg(feature = "dangerous_configuration")]
-fn apply_dangerous_options(args: &Args, cfg: &mut rustls::ClientConfig<impl CryptoProvider>) {
+fn apply_dangerous_options(args: &Args, cfg: &mut rustls::ClientConfig) {
     if args.flag_insecure {
         cfg.dangerous()
             .set_certificate_verifier(Arc::new(danger::NoCertificateVerification {}));
@@ -364,14 +362,14 @@ fn apply_dangerous_options(args: &Args, cfg: &mut rustls::ClientConfig<impl Cryp
 }
 
 #[cfg(not(feature = "dangerous_configuration"))]
-fn apply_dangerous_options(args: &Args, _: &mut rustls::ClientConfig<impl CryptoProvider>) {
+fn apply_dangerous_options(args: &Args, _: &mut rustls::ClientConfig) {
     if args.flag_insecure {
         panic!("This build does not support --insecure.");
     }
 }
 
 /// Build a `ClientConfig` from our arguments
-fn make_config(args: &Args) -> Arc<rustls::ClientConfig<Ring>> {
+fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     let mut root_store = RootCertStore::empty();
 
     if args.flag_cafile.is_some() {

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -9,7 +9,6 @@ use mio::net::{TcpListener, TcpStream};
 use pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use serde::Deserialize;
 
-use rustls::crypto::ring::Ring;
 use rustls::server::WebPkiClientVerifier;
 use rustls::{self, RootCertStore};
 
@@ -36,12 +35,12 @@ struct TlsServer {
     server: TcpListener,
     connections: HashMap<mio::Token, OpenConnection>,
     next_id: usize,
-    tls_config: Arc<rustls::ServerConfig<Ring>>,
+    tls_config: Arc<rustls::ServerConfig>,
     mode: ServerMode,
 }
 
 impl TlsServer {
-    fn new(server: TcpListener, mode: ServerMode, cfg: Arc<rustls::ServerConfig<Ring>>) -> Self {
+    fn new(server: TcpListener, mode: ServerMode, cfg: Arc<rustls::ServerConfig>) -> Self {
         Self {
             server,
             connections: HashMap::new(),
@@ -557,7 +556,7 @@ fn load_crls(filenames: &[String]) -> Vec<CertificateRevocationListDer<'static>>
         .collect()
 }
 
-fn make_config(args: &Args) -> Arc<rustls::ServerConfig<Ring>> {
+fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
     let client_auth = if args.flag_auth.is_some() {
         let roots = load_certs(args.flag_auth.as_ref().unwrap());
         let mut client_auth_roots = RootCertStore::empty();

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -4,7 +4,6 @@ extern crate libfuzzer_sys;
 extern crate rustls;
 extern crate webpki;
 
-use rustls::crypto::ring::Ring;
 use rustls::{ClientConfig, ClientConnection, RootCertStore};
 use std::io;
 use std::sync::Arc;
@@ -12,7 +11,7 @@ use std::sync::Arc;
 fuzz_target!(|data: &[u8]| {
     let root_store = RootCertStore::empty();
     let config = Arc::new(
-        ClientConfig::<Ring>::builder()
+        ClientConfig::builder()
             .with_safe_defaults()
             .with_root_certificates(root_store)
             .with_no_client_auth(),

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -3,7 +3,6 @@
 extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::crypto::ring::Ring;
 use rustls::server::ResolvesServerCert;
 use rustls::{ServerConfig, ServerConnection};
 
@@ -23,7 +22,7 @@ impl ResolvesServerCert for Fail {
 
 fuzz_target!(|data: &[u8]| {
     let config = Arc::new(
-        ServerConfig::<Ring>::builder()
+        ServerConfig::builder()
             .with_safe_defaults()
             .with_no_client_auth()
             .with_cert_resolver(Arc::new(Fail)),

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -2,7 +2,7 @@ use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls_provider_example::Provider;
+use rustls_provider_example::{certificate_verifier, PROVIDER};
 
 fn main() {
     env_logger::init();
@@ -14,9 +14,9 @@ fn main() {
             .cloned(),
     );
 
-    let config = rustls::ClientConfig::<Provider>::builder()
+    let config = rustls::ClientConfig::builder_with_provider(PROVIDER)
         .with_safe_defaults()
-        .with_custom_certificate_verifier(Provider::certificate_verifier(root_store))
+        .with_custom_certificate_verifier(certificate_verifier(root_store))
         .with_no_client_auth();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();

--- a/provider-example/src/kx.rs
+++ b/provider-example/src/kx.rs
@@ -1,4 +1,4 @@
-use crypto::SupportedGroup;
+use crypto::SupportedKxGroup;
 use rustls::crypto;
 
 pub struct KeyExchange {
@@ -6,34 +6,17 @@ pub struct KeyExchange {
     pub_key: x25519_dalek::PublicKey,
 }
 
-impl crypto::KeyExchange for KeyExchange {
-    type SupportedGroup = X25519;
-
-    fn start(
-        name: rustls::NamedGroup,
-        _: &[&'static Self::SupportedGroup],
-    ) -> Result<Self, crypto::KeyExchangeError> {
-        if name == rustls::NamedGroup::X25519 {
-            let priv_key = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
-            let pub_key = (&priv_key).into();
-            Ok(KeyExchange { priv_key, pub_key })
-        } else {
-            Err(crypto::KeyExchangeError::UnsupportedGroup)
-        }
-    }
-
-    fn complete<T>(
-        self,
+impl crypto::ActiveKeyExchange for KeyExchange {
+    fn complete(
+        self: Box<KeyExchange>,
         peer: &[u8],
-        f: impl FnOnce(&[u8]) -> Result<T, ()>,
-    ) -> Result<T, rustls::Error> {
+    ) -> Result<crypto::SharedSecret, rustls::Error> {
         let peer_array: [u8; 32] = peer
             .try_into()
             .map_err(|_| rustls::Error::from(rustls::PeerMisbehaved::InvalidKeyShare))?;
         let their_pub = x25519_dalek::PublicKey::from(peer_array);
         let shared_secret = self.priv_key.diffie_hellman(&their_pub);
-        f(shared_secret.as_bytes())
-            .map_err(|_| rustls::Error::from(rustls::PeerMisbehaved::InvalidKeyShare))
+        Ok(crypto::SharedSecret::from(&shared_secret.as_bytes()[..]))
     }
 
     fn pub_key(&self) -> &[u8] {
@@ -43,19 +26,23 @@ impl crypto::KeyExchange for KeyExchange {
     fn group(&self) -> rustls::NamedGroup {
         X25519.name()
     }
-
-    fn all_kx_groups() -> &'static [&'static Self::SupportedGroup] {
-        ALL_KX_GROUPS
-    }
 }
+
+pub const ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[&X25519 as &dyn SupportedKxGroup];
 
 #[derive(Debug)]
 pub struct X25519;
 
-impl crypto::SupportedGroup for X25519 {
+impl crypto::SupportedKxGroup for X25519 {
+    fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::crypto::GetRandomFailed> {
+        let priv_key = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
+        Ok(Box::new(KeyExchange {
+            pub_key: (&priv_key).into(),
+            priv_key,
+        }))
+    }
+
     fn name(&self) -> rustls::NamedGroup {
         rustls::NamedGroup::X25519
     }
 }
-
-const ALL_KX_GROUPS: &[&X25519] = &[&X25519];

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -6,32 +6,24 @@ mod hmac;
 mod kx;
 mod verify;
 
-pub struct Provider;
+pub static PROVIDER: &'static dyn rustls::crypto::CryptoProvider = &Provider;
 
-impl Provider {
-    pub fn certificate_verifier(
-        roots: rustls::RootCertStore,
-    ) -> Arc<dyn rustls::client::ServerCertVerifier> {
-        Arc::new(rustls::client::WebPkiServerVerifier::new_with_algorithms(
-            roots,
-            verify::ALGORITHMS,
-        ))
-    }
-}
+#[derive(Debug)]
+struct Provider;
 
 impl rustls::crypto::CryptoProvider for Provider {
-    fn fill_random(bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
+    fn fill_random(&self, bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
         use rand_core::RngCore;
         rand_core::OsRng
             .try_fill_bytes(bytes)
             .map_err(|_| rustls::crypto::GetRandomFailed)
     }
 
-    fn default_cipher_suites() -> &'static [rustls::SupportedCipherSuite] {
+    fn default_cipher_suites(&self) -> &'static [rustls::SupportedCipherSuite] {
         ALL_CIPHER_SUITES
     }
 
-    fn default_kx_groups() -> &'static [&'static dyn rustls::SupportedKxGroup] {
+    fn default_kx_groups(&self) -> &'static [&'static dyn rustls::SupportedKxGroup] {
         kx::ALL_KX_GROUPS
     }
 }
@@ -65,3 +57,12 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherS
         hmac_provider: &hmac::Sha256Hmac,
         aead_alg: &aead::Chacha20Poly1305,
     });
+
+pub fn certificate_verifier(
+    roots: rustls::RootCertStore,
+) -> Arc<dyn rustls::client::ServerCertVerifier> {
+    Arc::new(rustls::client::WebPkiServerVerifier::new_with_algorithms(
+        roots,
+        verify::ALGORITHMS,
+    ))
+}

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -20,8 +20,6 @@ impl Provider {
 }
 
 impl rustls::crypto::CryptoProvider for Provider {
-    type KeyExchange = kx::KeyExchange;
-
     fn fill_random(bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
         use rand_core::RngCore;
         rand_core::OsRng
@@ -31,6 +29,10 @@ impl rustls::crypto::CryptoProvider for Provider {
 
     fn default_cipher_suites() -> &'static [rustls::SupportedCipherSuite] {
         ALL_CIPHER_SUITES
+    }
+
+    fn default_kx_groups() -> &'static [&'static dyn rustls::SupportedKxGroup] {
+        kx::ALL_KX_GROUPS
     }
 }
 

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -14,7 +14,6 @@ use std::time::{Duration, Instant};
 use pki_types::{CertificateDer, PrivateKeyDer};
 
 use rustls::client::Resumption;
-use rustls::crypto::ring::Ring;
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::RootCertStore;
 use rustls::Ticketer;
@@ -293,7 +292,7 @@ fn make_server_config(
     client_auth: ClientAuth,
     resume: ResumptionParam,
     max_fragment_size: Option<usize>,
-) -> ServerConfig<Ring> {
+) -> ServerConfig {
     let client_auth = match client_auth {
         ClientAuth::Yes => {
             let roots = params.key_type.get_chain();
@@ -333,7 +332,7 @@ fn make_client_config(
     params: &BenchmarkParam,
     clientauth: ClientAuth,
     resume: ResumptionParam,
-) -> ClientConfig<Ring> {
+) -> ClientConfig {
     let mut root_store = RootCertStore::empty();
     let mut rootbuf =
         io::BufReader::new(fs::File::open(params.key_type.path_for("ca.cert")).unwrap());

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -7,8 +7,6 @@
 use rustls::client::{
     ClientConfig, ClientConnection, HandshakeSignatureValid, Resumption, WebPkiServerVerifier,
 };
-use rustls::crypto::ring::Ring;
-use rustls::crypto::CryptoProvider;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::persist;
 use rustls::server::{ClientHello, ServerConfig, ServerConnection};
@@ -427,7 +425,7 @@ impl server::StoresServerSessions for ServerCacheWithResumptionDelay {
     }
 }
 
-fn make_server_cfg(opts: &Options) -> Arc<ServerConfig<Ring>> {
+fn make_server_cfg(opts: &Options) -> Arc<ServerConfig> {
     let client_auth =
         if opts.verify_peer || opts.offer_no_client_cas || opts.require_any_client_cert {
             Arc::new(DummyClientAuth {
@@ -555,7 +553,7 @@ impl client::ClientSessionStore for ClientCacheWithoutKxHints {
     }
 }
 
-fn make_client_cfg(opts: &Options) -> Arc<ClientConfig<Ring>> {
+fn make_client_cfg(opts: &Options) -> Arc<ClientConfig> {
     let kx_groups = if let Some(curves) = &opts.curves {
         curves
             .iter()
@@ -1237,8 +1235,8 @@ fn main() {
 
     fn make_session(
         opts: &Options,
-        scfg: &Option<Arc<ServerConfig<impl CryptoProvider>>>,
-        ccfg: &Option<Arc<ClientConfig<impl CryptoProvider>>>,
+        scfg: &Option<Arc<ServerConfig>>,
+        ccfg: &Option<Arc<ClientConfig>>,
     ) -> Connection {
         assert!(opts.quic_transport_params.is_empty());
         assert!(opts

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -357,11 +357,11 @@ fn lookup_scheme(scheme: u16) -> SignatureScheme {
     }
 }
 
-fn lookup_kx_group(group: u16) -> &'static SupportedKxGroup {
+fn lookup_kx_group(group: u16) -> &'static dyn SupportedKxGroup {
     match group {
-        0x001d => &kx_group::X25519,
-        0x0017 => &kx_group::SECP256R1,
-        0x0018 => &kx_group::SECP384R1,
+        0x001d => kx_group::X25519,
+        0x0017 => kx_group::SECP256R1,
+        0x0018 => kx_group::SECP384R1,
         _ => {
             println_err!("Unsupported kx group {:04x}", group);
             process::exit(BOGO_NACK);

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,7 +1,7 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCommon, ConnectionCore};
-use crate::crypto::{CryptoProvider, KeyExchange};
+use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::dns_name::{DnsName, DnsNameRef, InvalidDnsNameError};
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
@@ -134,7 +134,7 @@ pub struct ClientConfig<C: CryptoProvider> {
     ///
     /// The first element in this list is the _default key share algorithm_,
     /// and in TLS1.3 a key share for it is sent in the client hello.
-    pub(super) kx_groups: Vec<&'static <C::KeyExchange as KeyExchange>::SupportedGroup>,
+    pub(super) kx_groups: Vec<&'static dyn SupportedKxGroup>,
 
     /// Which ALPN protocols we include in our client hello.
     /// If empty, no ALPN extension is sent.

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -274,6 +274,13 @@ impl<C: CryptoProvider> ClientConfig<C> {
             .copied()
             .find(|&scs| scs.suite() == suite)
     }
+
+    pub(super) fn find_kx_group(&self, group: NamedGroup) -> Option<&'static dyn SupportedKxGroup> {
+        self.kx_groups
+            .iter()
+            .copied()
+            .find(|skxg| skxg.name() == group)
+    }
 }
 
 /// Configuration for how/when a client is allowed to resume a previous session.

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -125,7 +125,7 @@ pub trait ResolvesClientCert: Send + Sync {
 /// * [`ClientConfig::key_log`]: key material is not logged.
 ///
 /// [`RootCertStore`]: crate::RootCertStore
-pub struct ClientConfig<C: CryptoProvider> {
+pub struct ClientConfig {
     /// List of ciphersuites, in preference order.
     pub(super) cipher_suites: Vec<SupportedCipherSuite>,
 
@@ -135,6 +135,9 @@ pub struct ClientConfig<C: CryptoProvider> {
     /// The first element in this list is the _default key share algorithm_,
     /// and in TLS1.3 a key share for it is sent in the client hello.
     pub(super) kx_groups: Vec<&'static dyn SupportedKxGroup>,
+
+    /// Source of randomness and other crypto.
+    pub(super) provider: &'static dyn CryptoProvider,
 
     /// Which ALPN protocols we include in our client hello.
     /// If empty, no ALPN extension is sent.
@@ -186,8 +189,6 @@ pub struct ClientConfig<C: CryptoProvider> {
     ///
     /// The default is false.
     pub enable_early_data: bool,
-
-    pub(crate) provider: PhantomData<C>,
 }
 
 /// What mechanisms to support for resuming a TLS 1.2 session.
@@ -206,11 +207,12 @@ pub enum Tls12Resumption {
     SessionIdOrTickets,
 }
 
-impl<C: CryptoProvider> Clone for ClientConfig<C> {
+impl Clone for ClientConfig {
     fn clone(&self) -> Self {
         Self {
             cipher_suites: self.cipher_suites.clone(),
             kx_groups: self.kx_groups.clone(),
+            provider: self.provider,
             resumption: self.resumption.clone(),
             alpn_protocols: self.alpn_protocols.clone(),
             max_fragment_size: self.max_fragment_size,
@@ -222,12 +224,11 @@ impl<C: CryptoProvider> Clone for ClientConfig<C> {
             #[cfg(feature = "secret_extraction")]
             enable_secret_extraction: self.enable_secret_extraction,
             enable_early_data: self.enable_early_data,
-            provider: PhantomData,
         }
     }
 }
 
-impl<C: CryptoProvider> fmt::Debug for ClientConfig<C> {
+impl fmt::Debug for ClientConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ClientConfig")
             .field("alpn_protocols", &self.alpn_protocols)
@@ -239,13 +240,25 @@ impl<C: CryptoProvider> fmt::Debug for ClientConfig<C> {
     }
 }
 
-impl<C: CryptoProvider> ClientConfig<C> {
-    /// Create a builder to build up the client configuration.
+impl ClientConfig {
+    #[cfg(feature = "ring")]
+    /// Create a builder to build up the client configuration with the default
+    /// [`CryptoProvider`].
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
     pub fn builder() -> ConfigBuilder<Self, WantsCipherSuites> {
+        Self::builder_with_provider(crate::crypto::ring::RING)
+    }
+
+    /// Create builder to build up the client configuration with a specific
+    /// `CryptoProvider`.
+    ///
+    /// For more information, see the [`ConfigBuilder`] documentation.
+    pub fn builder_with_provider(
+        provider: &'static dyn CryptoProvider,
+    ) -> ConfigBuilder<Self, WantsCipherSuites> {
         ConfigBuilder {
-            state: WantsCipherSuites(()),
+            state: WantsCipherSuites(provider),
             side: PhantomData,
         }
     }
@@ -264,7 +277,7 @@ impl<C: CryptoProvider> ClientConfig<C> {
     /// Access configuration options whose use is dangerous and requires
     /// extra care.
     #[cfg(feature = "dangerous_configuration")]
-    pub fn dangerous(&mut self) -> danger::DangerousClientConfig<'_, C> {
+    pub fn dangerous(&mut self) -> danger::DangerousClientConfig<'_> {
         danger::DangerousClientConfig { cfg: self }
     }
 
@@ -427,7 +440,6 @@ impl TryFrom<&str> for ServerName {
 /// Container for unsafe APIs
 #[cfg(feature = "dangerous_configuration")]
 pub(super) mod danger {
-    use crate::crypto::CryptoProvider;
     use alloc::sync::Arc;
 
     use super::verify::ServerCertVerifier;
@@ -435,12 +447,12 @@ pub(super) mod danger {
 
     /// Accessor for dangerous configuration options.
     #[derive(Debug)]
-    pub struct DangerousClientConfig<'a, C: CryptoProvider> {
+    pub struct DangerousClientConfig<'a> {
         /// The underlying ClientConfig
-        pub cfg: &'a mut ClientConfig<C>,
+        pub cfg: &'a mut ClientConfig,
     }
 
-    impl<'a, C: CryptoProvider> DangerousClientConfig<'a, C> {
+    impl<'a> DangerousClientConfig<'a> {
         /// Overrides the default `ServerCertVerifier` with something else.
         pub fn set_certificate_verifier(&mut self, verifier: Arc<dyn ServerCertVerifier>) {
             self.cfg.verifier = verifier;
@@ -578,10 +590,7 @@ impl ClientConnection {
     /// Make a new ClientConnection.  `config` controls how
     /// we behave in the TLS protocol, `name` is the
     /// name of the server we want to talk to.
-    pub fn new<C: CryptoProvider>(
-        config: Arc<ClientConfig<C>>,
-        name: ServerName,
-    ) -> Result<Self, Error> {
+    pub fn new(config: Arc<ClientConfig>, name: ServerName) -> Result<Self, Error> {
         Ok(Self {
             inner: ConnectionCore::for_client(config, name, Vec::new(), Protocol::Tcp)?.into(),
         })
@@ -681,8 +690,8 @@ impl From<ClientConnection> for crate::Connection {
 }
 
 impl ConnectionCore<ClientConnectionData> {
-    pub(crate) fn for_client<C: CryptoProvider>(
-        config: Arc<ClientConfig<C>>,
+    pub(crate) fn for_client(
+        config: Arc<ClientConfig>,
         name: ServerName,
         extra_exts: Vec<ClientExtension>,
         proto: Protocol,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -813,11 +813,7 @@ impl<C: CryptoProvider> ExpectServerHelloOrHelloRetryRequest<C> {
 
         let key_share = match req_group {
             Some(group) if group != offered_key_share.group() => {
-                let skxg = match config
-                    .kx_groups
-                    .iter()
-                    .find(|skxg| skxg.name() == group)
-                {
+                let skxg = match config.find_kx_group(group) {
                     Some(skxg) => skxg,
                     None => {
                         return Err(cx.common.send_fatal_alert(

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,7 +1,6 @@
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::common_state::{CommonState, Side, State};
 use crate::conn::ConnectionRandoms;
-use crate::crypto::CryptoProvider;
 use crate::enums::ProtocolVersion;
 use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
@@ -38,15 +37,14 @@ use alloc::sync::Arc;
 pub(super) use server_hello::CompleteServerHelloHandling;
 
 mod server_hello {
-    use crate::crypto::CryptoProvider;
     use crate::msgs::enums::ExtensionType;
     use crate::msgs::handshake::HasServerExtensions;
     use crate::msgs::handshake::ServerHelloPayload;
 
     use super::*;
 
-    pub(in crate::client) struct CompleteServerHelloHandling<C: CryptoProvider> {
-        pub(in crate::client) config: Arc<ClientConfig<C>>,
+    pub(in crate::client) struct CompleteServerHelloHandling {
+        pub(in crate::client) config: Arc<ClientConfig>,
         pub(in crate::client) resuming_session: Option<persist::Tls12ClientSessionValue>,
         pub(in crate::client) server_name: ServerName,
         pub(in crate::client) randoms: ConnectionRandoms,
@@ -54,7 +52,7 @@ mod server_hello {
         pub(in crate::client) transcript: HandshakeHash,
     }
 
-    impl<C: CryptoProvider> CompleteServerHelloHandling<C> {
+    impl CompleteServerHelloHandling {
         pub(in crate::client) fn handle_server_hello(
             mut self,
             cx: &mut ClientContext,
@@ -180,8 +178,8 @@ mod server_hello {
     }
 }
 
-struct ExpectCertificate<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectCertificate {
+    config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
     server_name: ServerName,
@@ -193,7 +191,7 @@ struct ExpectCertificate<C: CryptoProvider> {
     must_issue_new_ticket: bool,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificate<C> {
+impl State<ClientConnectionData> for ExpectCertificate {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -238,8 +236,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificate<C> {
     }
 }
 
-struct ExpectCertificateStatusOrServerKx<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectCertificateStatusOrServerKx {
+    config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
     server_name: ServerName,
@@ -251,7 +249,7 @@ struct ExpectCertificateStatusOrServerKx<C: CryptoProvider> {
     must_issue_new_ticket: bool,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateStatusOrServerKx<C> {
+impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::Handshake {
@@ -306,8 +304,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateStatusO
     }
 }
 
-struct ExpectCertificateStatus<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectCertificateStatus {
+    config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
     server_name: ServerName,
@@ -319,7 +317,7 @@ struct ExpectCertificateStatus<C: CryptoProvider> {
     must_issue_new_ticket: bool,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateStatus<C> {
+impl State<ClientConnectionData> for ExpectCertificateStatus {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -355,8 +353,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateStatus<
     }
 }
 
-struct ExpectServerKx<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectServerKx {
+    config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
     server_name: ServerName,
@@ -368,7 +366,7 @@ struct ExpectServerKx<C: CryptoProvider> {
     must_issue_new_ticket: bool,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectServerKx<C> {
+impl State<ClientConnectionData> for ExpectServerKx {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let opaque_kx = require_handshake_msg!(
             m,
@@ -520,8 +518,8 @@ impl ServerKxDetails {
 // --- Either a CertificateRequest, or a ServerHelloDone. ---
 // Existence of the CertificateRequest tells us the server is asking for
 // client auth.  Otherwise we go straight to ServerHelloDone.
-struct ExpectServerDoneOrCertReq<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectServerDoneOrCertReq {
+    config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
     server_name: ServerName,
@@ -534,7 +532,7 @@ struct ExpectServerDoneOrCertReq<C: CryptoProvider> {
     must_issue_new_ticket: bool,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectServerDoneOrCertReq<C> {
+impl State<ClientConnectionData> for ExpectServerDoneOrCertReq {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         if matches!(
             m.payload,
@@ -582,8 +580,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectServerDoneOrCertRe
     }
 }
 
-struct ExpectCertificateRequest<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectCertificateRequest {
+    config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
     server_name: ServerName,
@@ -596,7 +594,7 @@ struct ExpectCertificateRequest<C: CryptoProvider> {
     must_issue_new_ticket: bool,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateRequest<C> {
+impl State<ClientConnectionData> for ExpectCertificateRequest {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -643,8 +641,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateRequest
     }
 }
 
-struct ExpectServerDone<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectServerDone {
+    config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
     server_name: ServerName,
@@ -658,7 +656,7 @@ struct ExpectServerDone<C: CryptoProvider> {
     must_issue_new_ticket: bool,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectServerDone<C> {
+impl State<ClientConnectionData> for ExpectServerDone {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::Handshake {
@@ -845,8 +843,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectServerDone<C> {
     }
 }
 
-struct ExpectNewTicket<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectNewTicket {
+    config: Arc<ClientConfig>,
     secrets: ConnectionSecrets,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
@@ -858,7 +856,7 @@ struct ExpectNewTicket<C: CryptoProvider> {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectNewTicket<C> {
+impl State<ClientConnectionData> for ExpectNewTicket {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -889,8 +887,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectNewTicket<C> {
 }
 
 // -- Waiting for their CCS --
-struct ExpectCcs<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectCcs {
+    config: Arc<ClientConfig>,
     secrets: ConnectionSecrets,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
@@ -903,7 +901,7 @@ struct ExpectCcs<C: CryptoProvider> {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCcs<C> {
+impl State<ClientConnectionData> for ExpectCcs {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ChangeCipherSpec(..) => {}
@@ -939,8 +937,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCcs<C> {
     }
 }
 
-struct ExpectFinished<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectFinished {
+    config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
     server_name: ServerName,
@@ -953,7 +951,7 @@ struct ExpectFinished<C: CryptoProvider> {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl<C: CryptoProvider> ExpectFinished<C> {
+impl ExpectFinished {
     // -- Waiting for their finished --
     fn save_session(&mut self, cx: &ClientContext<'_>) {
         // Save a ticket.  If we got a new ticket, save that.  Otherwise, save the
@@ -995,7 +993,7 @@ impl<C: CryptoProvider> ExpectFinished<C> {
     }
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectFinished<C> {
+impl State<ClientConnectionData> for ExpectFinished {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let mut st = *self;
         let finished =

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -765,12 +765,7 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectServerDone<C> {
         let ecdh_params =
             tls12::decode_ecdh_params::<ServerECDHParams>(cx.common, &st.server_kx.kx_params)?;
         let named_group = ecdh_params.curve_params.named_group;
-        let skxg = match st
-            .config
-            .kx_groups
-            .iter()
-            .find(|skxg| skxg.name() == named_group)
-        {
+        let skxg = match st.config.find_kx_group(named_group) {
             Some(skxg) => skxg,
             None => {
                 return Err(PeerMisbehaved::SelectedUnofferedKxGroup.into());

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -211,16 +211,13 @@ pub(super) fn initial_key_share<C: CryptoProvider>(
         .resumption
         .store
         .kx_hint(server_name)
-        .and_then(|hint_group| {
-            config
-                .kx_groups
-                .iter()
-                .find(|kx_group| kx_group.name() == hint_group)
-        })
+        .and_then(|group_name| config.find_kx_group(group_name))
         .unwrap_or_else(|| {
             config
                 .kx_groups
-                .first()
+                .iter()
+                .copied()
+                .next()
                 .expect("No kx groups configured")
         });
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -151,7 +151,7 @@ pub(super) fn handle_server_hello<C: CryptoProvider>(
     };
 
     let shared_secret = our_key_share.complete(&their_key_share.payload.0)?;
-    let key_schedule = key_schedule_pre_handshake.into_handshake(shared_secret.secret_bytes());
+    let key_schedule = key_schedule_pre_handshake.into_handshake(shared_secret);
 
     // Remember what KX group the server liked for next time.
     config

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -6,7 +6,7 @@ use crate::common_state::Side;
 use crate::common_state::{CommonState, State};
 use crate::conn::ConnectionRandoms;
 use crate::crypto;
-use crate::crypto::{ActiveKeyExchange, CryptoProvider};
+use crate::crypto::ActiveKeyExchange;
 use crate::enums::{
     AlertDescription, ContentType, HandshakeType, ProtocolVersion, SignatureScheme,
 };
@@ -65,8 +65,8 @@ static DISALLOWED_TLS13_EXTS: &[ExtensionType] = &[
     ExtensionType::ExtendedMasterSecret,
 ];
 
-pub(super) fn handle_server_hello<C: CryptoProvider>(
-    config: Arc<ClientConfig<C>>,
+pub(super) fn handle_server_hello(
+    config: Arc<ClientConfig>,
     cx: &mut ClientContext,
     server_hello: &ServerHelloPayload,
     mut resuming_session: Option<persist::Tls13ClientSessionValue>,
@@ -203,8 +203,8 @@ fn validate_server_hello(
     Ok(())
 }
 
-pub(super) fn initial_key_share<C: CryptoProvider>(
-    config: &ClientConfig<C>,
+pub(super) fn initial_key_share(
+    config: &ClientConfig,
     server_name: &ServerName,
 ) -> Result<Box<dyn ActiveKeyExchange>, Error> {
     let group = config
@@ -255,7 +255,7 @@ pub(super) fn fill_in_psk_binder(
 }
 
 pub(super) fn prepare_resumption(
-    config: &ClientConfig<impl CryptoProvider>,
+    config: &ClientConfig,
     cx: &mut ClientContext<'_>,
     resuming_session: &persist::Retrieved<&persist::Tls13ClientSessionValue>,
     exts: &mut Vec<ClientExtension>,
@@ -368,8 +368,8 @@ fn validate_encrypted_extensions(
     Ok(())
 }
 
-struct ExpectEncryptedExtensions<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectEncryptedExtensions {
+    config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls13ClientSessionValue>,
     server_name: ServerName,
     randoms: ConnectionRandoms,
@@ -379,7 +379,7 @@ struct ExpectEncryptedExtensions<C: CryptoProvider> {
     hello: ClientHelloDetails,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectEncryptedExtensions<C> {
+impl State<ClientConnectionData> for ExpectEncryptedExtensions {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let exts = require_handshake_msg!(
             m,
@@ -461,8 +461,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectEncryptedExtension
     }
 }
 
-struct ExpectCertificateOrCertReq<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectCertificateOrCertReq {
+    config: Arc<ClientConfig>,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     suite: &'static Tls13CipherSuite,
@@ -470,7 +470,7 @@ struct ExpectCertificateOrCertReq<C: CryptoProvider> {
     key_schedule: KeyScheduleHandshake,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateOrCertReq<C> {
+impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::Handshake {
@@ -521,8 +521,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateOrCertR
 // TLS1.3 version of CertificateRequest handling.  We then move to expecting the server
 // Certificate. Unfortunately the CertificateRequest type changed in an annoying way
 // in TLS1.3.
-struct ExpectCertificateRequest<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectCertificateRequest {
+    config: Arc<ClientConfig>,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     suite: &'static Tls13CipherSuite,
@@ -530,7 +530,7 @@ struct ExpectCertificateRequest<C: CryptoProvider> {
     key_schedule: KeyScheduleHandshake,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateRequest<C> {
+impl State<ClientConnectionData> for ExpectCertificateRequest {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let certreq = &require_handshake_msg!(
             m,
@@ -589,8 +589,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateRequest
     }
 }
 
-struct ExpectCertificate<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectCertificate {
+    config: Arc<ClientConfig>,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     suite: &'static Tls13CipherSuite,
@@ -599,7 +599,7 @@ struct ExpectCertificate<C: CryptoProvider> {
     client_auth: Option<ClientAuthDetails>,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificate<C> {
+impl State<ClientConnectionData> for ExpectCertificate {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let cert_chain = require_handshake_msg!(
             m,
@@ -642,8 +642,8 @@ impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificate<C> {
 }
 
 // --- TLS1.3 CertificateVerify ---
-struct ExpectCertificateVerify<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectCertificateVerify {
+    config: Arc<ClientConfig>,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     suite: &'static Tls13CipherSuite,
@@ -653,7 +653,7 @@ struct ExpectCertificateVerify<C: CryptoProvider> {
     client_auth: Option<ClientAuthDetails>,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectCertificateVerify<C> {
+impl State<ClientConnectionData> for ExpectCertificateVerify {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let cert_verify = require_handshake_msg!(
             m,
@@ -808,8 +808,8 @@ fn emit_end_of_early_data_tls13(transcript: &mut HandshakeHash, common: &mut Com
     common.send_msg(m, true);
 }
 
-struct ExpectFinished<C: CryptoProvider> {
-    config: Arc<ClientConfig<C>>,
+struct ExpectFinished {
+    config: Arc<ClientConfig>,
     server_name: ServerName,
     randoms: ConnectionRandoms,
     suite: &'static Tls13CipherSuite,
@@ -820,7 +820,7 @@ struct ExpectFinished<C: CryptoProvider> {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl<C: CryptoProvider> State<ClientConnectionData> for ExpectFinished<C> {
+impl State<ClientConnectionData> for ExpectFinished {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let mut st = *self;
         let finished =

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -24,15 +24,15 @@ pub use crate::rand::GetRandomFailed;
 pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 
 /// Pluggable crypto galore.
-pub trait CryptoProvider: Send + Sync + 'static {
+pub trait CryptoProvider: Send + Sync + Debug + 'static {
     /// Fill the given buffer with random bytes.
-    fn fill_random(buf: &mut [u8]) -> Result<(), GetRandomFailed>;
+    fn fill_random(&self, buf: &mut [u8]) -> Result<(), GetRandomFailed>;
 
     /// Provide a safe set of cipher suites that can be used as the defaults.
-    fn default_cipher_suites() -> &'static [suites::SupportedCipherSuite];
+    fn default_cipher_suites(&self) -> &'static [suites::SupportedCipherSuite];
 
     /// Return a safe set of supported key exchange groups to be used as the defaults.
-    fn default_kx_groups() -> &'static [&'static dyn SupportedKxGroup];
+    fn default_kx_groups(&self) -> &'static [&'static dyn SupportedKxGroup];
 }
 
 /// A supported key exchange group.

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -1,4 +1,4 @@
-use crate::crypto::{CryptoProvider, KeyExchangeError, SupportedGroup};
+use crate::crypto::{ActiveKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup};
 use crate::error::{Error, PeerMisbehaved};
 use crate::msgs::enums::NamedGroup;
 use crate::rand::GetRandomFailed;
@@ -28,8 +28,6 @@ pub mod sign;
 pub struct Ring;
 
 impl CryptoProvider for Ring {
-    type KeyExchange = KeyExchange;
-
     fn fill_random(buf: &mut [u8]) -> Result<(), GetRandomFailed> {
         SystemRandom::new()
             .fill(buf)
@@ -38,6 +36,11 @@ impl CryptoProvider for Ring {
 
     fn default_cipher_suites() -> &'static [SupportedCipherSuite] {
         DEFAULT_CIPHER_SUITES
+    }
+
+    /// Return all supported key exchange groups.
+    fn default_kx_groups() -> &'static [&'static dyn SupportedKxGroup] {
+        ALL_KX_GROUPS
     }
 }
 
@@ -68,118 +71,98 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
-/// An in-progress key exchange.  This has the algorithm,
-/// our private key, and our public key.
-#[derive(Debug)]
-pub struct KeyExchange {
-    group: &'static SupportedKxGroup,
-    priv_key: EphemeralPrivateKey,
-    pub_key: ring::agreement::PublicKey,
-}
-
-impl super::KeyExchange for KeyExchange {
-    type SupportedGroup = SupportedKxGroup;
-
-    fn start(
-        name: NamedGroup,
-        supported: &[&'static SupportedKxGroup],
-    ) -> Result<Self, KeyExchangeError> {
-        let group = match supported
-            .iter()
-            .find(|group| group.name == name)
-        {
-            Some(group) => group,
-            None => return Err(KeyExchangeError::UnsupportedGroup),
-        };
-
-        let rng = SystemRandom::new();
-        let priv_key = match EphemeralPrivateKey::generate(group.agreement_algorithm, &rng) {
-            Ok(priv_key) => priv_key,
-            Err(_) => return Err(KeyExchangeError::GetRandomFailed),
-        };
-
-        let pub_key = match priv_key.compute_public_key() {
-            Ok(pub_key) => pub_key,
-            Err(_) => return Err(KeyExchangeError::GetRandomFailed),
-        };
-
-        Ok(Self {
-            group,
-            priv_key,
-            pub_key,
-        })
-    }
-
-    /// Completes the key exchange, given the peer's public key.
-    ///
-    /// The shared secret is passed into the closure passed down in `f`, and the result of calling
-    /// `f` is returned to the caller.
-    fn complete<T>(self, peer: &[u8], f: impl FnOnce(&[u8]) -> Result<T, ()>) -> Result<T, Error> {
-        let peer_key = UnparsedPublicKey::new(self.group.agreement_algorithm, peer);
-        agree_ephemeral(self.priv_key, &peer_key, (), f)
-            .map_err(|()| PeerMisbehaved::InvalidKeyShare.into())
-    }
-
-    /// Return the group being used.
-    fn group(&self) -> NamedGroup {
-        self.group.name
-    }
-
-    /// Return the public key being used.
-    fn pub_key(&self) -> &[u8] {
-        self.pub_key.as_ref()
-    }
-
-    /// Return all supported key exchange groups.
-    fn all_kx_groups() -> &'static [&'static Self::SupportedGroup] {
-        &ALL_KX_GROUPS
-    }
-}
-
 /// A key-exchange group supported by *ring*.
 ///
 /// All possible instances of this class are provided by the library in
 /// the `ALL_KX_GROUPS` array.
-pub struct SupportedKxGroup {
+pub struct KxGroup {
     /// The IANA "TLS Supported Groups" name of the group
-    pub name: NamedGroup,
+    name: NamedGroup,
 
     /// The corresponding ring agreement::Algorithm
     agreement_algorithm: &'static ring::agreement::Algorithm,
 }
 
-impl SupportedGroup for SupportedKxGroup {
+impl SupportedKxGroup for KxGroup {
+    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, GetRandomFailed> {
+        let rng = SystemRandom::new();
+        let priv_key = EphemeralPrivateKey::generate(self.agreement_algorithm, &rng)
+            .map_err(|_| GetRandomFailed)?;
+
+        let pub_key = priv_key
+            .compute_public_key()
+            .map_err(|_| GetRandomFailed)?;
+
+        Ok(Box::new(KeyExchange {
+            name: self.name,
+            agreement_algorithm: self.agreement_algorithm,
+            priv_key,
+            pub_key,
+        }))
+    }
+
     fn name(&self) -> NamedGroup {
         self.name
     }
 }
 
-impl fmt::Debug for SupportedKxGroup {
+impl fmt::Debug for KxGroup {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.name.fmt(f)
     }
 }
 
 /// Ephemeral ECDH on curve25519 (see RFC7748)
-pub static X25519: SupportedKxGroup = SupportedKxGroup {
+pub static X25519: &dyn SupportedKxGroup = &KxGroup {
     name: NamedGroup::X25519,
     agreement_algorithm: &ring::agreement::X25519,
 };
 
 /// Ephemeral ECDH on secp256r1 (aka NIST-P256)
-pub static SECP256R1: SupportedKxGroup = SupportedKxGroup {
+pub static SECP256R1: &dyn SupportedKxGroup = &KxGroup {
     name: NamedGroup::secp256r1,
     agreement_algorithm: &ring::agreement::ECDH_P256,
 };
 
 /// Ephemeral ECDH on secp384r1 (aka NIST-P384)
-pub static SECP384R1: SupportedKxGroup = SupportedKxGroup {
+pub static SECP384R1: &dyn SupportedKxGroup = &KxGroup {
     name: NamedGroup::secp384r1,
     agreement_algorithm: &ring::agreement::ECDH_P384,
 };
 
 /// A list of all the key exchange groups supported by rustls.
-pub static ALL_KX_GROUPS: [&SupportedKxGroup; 3] = [&X25519, &SECP256R1, &SECP384R1];
+pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[X25519, SECP256R1, SECP384R1];
+
+/// An in-progress key exchange.  This has the algorithm,
+/// our private key, and our public key.
+#[derive(Debug)]
+pub struct KeyExchange {
+    name: NamedGroup,
+    agreement_algorithm: &'static ring::agreement::Algorithm,
+    priv_key: EphemeralPrivateKey,
+    pub_key: ring::agreement::PublicKey,
+}
+
+impl ActiveKeyExchange for KeyExchange {
+    /// Completes the key exchange, given the peer's public key.
+    fn complete(self: Box<Self>, peer: &[u8]) -> Result<SharedSecret, Error> {
+        let peer_key = UnparsedPublicKey::new(self.agreement_algorithm, peer);
+        agree_ephemeral(self.priv_key, &peer_key, (), |secret| {
+            Ok(SharedSecret::from(secret))
+        })
+        .map_err(|()| PeerMisbehaved::InvalidKeyShare.into())
+    }
+
+    /// Return the group being used.
+    fn group(&self) -> NamedGroup {
+        self.name
+    }
+
+    /// Return the public key being used.
+    fn pub_key(&self) -> &[u8] {
+        self.pub_key.as_ref()
+    }
+}
 
 /// All defined key exchange groups supported by *ring* appear in this module.
 ///

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -114,7 +114,7 @@
 //! ```rust,no_run
 //! # #[cfg(feature = "ring")] {
 //! # let root_store: rustls::RootCertStore = panic!();
-//! let config = rustls::ClientConfig::<rustls::crypto::ring::Ring>::builder()
+//! let config = rustls::ClientConfig::builder()
 //!     .with_safe_defaults()
 //!     .with_root_certificates(root_store)
 //!     .with_no_client_auth();
@@ -135,7 +135,7 @@
 //! #      .iter()
 //! #      .cloned()
 //! # );
-//! # let config = rustls::ClientConfig::<rustls::crypto::ring::Ring>::builder()
+//! # let config = rustls::ClientConfig::builder()
 //! #     .with_safe_defaults()
 //! #     .with_root_certificates(root_store)
 //! #     .with_no_client_auth();
@@ -170,7 +170,7 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(feature = "ring")] {
-//! # let mut client = rustls::ClientConnection::new::<rustls::crypto::ring::Ring>(panic!(), panic!()).unwrap();
+//! # let mut client = rustls::ClientConnection::new(panic!(), panic!()).unwrap();
 //! # struct Socket { }
 //! # impl Socket {
 //! #   fn ready_for_write(&self) -> bool { false }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -379,9 +379,10 @@ pub use crate::conn::{Connection, ConnectionCommon, Reader, SideData, Writer};
 #[cfg(feature = "ring")]
 pub use crate::crypto::ring::Ticketer;
 #[cfg(feature = "ring")]
-pub use crate::crypto::ring::{SupportedKxGroup, ALL_KX_GROUPS};
+pub use crate::crypto::ring::ALL_KX_GROUPS;
 #[cfg(feature = "ring")]
 pub use crate::crypto::ring::{ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES};
+pub use crate::crypto::SupportedKxGroup;
 pub use crate::enums::{
     AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,
     SignatureScheme,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -88,9 +88,9 @@ impl Codec for Random {
 }
 
 impl Random {
-    pub fn new<C: CryptoProvider>() -> Result<Self, rand::GetRandomFailed> {
+    pub fn new(provider: &'static dyn CryptoProvider) -> Result<Self, rand::GetRandomFailed> {
         let mut data = [0u8; 32];
-        C::fill_random(&mut data)?;
+        provider.fill_random(&mut data)?;
         Ok(Self(data))
     }
 
@@ -159,9 +159,9 @@ impl Codec for SessionId {
 }
 
 impl SessionId {
-    pub fn random<C: CryptoProvider>() -> Result<Self, rand::GetRandomFailed> {
+    pub fn random(provider: &'static dyn CryptoProvider) -> Result<Self, rand::GetRandomFailed> {
         let mut data = [0u8; 32];
-        C::fill_random(&mut data)?;
+        provider.fill_random(&mut data)?;
         Ok(Self { data, len: 32 })
     }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1,5 +1,5 @@
 #![allow(non_camel_case_types)]
-use crate::crypto::CryptoProvider;
+use crate::crypto::{ActiveKeyExchange, CryptoProvider};
 use crate::dns_name::{DnsName, DnsNameRef};
 use crate::enums::{CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme};
 use crate::error::InvalidMessage;
@@ -1504,13 +1504,13 @@ pub struct ServerECDHParams {
 }
 
 impl ServerECDHParams {
-    pub fn new(named_group: NamedGroup, pubkey: &[u8]) -> Self {
+    pub fn new(kx: &dyn ActiveKeyExchange) -> Self {
         Self {
             curve_params: ECParameters {
                 curve_type: ECCurveType::NamedCurve,
-                named_group,
+                named_group: kx.group(),
             },
-            public: PayloadU8::new(pubkey.to_vec()),
+            public: PayloadU8::new(kx.pub_key().to_vec()),
         }
     }
 }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -2,7 +2,6 @@
 use crate::client::{ClientConfig, ClientConnectionData, ServerName};
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCore, SideData};
-use crate::crypto::CryptoProvider;
 use crate::enums::{AlertDescription, ProtocolVersion};
 use crate::error::Error;
 use crate::hkdf;
@@ -136,8 +135,8 @@ impl ClientConnection {
     /// Make a new QUIC ClientConnection. This differs from `ClientConnection::new()`
     /// in that it takes an extra argument, `params`, which contains the
     /// TLS-encoded transport parameters to send.
-    pub fn new<C: CryptoProvider>(
-        config: Arc<ClientConfig<C>>,
+    pub fn new(
+        config: Arc<ClientConfig>,
         quic_version: Version,
         name: ServerName,
         params: Vec<u8>,
@@ -206,8 +205,8 @@ impl ServerConnection {
     /// Make a new QUIC ServerConnection. This differs from `ServerConnection::new()`
     /// in that it takes an extra argument, `params`, which contains the
     /// TLS-encoded transport parameters to send.
-    pub fn new<C: CryptoProvider>(
-        config: Arc<ServerConfig<C>>,
+    pub fn new(
+        config: Arc<ServerConfig>,
         quic_version: Version,
         params: Vec<u8>,
     ) -> Result<Self, Error> {

--- a/rustls/src/rand.rs
+++ b/rustls/src/rand.rs
@@ -3,16 +3,19 @@
 use crate::crypto::CryptoProvider;
 
 /// Make a [`Vec<u8>`] of the given size containing random material.
-pub(crate) fn random_vec<C: CryptoProvider>(len: usize) -> Result<Vec<u8>, GetRandomFailed> {
+pub(crate) fn random_vec(
+    provider: &dyn CryptoProvider,
+    len: usize,
+) -> Result<Vec<u8>, GetRandomFailed> {
     let mut v = vec![0; len];
-    C::fill_random(&mut v)?;
+    provider.fill_random(&mut v)?;
     Ok(v)
 }
 
 /// Return a uniformly random [`u32`].
-pub(crate) fn random_u32<C: CryptoProvider>() -> Result<u32, GetRandomFailed> {
+pub(crate) fn random_u32(provider: &dyn CryptoProvider) -> Result<u32, GetRandomFailed> {
     let mut buf = [0u8; 4];
-    C::fill_random(&mut buf)?;
+    provider.fill_random(&mut buf)?;
     Ok(u32::from_be_bytes(buf))
 }
 

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -1,5 +1,5 @@
 use crate::builder::{ConfigBuilder, WantsVerifier};
-use crate::crypto::{CryptoProvider, KeyExchange};
+use crate::crypto::{CryptoProvider, SupportedKxGroup};
 #[cfg(feature = "ring")]
 use crate::error::Error;
 use crate::server::handy;
@@ -15,12 +15,12 @@ use pki_types::{CertificateDer, PrivateKeyDer};
 use alloc::sync::Arc;
 use core::marker::PhantomData;
 
-impl<C: CryptoProvider> ConfigBuilder<ServerConfig<C>, WantsVerifier<C>> {
+impl<C: CryptoProvider> ConfigBuilder<ServerConfig<C>, WantsVerifier> {
     /// Choose how to verify client certificates.
     pub fn with_client_cert_verifier(
         self,
         client_cert_verifier: Arc<dyn ClientCertVerifier>,
-    ) -> ConfigBuilder<ServerConfig<C>, WantsServerCert<C>> {
+    ) -> ConfigBuilder<ServerConfig<C>, WantsServerCert> {
         ConfigBuilder {
             state: WantsServerCert {
                 cipher_suites: self.state.cipher_suites,
@@ -33,7 +33,7 @@ impl<C: CryptoProvider> ConfigBuilder<ServerConfig<C>, WantsVerifier<C>> {
     }
 
     /// Disable client authentication.
-    pub fn with_no_client_auth(self) -> ConfigBuilder<ServerConfig<C>, WantsServerCert<C>> {
+    pub fn with_no_client_auth(self) -> ConfigBuilder<ServerConfig<C>, WantsServerCert> {
         self.with_client_cert_verifier(Arc::new(NoClientAuth))
     }
 }
@@ -43,14 +43,14 @@ impl<C: CryptoProvider> ConfigBuilder<ServerConfig<C>, WantsVerifier<C>> {
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
 #[derive(Clone, Debug)]
-pub struct WantsServerCert<C: CryptoProvider> {
+pub struct WantsServerCert {
     cipher_suites: Vec<SupportedCipherSuite>,
-    kx_groups: Vec<&'static <C::KeyExchange as KeyExchange>::SupportedGroup>,
+    kx_groups: Vec<&'static dyn SupportedKxGroup>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn ClientCertVerifier>,
 }
 
-impl<C: CryptoProvider> ConfigBuilder<ServerConfig<C>, WantsServerCert<C>> {
+impl<C: CryptoProvider> ConfigBuilder<ServerConfig<C>, WantsServerCert> {
     #[cfg(feature = "ring")]
     /// Sets a single certificate chain and matching private key.  This
     /// certificate and key is used for all subsequent connections,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,7 +1,7 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
 use crate::common_state::{CommonState, Context, Side, State};
 use crate::conn::{ConnectionCommon, ConnectionCore};
-use crate::crypto::{CryptoProvider, KeyExchange};
+use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::dns_name::DnsName;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
@@ -215,7 +215,7 @@ pub struct ServerConfig<C: CryptoProvider> {
     ///
     /// The first is the highest priority: they will be
     /// offered to the client in this order.
-    pub(super) kx_groups: Vec<&'static <C::KeyExchange as KeyExchange>::SupportedGroup>,
+    pub(super) kx_groups: Vec<&'static dyn SupportedKxGroup>,
 
     /// Ignore the client's ciphersuite order. Instead,
     /// choose the top ciphersuite in the server list

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -7,7 +7,6 @@ use crate::common_state::Protocol;
 use crate::common_state::Side;
 use crate::common_state::{CommonState, State};
 use crate::conn::ConnectionRandoms;
-use crate::crypto::CryptoProvider;
 use crate::enums::ProtocolVersion;
 use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
@@ -78,8 +77,8 @@ mod client_hello {
         Accepted,
     }
 
-    pub(in crate::server) struct CompleteClientHelloHandling<C: CryptoProvider> {
-        pub(in crate::server) config: Arc<ServerConfig<C>>,
+    pub(in crate::server) struct CompleteClientHelloHandling {
+        pub(in crate::server) config: Arc<ServerConfig>,
         pub(in crate::server) transcript: HandshakeHash,
         pub(in crate::server) suite: &'static Tls13CipherSuite,
         pub(in crate::server) randoms: ConnectionRandoms,
@@ -103,7 +102,7 @@ mod client_hello {
         }
     }
 
-    impl<C: CryptoProvider> CompleteClientHelloHandling<C> {
+    impl CompleteClientHelloHandling {
         fn check_binder(
             &self,
             suite: &'static Tls13CipherSuite,
@@ -475,7 +474,7 @@ mod client_hello {
         }
     }
 
-    fn emit_server_hello<C: CryptoProvider>(
+    fn emit_server_hello(
         transcript: &mut HandshakeHash,
         randoms: &ConnectionRandoms,
         suite: &'static Tls13CipherSuite,
@@ -484,7 +483,7 @@ mod client_hello {
         share_and_kxgroup: (&KeyShareEntry, &'static dyn SupportedKxGroup),
         chosen_psk_idx: Option<usize>,
         resuming_psk: Option<&[u8]>,
-        config: &ServerConfig<C>,
+        config: &ServerConfig,
     ) -> Result<KeyScheduleHandshake, Error> {
         let mut extensions = Vec::new();
 
@@ -604,12 +603,12 @@ mod client_hello {
 
     #[allow(unknown_lints)] // The lint allowed below is nightly only for now
     #[cfg_attr(not(feature = "quic"), allow(clippy::needless_pass_by_ref_mut))]
-    fn decide_if_early_data_allowed<C: CryptoProvider>(
+    fn decide_if_early_data_allowed(
         cx: &mut ServerContext<'_>,
         client_hello: &ClientHelloPayload,
         resumedata: Option<&persist::ServerSessionValue>,
         suite: &'static Tls13CipherSuite,
-        config: &ServerConfig<C>,
+        config: &ServerConfig,
     ) -> EarlyDataDecision {
         let early_data_requested = client_hello.early_data_extension_offered();
         let rejected_or_disabled = match early_data_requested {
@@ -664,7 +663,7 @@ mod client_hello {
         }
     }
 
-    fn emit_encrypted_extensions<C: CryptoProvider>(
+    fn emit_encrypted_extensions(
         transcript: &mut HandshakeHash,
         suite: &'static Tls13CipherSuite,
         cx: &mut ServerContext<'_>,
@@ -672,7 +671,7 @@ mod client_hello {
         hello: &ClientHelloPayload,
         resumedata: Option<&persist::ServerSessionValue>,
         extra_exts: Vec<ServerExtension>,
-        config: &ServerConfig<C>,
+        config: &ServerConfig,
     ) -> Result<EarlyDataDecision, Error> {
         let mut ep = hs::ExtensionProcessing::new();
         ep.process_common(config, cx, ocsp_response, hello, resumedata, extra_exts)?;
@@ -696,10 +695,10 @@ mod client_hello {
         Ok(early_data)
     }
 
-    fn emit_certificate_req_tls13<C: CryptoProvider>(
+    fn emit_certificate_req_tls13(
         transcript: &mut HandshakeHash,
         cx: &mut ServerContext<'_>,
-        config: &ServerConfig<C>,
+        config: &ServerConfig,
     ) -> Result<bool, Error> {
         if !config.verifier.offer_client_auth() {
             return Ok(false);
@@ -817,12 +816,12 @@ mod client_hello {
         Ok(())
     }
 
-    fn emit_finished_tls13<C: CryptoProvider>(
+    fn emit_finished_tls13(
         transcript: &mut HandshakeHash,
         randoms: &ConnectionRandoms,
         cx: &mut ServerContext<'_>,
         key_schedule: KeyScheduleHandshake,
-        config: &ServerConfig<C>,
+        config: &ServerConfig,
     ) -> KeyScheduleTrafficWithClientFinishedPending {
         let handshake_hash = transcript.get_current_hash();
         let verify_data = key_schedule.sign_server_finish(&handshake_hash);
@@ -852,12 +851,12 @@ mod client_hello {
     }
 }
 
-struct ExpectAndSkipRejectedEarlyData<C: CryptoProvider> {
+struct ExpectAndSkipRejectedEarlyData {
     skip_data_left: usize,
-    next: Box<hs::ExpectClientHello<C>>,
+    next: Box<hs::ExpectClientHello>,
 }
 
-impl<C: CryptoProvider> State<ServerConnectionData> for ExpectAndSkipRejectedEarlyData<C> {
+impl State<ServerConnectionData> for ExpectAndSkipRejectedEarlyData {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         /* "The server then ignores early data by skipping all records with an external
          *  content type of "application_data" (indicating that they are encrypted),
@@ -874,15 +873,15 @@ impl<C: CryptoProvider> State<ServerConnectionData> for ExpectAndSkipRejectedEar
     }
 }
 
-struct ExpectCertificate<C: CryptoProvider> {
-    config: Arc<ServerConfig<C>>,
+struct ExpectCertificate {
+    config: Arc<ServerConfig>,
     transcript: HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
     send_tickets: usize,
 }
 
-impl<C: CryptoProvider> State<ServerConnectionData> for ExpectCertificate<C> {
+impl State<ServerConnectionData> for ExpectCertificate {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let certp = require_handshake_msg!(
             m,
@@ -945,8 +944,8 @@ impl<C: CryptoProvider> State<ServerConnectionData> for ExpectCertificate<C> {
     }
 }
 
-struct ExpectCertificateVerify<C: CryptoProvider> {
-    config: Arc<ServerConfig<C>>,
+struct ExpectCertificateVerify {
+    config: Arc<ServerConfig>,
     transcript: HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
@@ -954,7 +953,7 @@ struct ExpectCertificateVerify<C: CryptoProvider> {
     send_tickets: usize,
 }
 
-impl<C: CryptoProvider> State<ServerConnectionData> for ExpectCertificateVerify<C> {
+impl State<ServerConnectionData> for ExpectCertificateVerify {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let rc = {
             let sig = require_handshake_msg!(
@@ -995,15 +994,15 @@ impl<C: CryptoProvider> State<ServerConnectionData> for ExpectCertificateVerify<
 // --- Process (any number of) early ApplicationData messages,
 //     followed by a terminating handshake EndOfEarlyData message ---
 
-struct ExpectEarlyData<C: CryptoProvider> {
-    config: Arc<ServerConfig<C>>,
+struct ExpectEarlyData {
+    config: Arc<ServerConfig>,
     transcript: HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
     send_tickets: usize,
 }
 
-impl<C: CryptoProvider> State<ServerConnectionData> for ExpectEarlyData<C> {
+impl State<ServerConnectionData> for ExpectEarlyData {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => {
@@ -1076,24 +1075,24 @@ fn get_server_session_value(
     )
 }
 
-struct ExpectFinished<C: CryptoProvider> {
-    config: Arc<ServerConfig<C>>,
+struct ExpectFinished {
+    config: Arc<ServerConfig>,
     transcript: HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
     send_tickets: usize,
 }
 
-impl<C: CryptoProvider> ExpectFinished<C> {
+impl ExpectFinished {
     fn emit_ticket(
         transcript: &HandshakeHash,
         suite: &'static Tls13CipherSuite,
         cx: &mut ServerContext<'_>,
         key_schedule: &KeyScheduleTraffic,
-        config: &ServerConfig<C>,
+        config: &ServerConfig,
     ) -> Result<(), Error> {
-        let nonce = rand::random_vec::<C>(32)?;
-        let age_add = rand::random_u32::<C>()?;
+        let nonce = rand::random_vec(config.provider, 32)?;
+        let age_add = rand::random_u32(config.provider)?;
         let plain = get_server_session_value(
             transcript,
             suite,
@@ -1113,7 +1112,7 @@ impl<C: CryptoProvider> ExpectFinished<C> {
             };
             (ticket, config.ticketer.lifetime())
         } else {
-            let id = rand::random_vec::<C>(32)?;
+            let id = rand::random_vec(config.provider, 32)?;
             let stored = config
                 .session_storage
                 .put(id.clone(), plain);
@@ -1155,7 +1154,7 @@ impl<C: CryptoProvider> ExpectFinished<C> {
     }
 }
 
-impl<C: CryptoProvider> State<ServerConnectionData> for ExpectFinished<C> {
+impl State<ServerConnectionData> for ExpectFinished {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -543,7 +543,7 @@ mod client_hello {
 
         // Do key exchange
         let shared_secret = kx.complete(&share.payload.0)?;
-        let key_schedule = key_schedule_pre_handshake.into_handshake(shared_secret.secret_bytes());
+        let key_schedule = key_schedule_pre_handshake.into_handshake(shared_secret);
 
         let handshake_hash = transcript.get_current_hash();
         let key_schedule = key_schedule.derive_server_handshake_secrets(

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -1,6 +1,6 @@
 use crate::common_state::{CommonState, Side};
 use crate::crypto::cipher::{AeadKey, Iv, MessageDecrypter};
-use crate::crypto::{hash, hmac};
+use crate::crypto::{hash, hmac, SharedSecret};
 use crate::error::Error;
 use crate::hkdf;
 #[cfg(feature = "quic")]
@@ -141,8 +141,9 @@ impl KeySchedulePreHandshake {
         }
     }
 
-    pub(crate) fn into_handshake(mut self, secret: &[u8]) -> KeyScheduleHandshakeStart {
-        self.ks.input_secret(secret);
+    pub(crate) fn into_handshake(mut self, secret: SharedSecret) -> KeyScheduleHandshakeStart {
+        self.ks
+            .input_secret(secret.secret_bytes());
         KeyScheduleHandshakeStart { ks: self.ks }
     }
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -452,7 +452,7 @@ fn test_config_builders_debug() {
     );
     let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
     assert_eq!("ConfigBuilder<ServerConfig<Ring>, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256] } }", format!("{:?}", b));
-    let b = b.with_kx_groups(&[&rustls::kx_group::X25519]);
+    let b = b.with_kx_groups(&[rustls::kx_group::X25519]);
     assert_eq!("ConfigBuilder<ServerConfig<Ring>, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519] } }", format!("{:?}", b));
     let b = b
         .with_protocol_versions(&[&rustls::version::TLS13])
@@ -467,7 +467,7 @@ fn test_config_builders_debug() {
     );
     let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
     assert_eq!("ConfigBuilder<ClientConfig<Ring>, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256] } }", format!("{:?}", b));
-    let b = b.with_kx_groups(&[&rustls::kx_group::X25519]);
+    let b = b.with_kx_groups(&[rustls::kx_group::X25519]);
     assert_eq!("ConfigBuilder<ClientConfig<Ring>, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519] } }", format!("{:?}", b));
     let b = b
         .with_protocol_versions(&[&rustls::version::TLS13])
@@ -4016,9 +4016,9 @@ fn test_client_does_not_offer_sha1() {
 #[test]
 fn test_client_config_keyshare() {
     let client_config =
-        make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::SECP384R1]);
+        make_client_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::SECP384R1]);
     let server_config =
-        make_server_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::SECP384R1]);
+        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::SECP384R1]);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     do_handshake_until_error(&mut client, &mut server).unwrap();
 }
@@ -4026,9 +4026,9 @@ fn test_client_config_keyshare() {
 #[test]
 fn test_client_config_keyshare_mismatch() {
     let client_config =
-        make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::SECP384R1]);
+        make_client_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::SECP384R1]);
     let server_config =
-        make_server_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
+        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::X25519]);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     assert!(do_handshake_until_error(&mut client, &mut server).is_err());
 }
@@ -4039,7 +4039,7 @@ fn test_client_sends_helloretryrequest() {
     // client sends a secp384r1 key share
     let mut client_config = make_client_config_with_kx_groups(
         KeyType::Rsa,
-        &[&rustls::kx_group::SECP384R1, &rustls::kx_group::X25519],
+        &[rustls::kx_group::SECP384R1, rustls::kx_group::X25519],
     );
 
     let storage = Arc::new(ClientStorage::new());
@@ -4047,7 +4047,7 @@ fn test_client_sends_helloretryrequest() {
 
     // but server only accepts x25519, so a HRR is required
     let server_config =
-        make_server_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
+        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::X25519]);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
@@ -4167,11 +4167,11 @@ fn test_client_rejects_hrr_with_varied_session_id() {
     // client prefers a secp384r1 key share, server only accepts x25519
     let client_config = make_client_config_with_kx_groups(
         KeyType::Rsa,
-        &[&rustls::kx_group::SECP384R1, &rustls::kx_group::X25519],
+        &[rustls::kx_group::SECP384R1, rustls::kx_group::X25519],
     );
 
     let server_config =
-        make_server_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
+        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::X25519]);
 
     let (client, server) = make_pair_for_configs(client_config, server_config);
     let (mut client, mut server) = (client.into(), server.into());
@@ -4203,13 +4203,13 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     // first, client sends a x25519 and server agrees. x25519 is inserted
     //   into kx group cache.
     let mut client_config_1 =
-        make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::X25519]);
+        make_client_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::X25519]);
     client_config_1.resumption = Resumption::store(shared_storage.clone());
 
     // second, client only supports secp-384 and so kx group cache
     //   contains an unusable value.
     let mut client_config_2 =
-        make_client_config_with_kx_groups(KeyType::Rsa, &[&rustls::kx_group::SECP384R1]);
+        make_client_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::SECP384R1]);
     client_config_2.resumption = Resumption::store(shared_storage.clone());
 
     let server_config = make_server_config(KeyType::Rsa);

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4984,3 +4984,21 @@ fn test_debug_server_name_from_string() {
         "DnsName(\"a.com\")"
     )
 }
+
+#[cfg(feature = "ring")]
+#[test]
+fn test_explicit_provider_selection() {
+    let client_config = finish_client_config(
+        KeyType::Rsa,
+        rustls::ClientConfig::builder_with_provider(rustls::crypto::ring::RING)
+            .with_safe_defaults(),
+    );
+    let server_config = finish_server_config(
+        KeyType::Rsa,
+        rustls::ServerConfig::builder_with_provider(rustls::crypto::ring::RING)
+            .with_safe_defaults(),
+    );
+
+    let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    do_handshake(&mut client, &mut server);
+}

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -12,8 +12,6 @@ use std::sync::Mutex;
 
 use pki_types::CertificateDer;
 use rustls::client::{ResolvesClientCert, Resumption};
-use rustls::crypto::ring::Ring;
-use rustls::crypto::CryptoProvider;
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::enums::AlertLevel;
@@ -221,7 +219,7 @@ fn check_read_buf_err(reader: &mut dyn io::Read, err_kind: io::ErrorKind) {
 #[test]
 fn config_builder_for_client_rejects_empty_kx_groups() {
     assert_eq!(
-        ClientConfig::<Ring>::builder()
+        ClientConfig::builder()
             .with_safe_default_cipher_suites()
             .with_kx_groups(&[])
             .with_safe_default_protocol_versions()
@@ -233,7 +231,7 @@ fn config_builder_for_client_rejects_empty_kx_groups() {
 #[test]
 fn config_builder_for_client_rejects_empty_cipher_suites() {
     assert_eq!(
-        ClientConfig::<Ring>::builder()
+        ClientConfig::builder()
             .with_cipher_suites(&[])
             .with_safe_default_kx_groups()
             .with_safe_default_protocol_versions()
@@ -246,7 +244,7 @@ fn config_builder_for_client_rejects_empty_cipher_suites() {
 #[test]
 fn config_builder_for_client_rejects_incompatible_cipher_suites() {
     assert_eq!(
-        ClientConfig::<Ring>::builder()
+        ClientConfig::builder()
             .with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS12])
@@ -258,7 +256,7 @@ fn config_builder_for_client_rejects_incompatible_cipher_suites() {
 #[test]
 fn config_builder_for_server_rejects_empty_kx_groups() {
     assert_eq!(
-        ServerConfig::<Ring>::builder()
+        ServerConfig::builder()
             .with_safe_default_cipher_suites()
             .with_kx_groups(&[])
             .with_safe_default_protocol_versions()
@@ -270,7 +268,7 @@ fn config_builder_for_server_rejects_empty_kx_groups() {
 #[test]
 fn config_builder_for_server_rejects_empty_cipher_suites() {
     assert_eq!(
-        ServerConfig::<Ring>::builder()
+        ServerConfig::builder()
             .with_cipher_suites(&[])
             .with_safe_default_kx_groups()
             .with_safe_default_protocol_versions()
@@ -283,7 +281,7 @@ fn config_builder_for_server_rejects_empty_cipher_suites() {
 #[test]
 fn config_builder_for_server_rejects_incompatible_cipher_suites() {
     assert_eq!(
-        ServerConfig::<Ring>::builder()
+        ServerConfig::builder()
             .with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS12])
@@ -445,34 +443,34 @@ fn server_can_get_client_cert_after_resumption() {
 
 #[test]
 fn test_config_builders_debug() {
-    let b = ServerConfig::<Ring>::builder();
+    let b = ServerConfig::builder();
     assert_eq!(
-        "ConfigBuilder<ServerConfig<Ring>, _> { state: WantsCipherSuites(()) }",
+        "ConfigBuilder<ServerConfig, _> { state: WantsCipherSuites(Ring) }",
         format!("{:?}", b)
     );
     let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
-    assert_eq!("ConfigBuilder<ServerConfig<Ring>, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256] } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], provider: Ring } }", format!("{:?}", b));
     let b = b.with_kx_groups(&[rustls::kx_group::X25519]);
-    assert_eq!("ConfigBuilder<ServerConfig<Ring>, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519] } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], provider: Ring } }", format!("{:?}", b));
     let b = b
         .with_protocol_versions(&[&rustls::version::TLS13])
         .unwrap();
     let b = b.with_no_client_auth();
-    assert_eq!("ConfigBuilder<ServerConfig<Ring>, _> { state: WantsServerCert { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], versions: [TLSv1_3], verifier: dyn ClientCertVerifier } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsServerCert { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], provider: Ring, versions: [TLSv1_3], verifier: dyn ClientCertVerifier } }", format!("{:?}", b));
 
-    let b = ClientConfig::<Ring>::builder();
+    let b = ClientConfig::builder();
     assert_eq!(
-        "ConfigBuilder<ClientConfig<Ring>, _> { state: WantsCipherSuites(()) }",
+        "ConfigBuilder<ClientConfig, _> { state: WantsCipherSuites(Ring) }",
         format!("{:?}", b)
     );
     let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
-    assert_eq!("ConfigBuilder<ClientConfig<Ring>, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256] } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], provider: Ring } }", format!("{:?}", b));
     let b = b.with_kx_groups(&[rustls::kx_group::X25519]);
-    assert_eq!("ConfigBuilder<ClientConfig<Ring>, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519] } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], provider: Ring } }", format!("{:?}", b));
     let b = b
         .with_protocol_versions(&[&rustls::version::TLS13])
         .unwrap();
-    assert_eq!("ConfigBuilder<ClientConfig<Ring>, _> { state: WantsVerifier { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], versions: [TLSv1_3] } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVerifier { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], provider: Ring, versions: [TLSv1_3] } }", format!("{:?}", b));
 }
 
 /// Test that the server handles combination of `offer_client_auth()` returning true
@@ -489,7 +487,7 @@ fn server_allow_any_anonymous_or_authenticated_client() {
             .build()
             .unwrap();
 
-        let server_config = ServerConfig::<Ring>::builder()
+        let server_config = ServerConfig::builder()
             .with_safe_defaults()
             .with_client_cert_verifier(client_auth)
             .with_single_cert(kt.get_chain(), kt.get_key())
@@ -897,7 +895,7 @@ fn check_sigalgs_reduced_by_ciphersuite(
 ) {
     let client_config = finish_client_config(
         kt,
-        ClientConfig::<Ring>::builder()
+        ClientConfig::builder()
             .with_cipher_suites(&[find_suite(suite)])
             .with_safe_default_kx_groups()
             .with_safe_default_protocol_versions()
@@ -1011,8 +1009,8 @@ fn client_checks_server_certificate_with_given_name() {
 #[test]
 fn client_checks_server_certificate_with_given_ip_address() {
     fn check_server_name(
-        client_config: Arc<ClientConfig<Ring>>,
-        server_config: Arc<ServerConfig<Ring>>,
+        client_config: Arc<ClientConfig>,
+        server_config: Arc<ServerConfig>,
         name: &'static str,
     ) -> Result<(), ErrorFromPeer> {
         let mut client = ClientConnection::new(client_config, server_name(name)).unwrap();
@@ -1935,7 +1933,7 @@ fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
     assert_eq!(format!("{:?}", rc), "Ok(5)");
 }
 
-fn make_disjoint_suite_configs() -> (ClientConfig<Ring>, ServerConfig<Ring>) {
+fn make_disjoint_suite_configs() -> (ClientConfig, ServerConfig) {
     let kt = KeyType::Rsa;
     let server_config = finish_server_config(
         kt,
@@ -2299,10 +2297,7 @@ fn sni_resolver_rejects_bad_certs() {
     );
 }
 
-fn do_exporter_test(
-    client_config: ClientConfig<impl CryptoProvider>,
-    server_config: ServerConfig<impl CryptoProvider>,
-) {
+fn do_exporter_test(client_config: ClientConfig, server_config: ServerConfig) {
     let mut client_secret = [0u8; 64];
     let mut server_secret = [0u8; 64];
 
@@ -2358,8 +2353,8 @@ fn test_tls13_exporter() {
 }
 
 fn do_suite_test(
-    client_config: ClientConfig<impl CryptoProvider>,
-    server_config: ServerConfig<impl CryptoProvider>,
+    client_config: ClientConfig,
+    server_config: ServerConfig,
     expect_suite: SupportedCipherSuite,
     expect_version: ProtocolVersion,
 ) {
@@ -2494,7 +2489,7 @@ fn negotiated_ciphersuite_client() {
         let scs = find_suite(suite);
         let client_config = finish_client_config(
             kt,
-            ClientConfig::<Ring>::builder()
+            ClientConfig::builder()
                 .with_cipher_suites(&[scs])
                 .with_safe_default_kx_groups()
                 .with_protocol_versions(&[version])
@@ -2512,7 +2507,7 @@ fn negotiated_ciphersuite_server() {
         let scs = find_suite(suite);
         let server_config = finish_server_config(
             kt,
-            ServerConfig::<Ring>::builder()
+            ServerConfig::builder()
                 .with_cipher_suites(&[scs])
                 .with_safe_default_kx_groups()
                 .with_protocol_versions(&[version])
@@ -2767,7 +2762,7 @@ fn vectored_write_for_server_handshake_with_half_rtt_data() {
     check_read(&mut client.reader(), b"012345678901234567890123456789");
 }
 
-fn check_half_rtt_does_not_work(server_config: ServerConfig<impl CryptoProvider>) {
+fn check_half_rtt_does_not_work(server_config: ServerConfig) {
     let (mut client, mut server) =
         make_pair_for_configs(make_client_config_with_auth(KeyType::Rsa), server_config);
 
@@ -3199,7 +3194,7 @@ fn early_data_not_available() {
     assert!(client.early_data().is_none());
 }
 
-fn early_data_configs() -> (Arc<ClientConfig<Ring>>, Arc<ServerConfig<Ring>>) {
+fn early_data_configs() -> (Arc<ClientConfig>, Arc<ServerConfig>) {
     let kt = KeyType::Rsa;
     let mut client_config = make_client_config(kt);
     client_config.enable_early_data = true;
@@ -3652,7 +3647,7 @@ mod test_quic {
         )
         .unwrap();
 
-        use ring::rand::SecureRandom;
+        use rustls::crypto::ring::RING;
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, NamedGroup};
         use rustls::internal::msgs::handshake::{
@@ -3660,11 +3655,11 @@ mod test_quic {
         };
         use rustls::{CipherSuite, HandshakeType, SignatureScheme};
 
-        let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
-        rng.fill(&mut random).unwrap();
+        RING.fill_random(&mut random).unwrap();
         let random = Random::from(random);
 
+        let rng = ring::rand::SystemRandom::new();
         let kx = ring::agreement::EphemeralPrivateKey::generate(&ring::agreement::X25519, &rng)
             .unwrap()
             .compute_public_key()
@@ -3675,7 +3670,7 @@ mod test_quic {
             payload: HandshakePayload::ClientHello(ClientHelloPayload {
                 client_version: ProtocolVersion::TLSv1_3,
                 random,
-                session_id: SessionId::random::<Ring>().unwrap(),
+                session_id: SessionId::random(RING).unwrap(),
                 cipher_suites: vec![CipherSuite::TLS13_AES_128_GCM_SHA256],
                 compression_methods: vec![Compression::Null],
                 extensions: vec![
@@ -3707,7 +3702,7 @@ mod test_quic {
         server_config.alpn_protocols = vec!["foo".into()];
         let server_config = Arc::new(server_config);
 
-        use ring::rand::SecureRandom;
+        use rustls::crypto::ring::RING;
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, NamedGroup};
         use rustls::internal::msgs::handshake::{
@@ -3715,11 +3710,11 @@ mod test_quic {
         };
         use rustls::{CipherSuite, HandshakeType, SignatureScheme};
 
-        let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
-        rng.fill(&mut random).unwrap();
+        RING.fill_random(&mut random).unwrap();
         let random = Random::from(random);
 
+        let rng = ring::rand::SystemRandom::new();
         let kx = ring::agreement::EphemeralPrivateKey::generate(&ring::agreement::X25519, &rng)
             .unwrap()
             .compute_public_key()
@@ -3737,7 +3732,7 @@ mod test_quic {
             payload: HandshakePayload::ClientHello(ClientHelloPayload {
                 client_version: ProtocolVersion::TLSv1_2,
                 random,
-                session_id: SessionId::random::<Ring>().unwrap(),
+                session_id: SessionId::random(RING).unwrap(),
                 cipher_suites: vec![CipherSuite::TLS13_AES_128_GCM_SHA256],
                 compression_methods: vec![Compression::Null],
                 extensions: vec![
@@ -4133,8 +4128,9 @@ fn test_client_sends_helloretryrequest() {
 
 #[test]
 fn test_client_rejects_hrr_with_varied_session_id() {
+    use rustls::crypto::ring::RING;
     use rustls::internal::msgs::handshake::SessionId;
-    let different_session_id = SessionId::random::<Ring>().unwrap();
+    let different_session_id = SessionId::random(RING).unwrap();
 
     let assert_client_sends_hello_with_secp384 = |msg: &mut Message| -> Altered {
         if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
@@ -4556,7 +4552,7 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
 
     let server_config_1 = Arc::new(common::finish_server_config(
         KeyType::Ed25519,
-        ServerConfig::<Ring>::builder()
+        ServerConfig::builder()
             .with_safe_default_cipher_suites()
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS13])
@@ -4565,7 +4561,7 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
 
     let mut server_config_2 = common::finish_server_config(
         KeyType::Ed25519,
-        ServerConfig::<Ring>::builder()
+        ServerConfig::builder()
             .with_safe_default_cipher_suites()
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS12])
@@ -4804,7 +4800,7 @@ fn test_secret_extraction_enabled() {
         println!("Testing suite {:?}", suite.suite().as_str());
 
         // Only offer the cipher suite (and protocol version) that we're testing
-        let mut server_config = ServerConfig::<Ring>::builder()
+        let mut server_config = ServerConfig::builder()
             .with_cipher_suites(&[suite])
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[version])
@@ -4862,7 +4858,7 @@ fn test_secret_extraction_disabled_or_too_early() {
     let kt = KeyType::Rsa;
 
     for (server_enable, client_enable) in [(true, false), (false, true)] {
-        let mut server_config = ServerConfig::<Ring>::builder()
+        let mut server_config = ServerConfig::builder()
             .with_cipher_suites(&[suite])
             .with_safe_default_kx_groups()
             .with_safe_default_protocol_versions()
@@ -4904,7 +4900,7 @@ fn test_received_plaintext_backpressure() {
     let kt = KeyType::Rsa;
 
     let server_config = Arc::new(
-        ServerConfig::<Ring>::builder()
+        ServerConfig::builder()
             .with_cipher_suites(&[suite])
             .with_safe_default_kx_groups()
             .with_safe_default_protocol_versions()

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -14,7 +14,6 @@ use crate::common::{
     make_pair_for_arc_configs, server_name, ErrorFromPeer, KeyType, ALL_KEY_TYPES,
 };
 use rustls::client::{HandshakeSignatureValid, WebPkiServerVerifier};
-use rustls::crypto::ring::Ring;
 use rustls::internal::msgs::handshake::DistinguishedName;
 use rustls::server::{ClientCertVerified, ClientCertVerifier};
 use rustls::{
@@ -44,7 +43,7 @@ fn ver_err() -> Result<ClientCertVerified, Error> {
 fn server_config_with_verifier(
     kt: KeyType,
     client_cert_verifier: MockClientVerifier,
-) -> ServerConfig<Ring> {
+) -> ServerConfig {
     ServerConfig::builder()
         .with_safe_defaults()
         .with_client_cert_verifier(Arc::new(client_cert_verifier))

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -245,7 +245,7 @@ impl KeyType {
 
 pub fn finish_server_config<C: CryptoProvider>(
     kt: KeyType,
-    conf: rustls::ConfigBuilder<ServerConfig<C>, rustls::WantsVerifier<C>>,
+    conf: rustls::ConfigBuilder<ServerConfig<C>, rustls::WantsVerifier>,
 ) -> ServerConfig<C> {
     conf.with_no_client_auth()
         .with_single_cert(kt.get_chain(), kt.get_key())
@@ -272,7 +272,7 @@ pub fn make_server_config_with_versions(
 
 pub fn make_server_config_with_kx_groups(
     kt: KeyType,
-    kx_groups: &[&'static rustls::SupportedKxGroup],
+    kx_groups: &[&'static dyn rustls::SupportedKxGroup],
 ) -> ServerConfig<Ring> {
     finish_server_config(
         kt,
@@ -338,7 +338,7 @@ pub fn make_server_config_with_optional_client_auth(
 
 pub fn finish_client_config<C: CryptoProvider>(
     kt: KeyType,
-    config: rustls::ConfigBuilder<ClientConfig<C>, rustls::WantsVerifier<C>>,
+    config: rustls::ConfigBuilder<ClientConfig<C>, rustls::WantsVerifier>,
 ) -> ClientConfig<C> {
     let mut root_store = RootCertStore::empty();
     let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
@@ -353,7 +353,7 @@ pub fn finish_client_config<C: CryptoProvider>(
 
 pub fn finish_client_config_with_creds<C: CryptoProvider>(
     kt: KeyType,
-    config: rustls::ConfigBuilder<ClientConfig<C>, rustls::WantsVerifier<C>>,
+    config: rustls::ConfigBuilder<ClientConfig<C>, rustls::WantsVerifier>,
 ) -> ClientConfig<C> {
     let mut root_store = RootCertStore::empty();
     let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
@@ -374,7 +374,7 @@ pub fn make_client_config(kt: KeyType) -> ClientConfig<Ring> {
 
 pub fn make_client_config_with_kx_groups(
     kt: KeyType,
-    kx_groups: &[&'static rustls::SupportedKxGroup],
+    kx_groups: &[&'static dyn rustls::SupportedKxGroup],
 ) -> ClientConfig<Ring> {
     let builder = ClientConfig::builder()
         .with_safe_default_cipher_suites()


### PR DESCRIPTION
The `ClientConfig::builder()` API is restored and suitable for most uses, but now is conditional on the `ring` crate feature. 

`ClientConfig::builder_with_provider(&'static dyn CryptoProvider)` is unconditionally provided for being explicit or use with custom providers. 

Consumers can make their choice explicit:

```rust
rustls::ClientConfig::builder_with_provider(rustls::crypto::ring::RING)
    .with_safe_defaults()
```
(this is durable to changes in our defaults changing the meaning of `ClientConfig::builder()`.)

fixes #1409