### PR TITLE
manual: update to clarify downgrade protection

### DIFF
--- a/rustls/src/manual/tlsvulns.rs
+++ b/rustls/src/manual/tlsvulns.rs
@@ -120,7 +120,8 @@ is an attack against CBC mode ciphersuites in SSLv3.  This was possible in most 
 downgraded to SSLv3 after failed handshakes for later versions.
 
 rustls does not support CBC mode ciphersuites, or SSLv3.  Note that rustls does not need to implement `TLS_FALLBACK_SCSV`
-introduced as a countermeasure because it contains no ability to downgrade to earlier protocol versions.
+introduced as a countermeasure because it contains no ability to downgrade from TLS 1.2 to earlier protocol versions,
+and TLS 1.3 has protocol-level downgrade protection based on the [ServerHello server random value](https://www.rfc-editor.org/rfc/rfc8446#section-4.1.3).
 
 ## GCM nonces
 


### PR DESCRIPTION
Previously the manual described Rustls not requiring the TLS_FALLBACK_SCSV countermeasure because it "contains no ability to downgrade to earlier protocol versions". With TLS 1.3 and TLS 1.2 support it makes sense to clarify that Rustls has no ability to downgrade from TLS 1.2 to earlier protocol versions, and TLS 1.3 has native downgrade protections to avoid inadvertent downgrade from 1.3 to 1.2.

Resolve https://github.com/rustls/rustls/issues/1513