### PR TITLE
[3/3] no-std support phase I

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,9 +108,17 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          target: x86_64-unknown-none
 
       - name: cargo build (debug; default features)
         run: cargo build --locked
+        working-directory: rustls
+
+        # this target does _not_ include the libstd crate in its sysroot
+        # it will catch unwanted usage of libstd in _dependencies_
+      - name: cargo build (debug; default features; no-std)
+        run: cargo build --locked --no-default-features --target x86_64-unknown-none
         working-directory: rustls
 
       - name: cargo test (debug; default features)

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -18,7 +18,7 @@ p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecd
 pkcs8 = "0.10.2"
 pki-types = { package = "rustls-pki-types", version = "1" }
 rand_core = { version = "0.6", features = ["getrandom"] }
-rustls = { path = "../rustls", default-features = false, features = ["logging", "tls12"] }
+rustls = { path = "../rustls", default-features = false, features = ["logging", "std", "tls12"] }
 rsa = { version = "0.9", features = ["sha2"], default-features = false }
 sha2 = { version = "0.10", default-features = false }
 signature = "2"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -19,20 +19,21 @@ rustversion = { version = "1.0.6", optional = true }
 aws-lc-rs = { version = "1.6", optional = true, default-features = false, features = ["aws-lc-sys"] }
 log = { version = "0.4.4", optional = true }
 # remove once our MSRV is >= 1.70
-once_cell = "1"
+once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }
 ring = { version = "0.17", optional = true }
 subtle = { version = "2.5.0", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.102.2", features = ["std"], default-features = false }
-pki-types = { package = "rustls-pki-types", version = "1.2", features = ["std"] }
+webpki = { package = "rustls-webpki", version = "0.102.2", features = ["alloc"], default-features = false }
+pki-types = { package = "rustls-pki-types", version = "1.2", features = ["alloc"] }
 zeroize = "1.7"
 
 [features]
-default = ["aws_lc_rs", "logging", "tls12"]
+default = ["logging", "std", "tls12"]
+std = ["aws_lc_rs", "webpki/std", "pki-types/std", "once_cell/std"]
 logging = ["log"]
-aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
+aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs", "std"]
 ring = ["dep:ring", "webpki/ring"]
 tls12 = []
-read_buf = ["rustversion"]
+read_buf = ["rustversion", "std"]
 fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
 
 [dev-dependencies]

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use crate::time_provider::TimeProvider;
 use crate::versions;
 use crate::{crypto::CryptoProvider, msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS};
 
@@ -184,6 +185,7 @@ impl<Side: ConfigSide, State: fmt::Debug> fmt::Debug for ConfigBuilder<Side, Sta
 #[derive(Clone, Debug)]
 pub struct WantsVersions {
     pub(crate) provider: Arc<CryptoProvider>,
+    pub(crate) time_provider: Arc<dyn TimeProvider>,
 }
 
 impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
@@ -248,6 +250,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
             state: WantsVerifier {
                 provider: self.state.provider,
                 versions: versions::EnabledVersions::new(versions),
+                time_provider: self.state.time_provider,
             },
             side: self.side,
         })
@@ -261,6 +264,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
 pub struct WantsVerifier {
     pub(crate) provider: Arc<CryptoProvider>,
     pub(crate) versions: versions::EnabledVersions,
+    pub(crate) time_provider: Arc<dyn TimeProvider>,
 }
 
 /// Helper trait to abstract [`ConfigBuilder`] over building a [`ClientConfig`] or [`ServerConfig`].

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -3,10 +3,10 @@ use crate::versions;
 use crate::{crypto::CryptoProvider, msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS};
 
 use alloc::format;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
-use std::sync::Arc;
 
 #[cfg(doc)]
 use crate::{ClientConfig, ServerConfig};

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -5,6 +5,7 @@ use crate::crypto::CryptoProvider;
 use crate::error::Error;
 use crate::key_log::NoKeyLog;
 use crate::msgs::handshake::CertificateChain;
+use crate::time_provider::TimeProvider;
 use crate::webpki::{self, WebPkiServerVerifier};
 use crate::{verify, versions};
 
@@ -56,6 +57,7 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
                 provider: self.state.provider,
                 versions: self.state.versions,
                 verifier,
+                time_provider: self.state.time_provider,
             },
             side: PhantomData,
         }
@@ -94,6 +96,7 @@ pub(super) mod danger {
                     provider: self.cfg.state.provider,
                     versions: self.cfg.state.versions,
                     verifier,
+                    time_provider: self.cfg.state.time_provider,
                 },
                 side: PhantomData,
             }
@@ -110,6 +113,7 @@ pub struct WantsClientCert {
     provider: Arc<CryptoProvider>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn verify::ServerCertVerifier>,
+    time_provider: Arc<dyn TimeProvider>,
 }
 
 impl ConfigBuilder<ClientConfig, WantsClientCert> {
@@ -161,6 +165,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             enable_early_data: false,
             #[cfg(feature = "tls12")]
             require_ems: cfg!(feature = "fips"),
+            time_provider: self.state.time_provider,
         }
     }
 }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -32,7 +32,6 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Deref, DerefMut};
-use std::error::Error as StdError;
 
 #[cfg(doc)]
 use crate::{crypto, DistinguishedName};
@@ -894,7 +893,8 @@ impl fmt::Display for EarlyDataError {
     }
 }
 
-impl StdError for EarlyDataError {}
+#[cfg(feature = "std")]
+impl std::error::Error for EarlyDataError {}
 
 /// State associated with a client connection.
 #[derive(Debug)]

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -714,6 +714,7 @@ impl DerefMut for ClientConnection {
     }
 }
 
+#[cfg(feature = "std")]
 #[doc(hidden)]
 impl<'a> TryFrom<&'a mut crate::Connection> for &'a mut ClientConnection {
     type Error = ();
