### PR TITLE
Group Dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    crates-io:
+      patterns:
+        - "*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Follow-up from discussion in #1506.

I think ignores won't work here, since the list of crates we depend on is just too long.

Instead, wire up Dependabot to submit one PR per week instead of one per dependency.