### PR TITLE
Remove TrustAnchorWithDn type

### DIFF
--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -10,7 +10,7 @@ use rustls::crypto::ring::Ring;
 
 fn main() {
     let mut root_store = rustls::RootCertStore::empty();
-    root_store.add_trust_anchors(
+    root_store.extend(
         webpki_roots::TLS_SERVER_ROOTS
             .iter()
             .cloned(),

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -59,7 +59,7 @@ fn main() {
     env_logger::init();
 
     let mut root_store = RootCertStore::empty();
-    root_store.add_trust_anchors(
+    root_store.extend(
         webpki_roots::TLS_SERVER_ROOTS
             .iter()
             .cloned(),

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -17,7 +17,7 @@ use rustls::RootCertStore;
 
 fn main() {
     let mut root_store = RootCertStore::empty();
-    root_store.add_trust_anchors(
+    root_store.extend(
         webpki_roots::TLS_SERVER_ROOTS
             .iter()
             .cloned(),

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -383,7 +383,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig<Ring>> {
             rustls_pemfile::certs(&mut reader).map(|result| result.unwrap()),
         );
     } else {
-        root_store.add_trust_anchors(
+        root_store.extend(
             webpki_roots::TLS_SERVER_ROOTS
                 .iter()
                 .cloned(),

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -393,7 +393,7 @@ pub use crate::tls12::Tls12CipherSuite;
 pub use crate::tls13::Tls13CipherSuite;
 pub use crate::verify::DigitallySignedStruct;
 pub use crate::versions::{SupportedProtocolVersion, ALL_VERSIONS, DEFAULT_VERSIONS};
-pub use crate::webpki::{RootCertStore, TrustAnchorWithDn};
+pub use crate::webpki::RootCertStore;
 
 /// Items for use in a client.
 pub mod client {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -104,7 +104,7 @@
 //!
 //! ```rust,no_run
 //! let mut root_store = rustls::RootCertStore::empty();
-//! root_store.add_trust_anchors(
+//! root_store.extend(
 //!     webpki_roots::TLS_SERVER_ROOTS
 //!         .iter()
 //!         .cloned()
@@ -130,7 +130,7 @@
 //! # use webpki;
 //! # use std::sync::Arc;
 //! # let mut root_store = rustls::RootCertStore::empty();
-//! # root_store.add_trust_anchors(
+//! # root_store.extend(
 //! #  webpki_roots::TLS_SERVER_ROOTS
 //! #      .iter()
 //! #      .cloned()

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -11,8 +11,8 @@ use crate::msgs::enums::{
     CertificateStatusType, ClientCertificateType, Compression, ECCurveType, ECPointFormat,
     ExtensionType, KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType,
 };
-use crate::rand;
 use crate::verify::DigitallySignedStruct;
+use crate::{rand, x509};
 
 use pki_types::CertificateDer;
 
@@ -1686,6 +1686,22 @@ wrapped_payload!(
     DistinguishedName,
     PayloadU16,
 );
+
+impl DistinguishedName {
+    /// Create a [`DistinguishedName`] after prepending its outer SEQUENCE encoding.
+    ///
+    /// This can be decoded using [x509-parser's FromDer trait](https://docs.rs/x509-parser/latest/x509_parser/prelude/trait.FromDer.html).
+    ///
+    /// ```ignore
+    /// use x509_parser::prelude::FromDer;
+    /// println!("{}", x509_parser::x509::X509Name::from_der(dn.as_ref())?.1);
+    /// ```
+    pub fn in_sequence(bytes: &[u8]) -> Self {
+        let mut wrapped = bytes.to_owned();
+        x509::wrap_in_sequence(&mut wrapped);
+        Self(PayloadU16::new(wrapped))
+    }
+}
 
 impl TlsListElement for DistinguishedName {
     const SIZE_LEN: ListLength = ListLength::U16;

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -1196,3 +1196,11 @@ fn can_decode_server_hello_from_api_devicecheck_apple_com() {
     let hm = HandshakeMessagePayload::read(&mut r).unwrap();
     println!("msg: {:?}", hm);
 }
+
+#[test]
+fn wrapped_dn_encoding() {
+    let subject = b"subject";
+    let dn = DistinguishedName::in_sequence(&subject[..]);
+    let expected_prefix = vec![ring::io::der::Tag::Sequence as u8, subject.len() as u8];
+    assert_eq!(dn.as_ref(), [expected_prefix, subject.to_vec()].concat());
+}

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -187,7 +187,7 @@ struct Context {
 impl Context {
     fn new(name: &'static str, domain: &'static str, certs: &[&'static [u8]]) -> Self {
         let mut roots = RootCertStore::empty();
-        roots.add_trust_anchors(
+        roots.extend(
             webpki_roots::TLS_SERVER_ROOTS
                 .iter()
                 .cloned(),

--- a/rustls/src/webpki/anchors.rs
+++ b/rustls/src/webpki/anchors.rs
@@ -48,11 +48,6 @@ impl RootCertStore {
         Ok(())
     }
 
-    /// Adds all the given TrustAnchors `anchors`.  This does not fail.
-    pub fn add_trust_anchors(&mut self, trust_anchors: impl Iterator<Item = TrustAnchor<'static>>) {
-        self.roots.extend(trust_anchors);
-    }
-
     /// Parse the given DER-encoded certificates and add all that can be parsed
     /// in a best-effort fashion.
     ///
@@ -88,5 +83,11 @@ impl RootCertStore {
         );
 
         (valid_count, invalid_count)
+    }
+}
+
+impl Extend<TrustAnchor<'static>> for RootCertStore {
+    fn extend<T: IntoIterator<Item = TrustAnchor<'static>>>(&mut self, iter: T) {
+        self.roots.extend(iter);
     }
 }

--- a/rustls/src/webpki/anchors.rs
+++ b/rustls/src/webpki/anchors.rs
@@ -4,7 +4,6 @@ use webpki::extract_trust_anchor;
 use super::pki_error;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
-use crate::x509;
 use crate::DistinguishedName;
 use crate::Error;
 
@@ -36,11 +35,8 @@ impl TrustAnchorWithDn {
 
 impl From<TrustAnchor<'static>> for TrustAnchorWithDn {
     fn from(inner: TrustAnchor<'static>) -> Self {
-        let mut subject = inner.subject.as_ref().to_owned();
-        x509::wrap_in_sequence(&mut subject);
-
         Self {
-            subject_dn: DistinguishedName::from(subject),
+            subject_dn: DistinguishedName::in_sequence(inner.subject.as_ref()),
             inner,
         }
     }

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -6,7 +6,7 @@ mod anchors;
 mod client_verifier_builder;
 mod verify;
 
-pub use anchors::{RootCertStore, TrustAnchorWithDn};
+pub use anchors::RootCertStore;
 
 pub use client_verifier_builder::{ClientCertVerifierBuilder, ClientCertVerifierBuilderError};
 

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -311,7 +311,7 @@ impl WebPkiClientVerifier {
             subjects: roots
                 .roots
                 .iter()
-                .map(|r| r.subject().clone())
+                .map(|r| DistinguishedName::in_sequence(r.inner().subject.as_ref()))
                 .collect(),
             crls,
             roots,

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -153,7 +153,7 @@ impl MockClientVerifier {
             subjects: get_client_root_store(kt)
                 .roots
                 .iter()
-                .map(|ta| ta.subject().clone())
+                .map(|ta| DistinguishedName::in_sequence(ta.inner().subject.as_ref()))
                 .collect(),
             mandatory: true,
             offered_schemes: None,

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -153,7 +153,7 @@ impl MockClientVerifier {
             subjects: get_client_root_store(kt)
                 .roots
                 .iter()
-                .map(|ta| DistinguishedName::in_sequence(ta.inner().subject.as_ref()))
+                .map(|ta| DistinguishedName::in_sequence(ta.subject.as_ref()))
                 .collect(),
             mandatory: true,
             offered_schemes: None,


### PR DESCRIPTION
TBD: do we still need/want the `RootCertStore` type after this, or can we make do with a `Vec<TrustAnchor<'static>>`? I think we'll still need a place to wrap `webpki::extract_trust_anchor()`, and this eliminates the annoying allocations required to convert a `Vec<TrustAnchorWithDn<'_>>` to a `&[TrustAnchor<'_>]` so keeping it probably makes sense?