@@ -727,6 +728,7 @@ impl<'a> TryFrom<&'a mut crate::Connection> for &'a mut ClientConnection {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<ClientConnection> for crate::Connection {
     fn from(conn: ClientConnection) -> Self {
         Self::Client(conn)

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -337,6 +337,7 @@ impl ClientConfig {
                 .any(|cs| cs.version().version == v)
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn supports_protocol(&self, proto: Protocol) -> bool {
         self.provider
             .cipher_suites
@@ -525,6 +526,7 @@ impl EarlyData {
         matches!(self.state, EarlyDataState::Ready | EarlyDataState::Accepted)
     }
 
+    #[cfg(feature = "std")]
     fn is_accepted(&self) -> bool {
         matches!(
             self.state,
@@ -779,6 +781,7 @@ impl ConnectionCore<ClientConnectionData> {
         Ok(Self::new(state, data, common_state))
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn is_early_data_accepted(&self) -> bool {
         self.data.early_data.is_accepted()
     }

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -1,7 +1,6 @@
 use crate::client;
 use crate::enums::SignatureScheme;
 use crate::error::Error;
-use crate::limited_cache;
 use crate::msgs::handshake::CertificateChain;
 use crate::msgs::persist;
 use crate::sign;
@@ -9,10 +8,7 @@ use crate::NamedGroup;
 
 use pki_types::ServerName;
 
-use alloc::collections::VecDeque;
 use alloc::sync::Arc;
-use core::fmt;
-use std::sync::Mutex;
 
 /// An implementer of `ClientSessionStore` which does nothing.
 #[derive(Debug)]
@@ -40,137 +36,155 @@ impl client::ClientSessionStore for NoClientSessionStorage {
     }
 }
 
-const MAX_TLS13_TICKETS_PER_SERVER: usize = 8;
+#[cfg(feature = "std")]
+mod cache {
+    use alloc::collections::VecDeque;
+    use core::fmt;
+    use std::sync::Mutex;
 
-struct ServerData {
-    kx_hint: Option<NamedGroup>,
+    use crate::limited_cache;
+    use crate::msgs::persist;
+    use crate::NamedGroup;
 
-    // Zero or one TLS1.2 sessions.
-    #[cfg(feature = "tls12")]
-    tls12: Option<persist::Tls12ClientSessionValue>,
+    use pki_types::ServerName;
 
-    // Up to MAX_TLS13_TICKETS_PER_SERVER TLS1.3 tickets, oldest first.
-    tls13: VecDeque<persist::Tls13ClientSessionValue>,
-}
+    const MAX_TLS13_TICKETS_PER_SERVER: usize = 8;
 
-impl Default for ServerData {
-    fn default() -> Self {
-        Self {
-            kx_hint: None,
+    struct ServerData {
+        kx_hint: Option<NamedGroup>,
+
+        // Zero or one TLS1.2 sessions.
+        #[cfg(feature = "tls12")]
+        tls12: Option<super::persist::Tls12ClientSessionValue>,
+
+        // Up to MAX_TLS13_TICKETS_PER_SERVER TLS1.3 tickets, oldest first.
+        tls13: VecDeque<super::persist::Tls13ClientSessionValue>,
+    }
+
+    impl Default for ServerData {
+        fn default() -> Self {
+            Self {
+                kx_hint: None,
+                #[cfg(feature = "tls12")]
+                tls12: None,
+                tls13: VecDeque::with_capacity(MAX_TLS13_TICKETS_PER_SERVER),
+            }
+        }
+    }
+
+    /// An implementer of `ClientSessionStore` that stores everything
+    /// in memory.
+    ///
+    /// It enforces a limit on the number of entries to bound memory usage.
+    pub struct ClientSessionMemoryCache {
+        servers: Mutex<limited_cache::LimitedCache<ServerName<'static>, ServerData>>,
+    }
+
+    impl ClientSessionMemoryCache {
+        /// Make a new ClientSessionMemoryCache.  `size` is the
+        /// maximum number of stored sessions.
+        pub fn new(size: usize) -> Self {
+            let max_servers = size.saturating_add(MAX_TLS13_TICKETS_PER_SERVER - 1)
+                / MAX_TLS13_TICKETS_PER_SERVER;
+            Self {
+                servers: Mutex::new(limited_cache::LimitedCache::new(max_servers)),
+            }
+        }
+    }
+
+    impl super::client::ClientSessionStore for ClientSessionMemoryCache {
+        fn set_kx_hint(&self, server_name: ServerName<'static>, group: NamedGroup) {
+            self.servers
+                .lock()
+                .unwrap()
+                .get_or_insert_default_and_edit(server_name, |data| data.kx_hint = Some(group));
+        }
+
+        fn kx_hint(&self, server_name: &ServerName<'_>) -> Option<NamedGroup> {
+            self.servers
+                .lock()
+                .unwrap()
+                .get(server_name)
+                .and_then(|sd| sd.kx_hint)
+        }
+
+        fn set_tls12_session(
+            &self,
+            _server_name: ServerName<'static>,
+            _value: persist::Tls12ClientSessionValue,
+        ) {
             #[cfg(feature = "tls12")]
-            tls12: None,
-            tls13: VecDeque::with_capacity(MAX_TLS13_TICKETS_PER_SERVER),
+            self.servers
+                .lock()
+                .unwrap()
+                .get_or_insert_default_and_edit(_server_name.clone(), |data| {
+                    data.tls12 = Some(_value)
+                });
+        }
+
+        fn tls12_session(
+            &self,
+            _server_name: &ServerName<'_>,
+        ) -> Option<persist::Tls12ClientSessionValue> {
+            #[cfg(not(feature = "tls12"))]
+            return None;
+
+            #[cfg(feature = "tls12")]
+            self.servers
+                .lock()
+                .unwrap()
+                .get(_server_name)
+                .and_then(|sd| sd.tls12.as_ref().cloned())
+        }
+
+        fn remove_tls12_session(&self, _server_name: &ServerName<'static>) {
+            #[cfg(feature = "tls12")]
+            self.servers
+                .lock()
+                .unwrap()
+                .get_mut(_server_name)
+                .and_then(|data| data.tls12.take());
+        }
+
+        fn insert_tls13_ticket(
+            &self,
+            server_name: ServerName<'static>,
+            value: persist::Tls13ClientSessionValue,
+        ) {
+            self.servers
+                .lock()
+                .unwrap()
+                .get_or_insert_default_and_edit(server_name.clone(), |data| {
+                    if data.tls13.len() == data.tls13.capacity() {
+                        data.tls13.pop_front();
+                    }
+                    data.tls13.push_back(value);
+                });
+        }
+
+        fn take_tls13_ticket(
+            &self,
+            server_name: &ServerName<'static>,
+        ) -> Option<persist::Tls13ClientSessionValue> {
+            self.servers
+                .lock()
+                .unwrap()
+                .get_mut(server_name)
+                .and_then(|data| data.tls13.pop_back())
+        }
+    }
+
+    impl fmt::Debug for ClientSessionMemoryCache {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            // Note: we omit self.servers as it may contain sensitive data.
+            f.debug_struct("ClientSessionMemoryCache")
+                .finish()
         }
     }
 }
 
-/// An implementer of `ClientSessionStore` that stores everything
-/// in memory.
-///
-/// It enforces a limit on the number of entries to bound memory usage.
-pub struct ClientSessionMemoryCache {
-    servers: Mutex<limited_cache::LimitedCache<ServerName<'static>, ServerData>>,
-}
-
-impl ClientSessionMemoryCache {
-    /// Make a new ClientSessionMemoryCache.  `size` is the
-    /// maximum number of stored sessions.
-    pub fn new(size: usize) -> Self {
-        let max_servers =
-            size.saturating_add(MAX_TLS13_TICKETS_PER_SERVER - 1) / MAX_TLS13_TICKETS_PER_SERVER;
-        Self {
-            servers: Mutex::new(limited_cache::LimitedCache::new(max_servers)),
-        }
-    }
-}
-
-impl client::ClientSessionStore for ClientSessionMemoryCache {
-    fn set_kx_hint(&self, server_name: ServerName<'static>, group: NamedGroup) {
-        self.servers
-            .lock()
-            .unwrap()
-            .get_or_insert_default_and_edit(server_name, |data| data.kx_hint = Some(group));
-    }
-
-    fn kx_hint(&self, server_name: &ServerName<'_>) -> Option<NamedGroup> {
-        self.servers
-            .lock()
-            .unwrap()
-            .get(server_name)
-            .and_then(|sd| sd.kx_hint)
-    }
-
-    fn set_tls12_session(
-        &self,
-        _server_name: ServerName<'static>,
-        _value: persist::Tls12ClientSessionValue,
-    ) {
-        #[cfg(feature = "tls12")]
-        self.servers
-            .lock()
-            .unwrap()
-            .get_or_insert_default_and_edit(_server_name.clone(), |data| data.tls12 = Some(_value));
-    }
-
-    fn tls12_session(
-        &self,
-        _server_name: &ServerName<'_>,
-    ) -> Option<persist::Tls12ClientSessionValue> {
-        #[cfg(not(feature = "tls12"))]
-        return None;
-
-        #[cfg(feature = "tls12")]
-        self.servers
-            .lock()
-            .unwrap()
-            .get(_server_name)
-            .and_then(|sd| sd.tls12.as_ref().cloned())
-    }
-
-    fn remove_tls12_session(&self, _server_name: &ServerName<'static>) {
-        #[cfg(feature = "tls12")]
-        self.servers
-            .lock()
-            .unwrap()
-            .get_mut(_server_name)
-            .and_then(|data| data.tls12.take());
-    }
-
-    fn insert_tls13_ticket(
-        &self,
-        server_name: ServerName<'static>,
-        value: persist::Tls13ClientSessionValue,
-    ) {
-        self.servers
-            .lock()
-            .unwrap()
-            .get_or_insert_default_and_edit(server_name.clone(), |data| {
-                if data.tls13.len() == data.tls13.capacity() {
-                    data.tls13.pop_front();
-                }
-                data.tls13.push_back(value);
-            });
-    }
-
-    fn take_tls13_ticket(
-        &self,
-        server_name: &ServerName<'static>,
-    ) -> Option<persist::Tls13ClientSessionValue> {
-        self.servers
-            .lock()
-            .unwrap()
-            .get_mut(server_name)
-            .and_then(|data| data.tls13.pop_back())
-    }
-}
-
-impl fmt::Debug for ClientSessionMemoryCache {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Note: we omit self.servers as it may contain sensitive data.
-        f.debug_struct("ClientSessionMemoryCache")
-            .finish()
-    }
-}
+#[cfg(feature = "std")]
+pub use cache::ClientSessionMemoryCache;
 
 #[derive(Debug)]
 pub(super) struct FailResolveClientCert {}

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -30,7 +30,7 @@ use crate::client::client_conn::ClientConnectionData;
 use crate::client::common::ClientHelloDetails;
 use crate::client::{tls13, ClientConfig};
 
-use pki_types::{ServerName, UnixTime};
+use pki_types::ServerName;
 
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
@@ -68,7 +68,12 @@ fn find_session(
             None
         })
         .and_then(|resuming| {
-            let retrieved = persist::Retrieved::new(resuming, UnixTime::now());
+            let now = config
+                .current_time()
+                .map_err(|_err| debug!("Could not get current time: {_err}"))
+                .ok()?;
+
+            let retrieved = persist::Retrieved::new(resuming, now);
             match retrieved.has_expired() {
                 false => Some(retrieved),
                 true => None,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -40,7 +40,7 @@ use crate::client::common::ServerCertDetails;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails};
 use crate::client::{hs, ClientConfig, ClientSessionStore};
 
-use pki_types::{ServerName, UnixTime};
+use pki_types::ServerName;
 use subtle::ConstantTimeEq;
 
 use alloc::boxed::Box;
@@ -713,6 +713,9 @@ impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
             .cert_chain
             .split_first()
             .ok_or(Error::NoCertificatesPresented)?;
+
+        let now = self.config.current_time()?;
+
         let cert_verified = self
             .config
             .verifier
@@ -721,7 +724,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
                 intermediates,
                 &self.server_name,
                 &self.server_cert.ocsp_response,
-                UnixTime::now(),
+                now,
             )
             .map_err(|err| {
                 cx.common
@@ -968,6 +971,7 @@ impl State<ClientConnectionData> for ExpectFinished {
             .start_traffic(&mut cx.sendable_plaintext);
 
         let st = ExpectTraffic {
+            config: Arc::clone(&st.config),
             session_storage: Arc::clone(&st.config.resumption.store),
             server_name: st.server_name,
             suite: st.suite,
@@ -993,6 +997,7 @@ impl State<ClientConnectionData> for ExpectFinished {
 // In this state we can be sent tickets, key updates,
 // and application data.
 struct ExpectTraffic {
+    config: Arc<ClientConfig>,
     session_storage: Arc<dyn ClientSessionStore>,
     server_name: ServerName<'static>,
     suite: &'static Tls13CipherSuite,
@@ -1021,6 +1026,8 @@ impl ExpectTraffic {
             .key_schedule
             .resumption_master_secret_and_derive_ticket_psk(&handshake_hash, &nst.nonce.0);
 
+        let now = self.config.current_time()?;
+
         #[allow(unused_mut)]
         let mut value = persist::Tls13ClientSessionValue::new(
             self.suite,
@@ -1030,7 +1037,7 @@ impl ExpectTraffic {
                 .peer_certificates
                 .clone()
                 .unwrap_or_default(),
-            UnixTime::now(),
+            now,
             nst.lifetime,
             nst.age_add,
             nst.max_early_data_size()

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -39,6 +39,7 @@ pub struct CommonState {
     sent_fatal_alert: bool,
     /// If the peer has signaled end of stream.
     pub(crate) has_received_close_notify: bool,
+    #[cfg(feature = "std")]
     pub(crate) has_seen_eof: bool,
     pub(crate) received_middlebox_ccs: u8,
     pub(crate) peer_certificates: Option<CertificateChain<'static>>,
@@ -67,6 +68,7 @@ impl CommonState {
             early_traffic: false,
             sent_fatal_alert: false,
             has_received_close_notify: false,
+            #[cfg(feature = "std")]
             has_seen_eof: false,
             received_middlebox_ccs: 0,
             peer_certificates: None,

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -243,6 +243,7 @@ impl CommonState {
         Ok(written)
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
         debug_assert!(self.early_traffic);
         debug_assert!(self.record_layer.is_encrypting());

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -182,20 +182,6 @@ impl CommonState {
         }
     }
 
-    /// Send plaintext application data, fragmenting and
-    /// encrypting it as it goes out.
-    ///
-    /// If internal buffers are too small, this function will not accept
-    /// all the data.
-    pub(crate) fn buffer_plaintext(
-        &mut self,
-        payload: OutboundChunks<'_>,
-        sendable_plaintext: &mut ChunkVecBuffer,
-    ) -> usize {
-        self.perhaps_write_key_update();
-        self.send_plain(payload, Limit::Yes, sendable_plaintext)
-    }
-
     pub(crate) fn write_plaintext(
         &mut self,
         payload: OutboundChunks<'_>,
@@ -243,19 +229,6 @@ impl CommonState {
         Ok(written)
     }
 
-    #[cfg(feature = "std")]
-    pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
-        debug_assert!(self.early_traffic);
-        debug_assert!(self.record_layer.is_encrypting());
-
-        if data.is_empty() {
-            // Don't send empty fragments.
-            return 0;
-        }
-
-        self.send_appdata_encrypt(data.into(), Limit::Yes)
-    }
-
     // Changing the keys must not span any fragmented handshake
     // messages.  Otherwise the defragmented messages will have
     // been protected with two different record layer protections,
@@ -289,6 +262,7 @@ impl CommonState {
         // be out by whatever the cipher+record overhead is.  That's a
         // constant and predictable amount, so it's not a terrible issue.
         let len = match limit {
+            #[cfg(feature = "std")]
             Limit::Yes => self
                 .sendable_tls
                 .apply_limit(payload.len()),
@@ -327,30 +301,6 @@ impl CommonState {
 
         let em = self.record_layer.encrypt_outgoing(m);
         self.queue_tls_message(em);
-    }
-
-    /// Encrypt and send some plaintext `data`.  `limit` controls
-    /// whether the per-connection buffer limits apply.
-    ///
-    /// Returns the number of bytes written from `data`: this might
-    /// be less than `data.len()` if buffer limits were exceeded.
-    fn send_plain(
-        &mut self,
-        payload: OutboundChunks<'_>,
-        limit: Limit,
-        sendable_plaintext: &mut ChunkVecBuffer,
-    ) -> usize {
-        if !self.may_send_application_data {
-            // If we haven't completed handshaking, buffer
-            // plaintext to send once we do.
-            let len = match limit {
-                Limit::Yes => sendable_plaintext.append_limited_copy(payload),
-                Limit::No => sendable_plaintext.append(payload.to_vec()),
-            };
-            return len;
-        }
-
-        self.send_plain_non_buffering(payload, limit)
     }
 
     fn send_plain_non_buffering(&mut self, payload: OutboundChunks<'_>, limit: Limit) -> usize {
@@ -671,6 +621,59 @@ impl CommonState {
                 .encode(),
         );
     }
+}
+
+#[cfg(feature = "std")]
+impl CommonState {
+    /// Send plaintext application data, fragmenting and
+    /// encrypting it as it goes out.
+    ///
+    /// If internal buffers are too small, this function will not accept
+    /// all the data.
+    pub(crate) fn buffer_plaintext(
+        &mut self,
+        payload: OutboundChunks<'_>,
+        sendable_plaintext: &mut ChunkVecBuffer,
+    ) -> usize {
+        self.perhaps_write_key_update();
+        self.send_plain(payload, Limit::Yes, sendable_plaintext)
+    }
+
+    pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
+        debug_assert!(self.early_traffic);
+        debug_assert!(self.record_layer.is_encrypting());
+
+        if data.is_empty() {
+            // Don't send empty fragments.
+            return 0;
+        }
+
+        self.send_appdata_encrypt(data.into(), Limit::Yes)
+    }
+
+    /// Encrypt and send some plaintext `data`.  `limit` controls
+    /// whether the per-connection buffer limits apply.
+    ///
+    /// Returns the number of bytes written from `data`: this might
+    /// be less than `data.len()` if buffer limits were exceeded.
+    fn send_plain(
+        &mut self,
+        payload: OutboundChunks<'_>,
+        limit: Limit,
+        sendable_plaintext: &mut ChunkVecBuffer,
+    ) -> usize {
+        if !self.may_send_application_data {
+            // If we haven't completed handshaking, buffer
+            // plaintext to send once we do.
+            let len = match limit {
+                Limit::Yes => sendable_plaintext.append_limited_copy(payload),
+                Limit::No => sendable_plaintext.append(payload.to_vec()),
+            };
+            return len;
+        }
+
+        self.send_plain_non_buffering(payload, limit)
+    }
 
     pub(crate) fn perhaps_write_key_update(&mut self) {
         if let Some(message) = self.queued_key_update_message.take() {
@@ -778,6 +781,7 @@ pub(crate) enum Protocol {
 }
 
 enum Limit {
+    #[cfg(feature = "std")]
     Yes,
     No,
 }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -489,6 +489,7 @@ impl<Data> ConnectionCommon<Data> {
     ///
     /// This is a shortcut to the `process_new_packets()` -> `process_msg()` ->
     /// `process_handshake_messages()` path, specialized for the first handshake message.
+    #[cfg(feature = "std")]
     pub(crate) fn first_handshake_message(&mut self) -> Result<Option<Message<'static>>, Error> {
         let mut deframer_buffer = self.deframer_buffer.borrow();
         let res = self

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -505,6 +505,7 @@ impl<Data> ConnectionCommon<Data> {
         }
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn replace_state(&mut self, new: Box<dyn State<Data>>) {
         self.core.state = Ok(new);
     }

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -3,6 +3,7 @@
 use alloc::vec::Vec;
 use core::num::NonZeroUsize;
 use core::{fmt, mem};
+#[cfg(feature = "std")]
 use std::error::Error as StdError;
 
 use super::UnbufferedConnectionCommon;
@@ -512,6 +513,7 @@ impl fmt::Display for EncodeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl StdError for EncodeError {}
 
 /// Errors that may arise when encrypting application data
@@ -542,6 +544,7 @@ impl fmt::Display for EncryptError {
     }
 }
 
+#[cfg(feature = "std")]
 impl StdError for EncryptError {}
 
 /// Provided buffer was too small

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -1,7 +1,6 @@
 use alloc::boxed::Box;
 use alloc::string::ToString;
 use core::fmt;
-use std::error::Error as StdError;
 
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::Error;
@@ -103,7 +102,8 @@ impl fmt::Display for UnsupportedOperationError {
     }
 }
 
-impl StdError for UnsupportedOperationError {}
+#[cfg(feature = "std")]
+impl std::error::Error for UnsupportedOperationError {}
 
 /// How a TLS1.2 `key_block` is partitioned.
 ///

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod hash;
 pub(crate) mod hmac;
 pub(crate) mod kx;
 pub(crate) mod quic;
+#[cfg(feature = "std")]
 pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
 pub(crate) mod tls12;
@@ -172,6 +173,7 @@ pub mod kx_group {
 }
 
 pub use kx::ALL_KX_GROUPS;
+#[cfg(feature = "std")]
 pub use ticketer::Ticketer;
 
 /// Compatibility shims between ring 0.16.x and 0.17.x API

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -6,6 +6,7 @@ use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
+#[cfg(feature = "std")]
 use std::time::SystemTimeError;
 
 /// rustls reports protocol errors using this type.
@@ -527,6 +528,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<SystemTimeError> for Error {
     #[inline]
     fn from(_: SystemTimeError) -> Self {
@@ -706,6 +708,7 @@ mod tests {
         assert_eq!(err, Error::FailedToGetRandomBytes);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn time_error_mapping() {
         use std::time::SystemTime;

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -6,7 +6,6 @@ use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use std::error::Error as StdError;
 use std::time::SystemTimeError;
 
 /// rustls reports protocol errors using this type.
@@ -535,7 +534,8 @@ impl From<SystemTimeError> for Error {
     }
 }
 
-impl StdError for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 impl From<rand::GetRandomFailed> for Error {
     fn from(_: rand::GetRandomFailed) -> Self {

--- a/rustls/src/key_log.rs
+++ b/rustls/src/key_log.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-#[cfg(doc)]
+#[cfg(all(doc, feature = "std"))]
 use crate::KeyLogFile;
 
 /// This trait represents the ability to do something useful

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -582,6 +582,7 @@ pub mod server {
         ClientCertVerifierBuilder, ParsedCertificate, VerifierBuilderError, WebPkiClientVerifier,
     };
     pub use builder::WantsServerCert;
+    #[cfg(feature = "std")]
     pub use handy::ResolvesServerCertUsingSni;
     pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
     pub use server_conn::StoresServerSessions;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -507,7 +507,11 @@ pub use crate::msgs::enums::NamedGroup;
 pub use crate::msgs::ffdhe_groups;
 pub use crate::msgs::handshake::DistinguishedName;
 pub use crate::stream::{Stream, StreamOwned};
-pub use crate::suites::{ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite};
+pub use crate::suites::{
+    CipherSuiteCommon, ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite,
+};
+#[cfg(feature = "std")]
+pub use crate::ticketer::TicketSwitcher;
 #[cfg(feature = "tls12")]
 pub use crate::tls12::Tls12CipherSuite;
 pub use crate::tls13::Tls13CipherSuite;
@@ -607,6 +611,7 @@ pub mod sign {
 /// APIs for implementing QUIC TLS
 pub mod quic;
 
+#[cfg(feature = "std")]
 /// APIs for implementing TLS tickets
 pub mod ticketer;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -404,6 +404,7 @@ mod bs_debug;
 mod builder;
 mod enums;
 mod key_log;
+#[cfg(feature = "std")]
 mod key_log_file;
 mod suites;
 mod versions;
@@ -502,6 +503,7 @@ pub use crate::error::{
     PeerMisbehaved,
 };
 pub use crate::key_log::{KeyLog, NoKeyLog};
+#[cfg(feature = "std")]
 pub use crate::key_log_file::KeyLogFile;
 pub use crate::msgs::enums::NamedGroup;
 pub use crate::msgs::ffdhe_groups;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -612,3 +612,5 @@ pub mod ticketer;
 
 /// This is the rustls manual.
 pub mod manual;
+
+pub mod time_provider;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -389,6 +389,7 @@ mod hash_hs;
 mod limited_cache;
 mod rand;
 mod record_layer;
+#[cfg(feature = "std")]
 mod stream;
 #[cfg(feature = "tls12")]
 mod tls12;
@@ -508,6 +509,7 @@ pub use crate::key_log_file::KeyLogFile;
 pub use crate::msgs::enums::NamedGroup;
 pub use crate::msgs::ffdhe_groups;
 pub use crate::msgs::handshake::DistinguishedName;
+#[cfg(feature = "std")]
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     CipherSuiteCommon, ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -536,6 +536,7 @@ pub mod client {
         ResolvesClientCert, Resumption, Tls12Resumption, UnbufferedClientConnection,
         WriteEarlyData,
     };
+    #[cfg(feature = "std")]
     pub use handy::ClientSessionMemoryCache;
 
     /// Dangerous configuration that should be audited and used with extreme care.

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -538,10 +538,11 @@ pub mod client {
 
     pub use builder::WantsClientCert;
     pub use client_conn::{
-        ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore, EarlyDataError,
-        ResolvesClientCert, Resumption, Tls12Resumption, UnbufferedClientConnection,
-        WriteEarlyData,
+        ClientConfig, ClientConnectionData, ClientSessionStore, EarlyDataError, ResolvesClientCert,
+        Resumption, Tls12Resumption, UnbufferedClientConnection,
     };
+    #[cfg(feature = "std")]
+    pub use client_conn::{ClientConnection, WriteEarlyData};
     #[cfg(feature = "std")]
     pub use handy::ClientSessionMemoryCache;
 
@@ -561,7 +562,9 @@ pub mod client {
     pub use crate::msgs::persist::Tls13ClientSessionValue;
 }
 
-pub use client::{ClientConfig, ClientConnection};
+pub use client::ClientConfig;
+#[cfg(feature = "std")]
+pub use client::ClientConnection;
 
 /// Items for use in a server.
 pub mod server {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -586,11 +586,11 @@ pub mod server {
     pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
     pub use server_conn::StoresServerSessions;
     pub use server_conn::{
-        Accepted, Acceptor, ServerConfig, ServerConnectionData, UnbufferedServerConnection,
+        Accepted, ServerConfig, ServerConnectionData, UnbufferedServerConnection,
     };
-    pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
     #[cfg(feature = "std")]
-    pub use server_conn::{ReadEarlyData, ServerConnection};
+    pub use server_conn::{Acceptor, ReadEarlyData, ServerConnection};
+    pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
 
     /// Dangerous configuration that should be audited and used with extreme care.
     pub mod danger {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -495,8 +495,8 @@ pub mod unbuffered {
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier, WantsVersions};
 pub use crate::common_state::{CommonState, IoState, Side};
 #[cfg(feature = "std")]
-pub use crate::conn::Connection;
-pub use crate::conn::{ConnectionCommon, Reader, SideData, Writer};
+pub use crate::conn::{Connection, Reader};
+pub use crate::conn::{ConnectionCommon, SideData, Writer};
 pub use crate::enums::{
     AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,
     SignatureScheme,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -495,8 +495,8 @@ pub mod unbuffered {
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier, WantsVersions};
 pub use crate::common_state::{CommonState, IoState, Side};
 #[cfg(feature = "std")]
-pub use crate::conn::{Connection, Reader};
-pub use crate::conn::{ConnectionCommon, SideData, Writer};
+pub use crate::conn::{Connection, Reader, Writer};
+pub use crate::conn::{ConnectionCommon, SideData};
 pub use crate::enums::{
     AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,
     SignatureScheme,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -386,6 +386,7 @@ mod conn;
 pub mod crypto;
 mod error;
 mod hash_hs;
+#[cfg(feature = "std")]
 mod limited_cache;
 mod rand;
 mod record_layer;
@@ -582,9 +583,11 @@ pub mod server {
         ClientCertVerifierBuilder, ParsedCertificate, VerifierBuilderError, WebPkiClientVerifier,
     };
     pub use builder::WantsServerCert;
+    pub use handy::NoServerSessionStorage;
     #[cfg(feature = "std")]
     pub use handy::ResolvesServerCertUsingSni;
-    pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
+    #[cfg(feature = "std")]
+    pub use handy::ServerSessionMemoryCache;
     pub use server_conn::StoresServerSessions;
     pub use server_conn::{
         Accepted, ServerConfig, ServerConnectionData, UnbufferedServerConnection,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -352,7 +352,7 @@ extern crate alloc;
 // is in `std::prelude` but not in `core::prelude`. This helps maintain no-std support as even
 // developers that are not interested in, or aware of, no-std support and / or that never run
 // `cargo build --no-default-features` locally will get errors when they rely on `std::prelude` API.
-#[cfg(not(test))]
+#[cfg(all(feature = "std", not(test)))]
 extern crate std;
 
 // Import `test` sysroot crate for `Bencher` definitions.

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -583,10 +583,11 @@ pub mod server {
     pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
     pub use server_conn::StoresServerSessions;
     pub use server_conn::{
-        Accepted, Acceptor, ReadEarlyData, ServerConfig, ServerConnection, ServerConnectionData,
-        UnbufferedServerConnection,
+        Accepted, Acceptor, ServerConfig, ServerConnectionData, UnbufferedServerConnection,
     };
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
+    #[cfg(feature = "std")]
+    pub use server_conn::{ReadEarlyData, ServerConnection};
 
     /// Dangerous configuration that should be audited and used with extreme care.
     pub mod danger {
@@ -594,7 +595,9 @@ pub mod server {
     }
 }
 
-pub use server::{ServerConfig, ServerConnection};
+pub use server::ServerConfig;
+#[cfg(feature = "std")]
+pub use server::ServerConnection;
 
 /// All defined protocol versions appear in this module.
 ///

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -494,7 +494,9 @@ pub mod unbuffered {
 // The public interface is:
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier, WantsVersions};
 pub use crate::common_state::{CommonState, IoState, Side};
-pub use crate::conn::{Connection, ConnectionCommon, Reader, SideData, Writer};
+#[cfg(feature = "std")]
+pub use crate::conn::Connection;
+pub use crate::conn::{ConnectionCommon, Reader, SideData, Writer};
 pub use crate::enums::{
     AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,
     SignatureScheme,

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -242,6 +242,7 @@ impl MessageDeframer {
     }
 
     /// Allow pushing handshake messages directly into the buffer.
+    #[cfg(feature = "std")]
     pub(crate) fn push(
         &mut self,
         version: ProtocolVersion,

--- a/rustls/src/msgs/message/inbound_plain.rs
+++ b/rustls/src/msgs/message/inbound_plain.rs
@@ -23,7 +23,7 @@ impl InboundPlainMessage<'_> {
         self.typ == ContentType::ChangeCipherSpec && self.payload == [0x01]
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "std"))]
     pub(crate) fn into_owned(self) -> super::PlainMessage {
         super::PlainMessage {
             version: self.version,

--- a/rustls/src/msgs/message/mod.rs
+++ b/rustls/src/msgs/message/mod.rs
@@ -183,6 +183,7 @@ impl Message<'_> {
         }
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn into_owned(self) -> Message<'static> {
         let Self { version, payload } = self;
         Message {

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -406,9 +406,9 @@ impl ServerSessionValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::enums::*;
     use crate::msgs::codec::{Codec, Reader};
 
+    #[cfg(feature = "std")]
     #[test]
     fn serversessionvalue_is_debug() {
         let ssv = ServerSessionValue::new(

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -118,7 +118,10 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             cert_resolver,
             ignore_client_order: false,
             max_fragment_size: None,
+            #[cfg(feature = "std")]
             session_storage: handy::ServerSessionMemoryCache::new(256),
+            #[cfg(not(feature = "std"))]
+            session_storage: Arc::new(handy::NoServerSessionStorage {}),
             ticketer: Arc::new(handy::NeverProducesTickets {}),
             alpn_protocols: Vec::new(),
             versions: self.state.versions,

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -4,6 +4,7 @@ use crate::error::Error;
 use crate::msgs::handshake::CertificateChain;
 use crate::server::handy;
 use crate::server::{ResolvesServerCert, ServerConfig};
+use crate::time_provider::TimeProvider;
 use crate::verify::{ClientCertVerifier, NoClientAuth};
 use crate::versions;
 use crate::NoKeyLog;
@@ -25,6 +26,7 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
                 provider: self.state.provider,
                 versions: self.state.versions,
                 verifier: client_cert_verifier,
+                time_provider: self.state.time_provider,
             },
             side: PhantomData,
         }
@@ -45,6 +47,7 @@ pub struct WantsServerCert {
     provider: Arc<CryptoProvider>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn ClientCertVerifier>,
+    time_provider: Arc<dyn TimeProvider>,
 }
 
 impl ConfigBuilder<ServerConfig, WantsServerCert> {
@@ -126,6 +129,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             send_tls13_tickets: 4,
             #[cfg(feature = "tls12")]
             require_ems: cfg!(feature = "fips"),
+            time_provider: self.state.time_provider,
         }
     }
 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -639,6 +639,7 @@ impl DerefMut for ServerConnection {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<ServerConnection> for crate::Connection {
     fn from(conn: ServerConnection) -> Self {
         Self::Server(conn)

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -10,6 +10,7 @@ use crate::msgs::base::Payload;
 use crate::msgs::handshake::{ClientHelloPayload, ProtocolName, ServerExtension};
 use crate::msgs::message::Message;
 use crate::suites::ExtractedSecrets;
+use crate::time_provider::{DefaultTimeProvider, TimeProvider};
 use crate::vecbuf::ChunkVecBuffer;
 use crate::verify;
 use crate::versions;
@@ -400,7 +401,10 @@ impl ServerConfig {
         provider: Arc<CryptoProvider>,
     ) -> ConfigBuilder<Self, WantsVersions> {
         ConfigBuilder {
-            state: WantsVersions { provider },
+            state: WantsVersions {
+                provider,
+                time_provider: Arc::new(DefaultTimeProvider),
+            },
             side: PhantomData,
         }
     }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -213,7 +213,9 @@ impl<'a> ClientHello<'a> {
 /// # Defaults
 ///
 /// * [`ServerConfig::max_fragment_size`]: the default is `None` (meaning 16kB).
-/// * [`ServerConfig::session_storage`]: the default stores 256 sessions in memory.
+/// * [`ServerConfig::session_storage`]: if the `std` feature is enabled, the default stores 256
+///   sessions in memory. If the `std` feature is not enabled, the default is to not store any
+///   sessions.
 /// * [`ServerConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ServerConfig::key_log`]: key material is not logged.
 /// * [`ServerConfig::send_tls13_tickets`]: 4 tickets are sent.

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,5 +1,7 @@
 use crate::builder::ConfigBuilder;
-use crate::common_state::{CommonState, Protocol, Side, State};
+#[cfg(feature = "std")]
+use crate::common_state::Protocol;
+use crate::common_state::{CommonState, Side, State};
 use crate::conn::{ConnectionCommon, ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::CryptoProvider;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
@@ -479,6 +481,7 @@ impl ServerConfig {
                 .any(|cs| cs.version().version == v)
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn supports_protocol(&self, proto: Protocol) -> bool {
         self.provider
             .cipher_suites
@@ -999,6 +1002,7 @@ impl ConnectionCore<ServerConnectionData> {
         ))
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn reject_early_data(&mut self) {
         assert!(
             self.common_state.is_handshaking(),
@@ -1007,6 +1011,7 @@ impl ConnectionCore<ServerConnectionData> {
         self.data.early_data.reject();
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn get_sni_str(&self) -> Option<&str> {
         self.data.get_sni_str()
     }
@@ -1022,6 +1027,7 @@ pub struct ServerConnectionData {
 }
 
 impl ServerConnectionData {
+    #[cfg(feature = "std")]
     pub(super) fn get_sni_str(&self) -> Option<&str> {
         self.sni.as_ref().map(AsRef::as_ref)
     }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -298,12 +298,15 @@ mod client_hello {
             cx.common.peer_certificates = resumedata.client_cert_chain;
 
             if self.send_ticket {
+                let now = self.config.current_time()?;
+
                 emit_ticket(
                     &secrets,
                     &mut self.transcript,
                     self.using_ems,
                     cx,
                     &*self.config.ticketer,
+                    now,
                 )?;
             }
             emit_ccs(cx.common);
@@ -538,9 +541,11 @@ impl State<ServerConnectionData> for ExpectCertificate {
                 None
             }
             Some((end_entity, intermediates)) => {
+                let now = self.config.current_time()?;
+
                 self.config
                     .verifier
-                    .verify_client_cert(end_entity, intermediates, UnixTime::now())
+                    .verify_client_cert(end_entity, intermediates, now)
                     .map_err(|err| {
                         cx.common
                             .send_cert_verify_error_alert(err)
@@ -832,9 +837,9 @@ fn emit_ticket(
     using_ems: bool,
     cx: &mut ServerContext<'_>,
     ticketer: &dyn ProducesTickets,
+    now: UnixTime,
 ) -> Result<(), Error> {
-    let plain =
-        get_server_connection_value_tls12(secrets, using_ems, cx, UnixTime::now()).get_encoding();
+    let plain = get_server_connection_value_tls12(secrets, using_ems, cx, now).get_encoding();
 
     // If we can't produce a ticket for some reason, we can't
     // report an error. Send an empty one.
@@ -928,12 +933,9 @@ impl State<ServerConnectionData> for ExpectFinished {
 
         // Save connection, perhaps
         if !self.resuming && !self.session_id.is_empty() {
-            let value = get_server_connection_value_tls12(
-                &self.secrets,
-                self.using_ems,
-                cx,
-                UnixTime::now(),
-            );
+            let now = self.config.current_time()?;
+
+            let value = get_server_connection_value_tls12(&self.secrets, self.using_ems, cx, now);
 
             let worked = self
                 .config
@@ -950,12 +952,14 @@ impl State<ServerConnectionData> for ExpectFinished {
         self.transcript.add_message(&m);
         if !self.resuming {
             if self.send_ticket {
+                let now = self.config.current_time()?;
                 emit_ticket(
                     &self.secrets,
                     &mut self.transcript,
                     self.using_ems,
                     cx,
                     &*self.config.ticketer,
+                    now,
                 )?;
             }
             emit_ccs(cx.common);

--- a/rustls/src/time_provider.rs
+++ b/rustls/src/time_provider.rs
@@ -1,0 +1,30 @@
+//! The library's source of time.
+
+use core::fmt::Debug;
+
+use pki_types::UnixTime;
+
+/// An object that provides the current time.
+///
+/// This is used to, for example, check if a certificate has expired during
+/// certificate validation, or to check the age of a ticket.
+pub trait TimeProvider: Debug + Send + Sync {
+    /// Returns the current wall time.
+    ///
+    /// This is not required to be monotonic.
+    ///
+    /// Return `None` if unable to retrieve the time.
+    fn current_time(&self) -> Option<UnixTime>;
+}
+
+#[derive(Debug)]
+#[cfg(feature = "std")]
+/// Default `TimeProvider` implementation that uses `std`
+pub struct DefaultTimeProvider;
+
+#[cfg(feature = "std")]
+impl TimeProvider for DefaultTimeProvider {
+    fn current_time(&self) -> Option<UnixTime> {
+        Some(UnixTime::now())
+    }
+}

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -2,8 +2,10 @@ use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use core::cmp;
 use std::io;
+#[cfg(feature = "std")]
 use std::io::Read;
 
+#[cfg(feature = "std")]
 use crate::msgs::message::OutboundChunks;
 
 /// This is a byte buffer that is built from a vector
@@ -93,6 +95,7 @@ impl ChunkVecBuffer {
 
     /// Read data out of this object, writing it into `buf`
     /// and returning how many bytes were written there.
+    #[cfg(feature = "std")]
     pub(crate) fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut offs = 0;
 
@@ -150,6 +153,7 @@ impl ChunkVecBuffer {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use super::ChunkVecBuffer;

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -70,6 +70,7 @@ impl ChunkVecBuffer {
 
     /// Append a copy of `bytes`, perhaps a prefix if
     /// we're near the limit.
+    #[cfg(feature = "std")]
     pub(crate) fn append_limited_copy(&mut self, payload: OutboundChunks<'_>) -> usize {
         let take = self.apply_limit(payload.len());
         self.append(payload.split_at(take).0.to_vec());

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -4,7 +4,6 @@ use alloc::vec::Vec;
 use core::fmt;
 
 use pki_types::CertificateRevocationListDer;
-use std::error::Error as StdError;
 use webpki::{CertRevocationList, OwnedCertRevocationList};
 
 use crate::error::{CertRevocationListError, CertificateError, Error, OtherError};
@@ -52,7 +51,8 @@ impl fmt::Display for VerifierBuilderError {
     }
 }
 
-impl StdError for VerifierBuilderError {}
+#[cfg(feature = "std")]
+impl std::error::Error for VerifierBuilderError {}
 
 fn pki_error(error: webpki::Error) -> Error {
     use webpki::Error::*;

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "std")]
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
@@ -75,7 +76,11 @@ fn pki_error(error: webpki::Error) -> Error {
             CertRevocationListError::BadSignature.into()
         }
 
-        _ => CertificateError::Other(OtherError(Arc::new(error))).into(),
+        _ => CertificateError::Other(OtherError(
+            #[cfg(feature = "std")]
+            Arc::new(error),
+        ))
+        .into(),
     }
 }
 
@@ -95,7 +100,10 @@ fn crl_error(e: webpki::Error) -> CertRevocationListError {
         UnsupportedIndirectCrl => CertRevocationListError::UnsupportedIndirectCrl,
         UnsupportedRevocationReason => CertRevocationListError::UnsupportedRevocationReason,
 
-        _ => CertRevocationListError::Other(OtherError(Arc::new(e))),
+        _ => CertRevocationListError::Other(OtherError(
+            #[cfg(feature = "std")]
+            Arc::new(e),
+        )),
     }
 }
 
@@ -184,7 +192,7 @@ mod tests {
 
         assert!(matches!(
             crl_error(webpki::Error::NameConstraintViolation),
-            Other(_)
+            Other(..)
         ));
     }
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -343,6 +343,16 @@ fn config_builder_for_client_with_time() {
 }
 
 #[test]
+fn config_builder_for_server_with_time() {
+    ServerConfig::builder_with_details(
+        provider::default_provider().into(),
+        Arc::new(rustls::time_provider::DefaultTimeProvider),
+    )
+    .with_safe_default_protocol_versions()
+    .unwrap();
+}
+
+#[test]
 fn buffered_client_data_sent() {
     let server_config = Arc::new(make_server_config(KeyType::Rsa));
 
@@ -514,7 +524,7 @@ fn test_config_builders_debug() {
         format!("{:?}", b)
     );
     let b = b.with_no_client_auth();
-    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsServerCert { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3], verifier: NoClientAuth } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsServerCert { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3], verifier: NoClientAuth, time_provider: DefaultTimeProvider } }", format!("{:?}", b));
 
     let b = ClientConfig::builder_with_provider(
         CryptoProvider {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -333,6 +333,16 @@ fn config_builder_for_server_rejects_incompatible_cipher_suites() {
 }
 
 #[test]
+fn config_builder_for_client_with_time() {
+    ClientConfig::builder_with_details(
+        provider::default_provider().into(),
+        Arc::new(rustls::time_provider::DefaultTimeProvider),
+    )
+    .with_safe_default_protocol_versions()
+    .unwrap();
+}
+
+#[test]
 fn buffered_client_data_sent() {
     let server_config = Arc::new(make_server_config(KeyType::Rsa));
 
@@ -497,10 +507,10 @@ fn test_config_builders_debug() {
         }
         .into(),
     );
-    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring } } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, time_provider: DefaultTimeProvider } }", format!("{:?}", b));
     let b = server_config_builder_with_versions(&[&rustls::version::TLS13]);
     assert_eq!(
-        "ConfigBuilder<ServerConfig, _> { state: WantsVerifier { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3] } }",
+        "ConfigBuilder<ServerConfig, _> { state: WantsVerifier { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3], time_provider: DefaultTimeProvider } }",
         format!("{:?}", b)
     );
     let b = b.with_no_client_auth();
@@ -514,10 +524,10 @@ fn test_config_builders_debug() {
         }
         .into(),
     );
-    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring } } }", format!("{:?}", b));
+    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, time_provider: DefaultTimeProvider } }", format!("{:?}", b));
     let b = client_config_builder_with_versions(&[&rustls::version::TLS13]);
     assert_eq!(
-       "ConfigBuilder<ClientConfig, _> { state: WantsVerifier { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3] } }",
+       "ConfigBuilder<ClientConfig, _> { state: WantsVerifier { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3], time_provider: DefaultTimeProvider } }",
         format!("{:?}", b)
     );
 }


### PR DESCRIPTION
this PR implements phase I of RFC #1399 . NOTE that this PR is built on top of PR #1583 

originally phase I aimed to only allowing client functionality in no-std context but turns out that the changes were sufficient to also enable server functionality as evidenced in #1534 

breaking changes: implementing the RFC requires no breaking changes

blockers:
- [x] #1583 

this PR is best reviewed on a commit by commit basis (do skip PR#1583 commits) 