### PR TITLE
Cargo: remove rcgen git patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.4"
+version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
+checksum = "824956d0dca8334758a5b7f7e50518d66ea319330cbceedcf76905c2f6ab30e3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.4"
+version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
+checksum = "122ec64120a49b4563ccaedcbea7818d069ed8e9aa6d829b82d8a4128936b2ab"
 dependencies = [
  "anstream",
  "anstyle",
@@ -612,9 +612,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pem"
-version = "2.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
 dependencies = [
  "base64",
  "serde",
@@ -742,8 +742,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.11.1"
-source = "git+https://github.com/est31/rcgen.git?rev=83e548a06848d923eada1ac66d1a912735b67e79#83e548a06848d923eada1ac66d1a912735b67e79"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4426f9f4d65c83b570885bee479ba4c5e78d7a5286c8a58e3d2570462121b447"
 dependencies = [
  "pem",
  "ring",
@@ -976,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,3 @@ default-members = [
 ]
 exclude = ["admin/rustfmt"]
 resolver = "2"
-
-[patch.crates-io]
-# TODO(XXX): Remove this once rcgen has cut a release w/ CRL support included. Only used in examples.
-rcgen = { git = 'https://github.com/est31/rcgen.git', rev = '83e548a06848d923eada1ac66d1a912735b67e79' }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = "0.10"
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 pki-types = { package = "rustls-pki-types", version = "0.2" }
-rcgen = { version = "0.11.1", features = ["pem"], default-features = false }
+rcgen = { version = "0.11.2", features = ["pem"], default-features = false }
 rustls = { path = "../rustls", features = [ "logging" ]}
 rustls-pemfile = "=2.0.0-alpha.1"
 serde = "1.0"

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -266,6 +266,7 @@ impl TestPki {
             this_update: now,
             next_update: now.add(Duration::from_secs(next_update_seconds)),
             crl_number: rcgen::SerialNumber::from(1234),
+            issuing_distribution_point: None,
             revoked_certs,
             key_identifier_method: rcgen::KeyIdMethod::Sha256,
             alg: &rcgen::PKCS_ECDSA_P256_SHA256,


### PR DESCRIPTION
The `rcgen` crate has cut a 0.11.2 release that includes the CRL functionality we were using a Cargo patch to depend on previously. This commit removes the patch, fixes one breakage in the server acceptor example, and updates the `Cargo.toml` and `Cargo.lock` files.