### PR TITLE
Bump MSRV to 1.61

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.60"
+          toolchain: "1.61"
 
       - run: cargo check --locked --lib --all-features -p rustls
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ supported by `ring`. At the time of writing, this means x86, x86-64, armv7, and
 aarch64. For more information, see [the supported `ring` CI
 targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
 
-Rustls requires Rust 1.60 or later.
+Rustls requires Rust 1.61 or later.
 
 # Example code
 There are two example programs which use

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -2,7 +2,6 @@
 name = "rustls-connect-tests"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"
 description = "Rustls connectivity based integration tests."
 publish = false

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,7 +2,6 @@
 name = "rustls-examples"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"
 description = "Rustls example code and tests."
 publish = false

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -2,7 +2,6 @@
 name = "rustls-provider-example"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"
 description = "Example of rustls with custom crypto provider."
 publish = false

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls"
 version = "0.22.0-alpha.3"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -57,7 +57,7 @@
 //! aarch64. For more information, see [the supported `ring` CI
 //! targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
 //!
-//! Rustls requires Rust 1.60 or later.
+//! Rustls requires Rust 1.61 or later.
 //!
 //! ## Design Overview
 //! ### Rustls does not take care of network IO


### PR DESCRIPTION
This is used in #1508 and #1414, so probably makes sense to pull this out separately and get it merged sooner.

Addressed comments from @cpu in #1508.