### PR TITLE
ci-bench: reduce noise in cg_diff output

### DIFF
--- a/ci-bench/src/cachegrind.rs
+++ b/ci-bench/src/cachegrind.rs
@@ -242,6 +242,10 @@ pub fn diff(baseline: &Path, candidate: &Path, scenario: &str) -> anyhow::Result
     // cg_diff generates a diff between two cachegrind output files in a custom format that is not
     // user-friendly
     let cg_diff = Command::new("cg_diff")
+        // remove per-compilation uniqueness in symbols, eg
+        // _ZN9hashbrown3raw21RawTable$LT$T$C$A$GT$14reserve_rehash17hc60392f3f3eac4b2E.llvm.9716880419886440089 ->
+        // _ZN9hashbrown3raw21RawTable$LT$T$C$A$GT$14reserve_rehashE
+        .arg("--mod-funcname=s/17h[0-9a-f]+E\\.llvm\\.\\d+/E/")
         .arg(
             baseline
                 .join(CACHEGRIND_OUTPUT_SUBDIR)


### PR DESCRIPTION
The diffs produced tend to be noisy here because two separate compilations have different per-type and per-compilation uniqueness. eg:

```
 29,792 (124.8%)  ???:_ZN5alloc7raw_vec11finish_grow17h463b2c6f0ba30854E.llvm.2614985587368234107
-29,792 (-124.8%)  ???:_ZN5alloc7raw_vec11finish_grow17h463b2c6f0ba30854E.llvm.3375118279659775674
```

This diff line is here because some per-compilation unique value (after the '.llvm.') changed, not because the instruction count changed.

We can chop these out by giving a regular expression to cg_diff.