### PR TITLE
add an example tls server with provider (again)

### DIFF
--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -20,5 +20,10 @@ sha2 = "0.10.0"
 webpki = { package = "rustls-webpki", version = "0.102.0-alpha.1", default-features = false, features = ["alloc", "std"] }
 webpki-roots = "0.26.0-alpha.1"
 x25519-dalek = "2"
+p256 = "0.13.2"
+ecdsa = "0.16.8"
+signature = "2.1.0"
+pkcs8 = "0.10.2"
 
 [dev-dependencies]
+rcgen = "0.11.1"

--- a/provider-example/examples/server.rs
+++ b/provider-example/examples/server.rs
@@ -1,0 +1,129 @@
+use pki_types::CertificateDer;
+use pki_types::PrivateKeyDer;
+use rustls::crypto::CryptoProvider;
+use rustls::server::{Acceptor, ClientHello, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
+use rustls::ServerConfig;
+use rustls_provider_example::sign::ecdsa::EcdsaSigningKeyP256;
+use rustls_provider_example::Provider;
+use std::io::Write;
+use std::sync::Arc;
+
+struct ExampleResolvesServerCert(Arc<CertifiedKey>);
+
+impl ExampleResolvesServerCert {
+    pub fn new(cert_chain: Vec<CertificateDer<'static>>, key_der: PrivateKeyDer<'_>) -> Self {
+        let key: EcdsaSigningKeyP256 = key_der.try_into().unwrap();
+
+        Self(Arc::new(CertifiedKey::new(cert_chain, Arc::new(key))))
+    }
+}
+
+impl ResolvesServerCert for ExampleResolvesServerCert {
+    fn resolve(&self, _client_hello: ClientHello) -> Option<Arc<CertifiedKey>> {
+        Some(self.0.clone())
+    }
+}
+
+struct TestPki {
+    server_cert_der: Vec<u8>,
+    server_key_der: Vec<u8>,
+}
+
+impl TestPki {
+    fn new() -> Self {
+        let alg = &rcgen::PKCS_ECDSA_P256_SHA256;
+        let mut ca_params = rcgen::CertificateParams::new(Vec::new());
+        ca_params
+            .distinguished_name
+            .push(rcgen::DnType::OrganizationName, "Rustls Server Acceptor");
+        ca_params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, "Example CA");
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![
+            rcgen::KeyUsagePurpose::KeyCertSign,
+            rcgen::KeyUsagePurpose::DigitalSignature,
+            rcgen::KeyUsagePurpose::CrlSign,
+        ];
+        ca_params.alg = alg;
+        let ca_cert = rcgen::Certificate::from_params(ca_params).unwrap();
+
+        // Create a server end entity cert issued by the CA.
+        let mut server_ee_params = rcgen::CertificateParams::new(vec!["localhost".to_string()]);
+        server_ee_params.is_ca = rcgen::IsCa::NoCa;
+        server_ee_params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ServerAuth];
+        server_ee_params.alg = alg;
+        let server_cert = rcgen::Certificate::from_params(server_ee_params).unwrap();
+        let server_cert_der = server_cert
+            .serialize_der_with_signer(&ca_cert)
+            .unwrap();
+        let server_key_der = server_cert.serialize_private_key_der();
+        Self {
+            server_cert_der,
+            server_key_der,
+        }
+    }
+
+    fn server_config<C: CryptoProvider>(&self) -> Arc<ServerConfig<C>> {
+        let mut server_config: ServerConfig<C> = ServerConfig::builder()
+            .with_safe_defaults()
+            .with_no_client_auth()
+            .with_cert_resolver(Arc::new(ExampleResolvesServerCert::new(
+                vec![self.server_cert_der.clone().into()],
+                PrivateKeyDer::Pkcs8(self.server_key_der.clone().into()),
+            )));
+
+        server_config.key_log = Arc::new(rustls::KeyLogFile::new());
+
+        Arc::new(server_config)
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    let pki = TestPki::new();
+    let server_config = pki.server_config::<Provider>();
+
+    let listener = std::net::TcpListener::bind(format!("0.0.0.0:{}", 4443)).unwrap();
+    'accept: for stream in listener.incoming() {
+        let mut stream = stream.unwrap();
+        let mut acceptor = Acceptor::default();
+
+        let accepted = loop {
+            if let Ok(_) = acceptor.read_tls(&mut stream) {
+                if let Ok(Some(accepted)) = acceptor.accept() {
+                    break accepted;
+                }
+            }
+
+            eprintln!("unexpected connection");
+            continue 'accept;
+        };
+
+        match accepted.into_connection(server_config.clone()) {
+            Ok(mut conn) => {
+                let msg = concat!(
+                    "HTTP/1.1 200 OK\r\n",
+                    "Connection: Closed\r\n",
+                    "Content-Type: text/html\r\n",
+                    "\r\n",
+                    "<h1>Hello World!</h1>\r\n"
+                )
+                .as_bytes();
+
+                let _ = conn.writer().write(msg);
+                let _ = conn.write_tls(&mut stream);
+                _ = conn.complete_io(&mut stream);
+
+                conn.send_close_notify();
+                let _ = conn.write_tls(&mut stream);
+                _ = conn.complete_io(&mut stream);
+            }
+            Err(e) => {
+                eprintln!("{}", e);
+            }
+        }
+    }
+}

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -4,6 +4,7 @@ mod aead;
 mod hash;
 mod hmac;
 mod kx;
