### PR TITLE
Fix pki-types dependency

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -20,7 +20,7 @@ log = { version = "0.4.4", optional = true }
 ring = { version = "0.16.20", optional = true }
 subtle = "2.5.0"
 webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.3", features = ["alloc", "std"], default-features = false }
-pki-types = { package = "rustls-pki-types", version = "0.2.0", features = ["std"] }
+pki-types = { package = "rustls-pki-types", version = "0.2.1", features = ["std"] }
 
 [features]
 default = ["logging", "ring", "tls12"]


### PR DESCRIPTION
This was an oversight from #1463. CI didn't catch it because (a) it always downloads fresh dependencies, so it gets the latest versions no matter what, (b) our minimal-versions job was broken (#1469) and (c) apparently Cargo's current minimal-versions support doesn't catch this case anyway (https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/New.20features.20vs.20minimal-versions).

Replaces #1467 (cc @stevefan1999-personal).