### PR TITLE
v0.21.8 preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.60"
+          toolchain: "1.61"
 
       - run: cargo check --lib --all-features -p rustls
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ supported by `ring`. At the time of writing this means x86, x86-64, armv7, and
 aarch64. For more information see [the supported `ring` CI
 targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
 
-Rustls requires Rust 1.60 or later.
+Rustls requires Rust 1.61 or later.
 
 # Example code
 There are two example programs which use

--- a/README.md
+++ b/README.md
@@ -86,13 +86,15 @@ need them.
 While Rustls itself is platform independent it uses
 [`ring`](https://crates.io/crates/ring) for implementing the cryptography in
 TLS. As a result, rustls only runs on platforms
-supported by `ring`. At the time of writing this means x86, x86-64, aarch64,
-armv7, powerpc64le, riscv64gc and s390x. For more information, see [the
-supported `ring` CI targets][ring-ci-targets].
+supported by `ring`. At the time of writing, this means 32-bit ARM, Aarch64 (64-bit ARM),
+x86, x86-64, LoongArch64, 32-bit & 64-bit Little Endian MIPS, 32-bit PowerPC (Big Endian),
+64-bit PowerPC (Big and Little Endian), 64-bit RISC-V, and s390x. We do not presently
+support WebAssembly.
+For more information, see [the supported `ring` target platforms][ring-target-platforms].
 
 Rustls requires Rust 1.61 or later.
 
-[ring-ci-targets]: https://github.com/briansmith/ring/blob/d34858a918b04127d085cdbc20325263bf8fdd36/.github/workflows/ci.yml#L171-L190
+[ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 
 # Example code
 There are two example programs which use

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ need them.
 While Rustls itself is platform independent it uses
 [`ring`](https://crates.io/crates/ring) for implementing the cryptography in
 TLS. As a result, rustls only runs on platforms
-supported by `ring`. At the time of writing this means x86, x86-64, armv7, and
-aarch64. For more information see [the supported `ring` CI
-targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
+supported by `ring`. At the time of writing this means x86, x86-64, aarch64,
+armv7, powerpc64le, riscv64gc and s390x. For more information, see [the
+supported `ring` CI targets][ring-ci-targets].
 
 Rustls requires Rust 1.61 or later.
+
+[ring-ci-targets]: https://github.com/briansmith/ring/blob/d34858a918b04127d085cdbc20325263bf8fdd36/.github/workflows/ci.yml#L171-L190
 
 # Example code
 There are two example programs which use

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -2,7 +2,6 @@
 name = "rustls-connect-tests"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"
 description = "Rustls connectivity based integration tests."
 publish = false

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -19,4 +19,4 @@ rustls = { path = "../rustls", features = [ "logging" ]}
 
 [dev-dependencies]
 regex = "1.0"
-ring = "0.16.20"
+ring = "0.17"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,7 +2,6 @@
 name = "rustls-examples"
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.60"
 license = "Apache-2.0 OR ISC OR MIT"
 description = "Rustls example code and tests."
 publish = false

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -111,8 +111,7 @@ impl TlsClient {
         //
         // Read it and then write it to stdout.
         if io_state.plaintext_bytes_to_read() > 0 {
-            let mut plaintext = Vec::new();
-            plaintext.resize(io_state.plaintext_bytes_to_read(), 0u8);
+            let mut plaintext = vec![0u8; io_state.plaintext_bytes_to_read()];
             self.tls_conn
                 .reader()
                 .read_exact(&mut plaintext)

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -241,8 +241,7 @@ impl OpenConnection {
         // Read and process all available plaintext.
         if let Ok(io_state) = self.tls_conn.process_new_packets() {
             if io_state.plaintext_bytes_to_read() > 0 {
-                let mut buf = Vec::new();
-                buf.resize(io_state.plaintext_bytes_to_read(), 0u8);
+                let mut buf = vec![0u8; io_state.plaintext_bytes_to_read()];
 
                 self.tls_conn
                     .reader()
@@ -276,7 +275,7 @@ impl OpenConnection {
         // If we have a successful but empty read, that's an EOF.
         // Otherwise, we shove the data into the TLS session.
         match maybe_len {
-            Some(len) if len == 0 => {
+            Some(0) => {
                 debug!("back eof");
                 self.closing = true;
             }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,9 +9,6 @@ edition = "2021"
 [package.metadata]
 cargo-fuzz = true
 
-[dependencies]
-webpki = { package = "rustls-webpki", version = "0.101.0", features = ["alloc", "std"] }
-
 [dependencies.rustls]
 path = "../rustls"
 [dependencies.libfuzzer-sys]

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -2,7 +2,6 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 extern crate rustls;
-extern crate webpki;
 
 use rustls::{ClientConfig, ClientConnection, RootCertStore};
 use std::io;

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.8"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls"
 version = "0.21.7"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -19,7 +19,7 @@ rustversion = { version = "1.0.6", optional = true }
 log = { version = "0.4.4", optional = true }
 ring = "0.16.20"
 sct = "0.7.0"
-webpki = { package = "rustls-webpki", version = "0.101.2", features = ["alloc", "std"] }
+webpki = { package = "rustls-webpki", version = "0.101.7", features = ["alloc", "std"] }
 
 [features]
 default = ["logging", "tls12"]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -17,7 +17,7 @@ rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
 log = { version = "0.4.4", optional = true }
-ring = "0.16.20"
+ring = "0.17"
 sct = "0.7.0"
 webpki = { package = "rustls-webpki", version = "0.101.7", features = ["alloc", "std"] }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -148,7 +148,7 @@ pub(super) fn handle_server_hello(
     };
 
     let key_schedule = our_key_share.complete(&their_key_share.payload.0, |secret| {
-        Ok(key_schedule_pre_handshake.into_handshake(secret))
+        key_schedule_pre_handshake.into_handshake(secret)
     })?;
 
     // Remember what KX group the server liked for next time.
@@ -277,7 +277,7 @@ pub(super) fn prepare_resumption(
 
     let binder_len = resuming_suite
         .hash_algorithm()
-        .output_len;
+        .output_len();
     let binder = vec![0u8; binder_len];
 
     let psk_identity =

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -381,6 +381,7 @@ impl<Data> ConnectionCommon<Data> {
             while self.wants_write() {
                 wrlen += self.write_tls(io)?;
             }
+            io.flush()?;
 
             if !until_handshaked && wrlen > 0 {
                 return Ok((rdlen, wrlen));
@@ -411,6 +412,7 @@ impl<Data> ConnectionCommon<Data> {
                     // try a last-gasp write -- but don't predate the primary
                     // error.
                     let _ignored = self.write_tls(io);
+                    let _ignored = io.flush();
 
                     return Err(io::Error::new(io::ErrorKind::InvalidData, e));
                 }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -324,8 +324,8 @@ impl<Data> ConnectionCommon<Data> {
         let common = &mut self.core.common_state;
         Reader {
             received_plaintext: &mut common.received_plaintext,
-            /// Are we done? i.e., have we processed all received messages, and received a
-            /// close_notify to indicate that no new messages will arrive?
+            // Are we done? i.e., have we processed all received messages, and received a
+            // close_notify to indicate that no new messages will arrive?
             peer_cleanly_closed: common.has_received_close_notify
                 && !self.core.message_deframer.has_pending(),
             has_seen_eof: common.has_seen_eof,

--- a/rustls/src/kx.rs
+++ b/rustls/src/kx.rs
@@ -49,14 +49,10 @@ impl KeyExchange {
     ///
     /// The shared secret is passed into the closure passed down in `f`, and the result of calling
     /// `f` is returned to the caller.
-    pub(crate) fn complete<T>(
-        self,
-        peer: &[u8],
-        f: impl FnOnce(&[u8]) -> Result<T, ()>,
-    ) -> Result<T, Error> {
+    pub(crate) fn complete<T>(self, peer: &[u8], f: impl FnOnce(&[u8]) -> T) -> Result<T, Error> {
         let peer_key = ring::agreement::UnparsedPublicKey::new(self.skxg.agreement_algorithm, peer);
-        ring::agreement::agree_ephemeral(self.privkey, &peer_key, (), f)
-            .map_err(|()| PeerMisbehaved::InvalidKeyShare.into())
+        ring::agreement::agree_ephemeral(self.privkey, &peer_key, f)
+            .map_err(|_| PeerMisbehaved::InvalidKeyShare.into())
     }
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -59,11 +59,13 @@
 //! While Rustls itself is platform independent it uses
 //! [`ring`](https://crates.io/crates/ring) for implementing the cryptography in
 //! TLS. As a result, rustls only runs on platforms
-//! supported by `ring`. At the time of writing this means x86, x86-64, armv7, and
-//! aarch64. For more information see [the supported `ring` CI
-//! targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
+//! supported by `ring`. At the time of writing this means x86, x86-64, aarch64,
+//! armv7, powerpc64le, riscv64gc and s390x. For more information, see [the
+//! supported `ring` CI targets][ring-ci-targets].
 //!
 //! Rustls requires Rust 1.61 or later.
+//!
+//! [ring-ci-targets]: https://github.com/briansmith/ring/blob/d34858a918b04127d085cdbc20325263bf8fdd36/.github/workflows/ci.yml#L171-L190
 //!
 //! ## Design Overview
 //! ### Rustls does not take care of network IO

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -63,7 +63,7 @@
 //! aarch64. For more information see [the supported `ring` CI
 //! targets](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/.github/workflows/ci.yml#L151-L167).
 //!
-//! Rustls requires Rust 1.60 or later.
+//! Rustls requires Rust 1.61 or later.
 //!
 //! ## Design Overview
 //! ### Rustls does not take care of network IO

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -59,13 +59,15 @@
 //! While Rustls itself is platform independent it uses
 //! [`ring`](https://crates.io/crates/ring) for implementing the cryptography in
 //! TLS. As a result, rustls only runs on platforms
-//! supported by `ring`. At the time of writing this means x86, x86-64, aarch64,
-//! armv7, powerpc64le, riscv64gc and s390x. For more information, see [the
-//! supported `ring` CI targets][ring-ci-targets].
+//! supported by `ring`. At the time of writing, this means 32-bit ARM, Aarch64 (64-bit ARM),
+//! x86, x86-64, LoongArch64, 32-bit & 64-bit Little Endian MIPS, 32-bit PowerPC (Big Endian),
+//! 64-bit PowerPC (Big and Little Endian), 64-bit RISC-V, and s390x. We do not presently
+//! support WebAssembly.
+//! For more information, see [the supported `ring` target platforms][ring-target-platforms].
 //!
 //! Rustls requires Rust 1.61 or later.
 //!
-//! [ring-ci-targets]: https://github.com/briansmith/ring/blob/d34858a918b04127d085cdbc20325263bf8fdd36/.github/workflows/ci.yml#L171-L190
+//! [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 //!
 //! ## Design Overview
 //! ### Rustls does not take care of network IO

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -543,7 +543,7 @@ mod client_hello {
 
         // Do key exchange
         let key_schedule = kx.complete(&share.payload.0, |secret| {
-            Ok(key_schedule_pre_handshake.into_handshake(secret))
+            key_schedule_pre_handshake.into_handshake(secret)
         })?;
 
         let handshake_hash = transcript.get_current_hash();

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -68,7 +68,7 @@ impl CertifiedKey {
 
     /// The end-entity certificate.
     pub fn end_entity_cert(&self) -> Result<&key::Certificate, SignError> {
-        self.cert.get(0).ok_or(SignError(()))
+        self.cert.first().ok_or(SignError(()))
     }
 }
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -234,7 +234,6 @@ impl ConnectionSecrets {
                 label.as_bytes(),
                 seed.as_ref(),
             );
-            Ok(())
         })?;
 
         Ok(ret)

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -313,8 +313,7 @@ impl ConnectionSecrets {
         let len =
             (common.aead_algorithm.key_len() + suite.fixed_iv_len) * 2 + suite.explicit_nonce_len;
 
-        let mut out = Vec::new();
-        out.resize(len, 0u8);
+        let mut out = vec![0u8; len];
 
         // NOTE: opposite order to above for no good reason.
         // Don't design security protocols on drugs, kids.
@@ -341,8 +340,7 @@ impl ConnectionSecrets {
     }
 
     fn make_verify_data(&self, handshake_hash: &Digest, label: &[u8]) -> Vec<u8> {
-        let mut out = Vec::new();
-        out.resize(12, 0u8);
+        let mut out = vec![0u8; 12];
 
         prf::prf(
             &mut out,

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -171,7 +171,7 @@ impl Tls12CipherSuite {
     }
 
     /// Which hash function to use with this suite.
-    pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
+    pub(crate) fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
         self.hmac_algorithm.digest_algorithm()
     }
 }

--- a/rustls/src/tls12/prf.rs
+++ b/rustls/src/tls12/prf.rs
@@ -12,7 +12,7 @@ fn p(out: &mut [u8], alg: hmac::Algorithm, secret: &[u8], seed: &[u8]) {
 
     // A(1)
     let mut current_a = hmac::sign(&hmac_key, seed);
-    let chunk_size = alg.digest_algorithm().output_len;
+    let chunk_size = alg.digest_algorithm().output_len();
     for chunk in out.chunks_mut(chunk_size) {
         // P_hash[i] = HMAC_hash(secret, A(i) + seed)
         let p_term = concat_sign(&hmac_key, current_a.as_ref(), seed);

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -76,7 +76,7 @@ pub struct Tls13CipherSuite {
 
 impl Tls13CipherSuite {
     /// Which hash function to use with this suite.
-    pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
+    pub(crate) fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
         self.hkdf_algorithm
             .hmac_algorithm()
             .digest_algorithm()


### PR DESCRIPTION
# Description

This branch targets the `rel-0.21` release branch to make a point release to upgrade to *ring* 0.17.

This involves bringing the work from https://github.com/rustls/rustls/pull/1508 onto the rel-0.101 branch. I didn't cherry-pick the commits directly because the restructuring of the modules in `main` made it more challenging to resolve conflicts than to re-implement the changes wholesale.

We don't typically mention MSRV updates, so that change is omitted from the proposed release notes. Other commits are clippy fixes and crate internal tidying also of no interest to downstream consumers.

As discussed in the [main 0.17 update PR](https://github.com/rustls/rustls/pull/1508#issuecomment-1748963163) and in [comments below](https://github.com/rustls/rustls/pull/1525#issuecomment-1755951802) updating *ring* is a breaking change for the 0.21.x release stream because we were accidentally exposing `ring::digest::Algorithm` via the `Tls13CipherSuite::hash_algorithm` and `Tls12CipherSuite::hash_algorithm` fns. We believe there should be few-to-none consumers of these fns downstream, and so a small breaking change within an otherwise semver compatible patch release to make these fn's crate-internal is the best way to unblock an update to *ring* that would be breaking on its own based on this API exposure.

## Proposed Release Notes

* Fixes `ConnectionCommon::complete_io()` to flush writers before potentially expecting a response.
* Upgrades `*ring*` to 0.17 - **Note**: ring 0.17 when built with `gcc` will experience slower X25519 and Ed25519 operations compared to previous releases.
* Upgrades `rustls-webpki` to 0.101.7 to match `*ring*` 0.17 dependency
* `Tls12CipherSuite::hash_algorithm()` and `Tls13CipherSuite::hash_algorithm()` are now crate-internal. This is a small breaking change to remove unintended exposure of underlying `*ring*` types in the public API.

## TODO

- [x] decide how to handle the semver breakage from `Tls13CipherSuite::hash_algorithm()` and `Tls12CipherSuite::hash_algorithm()` leaking `ring::digest::Algorithm`.
- [x] decide if we're comfortable releasing w/ the `gcc` ring 0.17 X25519/Ed25519 performance regression unresolved.
- [x] wait for `rustls-webpki` 0.101.7 release - https://github.com/rustls/webpki/pull/199
- [x] remove `Cargo.toml` patch