### PR TITLE
ci: remove `--locked` from cargo hack daily test

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -109,4 +109,4 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
 
       - name: Check feature powerset
-        run: cargo hack check --locked --feature-powerset --no-dev-deps
+        run: cargo hack check --feature-powerset --no-dev-deps


### PR DESCRIPTION
Running `cargo hack check --locked --feature-powerset` [seems to be failing](https://github.com/rustls/rustls/actions/runs/6316800199/job/17152174888) since #1469 added the `--locked` flag, as it detects that the lockfile needs to be updated each invocation. Updating the lockfile and re-running causes the same error. It looks as though it is removing items from the lockfile based on which features it's testing.

To prevent the daily test from failing, let's remove `--locked` and test the feature powerset with relaxed handling of the `Cargo.lock` file.