### PR TITLE
Upgrade to ring 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -747,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
  "pem",
- "ring",
+ "ring 0.16.20",
  "time",
  "yasna",
 ]
@@ -790,10 +790,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb9d44f9bf6b635117787f72416783eb7e4227aaf255e5ce739563d817176a7e"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -849,7 +863,7 @@ dependencies = [
  "bencher",
  "env_logger",
  "log",
- "ring",
+ "ring 0.17.0",
  "rustls-pemfile",
  "rustls-pki-types",
  "rustls-webpki",
@@ -878,7 +892,7 @@ name = "rustls-connect-tests"
 version = "0.0.1"
 dependencies = [
  "regex",
- "ring",
+ "ring 0.16.20",
  "rustls",
 ]
 
@@ -892,7 +906,7 @@ dependencies = [
  "mio",
  "rcgen",
  "regex",
- "ring",
+ "ring 0.16.20",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -941,9 +955,9 @@ version = "0.102.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fecb40b15f8d5d22e08f89e0a0bfa2c17ddd5fc385700f96920bba2b99b680"
 dependencies = [
- "ring",
+ "ring 0.16.20",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -1016,6 +1030,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -1103,6 +1123,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,13 +951,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0-alpha.3"
+version = "0.102.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fecb40b15f8d5d22e08f89e0a0bfa2c17ddd5fc385700f96920bba2b99b680"
+checksum = "aa3ae0c05ae540f6d9089b731c26e49863058f03082dcef070df987bcc8db7ba"
 dependencies = [
- "ring 0.16.20",
+ "ring 0.17.0",
  "rustls-pki-types",
- "untrusted 0.7.1",
+ "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ need them.
 While Rustls itself is platform independent, it uses
 [`ring`](https://crates.io/crates/ring) for implementing the cryptography in
 TLS. As a result, rustls only runs on platforms
-supported by `ring`. At the time of writing, this means x86, x86-64, armv7, and
-aarch64. For more information, see [the supported `ring` CI
-targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
+supported by `ring`. At the time of writing, this means x86, x86-64, aarch64,
+armv7, powerpc64le, riscv64gc and s390x. For more information, see [the
+supported `ring` CI targets][ring-ci-targets].
 
 Rustls requires Rust 1.61 or later.
+
+[ring-ci-targets]: https://github.com/briansmith/ring/blob/d34858a918b04127d085cdbc20325263bf8fdd36/.github/workflows/ci.yml#L171-L190
 
 # Example code
 There are two example programs which use

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -30,6 +30,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,10 +103,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb9d44f9bf6b635117787f72416783eb7e4227aaf255e5ce739563d817176a7e"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -103,7 +128,7 @@ name = "rustls"
 version = "0.22.0-alpha.3"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.0",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -129,9 +154,9 @@ version = "0.102.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fecb40b15f8d5d22e08f89e0a0bfa2c17ddd5fc385700f96920bba2b99b680"
 dependencies = [
- "ring",
+ "ring 0.16.20",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -139,6 +164,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "subtle"
@@ -168,6 +199,18 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -254,3 +297,69 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cf76cb6e2222ed0ea86b2b0ee2f71c96ec6edd5af42e84d59160e91b836ec4"
 
 [[package]]
-name = "bumpalo"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,15 +35,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,45 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,8 +64,8 @@ dependencies = [
  "cc",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys",
 ]
 
@@ -128,7 +74,7 @@ name = "rustls"
 version = "0.22.0-alpha.3"
 dependencies = [
  "log",
- "ring 0.17.0",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -150,20 +96,14 @@ checksum = "a47003264dea418db67060fa420ad16d0d2f8f0a0360d825c00e177ac52cb5d8"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0-alpha.3"
+version = "0.102.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fecb40b15f8d5d22e08f89e0a0bfa2c17ddd5fc385700f96920bba2b99b680"
+checksum = "aa3ae0c05ae540f6d9089b731c26e49863058f03082dcef070df987bcc8db7ba"
 dependencies = [
- "ring 0.16.20",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.7.1",
+ "untrusted",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -178,29 +118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
-name = "syn"
-version = "2.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,92 +128,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "web-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -17,7 +17,7 @@ rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
 log = { version = "0.4.4", optional = true }
-ring = { version = "0.16.20", optional = true }
+ring = { version = "0.17", optional = true }
 subtle = "2.5.0"
 webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.3", features = ["alloc", "std"], default-features = false }
 pki-types = { package = "rustls-pki-types", version = "0.2.1", features = ["std"] }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -19,7 +19,7 @@ rustversion = { version = "1.0.6", optional = true }
 log = { version = "0.4.4", optional = true }
 ring = { version = "0.17", optional = true }
 subtle = "2.5.0"
-webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.3", features = ["alloc", "std"], default-features = false }
+webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.4", features = ["alloc", "std"], default-features = false }
 pki-types = { package = "rustls-pki-types", version = "0.2.1", features = ["std"] }
 
 [features]

--- a/rustls/src/crypto/ring/hash.rs
+++ b/rustls/src/crypto/ring/hash.rs
@@ -19,7 +19,7 @@ impl crypto::hash::Hash for Hash {
     }
 
     fn output_len(&self) -> usize {
-        self.0.output_len
+        self.0.output_len()
     }
 
     fn algorithm(&self) -> HashAlgorithm {

--- a/rustls/src/crypto/ring/hmac.rs
+++ b/rustls/src/crypto/ring/hmac.rs
@@ -14,7 +14,7 @@ impl crypto::hmac::Hmac for Hmac {
     }
 
     fn hash_output_len(&self) -> usize {
-        self.0.digest_algorithm().output_len
+        self.0.digest_algorithm().output_len()
     }
 }
 
@@ -35,7 +35,7 @@ impl crypto::hmac::Key for Key {
         self.0
             .algorithm()
             .digest_algorithm()
-            .output_len
+            .output_len()
     }
 }
 

--- a/rustls/src/crypto/ring/kx.rs
+++ b/rustls/src/crypto/ring/kx.rs
@@ -84,10 +84,10 @@ impl ActiveKeyExchange for KeyExchange {
     /// Completes the key exchange, given the peer's public key.
     fn complete(self: Box<Self>, peer: &[u8]) -> Result<SharedSecret, Error> {
         let peer_key = UnparsedPublicKey::new(self.agreement_algorithm, peer);
-        agree_ephemeral(self.priv_key, &peer_key, (), |secret| {
-            Ok(SharedSecret::from(secret))
+        agree_ephemeral(self.priv_key, &peer_key, |secret| {
+            SharedSecret::from(secret)
         })
-        .map_err(|()| PeerMisbehaved::InvalidKeyShare.into())
+        .map_err(|_| PeerMisbehaved::InvalidKeyShare.into())
     }
 
     /// Return the group being used.

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -57,11 +57,13 @@
 //! While Rustls itself is platform independent, it uses
 //! [`ring`](https://crates.io/crates/ring) for implementing the cryptography in
 //! TLS. As a result, rustls only runs on platforms
-//! supported by `ring`. At the time of writing, this means x86, x86-64, armv7, and
-//! aarch64. For more information, see [the supported `ring` CI
-//! targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
+//! supported by `ring`. At the time of writing, this means x86, x86-64, aarch64,
+//! armv7, powerpc64le, riscv64gc and s390x. For more information, see [the
+//! supported `ring` CI targets][ring-ci-targets].
 //!
 //! Rustls requires Rust 1.61 or later.
+//!
+//! [ring-ci-targets]: https://github.com/briansmith/ring/blob/d34858a918b04127d085cdbc20325263bf8fdd36/.github/workflows/ci.yml#L171-L190
 //!
 //! ## Design Overview
 //! ### Rustls does not take care of network IO

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -2,6 +2,8 @@ use alloc::sync::Arc;
 use core::fmt;
 
 use pki_types::{CertificateDer, SignatureVerificationAlgorithm, UnixTime};
+#[cfg(feature = "ring")]
+use webpki::ring as webpki_algs;
 
 use super::anchors::RootCertStore;
 use super::client_verifier_builder::ClientCertVerifierBuilder;
@@ -470,53 +472,59 @@ impl WebPkiSupportedAlgorithms {
 #[cfg(feature = "ring")]
 pub(crate) static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[
-        webpki::ECDSA_P256_SHA256,
-        webpki::ECDSA_P256_SHA384,
-        webpki::ECDSA_P384_SHA256,
-        webpki::ECDSA_P384_SHA384,
-        webpki::ED25519,
-        webpki::RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
-        webpki::RSA_PSS_2048_8192_SHA384_LEGACY_KEY,
-        webpki::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
-        webpki::RSA_PKCS1_2048_8192_SHA256,
-        webpki::RSA_PKCS1_2048_8192_SHA384,
-        webpki::RSA_PKCS1_2048_8192_SHA512,
-        webpki::RSA_PKCS1_3072_8192_SHA384,
+        webpki_algs::ECDSA_P256_SHA256,
+        webpki_algs::ECDSA_P256_SHA384,
+        webpki_algs::ECDSA_P384_SHA256,
+        webpki_algs::ECDSA_P384_SHA384,
+        webpki_algs::ED25519,
+        webpki_algs::RSA_PSS_2048_8192_SHA256_LEGACY_KEY,
+        webpki_algs::RSA_PSS_2048_8192_SHA384_LEGACY_KEY,
+        webpki_algs::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
+        webpki_algs::RSA_PKCS1_2048_8192_SHA256,
+        webpki_algs::RSA_PKCS1_2048_8192_SHA384,
+        webpki_algs::RSA_PKCS1_2048_8192_SHA512,
+        webpki_algs::RSA_PKCS1_3072_8192_SHA384,
     ],
     mapping: &[
         // nb. for TLS1.2 the curve is not fixed by SignatureScheme. for TLS1.3 it is.
         (
             SignatureScheme::ECDSA_NISTP384_SHA384,
-            &[webpki::ECDSA_P384_SHA384, webpki::ECDSA_P256_SHA384],
+            &[
+                webpki_algs::ECDSA_P384_SHA384,
+                webpki_algs::ECDSA_P256_SHA384,
+            ],
         ),
         (
             SignatureScheme::ECDSA_NISTP256_SHA256,
-            &[webpki::ECDSA_P256_SHA256, webpki::ECDSA_P384_SHA256],
+            &[
+                webpki_algs::ECDSA_P256_SHA256,
+                webpki_algs::ECDSA_P384_SHA256,
+            ],
         ),
-        (SignatureScheme::ED25519, &[webpki::ED25519]),
+        (SignatureScheme::ED25519, &[webpki_algs::ED25519]),
         (
             SignatureScheme::RSA_PSS_SHA512,
-            &[webpki::RSA_PSS_2048_8192_SHA512_LEGACY_KEY],
+            &[webpki_algs::RSA_PSS_2048_8192_SHA512_LEGACY_KEY],
         ),
         (
             SignatureScheme::RSA_PSS_SHA384,
-            &[webpki::RSA_PSS_2048_8192_SHA384_LEGACY_KEY],
+            &[webpki_algs::RSA_PSS_2048_8192_SHA384_LEGACY_KEY],
         ),
         (
             SignatureScheme::RSA_PSS_SHA256,
-            &[webpki::RSA_PSS_2048_8192_SHA256_LEGACY_KEY],
+            &[webpki_algs::RSA_PSS_2048_8192_SHA256_LEGACY_KEY],
         ),
         (
             SignatureScheme::RSA_PKCS1_SHA512,
-            &[webpki::RSA_PKCS1_2048_8192_SHA512],
+            &[webpki_algs::RSA_PKCS1_2048_8192_SHA512],
         ),
         (
             SignatureScheme::RSA_PKCS1_SHA384,
-            &[webpki::RSA_PKCS1_2048_8192_SHA384],
+            &[webpki_algs::RSA_PKCS1_2048_8192_SHA384],
         ),
         (
             SignatureScheme::RSA_PKCS1_SHA256,
-            &[webpki::RSA_PKCS1_2048_8192_SHA256],
+            &[webpki_algs::RSA_PKCS1_2048_8192_SHA256],
         ),
     ],
 };


### PR DESCRIPTION
Question: do we want to backport this to rustls 0.21? Would enable usage of rustls a on bunch more targets.