### PR TITLE
CONTRIBUTING.md: "What would djc do"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,11 @@ a pcap or reproduction steps.
 
 Feel free to file github issues to get help, or ask a question.
 
+If you believe you've found a security bug please 
+[open a draft security advisory](https://github.com/rustls/rustls/security/advisories/new) 
+in GitHub, and not as a regular repository issue. See [SECURITY.md] for more
+information.
+
 ## Code changes
 
 Some ideas and guidelines for contributions:
@@ -30,13 +35,10 @@ Some ideas and guidelines for contributions:
 
 ## Security bugs
 
-Please report security bugs by filing a github issue, or by
-email to jbp@jbp.io if you want to disclose privately.  I'll then:
+Please report security bugs by [opening a draft security advisory](https://github.com/rustls/rustls/security/advisories/new)
+in GitHub, and not as a regular repository issue. 
 
-- Prepare a fix and regression tests.
-- Backport the fix and make a patch release for most recent release.
-- Submit an advisory to [rustsec/advisory-db](https://github.com/RustSec/advisory-db).
-- Refer to the advisory on the main README.md and release notes.
+See [SECURITY.md] for more information.
 
 If you're *looking* for security bugs, this crate is set up for
 `cargo fuzz` but would benefit from more runtime, targets and corpora.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,12 @@ differentiating between a given function and other functions, so putting them
 first makes it easier to infer the context/meaning of the function (compared to
 starting with a number of generic context-like types).
 
+#### Use `impl` where possible
+
+We prefer to use `impl ...` for arguments and return types when there's a single
+use of the type. Generic type argument bounds add a level of indirection that's
+harder to read in one pass.
+
 #### Validation
 
 Where possible, avoid writing `validate` or `check` type functions that try to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,14 +143,14 @@ be represented.
 
 #### Error handling
 
-We use `Result` types pervasively throughout the code to signal error cases. We
-prefer to avoid `unwrap()` and `expect()` calls unless there is a clear
-invariant which can be locally validated by the structure of the code. If
-there is such an invariant, we usually add a comment explaining how the
-invariant is upheld. In other cases (especially for error cases which can arise
-from network traffic, which could represent an attacker), we always prefer to
-handle errors and ultimately return an error to the network peer or close the
-connection.
+We use `Result` types pervasively throughout the code to signal error cases. 
+Outside of unit/integration tests we prefer to avoid `unwrap()` and `expect()`
+calls unless there is a clear invariant which can be locally validated by the
+structure of the code. If there is such an invariant, we usually add a comment
+explaining how the invariant is upheld. In other cases (especially for error
+cases which can arise from network traffic, which could represent an attacker),
+we always prefer to handle errors and ultimately return an error to the network
+peer or close the connection.
 
 ### Expressions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,14 @@ We use 3 blocks of imports in our Rust files:
 
 We believe that this makes it easier to see where a particular import comes from.
 
+We prefer to reference types and traits by an imported symbol name instead of
+using qualified references. Qualification paths generally add noise and are
+unnecessary. The one exception to this is when the symbol name is overly
+generic, or easily confused between different crates. In this case we prefer to
+import the symbol name under an alias, or if the parent module name is short,
+using a one-level qualified path. E.g. for a crate with a local `Error` type,
+prefer to `import std::error::Error as StdError`.
+
 ## Licensing
 
 Contributions are made under [rustls's licenses](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,18 @@ Ok(match foo {
 })
 ```
 
+#### Avoid `ref` in match patterns
+
+When writing match expressions, try to avoid using `ref` in patterns. Prefer
+taking a reference on the
+[scrutinee](https://doc.rust-lang.org/reference/expressions/match-expr.html) 
+of the `match`.
+
+Since the addition of [binding
+modes](https://rust-lang.github.io/rfcs/2005-match-ergonomics.html) for improved
+match ergonomics the `ref` keyword is unidiomatic and can be unfamiliar to
+readers.
+
 ### Naming
 
 #### Use concise names

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,14 @@ splitting it up into many small single-use functions. Single-caller functions
 can be useful, but consider whether the code would be easier to follow if the
 function was inlined (especially for short functions).
 
+#### Consider avoiding free-standing functions
+
+If a function's semantics or implementation are strongly dependent on one of its
+arguments, and the argument is defined in a type within the current crate,
+prefer using a method on the type. Similarly, if a function is taking multiple
+arguments that originate from the same common type in all call-sites it is
+a strong candidate for becoming a method on the type.
+
 #### Order arguments from most specific to least specific
 
 When writing a function, we prefer to order arguments from most specific to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,12 @@ Per the
 [API guidelines](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter),
 `get_()` prefixes are discouraged.
 
+#### Don't elide generic lifetimes
+
+We prefer not to elide lifetimes when naming types that are generic over
+lifetimes. Always include a lifetime placeholder (e.g. `<'_>`) to avoid
+confusion.
+
 ### Imports
 
 We use 3 blocks of imports in our Rust files:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,26 @@ levels, which we call "rightward drift". This makes lines shorter, making the
 code harder to read. To avoid this, try to `return` early for error cases, or
 `continue` early in a loop to skip an iteration.
 
+#### Hoist common expression returns
+
+When writing a `match` or `if` expression that has arms that each share a return
+type (e.g. `Ok(...)`), hoist the commonality outside the `match`. This helps
+separate out the important differences and reduces code duplication.
+
+```rust
+// Incorrect:
+match foo {
+    1..10 => Ok(do_one_thing()),
+    _ => Ok(do_another()),
+}
+
+// Correct:
+Ok(match foo {
+    1..10 => do_one_thing(),
+    _ => do_another(),
+})
+```
+
 ### Naming
 
 #### Use concise names

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,6 +254,15 @@ import the symbol name under an alias, or if the parent module name is short,
 using a one-level qualified path. E.g. for a crate with a local `Error` type,
 prefer to `import std::error::Error as StdError`.
 
+### Misc
+
+#### Avoid type aliases
+
+We prefer to avoid type aliases as they obfuscate the underlying type and
+don't provide additional type safety. Using the 
+[newtype idiom](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) 
+is one alternative when an abstraction boundary is worth the added complexity.
+
 ## Licensing
 
 Contributions are made under [rustls's licenses](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,11 +230,15 @@ Per the
 [API guidelines](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter),
 `get_()` prefixes are discouraged.
 
-#### Alphabetize enum variants
+#### Enum variants
 
 When implementing or modifying an `enum` type, list its variants in alphabetical
 order. It's acceptable to ignore this advice when matching the order imposed by
 an external source, e.g. a standards document.
+
+Prefer active verbs for variant names. E.g. `Allow` instead of `Allowed`,
+`Forbid` instead of `Forbidden`. Avoid faux-bools like `Yes` and `No`, instead
+preferring variant names that are descriptive of the different states.
 
 #### Don't elide generic lifetimes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,13 @@ prefer to `import std::error::Error as StdError`.
 
 ### Misc
 
+#### Numeric literals
+
+Prefer a numeric base that fits with the domain of the value being used. E.g.
+use hexadecimal for protocol message literals, and octal for UNIX privileges.
+Use digit grouping to make larger numeric constants easy to read, e.g. use
+`100_000_000` instead of `100000000`.
+
 #### Avoid type aliases
 
 We prefer to avoid type aliases as they obfuscate the underlying type and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,12 @@ Per the
 [API guidelines](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter),
 `get_()` prefixes are discouraged.
 
+#### Alphabetize enum variants
+
+When implementing or modifying an `enum` type, list its variants in alphabetical
+order. It's acceptable to ignore this advice when matching the order imposed by
+an external source, e.g. a standards document.
+
 #### Don't elide generic lifetimes
 
 We prefer not to elide lifetimes when naming types that are generic over

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,14 @@ differentiating between a given function and other functions, so putting them
 first makes it easier to infer the context/meaning of the function (compared to
 starting with a number of generic context-like types).
 
+#### Validation
+
+Where possible, avoid writing `validate` or `check` type functions that try to
+check for error conditions based on the state of a populated object. Prefer
+["parse, don't validate"](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)
+style and try to use the type system to make it impossible for invalid states to
+be represented.
+
 #### Error handling
 
 We use `Result` types pervasively throughout the code to signal error cases. We

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,11 +167,16 @@ code harder to read. To avoid this, try to `return` early for error cases, or
 
 #### Use concise names
 
-We prefer concise names, especially for local variables. Avoid adding a suffix
-for a variable that describes its type (provided that its type is hard to
-confuse with other types -- for example, we do still use `_id` suffixes because
-we usually use numeric IDs for database entities). The precision/conciseness
-trade-off for variable names also depends on the scope of the binding.
+We prefer concise names, especially for local variables, but prefer to
+expand acronyms/abbreviations that are not very well known (e.g. prefer
+`key_usage` instead of `ku`, `anonymous` instead of `anon`). Extremely common
+short-forms like `url` are acceptable.
+
+Avoid adding a suffix for a variable that describes its type (provided that its
+type is hard to confuse with other types -- for example, we do still use `_id`
+suffixes because we usually use numeric IDs for database entities). The
+precision/conciseness trade-off for variable names also depends on the scope of
+the binding. 
 
 #### Avoid `get_` prefixes
 


### PR DESCRIPTION
**Note: using #1407 as the merge base**.

Extends the RFC style-guide with additional wisdom gained from PR reviews. 

For now I've chosen not to include the (potentially controversial) guidance on preferring turbofish over explicit type annotations (e.g. when `collect`ing). We should probably confirm consensus on that one first.

