### PR TITLE
Use stable for coverage measurement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
           persist-credentials: false
 
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools
 


### PR DESCRIPTION
The limitation on this is that nightly was required to run doctests, however I don't believe those are contributing much incremental coverage.