### PR TITLE
Remove top-level re-exports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,15 @@ import the symbol name under an alias, or if the parent module name is short,
 using a one-level qualified path. E.g. for a crate with a local `Error` type,
 prefer to `import std::error::Error as StdError`.
 
+### Exports
+
+We prefer to export types under a single name, avoiding re-exporting types from
+the top-level `lib.rs`. The exception to this are "paved path" exports that we
+expect every user will need. The canonical example of such types are 
+`client::ClientConfig` and `server::ServerConfig`. In general this sort of type
+is rare and most new types should be exported only from the module in which they 
+are defined.
+
 ### Misc
 
 #### Numeric literals

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -14,10 +14,10 @@ use itertools::Itertools;
 use rayon::iter::Either;
 use rayon::prelude::*;
 use rustls::client::Resumption;
+use rustls::crypto::ring::Ticketer;
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::{
     ClientConfig, ClientConnection, ProtocolVersion, RootCertStore, ServerConfig, ServerConnection,
-    Ticketer,
 };
 
 use crate::benchmark::{

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -16,7 +16,7 @@ fn main() {
 
     let config = rustls::ClientConfig::builder()
         .with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256])
-        .with_kx_groups(&[rustls::kx_group::X25519])
+        .with_kx_groups(&[rustls::crypto::ring::kx_group::X25519])
         .with_protocol_versions(&[&rustls::version::TLS13])
         .unwrap()
         .with_root_certificates(root_store)

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -391,7 +391,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     let suites = if !args.flag_suite.is_empty() {
         lookup_suites(&args.flag_suite)
     } else {
-        rustls::DEFAULT_CIPHER_SUITES.to_vec()
+        rustls::crypto::ring::DEFAULT_CIPHER_SUITES.to_vec()
     };
 
     let versions = if !args.flag_protover.is_empty() {

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -236,7 +236,7 @@ struct Args {
 
 /// Find a ciphersuite with the given name
 fn find_suite(name: &str) -> Option<rustls::SupportedCipherSuite> {
-    for suite in rustls::ALL_CIPHER_SUITES {
+    for suite in rustls::crypto::ring::ALL_CIPHER_SUITES {
         let sname = format!("{:?}", suite.suite()).to_lowercase();
 
         if sname == name.to_string().to_lowercase() {

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -620,7 +620,7 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
     }
 
     if args.flag_tickets {
-        config.ticketer = rustls::Ticketer::new().unwrap();
+        config.ticketer = rustls::crypto::ring::Ticketer::new().unwrap();
     }
 
     config.alpn_protocols = args

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -457,7 +457,7 @@ struct Args {
 }
 
 fn find_suite(name: &str) -> Option<rustls::SupportedCipherSuite> {
-    for suite in rustls::ALL_CIPHER_SUITES {
+    for suite in rustls::crypto::ring::ALL_CIPHER_SUITES {
         let sname = format!("{:?}", suite.suite()).to_lowercase();
 
         if sname == name.to_string().to_lowercase() {
@@ -583,7 +583,7 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
     let suites = if !args.flag_suite.is_empty() {
         lookup_suites(&args.flag_suite)
     } else {
-        rustls::ALL_CIPHER_SUITES.to_vec()
+        rustls::crypto::ring::ALL_CIPHER_SUITES.to_vec()
     };
 
     let versions = if !args.flag_protover.is_empty() {

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -23,7 +23,7 @@ impl rustls::crypto::CryptoProvider for Provider {
         ALL_CIPHER_SUITES
     }
 
-    fn default_kx_groups(&self) -> &'static [&'static dyn rustls::SupportedKxGroup] {
+    fn default_kx_groups(&self) -> &'static [&'static dyn rustls::crypto::SupportedKxGroup] {
         kx::ALL_KX_GROUPS
     }
 }

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -14,9 +14,9 @@ use std::time::{Duration, Instant};
 use pki_types::{CertificateDer, PrivateKeyDer};
 
 use rustls::client::Resumption;
+use rustls::crypto::ring::Ticketer;
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::RootCertStore;
-use rustls::Ticketer;
 use rustls::{ClientConfig, ClientConnection};
 use rustls::{ConnectionCommon, SideData};
 use rustls::{ServerConfig, ServerConnection};

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -7,6 +7,7 @@
 use rustls::client::{
     ClientConfig, ClientConnection, HandshakeSignatureValid, Resumption, WebPkiServerVerifier,
 };
+use rustls::crypto::ring::Ticketer;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::persist;
 use rustls::server::{ClientHello, ServerConfig, ServerConnection};
@@ -14,7 +15,7 @@ use rustls::{
     self, client, kx_group, server, sign, version, AlertDescription, CertificateError, Connection,
     DigitallySignedStruct, DistinguishedName, Error, InvalidMessage, NamedGroup, PeerIncompatible,
     PeerMisbehaved, ProtocolVersion, ServerName, Side, SignatureAlgorithm, SignatureScheme,
-    SupportedKxGroup, SupportedProtocolVersion, Ticketer, ALL_KX_GROUPS,
+    SupportedKxGroup, SupportedProtocolVersion, ALL_KX_GROUPS,
 };
 
 use base64::prelude::{Engine, BASE64_STANDARD};

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -7,13 +7,13 @@
 use rustls::client::{
     ClientConfig, ClientConnection, HandshakeSignatureValid, Resumption, WebPkiServerVerifier,
 };
-use rustls::crypto::ring::{Ticketer, ALL_KX_GROUPS};
+use rustls::crypto::ring::{kx_group, Ticketer, ALL_KX_GROUPS};
 use rustls::crypto::SupportedKxGroup;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::persist;
 use rustls::server::{ClientHello, ServerConfig, ServerConnection};
 use rustls::{
-    self, client, kx_group, server, sign, version, AlertDescription, CertificateError, Connection,
+    self, client, server, sign, version, AlertDescription, CertificateError, Connection,
     DigitallySignedStruct, DistinguishedName, Error, InvalidMessage, NamedGroup, PeerIncompatible,
     PeerMisbehaved, ProtocolVersion, ServerName, Side, SignatureAlgorithm, SignatureScheme,
     SupportedProtocolVersion,

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -8,6 +8,7 @@ use rustls::client::{
     ClientConfig, ClientConnection, HandshakeSignatureValid, Resumption, WebPkiServerVerifier,
 };
 use rustls::crypto::ring::Ticketer;
+use rustls::crypto::SupportedKxGroup;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::persist;
 use rustls::server::{ClientHello, ServerConfig, ServerConnection};
@@ -15,7 +16,7 @@ use rustls::{
     self, client, kx_group, server, sign, version, AlertDescription, CertificateError, Connection,
     DigitallySignedStruct, DistinguishedName, Error, InvalidMessage, NamedGroup, PeerIncompatible,
     PeerMisbehaved, ProtocolVersion, ServerName, Side, SignatureAlgorithm, SignatureScheme,
-    SupportedKxGroup, SupportedProtocolVersion, ALL_KX_GROUPS,
+    SupportedProtocolVersion, ALL_KX_GROUPS,
 };
 
 use base64::prelude::{Engine, BASE64_STANDARD};

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -7,7 +7,7 @@
 use rustls::client::{
     ClientConfig, ClientConnection, HandshakeSignatureValid, Resumption, WebPkiServerVerifier,
 };
-use rustls::crypto::ring::Ticketer;
+use rustls::crypto::ring::{Ticketer, ALL_KX_GROUPS};
 use rustls::crypto::SupportedKxGroup;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::persist;
@@ -16,7 +16,7 @@ use rustls::{
     self, client, kx_group, server, sign, version, AlertDescription, CertificateError, Connection,
     DigitallySignedStruct, DistinguishedName, Error, InvalidMessage, NamedGroup, PeerIncompatible,
     PeerMisbehaved, ProtocolVersion, ServerName, Side, SignatureAlgorithm, SignatureScheme,
-    SupportedProtocolVersion, ALL_KX_GROUPS,
+    SupportedProtocolVersion,
 };
 
 use base64::prelude::{Engine, BASE64_STANDARD};

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -377,8 +377,6 @@ pub use crate::builder::{
 pub use crate::common_state::{CommonState, IoState, Side};
 pub use crate::conn::{Connection, ConnectionCommon, Reader, SideData, Writer};
 #[cfg(feature = "ring")]
-pub use crate::crypto::ring::ALL_KX_GROUPS;
-#[cfg(feature = "ring")]
 pub use crate::crypto::ring::{ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES};
 pub use crate::enums::{
     AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -377,8 +377,6 @@ pub use crate::builder::{
 pub use crate::common_state::{CommonState, IoState, Side};
 pub use crate::conn::{Connection, ConnectionCommon, Reader, SideData, Writer};
 #[cfg(feature = "ring")]
-pub use crate::crypto::ring::Ticketer;
-#[cfg(feature = "ring")]
 pub use crate::crypto::ring::ALL_KX_GROUPS;
 #[cfg(feature = "ring")]
 pub use crate::crypto::ring::{ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES};

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -380,7 +380,6 @@ pub use crate::conn::{Connection, ConnectionCommon, Reader, SideData, Writer};
 pub use crate::crypto::ring::ALL_KX_GROUPS;
 #[cfg(feature = "ring")]
 pub use crate::crypto::ring::{ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES};
-pub use crate::crypto::SupportedKxGroup;
 pub use crate::enums::{
     AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,
     SignatureScheme,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -377,7 +377,7 @@ pub use crate::builder::{
 pub use crate::common_state::{CommonState, IoState, Side};
 pub use crate::conn::{Connection, ConnectionCommon, Reader, SideData, Writer};
 #[cfg(feature = "ring")]
-pub use crate::crypto::ring::{ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES};
+pub use crate::crypto::ring::DEFAULT_CIPHER_SUITES;
 pub use crate::enums::{
     AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,
     SignatureScheme,
@@ -471,7 +471,7 @@ pub use server::{ServerConfig, ServerConnection};
 
 /// All defined ciphersuites appear in this module.
 ///
-/// [`ALL_CIPHER_SUITES`] is provided as an array of all of these values.
+/// [`crypto::ring::ALL_CIPHER_SUITES`] is provided as an array of all of these values.
 pub mod cipher_suite {
     #[cfg(all(feature = "tls12", feature = "ring"))]
     pub use crate::crypto::ring::tls12::{

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -376,8 +376,6 @@ pub use crate::builder::{
 };
 pub use crate::common_state::{CommonState, IoState, Side};
 pub use crate::conn::{Connection, ConnectionCommon, Reader, SideData, Writer};
-#[cfg(feature = "ring")]
-pub use crate::crypto::ring::DEFAULT_CIPHER_SUITES;
 pub use crate::enums::{
     AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,
     SignatureScheme,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -493,10 +493,6 @@ pub mod version {
     pub use crate::versions::TLS13;
 }
 
-#[cfg(feature = "ring")]
-/// All defined key exchange groups supported by *ring* appear in this module.
-pub use crypto::ring::kx_group;
-
 /// Message signing interfaces and implementations.
 pub mod sign {
     #[cfg(feature = "ring")]

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -142,7 +142,7 @@ enum_builder! {
     ///
     /// This enum is used for recognizing elliptic curve parameters advertised
     /// by a peer during a TLS handshake. It is **not** a list of curves that
-    /// Rustls supports. See [`crate::kx_group`] for the list of supported
+    /// Rustls supports. See [`crate::crypto::ring::kx_group`] for the list of supported
     /// elliptic curve groups.
     @U16
     EnumName: NamedCurve;

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -21,7 +21,7 @@ pub struct CipherSuiteCommon {
 /// A cipher suite supported by rustls.
 ///
 /// All possible instances of this type are provided by the library in
-/// the [`crate::ALL_CIPHER_SUITES`] array.
+/// the [`crypto::ring::ALL_CIPHER_SUITES`] array.
 #[derive(Clone, Copy, PartialEq)]
 pub enum SupportedCipherSuite {
     /// A TLS 1.2 cipher suite
@@ -250,19 +250,19 @@ mod tests {
     fn test_pref_fails() {
         assert!(choose_ciphersuite_preferring_client(
             &[CipherSuite::TLS_NULL_WITH_NULL_NULL],
-            crate::ALL_CIPHER_SUITES
+            crypto::ring::ALL_CIPHER_SUITES
         )
         .is_none());
         assert!(choose_ciphersuite_preferring_server(
             &[CipherSuite::TLS_NULL_WITH_NULL_NULL],
-            crate::ALL_CIPHER_SUITES
+            crypto::ring::ALL_CIPHER_SUITES
         )
         .is_none());
     }
 
     #[test]
     fn test_scs_is_debug() {
-        println!("{:?}", crate::ALL_CIPHER_SUITES);
+        println!("{:?}", crypto::ring::ALL_CIPHER_SUITES);
     }
 
     #[test]

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -451,7 +451,7 @@ fn test_config_builders_debug() {
     );
     let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
     assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], provider: Ring } }", format!("{:?}", b));
-    let b = b.with_kx_groups(&[rustls::kx_group::X25519]);
+    let b = b.with_kx_groups(&[rustls::crypto::ring::kx_group::X25519]);
     assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], provider: Ring } }", format!("{:?}", b));
     let b = b
         .with_protocol_versions(&[&rustls::version::TLS13])
@@ -466,7 +466,7 @@ fn test_config_builders_debug() {
     );
     let b = b.with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]);
     assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsKxGroups { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], provider: Ring } }", format!("{:?}", b));
-    let b = b.with_kx_groups(&[rustls::kx_group::X25519]);
+    let b = b.with_kx_groups(&[rustls::crypto::ring::kx_group::X25519]);
     assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVersions { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], provider: Ring } }", format!("{:?}", b));
     let b = b
         .with_protocol_versions(&[&rustls::version::TLS13])
@@ -4011,20 +4011,26 @@ fn test_client_does_not_offer_sha1() {
 
 #[test]
 fn test_client_config_keyshare() {
-    let client_config =
-        make_client_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::SECP384R1]);
-    let server_config =
-        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::SECP384R1]);
+    let client_config = make_client_config_with_kx_groups(
+        KeyType::Rsa,
+        &[rustls::crypto::ring::kx_group::SECP384R1],
+    );
+    let server_config = make_server_config_with_kx_groups(
+        KeyType::Rsa,
+        &[rustls::crypto::ring::kx_group::SECP384R1],
+    );
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     do_handshake_until_error(&mut client, &mut server).unwrap();
 }
 
 #[test]
 fn test_client_config_keyshare_mismatch() {
-    let client_config =
-        make_client_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::SECP384R1]);
+    let client_config = make_client_config_with_kx_groups(
+        KeyType::Rsa,
+        &[rustls::crypto::ring::kx_group::SECP384R1],
+    );
     let server_config =
-        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::X25519]);
+        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::crypto::ring::kx_group::X25519]);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     assert!(do_handshake_until_error(&mut client, &mut server).is_err());
 }
@@ -4035,7 +4041,10 @@ fn test_client_sends_helloretryrequest() {
     // client sends a secp384r1 key share
     let mut client_config = make_client_config_with_kx_groups(
         KeyType::Rsa,
-        &[rustls::kx_group::SECP384R1, rustls::kx_group::X25519],
+        &[
+            rustls::crypto::ring::kx_group::SECP384R1,
+            rustls::crypto::ring::kx_group::X25519,
+        ],
     );
 
     let storage = Arc::new(ClientStorage::new());
@@ -4043,7 +4052,7 @@ fn test_client_sends_helloretryrequest() {
 
     // but server only accepts x25519, so a HRR is required
     let server_config =
-        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::X25519]);
+        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::crypto::ring::kx_group::X25519]);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
@@ -4164,11 +4173,14 @@ fn test_client_rejects_hrr_with_varied_session_id() {
     // client prefers a secp384r1 key share, server only accepts x25519
     let client_config = make_client_config_with_kx_groups(
         KeyType::Rsa,
-        &[rustls::kx_group::SECP384R1, rustls::kx_group::X25519],
+        &[
+            rustls::crypto::ring::kx_group::SECP384R1,
+            rustls::crypto::ring::kx_group::X25519,
+        ],
     );
 
     let server_config =
-        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::X25519]);
+        make_server_config_with_kx_groups(KeyType::Rsa, &[rustls::crypto::ring::kx_group::X25519]);
 
     let (client, server) = make_pair_for_configs(client_config, server_config);
     let (mut client, mut server) = (client.into(), server.into());
