### PR TITLE
ci: run cargo dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
Now that we're checking in `Cargo.lock` files we'll be getting more Dependabot PRs for semver compatible Cargo dependency updates. This commit switches the tool to run weekly instead of daily so that we don't have to spend as much time triaging these on a day-by-day basis.