### PR TITLE
suites: rework `ConnectionTrafficSecrets`

### DIFF
--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -86,10 +86,6 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
         key: AeadKey,
         iv: Iv,
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
-        let (key, iv) = (
-            ConnectionTrafficSecrets::slice_to_array(key.as_ref()),
-            ConnectionTrafficSecrets::slice_to_array(iv.as_ref()),
-        );
         Ok(ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv })
     }
 }
@@ -114,10 +110,7 @@ impl Tls13AeadAlgorithm for Aes256GcmAead {
         key: AeadKey,
         iv: Iv,
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
-        let iv = iv.as_ref();
-        let (key, salt, iv) =
-            ConnectionTrafficSecrets::slices_to_arrays(key.as_ref(), &iv[..4], &iv[4..]);
-        Ok(ConnectionTrafficSecrets::Aes256Gcm { key, salt, iv })
+        Ok(ConnectionTrafficSecrets::Aes256Gcm { key, iv })
     }
 }
 
@@ -141,10 +134,7 @@ impl Tls13AeadAlgorithm for Aes128GcmAead {
         key: AeadKey,
         iv: Iv,
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
-        let iv = iv.as_ref();
-        let (key, salt, iv) =
-            ConnectionTrafficSecrets::slices_to_arrays(key.as_ref(), &iv[..4], &iv[4..]);
-        Ok(ConnectionTrafficSecrets::Aes128Gcm { key, salt, iv })
+        Ok(ConnectionTrafficSecrets::Aes128Gcm { key, iv })
     }
 }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4845,11 +4845,13 @@ fn test_secret_extraction_enabled() {
         // Comparing secrets for equality is something you should never have to
         // do in production code, so ConnectionTrafficSecrets doesn't implement
         // PartialEq/Eq on purpose. Instead, we have to get creative.
-        fn explode_secrets(s: &ConnectionTrafficSecrets) -> (&[u8], &[u8], &[u8]) {
+        fn explode_secrets(s: &ConnectionTrafficSecrets) -> (&[u8], &[u8]) {
             match s {
-                ConnectionTrafficSecrets::Aes128Gcm { key, salt, iv } => (key, salt, iv),
-                ConnectionTrafficSecrets::Aes256Gcm { key, salt, iv } => (key, salt, iv),
-                ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv } => (key, &[], iv),
+                ConnectionTrafficSecrets::Aes128Gcm { key, iv } => (key.as_ref(), iv.as_ref()),
+                ConnectionTrafficSecrets::Aes256Gcm { key, iv } => (key.as_ref(), iv.as_ref()),
+                ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv } => {
+                    (key.as_ref(), iv.as_ref())
+                }
                 _ => panic!("unexpected secret type"),
             }
         }


### PR DESCRIPTION
This branch is a follow up to https://github.com/rustls/rustls/pull/1484. It updates `ConnectionTrafficSecrets` to hold `AeadKey` and `Iv` instances, instead of byte arrays, removing the need for the `slices_to_arrays` and `slice_to_array` helpers, as [suggested by ctz](https://github.com/rustls/rustls/pull/1484#discussion_r1331477766).