@@ -4200,13 +4212,15 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     // first, client sends a x25519 and server agrees. x25519 is inserted
     //   into kx group cache.
     let mut client_config_1 =
-        make_client_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::X25519]);
+        make_client_config_with_kx_groups(KeyType::Rsa, &[rustls::crypto::ring::kx_group::X25519]);
     client_config_1.resumption = Resumption::store(shared_storage.clone());
 
     // second, client only supports secp-384 and so kx group cache
     //   contains an unusable value.
-    let mut client_config_2 =
-        make_client_config_with_kx_groups(KeyType::Rsa, &[rustls::kx_group::SECP384R1]);
+    let mut client_config_2 = make_client_config_with_kx_groups(
+        KeyType::Rsa,
+        &[rustls::crypto::ring::kx_group::SECP384R1],
+    );
     client_config_2.resumption = Resumption::store(shared_storage.clone());
 
     let server_config = make_server_config(KeyType::Rsa);

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -12,6 +12,7 @@ use std::sync::Mutex;
 
 use pki_types::CertificateDer;
 use rustls::client::{ResolvesClientCert, Resumption};
+use rustls::crypto::ring::ALL_CIPHER_SUITES;
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::enums::AlertLevel;
@@ -19,6 +20,7 @@ use rustls::internal::msgs::message::PlainMessage;
 use rustls::server::{ClientHello, ResolvesServerCert, WebPkiClientVerifier};
 #[cfg(feature = "secret_extraction")]
 use rustls::ConnectionTrafficSecrets;