+pub mod sign;
 mod verify;
 
 pub struct Provider;

--- a/provider-example/src/sign.rs
+++ b/provider-example/src/sign.rs
@@ -1,0 +1,1 @@
+pub mod ecdsa;

--- a/provider-example/src/sign/ecdsa.rs
+++ b/provider-example/src/sign/ecdsa.rs
@@ -1,0 +1,58 @@
+use pkcs8::DecodePrivateKey;
+use pki_types::PrivateKeyDer;
+use rustls::{
+    sign::{Signer, SigningKey},
+    SignatureAlgorithm, SignatureScheme,
+};
+use signature::RandomizedSigner;
+use signature::SignatureEncoding;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct EcdsaSigningKeyP256 {
+    key: Arc<p256::ecdsa::SigningKey>,
+    scheme: SignatureScheme,
+}
+
+impl TryFrom<PrivateKeyDer<'_>> for EcdsaSigningKeyP256 {
+    type Error = pkcs8::Error;
+
+    fn try_from(value: PrivateKeyDer<'_>) -> Result<Self, Self::Error> {
+        match value {
+            PrivateKeyDer::Pkcs8(der) => {
+                p256::ecdsa::SigningKey::from_pkcs8_der(der.secret_pkcs8_der()).map(|kp| Self {
+                    key: Arc::new(kp),
+                    scheme: SignatureScheme::ECDSA_NISTP256_SHA256,
+                })
+            }
+            _ => todo!(),
+        }
+    }
+}
+
+impl SigningKey for EcdsaSigningKeyP256 {
+    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
+        if offered.contains(&self.scheme) {
+            Some(Box::new(self.clone()))
+        } else {
+            None
+        }
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        SignatureAlgorithm::ECDSA
+    }
+}
+
+impl Signer for EcdsaSigningKeyP256 {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        self.key
+            .try_sign_with_rng(&mut rand_core::OsRng, message)
+            .map_err(|_| rustls::Error::General("signing failed".into()))
+            .map(|sig: p256::ecdsa::DerSignature| sig.to_vec())
+    }
+
+    fn scheme(&self) -> SignatureScheme {
+        self.scheme
+    }
+}


### PR DESCRIPTION
Per https://github.com/rustls/rustls/pull/1405#issuecomment-1717905136, but this time I just added the minimal requirements. More specifically I removed the generic code and flattened it out to support P256 only. I have a more comprehensive provider at https://github.com/stevefan1999-personal/rustls-provider-rustcrypto that uses generics to eliminate boilerplate code.