### PR TITLE
proj: remove dangerous_configuration feature

### DIFF
--- a/bogo/runme
+++ b/bogo/runme
@@ -6,7 +6,7 @@
 set -xe
 
 if [ "x$USE_EXISTING_BOGO_SHIM" = "x" ] ; then
-  cargo build --example bogo_shim --features dangerous_configuration,quic
+  cargo build --example bogo_shim --features quic
 fi
 
 if [ ! -e bogo/ssl/test/runner/runner.test ] ; then

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 members = ["."]
 
 [features]
-dangerous_configuration = ["rustls/dangerous_configuration"]
 quic = ["rustls/quic"]
 
 [dependencies]

--- a/connect-tests/tests/badssl.rs
+++ b/connect-tests/tests/badssl.rs
@@ -123,7 +123,6 @@ mod online {
             .unwrap();
     }
 
-    #[cfg(feature = "dangerous_configuration")]
     mod danger {
         #[test]
         fn self_signed() {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,6 @@ description = "Rustls example code and tests."
 publish = false
 
 [features]
-dangerous_configuration = ["rustls/dangerous_configuration"]
 quic = ["rustls/quic"]
 
 [dependencies]

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10"
 hmac = "0.12.0"
 pki-types = { package = "rustls-pki-types", version = "0.2.0" }
 rand_core = "0.6.0"
-rustls = { path = "../rustls", default-features = false, features = ["logging", "dangerous_configuration", "tls12"] }
+rustls = { path = "../rustls", default-features = false, features = ["logging", "tls12"] }
 rsa = { version = "0.9.0", features = ["sha2"] }
 sha2 = "0.10.0"
 webpki = { package = "rustls-webpki", version = "0.102.0-alpha.1", default-features = false, features = ["alloc", "std"] }

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -16,6 +16,7 @@ fn main() {
 
     let config = rustls::ClientConfig::builder_with_provider(PROVIDER)
         .with_safe_defaults()
+        .dangerous()
         .with_custom_certificate_verifier(certificate_verifier(root_store))
         .with_no_client_auth();
 

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -60,7 +60,7 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherS
 
 pub fn certificate_verifier(
     roots: rustls::RootCertStore,
-) -> Arc<dyn rustls::client::ServerCertVerifier> {
+) -> Arc<dyn rustls::client::danger::ServerCertVerifier> {
     Arc::new(rustls::client::WebPkiServerVerifier::new_with_algorithms(
         roots,
         verify::ALGORITHMS,

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -25,7 +25,6 @@ pki-types = { package = "rustls-pki-types", version = "0.2.1", features = ["std"
 [features]
 default = ["logging", "ring", "tls12"]
 logging = ["log"]
-dangerous_configuration = []
 ring = ["dep:ring", "webpki/ring"]
 secret_extraction = []
 quic = []
@@ -43,7 +42,7 @@ base64 = "0.21"
 [[example]]
 name = "bogo_shim"
 path = "examples/internal/bogo_shim.rs"
-required-features = ["dangerous_configuration", "quic", "tls12", "ring"]
+required-features = ["quic", "tls12", "ring"]
 
 [[example]]
 name = "bench"

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -4,9 +4,8 @@
 // https://boringssl.googlesource.com/boringssl/+/master/ssl/test
 //
 
-use rustls::client::{
-    ClientConfig, ClientConnection, HandshakeSignatureValid, Resumption, WebPkiServerVerifier,
-};
+use rustls::client::danger::HandshakeSignatureValid;
+use rustls::client::{ClientConfig, ClientConnection, Resumption, WebPkiServerVerifier};
 use rustls::crypto::ring::{kx_group, Ticketer, ALL_KX_GROUPS};
 use rustls::crypto::SupportedKxGroup;
 use rustls::internal::msgs::codec::Codec;
@@ -192,7 +191,7 @@ struct DummyClientAuth {
     mandatory: bool,
 }
 
-impl server::ClientCertVerifier for DummyClientAuth {
+impl server::danger::ClientCertVerifier for DummyClientAuth {
     fn offer_client_auth(&self) -> bool {
         true
     }
@@ -210,8 +209,8 @@ impl server::ClientCertVerifier for DummyClientAuth {
         _end_entity: &CertificateDer<'_>,
         _intermediates: &[CertificateDer<'_>],
         _now: UnixTime,
-    ) -> Result<server::ClientCertVerified, Error> {
-        Ok(server::ClientCertVerified::assertion())
+    ) -> Result<server::danger::ClientCertVerified, Error> {
+        Ok(server::danger::ClientCertVerified::assertion())
     }
 
     fn verify_tls12_signature(
@@ -239,7 +238,7 @@ impl server::ClientCertVerifier for DummyClientAuth {
 
 struct DummyServerAuth {}
 
-impl client::ServerCertVerifier for DummyServerAuth {
+impl client::danger::ServerCertVerifier for DummyServerAuth {
     fn verify_server_cert(
         &self,
         _end_entity: &CertificateDer<'_>,
@@ -247,8 +246,8 @@ impl client::ServerCertVerifier for DummyServerAuth {
         _hostname: &ServerName,
         _ocsp: &[u8],
         _now: UnixTime,
-    ) -> Result<client::ServerCertVerified, Error> {
-        Ok(client::ServerCertVerified::assertion())
+    ) -> Result<client::danger::ServerCertVerified, Error> {
+        Ok(client::danger::ServerCertVerified::assertion())
     }
 
     fn verify_tls12_signature(
@@ -570,6 +569,7 @@ fn make_client_cfg(opts: &Options) -> Arc<ClientConfig> {
         .with_kx_groups(&kx_groups)
         .with_protocol_versions(&opts.supported_versions())
         .expect("inconsistent settings")
+        .dangerous()
         .with_custom_certificate_verifier(Arc::new(DummyServerAuth {}));
 
     let mut cfg = if !opts.cert_file.is_empty() && !opts.key_file.is_empty() {

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -70,7 +70,7 @@ use core::marker::PhantomData;
 ///
 /// For a client, _certificate verification_ must be configured either by calling one of:
 ///  - [`ConfigBuilder::with_root_certificates`] or
-///  - [`ConfigBuilder::with_custom_certificate_verifier`] - requires dangerous_configuration feature flag
+///  - [`ConfigBuilder::dangerous.with_custom_certificate_verifier`]
 ///
 /// Next, _certificate sending_ (also known as "client authentication", "mutual TLS", or "mTLS") must be configured
 /// or disabled using one of:
@@ -95,7 +95,7 @@ use core::marker::PhantomData;
 ///
 /// For a server, _certificate verification_ must be configured by calling one of:
 /// - [`ConfigBuilder::with_no_client_auth`] - to not require client authentication (most common)
-/// - [`ConfigBuilder::with_client_cert_verifier`] - to use a custom verifier
+/// - [`ConfigBuilder::dangerous.with_client_cert_verifier`] - to use a custom verifier
 ///
 /// Next, _certificate sending_ must be configured by calling one of:
 /// - [`ConfigBuilder::with_single_cert`] - to send a specific certificate

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -276,7 +276,6 @@ impl ClientConfig {
 
     /// Access configuration options whose use is dangerous and requires
     /// extra care.
-    #[cfg(feature = "dangerous_configuration")]
     pub fn dangerous(&mut self) -> danger::DangerousClientConfig<'_> {
         danger::DangerousClientConfig { cfg: self }
     }
@@ -438,7 +437,6 @@ impl TryFrom<&str> for ServerName {
 }
 
 /// Container for unsafe APIs
-#[cfg(feature = "dangerous_configuration")]
 pub(super) mod danger {
     use alloc::sync::Arc;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -229,11 +229,6 @@
 //!   messages do not contain secret key data, and so are safe to archive without
 //!   affecting session security.  This feature is in the default set.
 //!
-//! - `dangerous_configuration`: this feature enables a `dangerous()` method on
-//!   `ClientConfig` and `ServerConfig` that allows setting inadvisable options,
-//!   such as replacing the certificate verification process.  Applications
-//!   requesting this feature should be reviewed carefully.
-//!
 //! - `quic`: this feature exposes additional constructors and functions
 //!   for using rustls as a TLS library for QUIC.  See the `quic` module for
 //!   details of these.  You will only need this if you're writing a QUIC
@@ -419,14 +414,15 @@ pub mod client {
     };
     pub use handy::ClientSessionMemoryCache;
 
-    #[cfg(feature = "dangerous_configuration")]
-    pub use crate::verify::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-    #[cfg(feature = "dangerous_configuration")]
+    /// Dangerous configuration that should be audited and used with extreme care.
+    pub mod danger {
+        pub use super::client_conn::danger::DangerousClientConfig;
+        pub use crate::verify::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+    }
+
     pub use crate::webpki::{
         verify_server_cert_signed_by_trust_anchor, verify_server_name, WebPkiServerVerifier,
     };
-    #[cfg(feature = "dangerous_configuration")]
-    pub use client_conn::danger::DangerousClientConfig;
 
     pub use crate::msgs::persist::Tls12ClientSessionValue;
     pub use crate::msgs::persist::Tls13ClientSessionValue;
@@ -457,11 +453,12 @@ pub mod server {
     };
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
 
-    #[cfg(feature = "dangerous_configuration")]
-    pub use crate::dns_name::DnsName;
-    #[cfg(feature = "dangerous_configuration")]
-    pub use crate::verify::{ClientCertVerified, ClientCertVerifier};
-    #[cfg(feature = "dangerous_configuration")]
+    /// Dangerous configuration that should be audited and used with extreme care.
+    pub mod danger {
+        pub use crate::dns_name::DnsName;
+        pub use crate::verify::{ClientCertVerified, ClientCertVerifier};
+    }
+
     pub use crate::webpki::ParsedCertificate;
 }
 

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -24,7 +24,6 @@ use crate::verify::{
 /// were sent as part of the server's `Certificate` message. It is in the
 /// same order that the server sent them and may be empty.
 #[allow(dead_code)]
-#[cfg_attr(not(feature = "dangerous_configuration"), allow(unreachable_pub))]
 pub fn verify_server_cert_signed_by_trust_anchor(
     cert: &ParsedCertificate,
     roots: &RootCertStore,
@@ -48,7 +47,6 @@ pub fn verify_server_cert_signed_by_trust_anchor(
 /// Verify that the `end_entity` has a name or alternative name matching the `server_name`
 /// note: this only verifies the name and should be used in conjuction with more verification
 /// like [verify_server_cert_signed_by_trust_anchor]
-#[cfg_attr(not(feature = "dangerous_configuration"), allow(unreachable_pub))]
 pub fn verify_server_name(cert: &ParsedCertificate, server_name: &ServerName) -> Result<(), Error> {
     match server_name {
         ServerName::DnsName(dns_name) => {
@@ -149,7 +147,6 @@ impl WebPkiServerVerifier {
     /// `roots` is the set of trust anchors to trust for issuing server certs.
     /// `supported` is the set of supported algorithms that will be used for
     /// certificate verification and TLS handshake signature verification.
-    #[cfg_attr(not(feature = "dangerous_configuration"), allow(dead_code))]
     pub fn new_with_algorithms(
         roots: impl Into<Arc<RootCertStore>>,
         supported: WebPkiSupportedAlgorithms,
@@ -163,7 +160,6 @@ impl WebPkiServerVerifier {
     /// A full implementation of `ServerCertVerifier::verify_tls12_signature` or
     /// `ClientCertVerifier::verify_tls12_signature`.
     #[cfg(feature = "ring")]
-    #[cfg_attr(not(feature = "dangerous_configuration"), allow(dead_code))]
     pub fn default_verify_tls12_signature(
         message: &[u8],
         cert: &CertificateDer<'_>,
@@ -175,7 +171,6 @@ impl WebPkiServerVerifier {
     /// A full implementation of `ServerCertVerifier::verify_tls13_signature` or
     /// `ClientCertVerifier::verify_tls13_signature`.
     #[cfg(feature = "ring")]
-    #[cfg_attr(not(feature = "dangerous_configuration"), allow(dead_code))]
     pub fn default_verify_tls13_signature(
         message: &[u8],
         cert: &CertificateDer<'_>,
@@ -187,7 +182,6 @@ impl WebPkiServerVerifier {
     /// A full implementation of `ServerCertVerifier::supported_verify_schemes()` or
     /// `ClientCertVerifier::supported_verify_schemes()`.
     #[cfg(feature = "ring")]
-    #[cfg_attr(not(feature = "dangerous_configuration"), allow(dead_code))]
     pub fn default_supported_verify_schemes() -> Vec<SignatureScheme> {
         SUPPORTED_SIG_ALGS.supported_schemes()
     }
@@ -579,7 +573,6 @@ fn verify_tls13(
 }
 
 /// wrapper around internal representation of a parsed certificate. This is used in order to avoid parsing twice when specifying custom verification
-#[cfg_attr(not(feature = "dangerous_configuration"), allow(unreachable_pub))]
 pub struct ParsedCertificate<'a>(pub(crate) webpki::EndEntityCert<'a>);
 
 impl<'a> TryFrom<&'a CertificateDer<'a>> for ParsedCertificate<'a> {

--- a/rustls/tests/bogo.rs
+++ b/rustls/tests/bogo.rs
@@ -3,7 +3,7 @@
 // and run.
 
 #[test]
-#[cfg(all(coverage, feature = "quic", feature = "dangerous_configuration"))]
+#[cfg(all(coverage, feature = "quic"))]
 fn run_bogo_tests() {
     use std::process::Command;
 

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -1,10 +1,6 @@
 //! Tests for configuring and using a [`ClientCertVerifier`] for a server.
 
-#![cfg(all(
-    feature = "dangerous_configuration",
-    feature = "webpki",
-    feature = "ring"
-))]
+#![cfg(all(feature = "webpki", feature = "ring"))]
 
 mod common;
 
@@ -13,9 +9,10 @@ use crate::common::{
     make_client_config_with_versions, make_client_config_with_versions_with_auth,
     make_pair_for_arc_configs, server_name, ErrorFromPeer, KeyType, ALL_KEY_TYPES,
 };
-use rustls::client::{HandshakeSignatureValid, WebPkiServerVerifier};
+use rustls::client::danger::HandshakeSignatureValid;
+use rustls::client::WebPkiServerVerifier;
 use rustls::internal::msgs::handshake::DistinguishedName;
-use rustls::server::{ClientCertVerified, ClientCertVerifier};
+use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::{
     AlertDescription, ClientConnection, DigitallySignedStruct, Error, InvalidMessage, ServerConfig,
     ServerConnection, SignatureScheme,
@@ -27,7 +24,7 @@ use std::sync::Arc;
 
 // Client is authorized!
 fn ver_ok() -> Result<ClientCertVerified, Error> {
-    Ok(rustls::server::ClientCertVerified::assertion())
+    Ok(ClientCertVerified::assertion())
 }
 
 // Use when we shouldn't even attempt verification

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -1,19 +1,14 @@
 //! Tests for configuring and using a [`ServerCertVerifier`] for a client.
 
-#![cfg(all(
-    feature = "dangerous_configuration",
-    feature = "webpki",
-    feature = "ring"
-))]
+#![cfg(all(feature = "webpki", feature = "ring"))]
 
 mod common;
 use crate::common::{
     do_handshake, do_handshake_until_both_error, make_client_config_with_versions,
     make_pair_for_arc_configs, make_server_config, ErrorFromPeer, ALL_KEY_TYPES,
 };
-use rustls::client::{
-    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, WebPkiServerVerifier,
-};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::client::WebPkiServerVerifier;
 use rustls::DigitallySignedStruct;
 use rustls::{AlertDescription, Error, InvalidMessage, SignatureScheme};
 


### PR DESCRIPTION
In an effort to reduce our feature list, this commit replaces the `dangerous_configuration` feature flag with separate `danger` modules.

Cargo features are additive, which means transitive dependencies could enable them for you without explicit opt-in. Using obviously named modules will maintain the property that it's easy to grep for imports, but avoids feature flag bloat and the additive downsides.

After discussion we've chosen to not include the webpki verifier and helper functions as part of the dangerous API surface. Functionality for setting a custom verifier, or implementing one to make assertions about verification status, remain marked as dangerous via their module name.

Updates https://github.com/rustls/rustls/issues/1437