### PR TITLE
Use cargo-check-external-types to control type leakage in public API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,3 +312,21 @@ jobs:
       - run: cargo clippy --locked --manifest-path=connect-tests/Cargo.toml --all-features --all-targets
       - run: cargo clippy --locked --manifest-path=fuzz/Cargo.toml --all-features --all-targets
       - run: cargo clippy --locked --manifest-path=provider-example/Cargo.toml --all-features --all-targets
+
+  check-external-types:
+    name: Validate external types appearing in public API
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2023-10-10
+          # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
+      - run: cargo install --locked cargo-check-external-types
+      - name: run cargo-check-external-types for rustls/
+        working-directory: rustls/
+        run: cargo check-external-types --config external-types.toml

--- a/rustls/external-types.toml
+++ b/rustls/external-types.toml
@@ -1,0 +1,3 @@
+allowed_external_types = [
+    "rustls_pki_types::*",
+]

--- a/rustls/src/crypto/ring/hash.rs
+++ b/rustls/src/crypto/ring/hash.rs
@@ -17,7 +17,7 @@ impl crypto::hash::Hash for Hash {
     fn hash(&self, bytes: &[u8]) -> crypto::hash::Output {
         let mut ctx = ring::digest::Context::new(self.0);
         ctx.update(bytes);
-        ctx.finish().into()
+        convert(ctx.finish())
     }
 
     fn output_len(&self) -> usize {
@@ -33,7 +33,7 @@ struct Context(ring::digest::Context);
 
 impl crypto::hash::Context for Context {
     fn fork_finish(&self) -> crypto::hash::Output {
-        self.0.clone().finish().into()
+        convert(self.0.clone().finish())
     }
 
     fn fork(&self) -> Box<dyn crypto::hash::Context> {
@@ -41,7 +41,7 @@ impl crypto::hash::Context for Context {
     }
 
     fn finish(self: Box<Self>) -> crypto::hash::Output {
-        self.0.finish().into()
+        convert(self.0.finish())
     }
 
     fn update(&mut self, data: &[u8]) {
@@ -49,8 +49,6 @@ impl crypto::hash::Context for Context {
     }
 }
 
-impl From<ring::digest::Digest> for crypto::hash::Output {
-    fn from(val: ring::digest::Digest) -> Self {
-        Self::new(val.as_ref())
-    }
+fn convert(val: ring::digest::Digest) -> crypto::hash::Output {
+    crypto::hash::Output::new(val.as_ref())
 }

--- a/rustls/src/crypto/ring/hmac.rs
+++ b/rustls/src/crypto/ring/hmac.rs
@@ -30,7 +30,7 @@ impl crypto::hmac::Key for Key {
             ctx.update(d);
         }
         ctx.update(last);
-        ctx.sign().into()
+        crypto::hmac::Tag::new(ctx.sign().as_ref())
     }
 
     fn tag_len(&self) -> usize {
@@ -38,11 +38,5 @@ impl crypto::hmac::Key for Key {
             .algorithm()
             .digest_algorithm()
             .output_len()
-    }
-}
-
-impl From<ring::hmac::Tag> for crypto::hmac::Tag {
-    fn from(val: ring::hmac::Tag) -> Self {
-        Self::new(val.as_ref())
     }
 }

--- a/rustls/src/webpki/client_verifier_builder.rs
+++ b/rustls/src/webpki/client_verifier_builder.rs
@@ -6,6 +6,7 @@ use std::error::Error as StdError;
 use pki_types::CertificateRevocationListDer;
 use webpki::BorrowedCertRevocationList;
 
+use super::crl_error;
 use super::verify::{AnonymousClientPolicy, WebPkiClientVerifier, WebPkiSupportedAlgorithms};
 use crate::verify::ClientCertVerifier;
 use crate::{CertRevocationListError, RootCertStore};
@@ -101,7 +102,7 @@ impl ClientCertVerifierBuilder {
                 .map(|der_crl| {
                     BorrowedCertRevocationList::from_der(der_crl.as_ref())
                         .and_then(|crl| crl.to_owned())
-                        .map_err(CertRevocationListError::from)
+                        .map_err(crl_error)
                 })
                 .collect::<Result<Vec<_>, CertRevocationListError>>()?,
             self.anon_policy,

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -44,24 +44,22 @@ fn pki_error(error: webpki::Error) -> Error {
     }
 }
 
-impl From<webpki::Error> for CertRevocationListError {
-    fn from(e: webpki::Error) -> Self {
-        use webpki::Error::*;
-        match e {
-            InvalidCrlSignatureForPublicKey
-            | UnsupportedCrlSignatureAlgorithm
-            | UnsupportedCrlSignatureAlgorithmForPublicKey => Self::BadSignature,
-            InvalidCrlNumber => Self::InvalidCrlNumber,
-            InvalidSerialNumber => Self::InvalidRevokedCertSerialNumber,
-            IssuerNotCrlSigner => Self::IssuerInvalidForCrl,
-            MalformedExtensions | BadDer | BadDerTime => Self::ParseError,
-            UnsupportedCriticalExtension => Self::UnsupportedCriticalExtension,
-            UnsupportedCrlVersion => Self::UnsupportedCrlVersion,
-            UnsupportedDeltaCrl => Self::UnsupportedDeltaCrl,
-            UnsupportedIndirectCrl => Self::UnsupportedIndirectCrl,
-            UnsupportedRevocationReason => Self::UnsupportedRevocationReason,
+fn crl_error(e: webpki::Error) -> CertRevocationListError {
+    use webpki::Error::*;
+    match e {
+        InvalidCrlSignatureForPublicKey
+        | UnsupportedCrlSignatureAlgorithm
+        | UnsupportedCrlSignatureAlgorithmForPublicKey => CertRevocationListError::BadSignature,
+        InvalidCrlNumber => CertRevocationListError::InvalidCrlNumber,
+        InvalidSerialNumber => CertRevocationListError::InvalidRevokedCertSerialNumber,
+        IssuerNotCrlSigner => CertRevocationListError::IssuerInvalidForCrl,
+        MalformedExtensions | BadDer | BadDerTime => CertRevocationListError::ParseError,
+        UnsupportedCriticalExtension => CertRevocationListError::UnsupportedCriticalExtension,
+        UnsupportedCrlVersion => CertRevocationListError::UnsupportedCrlVersion,
+        UnsupportedDeltaCrl => CertRevocationListError::UnsupportedDeltaCrl,
+        UnsupportedIndirectCrl => CertRevocationListError::UnsupportedIndirectCrl,
+        UnsupportedRevocationReason => CertRevocationListError::UnsupportedRevocationReason,
 
-            _ => Self::Other(Arc::new(e)),
-        }
+        _ => CertRevocationListError::Other(Arc::new(e)),
     }
 }

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -43,3 +43,25 @@ fn pki_error(error: webpki::Error) -> Error {
         _ => CertificateError::Other(Arc::new(error)).into(),
     }
 }
+
+impl From<webpki::Error> for CertRevocationListError {
+    fn from(e: webpki::Error) -> Self {
+        use webpki::Error::*;
+        match e {
+            InvalidCrlSignatureForPublicKey
+            | UnsupportedCrlSignatureAlgorithm
+            | UnsupportedCrlSignatureAlgorithmForPublicKey => Self::BadSignature,
+            InvalidCrlNumber => Self::InvalidCrlNumber,
+            InvalidSerialNumber => Self::InvalidRevokedCertSerialNumber,
+            IssuerNotCrlSigner => Self::IssuerInvalidForCrl,
+            MalformedExtensions | BadDer | BadDerTime => Self::ParseError,
+            UnsupportedCriticalExtension => Self::UnsupportedCriticalExtension,
+            UnsupportedCrlVersion => Self::UnsupportedCrlVersion,
+            UnsupportedDeltaCrl => Self::UnsupportedDeltaCrl,
+            UnsupportedIndirectCrl => Self::UnsupportedIndirectCrl,
+            UnsupportedRevocationReason => Self::UnsupportedRevocationReason,
+
+            _ => Self::Other(Arc::new(e)),
+        }
+    }
+}

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -573,6 +573,7 @@ impl<'a> TryFrom<&'a CertificateDer<'a>> for ParsedCertificate<'a> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::crl_error;
     use super::*;
     use crate::error::CertRevocationListError;
 
@@ -643,16 +644,11 @@ mod tests {
             ),
         ];
         for t in testcases {
-            assert_eq!(
-                <webpki::Error as Into<CertRevocationListError>>::into(t.0),
-                t.1
-            );
+            assert_eq!(crl_error(t.0), t.1);
         }
 
         assert!(matches!(
-            <webpki::Error as Into<CertRevocationListError>>::into(
-                webpki::Error::NameConstraintViolation
-            ),
+            crl_error(webpki::Error::NameConstraintViolation),
             Other(_)
         ));
     }


### PR DESCRIPTION
I learned about this today, so thought I'd give it a try. It pointed out one `rustls-webpki` and two `ring` leakages that this PR fixes.

See https://github.com/rustls/rustls/actions/runs/6511651812/job/17687753330 for the example failing output.