### PR TITLE
More consistently use modules for unit tests

### DIFF
--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -14,11 +14,9 @@ env_logger = "0.10"
 hmac = "0.12.0"
 pki-types = { package = "rustls-pki-types", version = "0.2.0" }
 rand_core = "0.6.0"
-rustls = { path = "../rustls", default-features = false, features = [ "logging", "dangerous_configuration", "tls12" ]}
-rsa = { version = "0.9.0", features = [ "sha2" ] }
+rustls = { path = "../rustls", default-features = false, features = ["logging", "dangerous_configuration", "tls12"] }
+rsa = { version = "0.9.0", features = ["sha2"] }
 sha2 = "0.10.0"
 webpki = { package = "rustls-webpki", version = "0.102.0-alpha.1", default-features = false, features = ["alloc", "std"] }
 webpki-roots = "0.26.0-alpha.1"
 x25519-dalek = "2"
-
-[dev-dependencies]

--- a/rustls/src/bs_debug.rs
+++ b/rustls/src/bs_debug.rs
@@ -40,7 +40,7 @@ impl<'a> fmt::Debug for BsDebug<'a> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::BsDebug;
 
     #[test]

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -206,7 +206,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
 }
 
 #[cfg(all(test, feature = "ring"))]
-mod test {
+mod tests {
     use super::NoClientSessionStorage;
     use crate::client::ClientSessionStore;
     use crate::msgs::enums::NamedGroup;

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -282,76 +282,79 @@ impl ProducesTickets for AeadTicketer {
 }
 
 #[cfg(test)]
-use core::time::Duration;
-#[cfg(test)]
-use pki_types::UnixTime;
+mod tests {
+    use super::*;
 
-#[test]
-fn basic_pairwise_test() {
-    let t = Ticketer::new().unwrap();
-    assert!(t.enabled());
-    let cipher = t.encrypt(b"hello world").unwrap();
-    let plain = t.decrypt(&cipher).unwrap();
-    assert_eq!(plain, b"hello world");
-}
+    use core::time::Duration;
+    use pki_types::UnixTime;
 
-#[test]
-fn ticketswitcher_switching_test() {
-    let t = Arc::new(crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap());
-    let now = UnixTime::now();
-    let cipher1 = t.encrypt(b"ticket 1").unwrap();
-    assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
-    {
-        // Trigger new ticketer
-        t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
-            now.as_secs() + 10,
-        )));
+    #[test]
+    fn basic_pairwise_test() {
+        let t = Ticketer::new().unwrap();
+        assert!(t.enabled());
+        let cipher = t.encrypt(b"hello world").unwrap();
+        let plain = t.decrypt(&cipher).unwrap();
+        assert_eq!(plain, b"hello world");
     }
-    let cipher2 = t.encrypt(b"ticket 2").unwrap();
-    assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
-    assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
-    {
-        // Trigger new ticketer
-        t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
-            now.as_secs() + 20,
-        )));
-    }
-    let cipher3 = t.encrypt(b"ticket 3").unwrap();
-    assert!(t.decrypt(&cipher1).is_none());
-    assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
-    assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
-}
 
-#[cfg(test)]
-fn fail_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> {
-    Err(GetRandomFailed)
-}
+    #[test]
+    fn ticketswitcher_switching_test() {
+        let t = Arc::new(crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap());
+        let now = UnixTime::now();
+        let cipher1 = t.encrypt(b"ticket 1").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        {
+            // Trigger new ticketer
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 10,
+            )));
+        }
+        let cipher2 = t.encrypt(b"ticket 2").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        {
+            // Trigger new ticketer
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 20,
+            )));
+        }
+        let cipher3 = t.encrypt(b"ticket 3").unwrap();
+        assert!(t.decrypt(&cipher1).is_none());
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
+    }
 
-#[test]
-fn ticketswitcher_recover_test() {
-    let mut t = crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap();
-    let now = UnixTime::now();
-    let cipher1 = t.encrypt(b"ticket 1").unwrap();
-    assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
-    t.generator = fail_generator;
-    {
-        // Failed new ticketer
-        t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
-            now.as_secs() + 10,
-        )));
+    #[cfg(test)]
+    fn fail_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> {
+        Err(GetRandomFailed)
     }
