### PR TITLE
CI bench: save cachegrind logs

### DIFF
--- a/ci-bench/README.md
+++ b/ci-bench/README.md
@@ -33,7 +33,9 @@ handshake_no_resume_1.3_rsa_aes_client,4212770
 ```
 
 In the `cachegrind` subdirectory you will find output files emitted by the `cachegrind` tool, which
-are useful to report detailed instruction count differences when comparing two benchmark runs.
+are useful to report detailed instruction count differences when comparing two benchmark runs. This
+subdirectory also contains log information from cachegrind itself (in `.log` files), which can be
+used to diagnose unexpected cachegrind crashes.
 
 ### Comparing results
 

--- a/ci-bench/src/cachegrind.rs
+++ b/ci-bench/src/cachegrind.rs
@@ -132,6 +132,7 @@ impl CachegrindRunner {
         output_dir: &Path,
     ) -> anyhow::Result<BenchSubprocess> {
         let cachegrind_output_file = output_dir.join(name);
+        let cachegrind_log_file = output_dir.join(format!("{name}.log"));
 
         // Run under setarch to disable ASLR, to reduce noise
         let mut cmd = Command::new("setarch");
@@ -141,9 +142,9 @@ impl CachegrindRunner {
             .arg("--tool=cachegrind")
             // Disable the cache simulation, since we are only interested in instruction counts
             .arg("--cache-sim=no")
-            // Discard cachegrind's logs, which would otherwise be printed to stderr (we want to
+            // Save cachegrind's logs, which would otherwise be printed to stderr (we want to
             // keep stderr free of noise, to see any errors from the child process)
-            .arg("--log-file=/dev/null")
+            .arg(format!("--log-file={}", cachegrind_log_file.display()))
             // The file where the instruction counts will be stored
             .arg(format!(
                 "--cachegrind-out-file={}",


### PR DESCRIPTION
I needed this for debugging a cachegrind crash today. It might come in handy for others in the future, hence this PR.