### PR TITLE
Export `DangerousClientConfigBuilder`, follow-up doc tweaks

### DIFF
--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -95,7 +95,7 @@ use core::marker::PhantomData;
 ///
 /// For a server, _certificate verification_ must be configured by calling one of:
 /// - [`ConfigBuilder::with_no_client_auth`] - to not require client authentication (most common)
-/// - [`ConfigBuilder::dangerous.with_client_cert_verifier`] - to use a custom verifier
+/// - [`ConfigBuilder::with_client_cert_verifier`] - to use a custom verifier
 ///
 /// Next, _certificate sending_ must be configured by calling one of:
 /// - [`ConfigBuilder::with_single_cert`] - to send a specific certificate

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -70,7 +70,7 @@ use core::marker::PhantomData;
 ///
 /// For a client, _certificate verification_ must be configured either by calling one of:
 ///  - [`ConfigBuilder::with_root_certificates`] or
-///  - [`ConfigBuilder::dangerous()`]`.with_custom_certificate_verifier`
+///  - [`ConfigBuilder::dangerous()`] and [`DangerousClientConfigBuilder::with_custom_certificate_verifier`]
 ///
 /// Next, _certificate sending_ (also known as "client authentication", "mutual TLS", or "mTLS") must be configured
 /// or disabled using one of:
@@ -160,6 +160,7 @@ use core::marker::PhantomData;
 /// [`WantsClientCert`]: crate::client::WantsClientCert
 /// [`WantsServerCert`]: crate::server::WantsServerCert
 /// [`RING`]: crate::crypto::ring::RING
+/// [`DangerousClientConfigBuilder::with_custom_certificate_verifier`]: crate::client::danger::DangerousClientConfigBuilder::with_custom_certificate_verifier
 #[derive(Clone)]
 pub struct ConfigBuilder<Side: ConfigSide, State> {
     pub(crate) state: State,

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -144,7 +144,7 @@ use core::marker::PhantomData;
 /// Additionally, ServerConfig and ClientConfig carry a private field containing a
 /// `&'static dyn `[`CryptoProvider`], from [`ClientConfig::builder_with_provider()`] or
 /// [`ServerConfig::builder_with_provider()`]. This determines which cryptographic backend
-/// is used. The default is [*ring*].
+/// is used. The default is [`RING`].
 ///
 /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 /// [typestate]: http://cliffle.com/blog/rust-typestate/
@@ -159,7 +159,7 @@ use core::marker::PhantomData;
 /// [`ConfigBuilder<ServerConfig, WantsVerifier>`]: struct.ConfigBuilder.html#impl-6
 /// [`WantsClientCert`]: crate::client::WantsClientCert
 /// [`WantsServerCert`]: crate::server::WantsServerCert
-/// [*ring*]: crate::crypto::ring::RING
+/// [`RING`]: crate::crypto::ring::RING
 #[derive(Clone)]
 pub struct ConfigBuilder<Side: ConfigSide, State> {
     pub(crate) state: State,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -416,6 +416,7 @@ pub mod client {
 
     /// Dangerous configuration that should be audited and used with extreme care.
     pub mod danger {
+        pub use super::builder::danger::DangerousClientConfigBuilder;
         pub use super::client_conn::danger::DangerousClientConfig;
         pub use crate::verify::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
     }


### PR DESCRIPTION
This branch lands some small follow-ups to #1483:

* It changes the link display name for the default crypto provider to `RING` to match the target, and the module name.
* It exports `DangerousClientConfigBuilder`.
* It links directly to `DangerousClientConfigBuilder::with_custom_certificate_verifier`.
* It fixes the server config docs broken link to the `with_client_cert_verifier` fn.