+use rustls::SupportedCipherSuite;
 use rustls::{
     sign, AlertDescription, CertificateError, ConnectionCommon, ContentType, Error, KeyLog,
     PeerIncompatible, PeerMisbehaved, SideData,
@@ -27,7 +29,6 @@ use rustls::{CipherSuite, ProtocolVersion, SignatureScheme};
 use rustls::{ClientConfig, ClientConnection};
 use rustls::{ServerConfig, ServerConnection};
 use rustls::{Stream, StreamOwned};
-use rustls::{SupportedCipherSuite, ALL_CIPHER_SUITES};
 
 mod common;
 use crate::common::*;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3139,7 +3139,7 @@ fn tls13_stateless_resumption() {
     let client_config = Arc::new(client_config);
 
     let mut server_config = make_server_config(kt);
-    server_config.ticketer = rustls::Ticketer::new().unwrap();
+    server_config.ticketer = rustls::crypto::ring::Ticketer::new().unwrap();
     let storage = Arc::new(ServerStorage::new());
     server_config.session_storage = storage.clone();
     let server_config = Arc::new(server_config);

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -270,7 +270,7 @@ pub fn make_server_config_with_versions(
 
 pub fn make_server_config_with_kx_groups(
     kt: KeyType,
-    kx_groups: &[&'static dyn rustls::SupportedKxGroup],
+    kx_groups: &[&'static dyn rustls::crypto::SupportedKxGroup],
 ) -> ServerConfig {
     finish_server_config(
         kt,
@@ -372,7 +372,7 @@ pub fn make_client_config(kt: KeyType) -> ClientConfig {
 
 pub fn make_client_config_with_kx_groups(
     kt: KeyType,
-    kx_groups: &[&'static dyn rustls::SupportedKxGroup],
+    kx_groups: &[&'static dyn rustls::crypto::SupportedKxGroup],
 ) -> ClientConfig {
     let builder = ClientConfig::builder()
         .with_safe_default_cipher_suites()


### PR DESCRIPTION
This branch removes all top-level re-exports except for the "paved path" re-exports we expect all-to-most users will be using. 

An [informal poll](https://hachyderm.io/@djc/110824267001415573) indicates users find it confusing when there are multiple names for the same things. See https://github.com/rustls/rustls/issues/1386 for more discussion.