-    t.generator = make_ticket_generator;
-    let cipher2 = t.encrypt(b"ticket 2").unwrap();
-    assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
-    assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
-    {
-        // recover
-        t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
-            now.as_secs() + 20,
-        )));
+
+    #[test]
+    fn ticketswitcher_recover_test() {
+        let mut t = crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap();
+        let now = UnixTime::now();
+        let cipher1 = t.encrypt(b"ticket 1").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        t.generator = fail_generator;
+        {
+            // Failed new ticketer
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 10,
+            )));
+        }
+        t.generator = make_ticket_generator;
+        let cipher2 = t.encrypt(b"ticket 2").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        {
+            // recover
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 20,
+            )));
+        }
+        let cipher3 = t.encrypt(b"ticket 3").unwrap();
+        assert!(t.decrypt(&cipher1).is_none());
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
     }
-    let cipher3 = t.encrypt(b"ticket 3").unwrap();
-    assert!(t.decrypt(&cipher1).is_none());
-    assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
-    assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
 }

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -226,7 +226,7 @@ impl crate::quic::Algorithm for KeyBuilder {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::common_state::Side;
     use crate::crypto::ring;

--- a/rustls/src/dns_name.rs
+++ b/rustls/src/dns_name.rs
@@ -145,7 +145,7 @@ enum State {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     static TESTS: &[(&str, bool)] = &[
         ("", false),
         ("localhost", true),

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -164,7 +164,7 @@ impl HandshakeHash {
 }
 
 #[cfg(all(test, feature = "ring"))]
-mod test {
+mod tests {
     use super::HandshakeHashBuffer;
     use crate::crypto::ring;
 

--- a/rustls/src/hkdf.rs
+++ b/rustls/src/hkdf.rs
@@ -124,7 +124,7 @@ impl Expander {
 }
 
 #[cfg(all(test, feature = "ring"))]
-mod test {
+mod tests {
     use super::Extractor;
     use crate::crypto::ring;
 

--- a/rustls/src/key_log_file.rs
+++ b/rustls/src/key_log_file.rs
@@ -105,7 +105,7 @@ impl KeyLog for KeyLogFile {
 }
 
 #[cfg(all(test, target_os = "linux"))]
-mod test {
+mod tests {
     use super::*;
 
     fn init() {

--- a/rustls/src/limited_cache.rs
+++ b/rustls/src/limited_cache.rs
@@ -116,7 +116,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     type Test = super::LimitedCache<String, usize>;
 
     #[test]

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -313,16 +313,21 @@ impl<'a> Drop for LengthPrefixedBuffer<'a> {
     }
 }
 
-#[test]
-fn interrupted_length_prefixed_buffer_leaves_maximum_length() {
-    let mut buf = Vec::new();
-    let nested = LengthPrefixedBuffer::new(ListLength::U16, &mut buf);
-    nested.buf.push(0xaa);
-    assert_eq!(nested.buf, &vec![0xff, 0xff, 0xaa]);
-    // <- if the buffer is accidentally read here, there is no possiblity
-    //    that the contents of the length-prefixed buffer are interpretted
-    //    as a subsequent encoding (perhaps allowing injection of a different
-    //    extension)
-    drop(nested);
-    assert_eq!(buf, vec![0x00, 0x01, 0xaa]);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interrupted_length_prefixed_buffer_leaves_maximum_length() {
+        let mut buf = Vec::new();
+        let nested = LengthPrefixedBuffer::new(ListLength::U16, &mut buf);
+        nested.buf.push(0xaa);
+        assert_eq!(nested.buf, &vec![0xff, 0xff, 0xaa]);
+        // <- if the buffer is accidentally read here, there is no possiblity
+        //    that the contents of the length-prefixed buffer are interpretted
+        //    as a subsequent encoding (perhaps allowing injection of a different
+        //    extension)
+        drop(nested);
+        assert_eq!(buf, vec![0x00, 0x01, 0xaa]);
+    }
 }

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -22,11 +22,12 @@ mod handshake_test;
 mod message_test;
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use super::codec::Reader;
+    use super::message::{Message, OpaqueMessage};
+
     #[test]
     fn smoketest() {
-        use super::codec::Reader;
-        use super::message::{Message, OpaqueMessage};
         let bytes = include_bytes!("handshake-test.1.bin");
         let mut r = Reader::init(bytes);
 

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -201,7 +201,7 @@ impl server::ResolvesServerCert for ResolvesServerCertUsingSni {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::server::ProducesTickets;
     use crate::server::ResolvesServerCert;

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -786,28 +786,6 @@ impl EarlyDataState {
     }
 }
 
-// these branches not reachable externally, unless something else goes wrong.
-#[test]
-fn test_read_in_new_state() {
-    assert_eq!(
-        format!("{:?}", EarlyDataState::default().read(&mut [0u8; 5])),
-        "Err(Kind(BrokenPipe))"
-    );
-}
-
-#[cfg(read_buf)]
-#[test]
-fn test_read_buf_in_new_state() {
-    use std::io::BorrowedBuf;
-
-    let mut buf = [0u8; 5];
-    let mut buf: BorrowedBuf<'_> = buf.as_mut_slice().into();
-    assert_eq!(
-        format!("{:?}", EarlyDataState::default().read_buf(buf.unfilled())),
-        "Err(Kind(BrokenPipe))"
-    );
-}
-
 impl ConnectionCore<ServerConnectionData> {
     pub(crate) fn for_server<C: CryptoProvider>(
         config: Arc<ServerConfig<C>>,
@@ -855,3 +833,30 @@ impl ServerConnectionData {
 }
 
 impl crate::conn::SideData for ServerConnectionData {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // these branches not reachable externally, unless something else goes wrong.
+    #[test]
+    fn test_read_in_new_state() {
+        assert_eq!(
+            format!("{:?}", EarlyDataState::default().read(&mut [0u8; 5])),
+            "Err(Kind(BrokenPipe))"
+        );
+    }
+
+    #[cfg(read_buf)]
+    #[test]
+    fn test_read_buf_in_new_state() {
+        use std::io::BorrowedBuf;
+
+        let mut buf = [0u8; 5];
+        let mut buf: BorrowedBuf<'_> = buf.as_mut_slice().into();
+        assert_eq!(
+            format!("{:?}", EarlyDataState::default().read_buf(buf.unfilled())),
+            "Err(Kind(BrokenPipe))"
+        );
+    }
+}

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -217,7 +217,7 @@ pub enum ConnectionTrafficSecrets {
 }
 
 #[cfg(all(test, feature = "ring"))]
-mod test {
+mod tests {
     use super::crypto::ring::tls13::*;
     use super::*;
     use crate::enums::CipherSuite;

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -786,7 +786,7 @@ where
 }
 
 #[cfg(all(test, feature = "ring"))]
-mod test {
+mod tests {
     use super::{derive_traffic_iv, derive_traffic_key, KeySchedule, SecretKind};
     use crate::crypto::ring::tls13::TLS13_CHACHA20_POLY1305_SHA256_INTERNAL;
     use crate::KeyLog;

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -148,7 +148,7 @@ impl ChunkVecBuffer {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::ChunkVecBuffer;
 
     #[test]

--- a/rustls/src/x509.rs
+++ b/rustls/src/x509.rs
@@ -25,69 +25,74 @@ pub(crate) fn wrap_in_sequence(bytes: &mut Vec<u8>) {
 
 const DER_SEQUENCE_TAG: u8 = 0x30;
 
-#[test]
-fn test_empty() {
-    let mut val = Vec::new();
-    wrap_in_sequence(&mut val);
-    assert_eq!(vec![0x30, 0x00], val);
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_small() {
-    let mut val = Vec::new();
-    val.insert(0, 0x00);
-    val.insert(1, 0x11);
-    val.insert(2, 0x22);
-    val.insert(3, 0x33);
-    wrap_in_sequence(&mut val);
-    assert_eq!(vec![0x30, 0x04, 0x00, 0x11, 0x22, 0x33], val);
-}
+    #[test]
+    fn test_empty() {
+        let mut val = Vec::new();
+        wrap_in_sequence(&mut val);
+        assert_eq!(vec![0x30, 0x00], val);
+    }
 
-#[test]
-fn test_medium() {
-    let mut val = Vec::new();
-    val.resize(255, 0x12);
-    wrap_in_sequence(&mut val);
-    assert_eq!(vec![0x30, 0x81, 0xff, 0x12, 0x12, 0x12], val[..6].to_vec());
-}
+    #[test]
+    fn test_small() {
+        let mut val = Vec::new();
+        val.insert(0, 0x00);
+        val.insert(1, 0x11);
+        val.insert(2, 0x22);
+        val.insert(3, 0x33);
+        wrap_in_sequence(&mut val);
+        assert_eq!(vec![0x30, 0x04, 0x00, 0x11, 0x22, 0x33], val);
+    }
 
-#[test]
-fn test_large() {
-    let mut val = Vec::new();
-    val.resize(4660, 0x12);
-    wrap_in_sequence(&mut val);
-    assert_eq!(vec![0x30, 0x82, 0x12, 0x34, 0x12, 0x12], val[..6].to_vec());
-}
+    #[test]
+    fn test_medium() {
+        let mut val = Vec::new();
+        val.resize(255, 0x12);
+        wrap_in_sequence(&mut val);
+        assert_eq!(vec![0x30, 0x81, 0xff, 0x12, 0x12, 0x12], val[..6].to_vec());
+    }
 
-#[test]
-fn test_huge() {
-    let mut val = Vec::new();
-    val.resize(0xffff, 0x12);
-    wrap_in_sequence(&mut val);
-    assert_eq!(vec![0x30, 0x82, 0xff, 0xff, 0x12, 0x12], val[..6].to_vec());
-    assert_eq!(val.len(), 0xffff + 4);
-}
+    #[test]
+    fn test_large() {
+        let mut val = Vec::new();
+        val.resize(4660, 0x12);
+        wrap_in_sequence(&mut val);
+        assert_eq!(vec![0x30, 0x82, 0x12, 0x34, 0x12, 0x12], val[..6].to_vec());
+    }
 
-#[test]
-fn test_gigantic() {
-    let mut val = Vec::new();
-    val.resize(0x100000, 0x12);
-    wrap_in_sequence(&mut val);
-    assert_eq!(
-        vec![0x30, 0x83, 0x10, 0x00, 0x00, 0x12, 0x12],
-        val[..7].to_vec()
-    );
-    assert_eq!(val.len(), 0x100000 + 5);
-}
+    #[test]
+    fn test_huge() {
+        let mut val = Vec::new();
+        val.resize(0xffff, 0x12);
+        wrap_in_sequence(&mut val);
+        assert_eq!(vec![0x30, 0x82, 0xff, 0xff, 0x12, 0x12], val[..6].to_vec());
+        assert_eq!(val.len(), 0xffff + 4);
+    }
 
-#[test]
-fn test_ludicrous() {
-    let mut val = Vec::new();
-    val.resize(0x1000000, 0x12);
-    wrap_in_sequence(&mut val);
-    assert_eq!(
-        vec![0x30, 0x84, 0x01, 0x00, 0x00, 0x00, 0x12, 0x12],
-        val[..8].to_vec()
-    );
-    assert_eq!(val.len(), 0x1000000 + 6);
+    #[test]
+    fn test_gigantic() {
+        let mut val = Vec::new();
+        val.resize(0x100000, 0x12);
+        wrap_in_sequence(&mut val);
+        assert_eq!(
+            vec![0x30, 0x83, 0x10, 0x00, 0x00, 0x12, 0x12],
+            val[..7].to_vec()
+        );
+        assert_eq!(val.len(), 0x100000 + 5);
+    }
+
+    #[test]
+    fn test_ludicrous() {
+        let mut val = Vec::new();
+        val.resize(0x1000000, 0x12);
+        wrap_in_sequence(&mut val);
+        assert_eq!(
+            vec![0x30, 0x84, 0x01, 0x00, 0x00, 0x00, 0x12, 0x12],
+            val[..8].to_vec()
+        );
+        assert_eq!(val.len(), 0x1000000 + 6);
+    }
 }


### PR DESCRIPTION
(`tests` is the convention, as demonstrated by looking at the code produced by `cargo init --lib`.)