### PR TITLE
Tidy up remaining non-standard names

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+upper-case-acronyms-aggressive = true

--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -101,19 +101,19 @@ pub enum ResumptionKind {
     /// No resumption
     No,
     /// Session ID
-    SessionID,
+    SessionId,
     /// Session tickets
     Tickets,
 }
 
 impl ResumptionKind {
-    pub const ALL: &'static [ResumptionKind] = &[Self::No, Self::SessionID, Self::Tickets];
+    pub const ALL: &'static [ResumptionKind] = &[Self::No, Self::SessionId, Self::Tickets];
 
     /// Returns a user-facing label that identifies the resumption kind
     pub fn label(&self) -> &'static str {
         match *self {
             Self::No => "no_resume",
-            Self::SessionID => "session_id",
+            Self::SessionId => "session_id",
             Self::Tickets => "tickets",
         }
     }

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -144,7 +144,7 @@ fn main() -> anyhow::Result<()> {
             let handshake_buf = &mut [0u8; 262144];
             let resumption_kind = black_box(bench.kind.resumption_kind());
             let params = black_box(bench.params);
-            let io = StepperIO {
+            let io = StepperIo {
                 reader: &mut stdin,
                 writer: &mut stdout,
                 handshake_buf,
@@ -334,7 +334,7 @@ trait BenchStepper {
 }
 
 /// Stepper fields necessary for IO
-struct StepperIO<'a> {
+struct StepperIo<'a> {
     reader: &'a mut dyn Read,
     writer: &'a mut dyn Write,
     handshake_buf: &'a mut [u8],
@@ -342,7 +342,7 @@ struct StepperIO<'a> {
 
 /// A benchmark stepper for the client-side of the connection
 struct ClientSideStepper<'a> {
-    io: StepperIO<'a>,
+    io: StepperIo<'a>,
     resumption_kind: ResumptionKind,
     config: Arc<ClientConfig>,
 }
@@ -420,7 +420,7 @@ impl BenchStepper for ClientSideStepper<'_> {
 
 /// A benchmark stepper for the server-side of the connection
 struct ServerSideStepper<'a> {
-    io: StepperIO<'a>,
+    io: StepperIo<'a>,
     config: Arc<ServerConfig>,
 }
 

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -437,7 +437,7 @@ impl ServerSideStepper<'_> {
             .with_single_cert(params.key_type.get_chain(), params.key_type.get_key())
             .expect("bad certs/private key?");
 
-        if resume == ResumptionKind::SessionID {
+        if resume == ResumptionKind::SessionId {
             cfg.session_storage = ServerSessionMemoryCache::new(128);
         } else if resume == ResumptionKind::Tickets {
             cfg.ticketer = Ticketer::new().unwrap();

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -97,7 +97,7 @@ fn main() {
     //
     // For this demo we spawn a thread that flips between writing a CRL that lists the client
     // certificate as revoked and a CRL that has no revoked certificates.
-    let crl_updater = CRLUpdater {
+    let crl_updater = CrlUpdater {
         sleep_duration: Duration::from_secs(update_seconds),
         crl_path: PathBuf::from(crl_path.clone()),
         pki: test_pki.clone(),
@@ -284,13 +284,13 @@ impl TestPki {
 ///
 /// In a real use case, the CRL would be updated by fetching fresh CRL data from an authoritative
 /// distribution point.
-struct CRLUpdater {
+struct CrlUpdater {
     sleep_duration: Duration,
     crl_path: PathBuf,
     pki: Arc<TestPki>,
 }
 
-impl CRLUpdater {
+impl CrlUpdater {
     fn run(self) {
         let mut revoked = true;
 

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -129,7 +129,7 @@ enum ClientAuth {
 #[derive(PartialEq, Clone, Copy)]
 enum ResumptionParam {
     No,
-    SessionID,
+    SessionId,
     Tickets,
 }
 
@@ -137,7 +137,7 @@ impl ResumptionParam {
     fn label(&self) -> &'static str {
         match *self {
             Self::No => "no-resume",
-            Self::SessionID => "sessionid",
+            Self::SessionId => "sessionid",
             Self::Tickets => "tickets",
         }
     }
@@ -316,7 +316,7 @@ fn make_server_config(
         .with_single_cert(params.key_type.get_chain(), params.key_type.get_key())
         .expect("bad certs/private key?");
 
-    if resume == ResumptionParam::SessionID {
+    if resume == ResumptionParam::SessionId {
         cfg.session_storage = ServerSessionMemoryCache::new(128);
     } else if resume == ResumptionParam::Tickets {
         cfg.ticketer = Ticketer::new().unwrap();
@@ -611,7 +611,7 @@ fn selected_tests(mut args: env::Args) {
                 let resume = if mode == "handshake" {
                     ResumptionParam::No
                 } else if mode == "handshake-resume" {
-                    ResumptionParam::SessionID
+                    ResumptionParam::SessionId
                 } else {
                     ResumptionParam::Tickets
                 };
@@ -655,8 +655,8 @@ fn all_tests() {
         bench_bulk(test, 1024 * 1024, Some(10000));
         bench_handshake(test, ClientAuth::No, ResumptionParam::No);
         bench_handshake(test, ClientAuth::Yes, ResumptionParam::No);
-        bench_handshake(test, ClientAuth::No, ResumptionParam::SessionID);
-        bench_handshake(test, ClientAuth::Yes, ResumptionParam::SessionID);
+        bench_handshake(test, ClientAuth::No, ResumptionParam::SessionId);
+        bench_handshake(test, ClientAuth::Yes, ResumptionParam::SessionId);
         bench_handshake(test, ClientAuth::No, ResumptionParam::Tickets);
         bench_handshake(test, ClientAuth::Yes, ResumptionParam::Tickets);
     }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -221,7 +221,7 @@ fn emit_client_hello_for_retry(
 
     let mut exts = vec![
         ClientExtension::SupportedVersions(supported_versions),
-        ClientExtension::ECPointFormats(ECPointFormat::SUPPORTED.to_vec()),
+        ClientExtension::EcPointFormats(ECPointFormat::SUPPORTED.to_vec()),
         ClientExtension::NamedGroups(
             config
                 .kx_groups

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -12,7 +12,7 @@ use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
 use crate::msgs::handshake::{
     CertificatePayload, HandshakeMessagePayload, HandshakePayload, NewSessionTicketPayload,
-    ServerECDHParams, SessionId,
+    ServerEcdhParams, SessionId,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -763,7 +763,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
 
         // 5a.
         let ecdh_params =
-            tls12::decode_ecdh_params::<ServerECDHParams>(cx.common, &st.server_kx.kx_params)?;
+            tls12::decode_ecdh_params::<ServerEcdhParams>(cx.common, &st.server_kx.kx_params)?;
         let named_group = ecdh_params.curve_params.named_group;
         let skxg = match st.config.find_kx_group(named_group) {
             Some(skxg) => skxg,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1027,7 +1027,7 @@ impl State<ClientConnectionData> for ExpectTraffic {
             MessagePayload::Handshake {
                 parsed:
                     HandshakeMessagePayload {
-                        payload: HandshakePayload::NewSessionTicketTLS13(ref new_ticket),
+                        payload: HandshakePayload::NewSessionTicketTls13(ref new_ticket),
                         ..
                     },
                 ..
@@ -1077,7 +1077,7 @@ impl State<ClientConnectionData> for ExpectQuicTraffic {
         let nst = require_handshake_msg!(
             m,
             HandshakeType::NewSessionTicket,
-            HandshakePayload::NewSessionTicketTLS13
+            HandshakePayload::NewSessionTicketTls13
         )?;
         self.0
             .handle_new_ticket_tls13(cx, nst)?;

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -17,7 +17,7 @@ use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::enums::KeyUpdateRequest;
 use crate::msgs::handshake::NewSessionTicketPayloadTLS13;
-use crate::msgs::handshake::{CertificateEntry, CertificatePayloadTLS13};
+use crate::msgs::handshake::{CertificateEntry, CertificatePayloadTls13};
 use crate::msgs::handshake::{ClientExtension, ServerExtension};
 use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
 use crate::msgs::handshake::{HasServerExtensions, ServerHelloPayload};
@@ -724,7 +724,7 @@ fn emit_certificate_tls13(
 ) {
     let context = auth_context.unwrap_or_default();
 
-    let mut cert_payload = CertificatePayloadTLS13 {
+    let mut cert_payload = CertificatePayloadTls13 {
         context: PayloadU8::new(context),
         entries: Vec::new(),
     };

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -493,7 +493,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
             MessagePayload::Handshake {
                 parsed:
                     HandshakeMessagePayload {
-                        payload: HandshakePayload::CertificateRequestTLS13(..),
+                        payload: HandshakePayload::CertificateRequestTls13(..),
                         ..
                     },
                 ..
@@ -535,7 +535,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
         let certreq = &require_handshake_msg!(
             m,
             HandshakeType::CertificateRequest,
-            HandshakePayload::CertificateRequestTLS13
+            HandshakePayload::CertificateRequestTls13
         )?;
         self.transcript.add_message(&m);
         debug!("Got CertificateRequest {:?}", certreq);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -476,7 +476,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
             MessagePayload::Handshake {
                 parsed:
                     HandshakeMessagePayload {
-                        payload: HandshakePayload::CertificateTLS13(..),
+                        payload: HandshakePayload::CertificateTls13(..),
                         ..
                     },
                 ..
@@ -604,7 +604,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
         let cert_chain = require_handshake_msg!(
             m,
             HandshakeType::Certificate,
-            HandshakePayload::CertificateTLS13
+            HandshakePayload::CertificateTls13
         )?;
         self.transcript.add_message(&m);
 
@@ -741,7 +741,7 @@ fn emit_certificate_tls13(
         version: ProtocolVersion::TLSv1_3,
         payload: MessagePayload::handshake(HandshakeMessagePayload {
             typ: HandshakeType::Certificate,
-            payload: HandshakePayload::CertificateTLS13(cert_payload),
+            payload: HandshakePayload::CertificateTls13(cert_payload),
         }),
     };
     transcript.add_message(&m);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -16,7 +16,7 @@ use crate::msgs::base::{Payload, PayloadU8};
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::enums::KeyUpdateRequest;
-use crate::msgs::handshake::NewSessionTicketPayloadTLS13;
+use crate::msgs::handshake::NewSessionTicketPayloadTls13;
 use crate::msgs::handshake::{CertificateEntry, CertificatePayloadTls13};
 use crate::msgs::handshake::{ClientExtension, ServerExtension};
 use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
@@ -940,7 +940,7 @@ impl ExpectTraffic {
     fn handle_new_ticket_tls13(
         &mut self,
         cx: &mut ClientContext<'_>,
-        nst: &NewSessionTicketPayloadTLS13,
+        nst: &NewSessionTicketPayloadTls13,
     ) -> Result<(), Error> {
         if nst.has_duplicate_extension() {
             return Err(cx.common.send_fatal_alert(

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -265,6 +265,7 @@
     clippy::clone_on_ref_ptr,
     clippy::std_instead_of_core,
     clippy::use_self,
+    clippy::upper_case_acronyms,
     trivial_casts,
     trivial_numeric_casts,
     missing_docs,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2038,7 +2038,7 @@ pub enum HandshakePayload {
     ServerHello(ServerHelloPayload),
     HelloRetryRequest(HelloRetryRequest),
     Certificate(CertificatePayload),
-    CertificateTLS13(CertificatePayloadTls13),
+    CertificateTls13(CertificatePayloadTls13),
     ServerKeyExchange(ServerKeyExchangePayload),
     CertificateRequest(CertificateRequestPayload),
     CertificateRequestTLS13(CertificateRequestPayloadTls13),
@@ -2065,7 +2065,7 @@ impl HandshakePayload {
             ServerHello(ref x) => x.encode(bytes),
             HelloRetryRequest(ref x) => x.encode(bytes),
             Certificate(ref x) => x.encode(bytes),
-            CertificateTLS13(ref x) => x.encode(bytes),
+            CertificateTls13(ref x) => x.encode(bytes),
             ServerKeyExchange(ref x) => x.encode(bytes),
             ClientKeyExchange(ref x) => x.encode(bytes),
             CertificateRequest(ref x) => x.encode(bytes),
@@ -2136,7 +2136,7 @@ impl HandshakeMessagePayload {
             }
             HandshakeType::Certificate if vers == ProtocolVersion::TLSv1_3 => {
                 let p = CertificatePayloadTls13::read(&mut sub)?;
-                HandshakePayload::CertificateTLS13(p)
+                HandshakePayload::CertificateTls13(p)
             }
             HandshakeType::Certificate => {
                 HandshakePayload::Certificate(CertificatePayload::read(&mut sub)?)

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1792,12 +1792,12 @@ impl TlsListElement for CertReqExtension {
 }
 
 #[derive(Debug)]
-pub struct CertificateRequestPayloadTLS13 {
+pub struct CertificateRequestPayloadTls13 {
     pub context: PayloadU8,
     pub extensions: Vec<CertReqExtension>,
 }
 
-impl Codec for CertificateRequestPayloadTLS13 {
+impl Codec for CertificateRequestPayloadTls13 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.context.encode(bytes);
         self.extensions.encode(bytes);
@@ -1814,7 +1814,7 @@ impl Codec for CertificateRequestPayloadTLS13 {
     }
 }
 
-impl CertificateRequestPayloadTLS13 {
+impl CertificateRequestPayloadTls13 {
     pub fn find_extension(&self, ext: ExtensionType) -> Option<&CertReqExtension> {
         self.extensions
             .iter()
@@ -2041,7 +2041,7 @@ pub enum HandshakePayload {
     CertificateTLS13(CertificatePayloadTls13),
     ServerKeyExchange(ServerKeyExchangePayload),
     CertificateRequest(CertificateRequestPayload),
-    CertificateRequestTLS13(CertificateRequestPayloadTLS13),
+    CertificateRequestTLS13(CertificateRequestPayloadTls13),
     CertificateVerify(DigitallySignedStruct),
     ServerHelloDone,
     EndOfEarlyData,
@@ -2153,7 +2153,7 @@ impl HandshakeMessagePayload {
                 HandshakePayload::ClientKeyExchange(Payload::read(&mut sub))
             }
             HandshakeType::CertificateRequest if vers == ProtocolVersion::TLSv1_3 => {
-                let p = CertificateRequestPayloadTLS13::read(&mut sub)?;
+                let p = CertificateRequestPayloadTls13::read(&mut sub)?;
                 HandshakePayload::CertificateRequestTLS13(p)
             }
             HandshakeType::CertificateRequest => {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1377,12 +1377,12 @@ impl TlsListElement for CertificateEntry {
 }
 
 #[derive(Debug)]
-pub struct CertificatePayloadTLS13 {
+pub struct CertificatePayloadTls13 {
     pub context: PayloadU8,
     pub entries: Vec<CertificateEntry>,
 }
 
-impl Codec for CertificatePayloadTLS13 {
+impl Codec for CertificatePayloadTls13 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.context.encode(bytes);
         self.entries.encode(bytes);
@@ -1396,7 +1396,7 @@ impl Codec for CertificatePayloadTLS13 {
     }
 }
 
-impl CertificatePayloadTLS13 {
+impl CertificatePayloadTls13 {
     pub fn new(entries: Vec<CertificateEntry>) -> Self {
         Self {
             context: PayloadU8::empty(),
@@ -2038,7 +2038,7 @@ pub enum HandshakePayload {
     ServerHello(ServerHelloPayload),
     HelloRetryRequest(HelloRetryRequest),
     Certificate(CertificatePayload),
-    CertificateTLS13(CertificatePayloadTLS13),
+    CertificateTLS13(CertificatePayloadTls13),
     ServerKeyExchange(ServerKeyExchangePayload),
     CertificateRequest(CertificateRequestPayload),
     CertificateRequestTLS13(CertificateRequestPayloadTLS13),
@@ -2135,7 +2135,7 @@ impl HandshakeMessagePayload {
                 }
             }
             HandshakeType::Certificate if vers == ProtocolVersion::TLSv1_3 => {
-                let p = CertificatePayloadTLS13::read(&mut sub)?;
+                let p = CertificatePayloadTls13::read(&mut sub)?;
                 HandshakePayload::CertificateTLS13(p)
             }
             HandshakeType::Certificate => {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1488,11 +1488,11 @@ impl Codec for EcParameters {
 }
 
 #[derive(Debug)]
-pub struct ClientECDHParams {
+pub struct ClientEcdhParams {
     pub public: PayloadU8,
 }
 
-impl Codec for ClientECDHParams {
+impl Codec for ClientEcdhParams {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.public.encode(bytes);
     }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2041,7 +2041,7 @@ pub enum HandshakePayload {
     CertificateTls13(CertificatePayloadTls13),
     ServerKeyExchange(ServerKeyExchangePayload),
     CertificateRequest(CertificateRequestPayload),
-    CertificateRequestTLS13(CertificateRequestPayloadTls13),
+    CertificateRequestTls13(CertificateRequestPayloadTls13),
     CertificateVerify(DigitallySignedStruct),
     ServerHelloDone,
     EndOfEarlyData,
@@ -2069,7 +2069,7 @@ impl HandshakePayload {
             ServerKeyExchange(ref x) => x.encode(bytes),
             ClientKeyExchange(ref x) => x.encode(bytes),
             CertificateRequest(ref x) => x.encode(bytes),
-            CertificateRequestTLS13(ref x) => x.encode(bytes),
+            CertificateRequestTls13(ref x) => x.encode(bytes),
             CertificateVerify(ref x) => x.encode(bytes),
             NewSessionTicket(ref x) => x.encode(bytes),
             NewSessionTicketTLS13(ref x) => x.encode(bytes),
@@ -2154,7 +2154,7 @@ impl HandshakeMessagePayload {
             }
             HandshakeType::CertificateRequest if vers == ProtocolVersion::TLSv1_3 => {
                 let p = CertificateRequestPayloadTls13::read(&mut sub)?;
-                HandshakePayload::CertificateRequestTLS13(p)
+                HandshakePayload::CertificateRequestTls13(p)
             }
             HandshakeType::CertificateRequest => {
                 let p = CertificateRequestPayload::read(&mut sub)?;

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1539,12 +1539,12 @@ impl Codec for ServerEcdhParams {
 }
 
 #[derive(Debug)]
-pub struct ECDHEServerKeyExchange {
+pub struct EcdheServerKeyExchange {
     pub params: ServerEcdhParams,
     pub dss: DigitallySignedStruct,
 }
 
-impl Codec for ECDHEServerKeyExchange {
+impl Codec for EcdheServerKeyExchange {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.params.encode(bytes);
         self.dss.encode(bytes);
@@ -1560,7 +1560,7 @@ impl Codec for ECDHEServerKeyExchange {
 
 #[derive(Debug)]
 pub enum ServerKeyExchangePayload {
-    ECDHE(ECDHEServerKeyExchange),
+    ECDHE(EcdheServerKeyExchange),
     Unknown(Payload),
 }
 
@@ -1580,12 +1580,12 @@ impl Codec for ServerKeyExchangePayload {
 }
 
 impl ServerKeyExchangePayload {
-    pub fn unwrap_given_kxa(&self, kxa: KeyExchangeAlgorithm) -> Option<ECDHEServerKeyExchange> {
+    pub fn unwrap_given_kxa(&self, kxa: KeyExchangeAlgorithm) -> Option<EcdheServerKeyExchange> {
         if let Self::Unknown(ref unk) = *self {
             let mut rd = Reader::init(&unk.0);
 
             let result = match kxa {
-                KeyExchangeAlgorithm::ECDHE => ECDHEServerKeyExchange::read(&mut rd),
+                KeyExchangeAlgorithm::ECDHE => EcdheServerKeyExchange::read(&mut rd),
             };
 
             if !rd.any_left() {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2047,7 +2047,7 @@ pub enum HandshakePayload {
     EndOfEarlyData,
     ClientKeyExchange(Payload),
     NewSessionTicket(NewSessionTicketPayload),
-    NewSessionTicketTLS13(NewSessionTicketPayloadTls13),
+    NewSessionTicketTls13(NewSessionTicketPayloadTls13),
     EncryptedExtensions(Vec<ServerExtension>),
     KeyUpdate(KeyUpdateRequest),
     Finished(Payload),
@@ -2072,7 +2072,7 @@ impl HandshakePayload {
             CertificateRequestTls13(ref x) => x.encode(bytes),
             CertificateVerify(ref x) => x.encode(bytes),
             NewSessionTicket(ref x) => x.encode(bytes),
-            NewSessionTicketTLS13(ref x) => x.encode(bytes),
+            NewSessionTicketTls13(ref x) => x.encode(bytes),
             EncryptedExtensions(ref x) => x.encode(bytes),
             KeyUpdate(ref x) => x.encode(bytes),
             Finished(ref x) => x.encode(bytes),
@@ -2165,7 +2165,7 @@ impl HandshakeMessagePayload {
             }
             HandshakeType::NewSessionTicket if vers == ProtocolVersion::TLSv1_3 => {
                 let p = NewSessionTicketPayloadTls13::read(&mut sub)?;
-                HandshakePayload::NewSessionTicketTLS13(p)
+                HandshakePayload::NewSessionTicketTls13(p)
             }
             HandshakeType::NewSessionTicket => {
                 let p = NewSessionTicketPayload::read(&mut sub)?;

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -483,14 +483,14 @@ impl Codec for OcspCertificateStatusRequest {
 
 #[derive(Clone, Debug)]
 pub enum CertificateStatusRequest {
-    OCSP(OcspCertificateStatusRequest),
+    Ocsp(OcspCertificateStatusRequest),
     Unknown((CertificateStatusType, Payload)),
 }
 
 impl Codec for CertificateStatusRequest {
     fn encode(&self, bytes: &mut Vec<u8>) {
         match self {
-            Self::OCSP(ref r) => r.encode(bytes),
+            Self::Ocsp(ref r) => r.encode(bytes),
             Self::Unknown((typ, payload)) => {
                 typ.encode(bytes);
                 payload.encode(bytes);
@@ -504,7 +504,7 @@ impl Codec for CertificateStatusRequest {
         match typ {
             CertificateStatusType::OCSP => {
                 let ocsp_req = OcspCertificateStatusRequest::read(r)?;
-                Ok(Self::OCSP(ocsp_req))
+                Ok(Self::Ocsp(ocsp_req))
             }
             _ => {
                 let data = Payload::read(r);
@@ -520,7 +520,7 @@ impl CertificateStatusRequest {
             responder_ids: Vec::new(),
             extensions: PayloadU16::empty(),
         };
-        Self::OCSP(ocsp)
+        Self::Ocsp(ocsp)
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1504,12 +1504,12 @@ impl Codec for ClientEcdhParams {
 }
 
 #[derive(Debug)]
-pub struct ServerECDHParams {
+pub struct ServerEcdhParams {
     pub curve_params: EcParameters,
     pub public: PayloadU8,
 }
 
-impl ServerECDHParams {
+impl ServerEcdhParams {
     pub fn new(kx: &dyn ActiveKeyExchange) -> Self {
         Self {
             curve_params: EcParameters {
@@ -1521,7 +1521,7 @@ impl ServerECDHParams {
     }
 }
 
-impl Codec for ServerECDHParams {
+impl Codec for ServerEcdhParams {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.curve_params.encode(bytes);
         self.public.encode(bytes);
@@ -1540,7 +1540,7 @@ impl Codec for ServerECDHParams {
 
 #[derive(Debug)]
 pub struct ECDHEServerKeyExchange {
-    pub params: ServerECDHParams,
+    pub params: ServerEcdhParams,
     pub dss: DigitallySignedStruct,
 }
 
@@ -1551,7 +1551,7 @@ impl Codec for ECDHEServerKeyExchange {
     }
 
     fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
-        let params = ServerECDHParams::read(r)?;
+        let params = ServerEcdhParams::read(r)?;
         let dss = DigitallySignedStruct::read(r)?;
 
         Ok(Self { params, dss })

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1560,14 +1560,14 @@ impl Codec for EcdheServerKeyExchange {
 
 #[derive(Debug)]
 pub enum ServerKeyExchangePayload {
-    ECDHE(EcdheServerKeyExchange),
+    Ecdhe(EcdheServerKeyExchange),
     Unknown(Payload),
 }
 
 impl Codec for ServerKeyExchangePayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         match *self {
-            Self::ECDHE(ref x) => x.encode(bytes),
+            Self::Ecdhe(ref x) => x.encode(bytes),
             Self::Unknown(ref x) => x.encode(bytes),
         }
     }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -690,7 +690,7 @@ pub enum ClientSessionTicket {
 
 #[derive(Clone, Debug)]
 pub enum ServerExtension {
-    ECPointFormats(Vec<ECPointFormat>),
+    EcPointFormats(Vec<ECPointFormat>),
     ServerNameAck,
     SessionTicketAck,
     RenegotiationInfo(PayloadU8),
@@ -709,7 +709,7 @@ pub enum ServerExtension {
 impl ServerExtension {
     pub fn get_type(&self) -> ExtensionType {
         match *self {
-            Self::ECPointFormats(_) => ExtensionType::ECPointFormats,
+            Self::EcPointFormats(_) => ExtensionType::ECPointFormats,
             Self::ServerNameAck => ExtensionType::ServerName,
             Self::SessionTicketAck => ExtensionType::SessionTicket,
             Self::RenegotiationInfo(_) => ExtensionType::RenegotiationInfo,
@@ -733,7 +733,7 @@ impl Codec for ServerExtension {
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
         match *self {
-            Self::ECPointFormats(ref r) => r.encode(nested.buf),
+            Self::EcPointFormats(ref r) => r.encode(nested.buf),
             Self::ServerNameAck
             | Self::SessionTicketAck
             | Self::ExtendedMasterSecretAck
@@ -757,7 +757,7 @@ impl Codec for ServerExtension {
         let mut sub = r.sub(len)?;
 
         let ext = match typ {
-            ExtensionType::ECPointFormats => Self::ECPointFormats(Vec::read(&mut sub)?),
+            ExtensionType::ECPointFormats => Self::EcPointFormats(Vec::read(&mut sub)?),
             ExtensionType::ServerName => Self::ServerNameAck,
             ExtensionType::SessionTicket => Self::SessionTicketAck,
             ExtensionType::StatusRequest => Self::CertificateStatusAck,
@@ -1231,7 +1231,7 @@ impl ServerHelloPayload {
     pub fn get_ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
         let ext = self.find_extension(ExtensionType::ECPointFormats)?;
         match *ext {
-            ServerExtension::ECPointFormats(ref fmts) => Some(fmts),
+            ServerExtension::EcPointFormats(ref fmts) => Some(fmts),
             _ => None,
         }
     }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1918,7 +1918,7 @@ impl TlsListElement for NewSessionTicketExtension {
 }
 
 #[derive(Debug)]
-pub struct NewSessionTicketPayloadTLS13 {
+pub struct NewSessionTicketPayloadTls13 {
     pub lifetime: u32,
     pub age_add: u32,
     pub nonce: PayloadU8,
@@ -1926,7 +1926,7 @@ pub struct NewSessionTicketPayloadTLS13 {
     pub exts: Vec<NewSessionTicketExtension>,
 }
 
-impl NewSessionTicketPayloadTLS13 {
+impl NewSessionTicketPayloadTls13 {
     pub fn new(lifetime: u32, age_add: u32, nonce: Vec<u8>, ticket: Vec<u8>) -> Self {
         Self {
             lifetime,
@@ -1967,7 +1967,7 @@ impl NewSessionTicketPayloadTLS13 {
     }
 }
 
-impl Codec for NewSessionTicketPayloadTLS13 {
+impl Codec for NewSessionTicketPayloadTls13 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.lifetime.encode(bytes);
         self.age_add.encode(bytes);
@@ -2047,7 +2047,7 @@ pub enum HandshakePayload {
     EndOfEarlyData,
     ClientKeyExchange(Payload),
     NewSessionTicket(NewSessionTicketPayload),
-    NewSessionTicketTLS13(NewSessionTicketPayloadTLS13),
+    NewSessionTicketTLS13(NewSessionTicketPayloadTls13),
     EncryptedExtensions(Vec<ServerExtension>),
     KeyUpdate(KeyUpdateRequest),
     Finished(Payload),
@@ -2164,7 +2164,7 @@ impl HandshakeMessagePayload {
                 HandshakePayload::CertificateVerify(DigitallySignedStruct::read(&mut sub)?)
             }
             HandshakeType::NewSessionTicket if vers == ProtocolVersion::TLSv1_3 => {
-                let p = NewSessionTicketPayloadTLS13::read(&mut sub)?;
+                let p = NewSessionTicketPayloadTls13::read(&mut sub)?;
                 HandshakePayload::NewSessionTicketTLS13(p)
             }
             HandshakeType::NewSessionTicket => {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1461,12 +1461,12 @@ pub enum KeyExchangeAlgorithm {
 // idea and unnecessary attack surface.  Please,
 // get a grip.
 #[derive(Debug)]
-pub struct ECParameters {
+pub struct EcParameters {
     pub curve_type: ECCurveType,
     pub named_group: NamedGroup,
 }
 
-impl Codec for ECParameters {
+impl Codec for EcParameters {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.curve_type.encode(bytes);
         self.named_group.encode(bytes);
@@ -1505,14 +1505,14 @@ impl Codec for ClientECDHParams {
 
 #[derive(Debug)]
 pub struct ServerECDHParams {
-    pub curve_params: ECParameters,
+    pub curve_params: EcParameters,
     pub public: PayloadU8,
 }
 
 impl ServerECDHParams {
     pub fn new(kx: &dyn ActiveKeyExchange) -> Self {
         Self {
-            curve_params: ECParameters {
+            curve_params: EcParameters {
                 curve_type: ECCurveType::NamedCurve,
                 named_group: kx.group(),
             },
@@ -1528,7 +1528,7 @@ impl Codec for ServerECDHParams {
     }
 
     fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
-        let cp = ECParameters::read(r)?;
+        let cp = EcParameters::read(r)?;
         let pb = PayloadU8::read(r)?;
 
         Ok(Self {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -461,12 +461,12 @@ impl TlsListElement for ResponderId {
 }
 
 #[derive(Clone, Debug)]
-pub struct OCSPCertificateStatusRequest {
+pub struct OcspCertificateStatusRequest {
     pub responder_ids: Vec<ResponderId>,
     pub extensions: PayloadU16,
 }
 
-impl Codec for OCSPCertificateStatusRequest {
+impl Codec for OcspCertificateStatusRequest {
     fn encode(&self, bytes: &mut Vec<u8>) {
         CertificateStatusType::OCSP.encode(bytes);
         self.responder_ids.encode(bytes);
@@ -483,7 +483,7 @@ impl Codec for OCSPCertificateStatusRequest {
 
 #[derive(Clone, Debug)]
 pub enum CertificateStatusRequest {
-    OCSP(OCSPCertificateStatusRequest),
+    OCSP(OcspCertificateStatusRequest),
     Unknown((CertificateStatusType, Payload)),
 }
 
@@ -503,7 +503,7 @@ impl Codec for CertificateStatusRequest {
 
         match typ {
             CertificateStatusType::OCSP => {
-                let ocsp_req = OCSPCertificateStatusRequest::read(r)?;
+                let ocsp_req = OcspCertificateStatusRequest::read(r)?;
                 Ok(Self::OCSP(ocsp_req))
             }
             _ => {
@@ -516,7 +516,7 @@ impl Codec for CertificateStatusRequest {
 
 impl CertificateStatusRequest {
     pub fn build_ocsp() -> Self {
-        let ocsp = OCSPCertificateStatusRequest {
+        let ocsp = OcspCertificateStatusRequest {
             responder_ids: Vec::new(),
             extensions: PayloadU16::empty(),
         };

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -540,7 +540,7 @@ impl TlsListElement for ProtocolVersion {
 
 #[derive(Clone, Debug)]
 pub enum ClientExtension {
-    ECPointFormats(Vec<ECPointFormat>),
+    EcPointFormats(Vec<ECPointFormat>),
     NamedGroups(Vec<NamedGroup>),
     SignatureAlgorithms(Vec<SignatureScheme>),
     ServerName(Vec<ServerName>),
@@ -562,7 +562,7 @@ pub enum ClientExtension {
 impl ClientExtension {
     pub fn get_type(&self) -> ExtensionType {
         match *self {
-            Self::ECPointFormats(_) => ExtensionType::ECPointFormats,
+            Self::EcPointFormats(_) => ExtensionType::ECPointFormats,
             Self::NamedGroups(_) => ExtensionType::EllipticCurves,
             Self::SignatureAlgorithms(_) => ExtensionType::SignatureAlgorithms,
             Self::ServerName(_) => ExtensionType::ServerName,
@@ -589,7 +589,7 @@ impl Codec for ClientExtension {
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
         match *self {
-            Self::ECPointFormats(ref r) => r.encode(nested.buf),
+            Self::EcPointFormats(ref r) => r.encode(nested.buf),
             Self::NamedGroups(ref r) => r.encode(nested.buf),
             Self::SignatureAlgorithms(ref r) => r.encode(nested.buf),
             Self::ServerName(ref r) => r.encode(nested.buf),
@@ -617,7 +617,7 @@ impl Codec for ClientExtension {
         let mut sub = r.sub(len)?;
 
         let ext = match typ {
-            ExtensionType::ECPointFormats => Self::ECPointFormats(Vec::read(&mut sub)?),
+            ExtensionType::ECPointFormats => Self::EcPointFormats(Vec::read(&mut sub)?),
             ExtensionType::EllipticCurves => Self::NamedGroups(Vec::read(&mut sub)?),
             ExtensionType::SignatureAlgorithms => Self::SignatureAlgorithms(Vec::read(&mut sub)?),
             ExtensionType::ServerName => Self::ServerName(Vec::read(&mut sub)?),
@@ -901,7 +901,7 @@ impl ClientHelloPayload {
     pub fn get_ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
         let ext = self.find_extension(ExtensionType::ECPointFormats)?;
         match *ext {
-            ClientExtension::ECPointFormats(ref req) => Some(req),
+            ClientExtension::EcPointFormats(ref req) => Some(req),
             _ => None,
         }
     }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -745,7 +745,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
         cipher_suite: CipherSuite::TLS_NULL_WITH_NULL_NULL,
         compression_method: Compression::Null,
         extensions: vec![
-            ServerExtension::ECPointFormats(ECPointFormat::SUPPORTED.to_vec()),
+            ServerExtension::EcPointFormats(ECPointFormat::SUPPORTED.to_vec()),
             ServerExtension::ServerNameAck,
             ServerExtension::SessionTicketAck,
             ServerExtension::RenegotiationInfo(PayloadU8(vec![0])),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -8,7 +8,7 @@ use crate::msgs::enums::{
 };
 use crate::msgs::handshake::{
     CertReqExtension, CertificateEntry, CertificateExtension, CertificatePayloadTls13,
-    CertificateRequestPayload, CertificateRequestPayloadTLS13, CertificateStatus,
+    CertificateRequestPayload, CertificateRequestPayloadTls13, CertificateStatus,
     CertificateStatusRequest, ClientExtension, ClientHelloPayload, ClientSessionTicket,
     ConvertProtocolNameList, ConvertServerNameList, DistinguishedName, EcParameters,
     EcdheServerKeyExchange, HandshakeMessagePayload, HandshakePayload, HasServerExtensions,
@@ -834,8 +834,8 @@ fn get_sample_certificaterequestpayload() -> CertificateRequestPayload {
     }
 }
 
-fn get_sample_certificaterequestpayloadtls13() -> CertificateRequestPayloadTLS13 {
-    CertificateRequestPayloadTLS13 {
+fn get_sample_certificaterequestpayloadtls13() -> CertificateRequestPayloadTls13 {
+    CertificateRequestPayloadTls13 {
         context: PayloadU8(vec![1, 2, 3]),
         extensions: vec![
             CertReqExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -810,7 +810,7 @@ fn get_sample_certificatepayloadtls13() -> CertificatePayloadTls13 {
 }
 
 fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
-    ServerKeyExchangePayload::ECDHE(EcdheServerKeyExchange {
+    ServerKeyExchangePayload::Ecdhe(EcdheServerKeyExchange {
         params: ServerEcdhParams {
             curve_params: EcParameters {
                 curve_type: ECCurveType::NamedCurve,

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -11,7 +11,7 @@ use crate::msgs::handshake::{
     CertificateRequestPayload, CertificateRequestPayloadTLS13, CertificateStatus,
     CertificateStatusRequest, ClientExtension, ClientHelloPayload, ClientSessionTicket,
     ConvertProtocolNameList, ConvertServerNameList, DistinguishedName, ECDHEServerKeyExchange,
-    ECParameters, HandshakeMessagePayload, HandshakePayload, HasServerExtensions,
+    EcParameters, HandshakeMessagePayload, HandshakePayload, HasServerExtensions,
     HelloRetryExtension, HelloRetryRequest, KeyShareEntry, NewSessionTicketExtension,
     NewSessionTicketPayload, NewSessionTicketPayloadTLS13, PresharedKeyBinder,
     PresharedKeyIdentity, PresharedKeyOffer, ProtocolName, Random, ServerECDHParams,
@@ -812,7 +812,7 @@ fn get_sample_certificatepayloadtls13() -> CertificatePayloadTls13 {
 fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
     ServerKeyExchangePayload::ECDHE(ECDHEServerKeyExchange {
         params: ServerECDHParams {
-            curve_params: ECParameters {
+            curve_params: EcParameters {
                 curve_type: ECCurveType::NamedCurve,
                 named_group: NamedGroup::X25519,
             },

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -10,8 +10,8 @@ use crate::msgs::handshake::{
     CertReqExtension, CertificateEntry, CertificateExtension, CertificatePayloadTls13,
     CertificateRequestPayload, CertificateRequestPayloadTLS13, CertificateStatus,
     CertificateStatusRequest, ClientExtension, ClientHelloPayload, ClientSessionTicket,
-    ConvertProtocolNameList, ConvertServerNameList, DistinguishedName, ECDHEServerKeyExchange,
-    EcParameters, HandshakeMessagePayload, HandshakePayload, HasServerExtensions,
+    ConvertProtocolNameList, ConvertServerNameList, DistinguishedName, EcParameters,
+    EcdheServerKeyExchange, HandshakeMessagePayload, HandshakePayload, HasServerExtensions,
     HelloRetryExtension, HelloRetryRequest, KeyShareEntry, NewSessionTicketExtension,
     NewSessionTicketPayload, NewSessionTicketPayloadTLS13, PresharedKeyBinder,
     PresharedKeyIdentity, PresharedKeyOffer, ProtocolName, Random, ServerEcdhParams,
@@ -810,7 +810,7 @@ fn get_sample_certificatepayloadtls13() -> CertificatePayloadTls13 {
 }
 
 fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
-    ServerKeyExchangePayload::ECDHE(ECDHEServerKeyExchange {
+    ServerKeyExchangePayload::ECDHE(EcdheServerKeyExchange {
         params: ServerEcdhParams {
             curve_params: EcParameters {
                 curve_type: ECCurveType::NamedCurve,

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -1063,7 +1063,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
-            payload: HandshakePayload::NewSessionTicketTLS13(
+            payload: HandshakePayload::NewSessionTicketTls13(
                 get_sample_newsessionticketpayloadtls13(),
             ),
         },

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -363,7 +363,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
         cipher_suites: vec![CipherSuite::TLS_NULL_WITH_NULL_NULL],
         compression_methods: vec![Compression::Null],
         extensions: vec![
-            ClientExtension::ECPointFormats(ECPointFormat::SUPPORTED.to_vec()),
+            ClientExtension::EcPointFormats(ECPointFormat::SUPPORTED.to_vec()),
             ClientExtension::NamedGroups(vec![NamedGroup::X25519]),
             ClientExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
             ClientExtension::make_sni(DnsNameRef::try_from("hello").unwrap()),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -1026,7 +1026,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Certificate,
-            payload: HandshakePayload::CertificateTLS13(get_sample_certificatepayloadtls13()),
+            payload: HandshakePayload::CertificateTls13(get_sample_certificatepayloadtls13()),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::ServerKeyExchange,

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -7,7 +7,7 @@ use crate::msgs::enums::{
     KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType,
 };
 use crate::msgs::handshake::{
-    CertReqExtension, CertificateEntry, CertificateExtension, CertificatePayloadTLS13,
+    CertReqExtension, CertificateEntry, CertificateExtension, CertificatePayloadTls13,
     CertificateRequestPayload, CertificateRequestPayloadTLS13, CertificateStatus,
     CertificateStatusRequest, ClientExtension, ClientHelloPayload, ClientSessionTicket,
     ConvertProtocolNameList, ConvertServerNameList, DistinguishedName, ECDHEServerKeyExchange,
@@ -791,8 +791,8 @@ fn get_sample_helloretryrequest() -> HelloRetryRequest {
     }
 }
 
-fn get_sample_certificatepayloadtls13() -> CertificatePayloadTLS13 {
-    CertificatePayloadTLS13 {
+fn get_sample_certificatepayloadtls13() -> CertificatePayloadTls13 {
+    CertificatePayloadTls13 {
         context: PayloadU8(vec![1, 2, 3]),
         entries: vec![CertificateEntry {
             cert: CertificateDer::from(vec![3, 4, 5]),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -13,7 +13,7 @@ use crate::msgs::handshake::{
     ConvertProtocolNameList, ConvertServerNameList, DistinguishedName, EcParameters,
     EcdheServerKeyExchange, HandshakeMessagePayload, HandshakePayload, HasServerExtensions,
     HelloRetryExtension, HelloRetryRequest, KeyShareEntry, NewSessionTicketExtension,
-    NewSessionTicketPayload, NewSessionTicketPayloadTLS13, PresharedKeyBinder,
+    NewSessionTicketPayload, NewSessionTicketPayloadTls13, PresharedKeyBinder,
     PresharedKeyIdentity, PresharedKeyOffer, ProtocolName, Random, ServerEcdhParams,
     ServerExtension, ServerHelloPayload, ServerKeyExchangePayload, SessionId, UnknownExtension,
 };
@@ -855,8 +855,8 @@ fn get_sample_newsessionticketpayload() -> NewSessionTicketPayload {
     }
 }
 
-fn get_sample_newsessionticketpayloadtls13() -> NewSessionTicketPayloadTLS13 {
-    NewSessionTicketPayloadTLS13 {
+fn get_sample_newsessionticketpayloadtls13() -> NewSessionTicketPayloadTls13 {
+    NewSessionTicketPayloadTls13 {
         lifetime: 123,
         age_add: 1234,
         nonce: PayloadU8(vec![1, 2, 3]),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -1042,7 +1042,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::CertificateRequest,
-            payload: HandshakePayload::CertificateRequestTLS13(
+            payload: HandshakePayload::CertificateRequestTls13(
                 get_sample_certificaterequestpayloadtls13(),
             ),
         },

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -14,7 +14,7 @@ use crate::msgs::handshake::{
     EcParameters, HandshakeMessagePayload, HandshakePayload, HasServerExtensions,
     HelloRetryExtension, HelloRetryRequest, KeyShareEntry, NewSessionTicketExtension,
     NewSessionTicketPayload, NewSessionTicketPayloadTLS13, PresharedKeyBinder,
-    PresharedKeyIdentity, PresharedKeyOffer, ProtocolName, Random, ServerECDHParams,
+    PresharedKeyIdentity, PresharedKeyOffer, ProtocolName, Random, ServerEcdhParams,
     ServerExtension, ServerHelloPayload, ServerKeyExchangePayload, SessionId, UnknownExtension,
 };
 use crate::verify::DigitallySignedStruct;
@@ -811,7 +811,7 @@ fn get_sample_certificatepayloadtls13() -> CertificatePayloadTls13 {
 
 fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
     ServerKeyExchangePayload::ECDHE(ECDHEServerKeyExchange {
-        params: ServerECDHParams {
+        params: ServerEcdhParams {
             curve_params: EcParameters {
                 curve_type: ECCurveType::NamedCurve,
                 named_group: NamedGroup::X25519,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -42,7 +42,7 @@ mod client_hello {
     use crate::msgs::enums::{ClientCertificateType, Compression};
     use crate::msgs::handshake::ServerEcdhParams;
     use crate::msgs::handshake::{CertificateRequestPayload, ClientSessionTicket, Random};
-    use crate::msgs::handshake::{CertificateStatus, ECDHEServerKeyExchange};
+    use crate::msgs::handshake::{CertificateStatus, EcdheServerKeyExchange};
     use crate::msgs::handshake::{ClientExtension, SessionId};
     use crate::msgs::handshake::{ClientHelloPayload, ServerHelloPayload};
     use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
@@ -428,7 +428,7 @@ mod client_hello {
         let sigscheme = signer.scheme();
         let sig = signer.sign(&msg)?;
 
-        let skx = ServerKeyExchangePayload::ECDHE(ECDHEServerKeyExchange {
+        let skx = ServerKeyExchangePayload::ECDHE(EcdheServerKeyExchange {
             params: secdh,
             dss: DigitallySignedStruct::new(sigscheme, sig),
         });

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -428,7 +428,7 @@ mod client_hello {
         let sigscheme = signer.scheme();
         let sig = signer.sign(&msg)?;
 
-        let skx = ServerKeyExchangePayload::ECDHE(EcdheServerKeyExchange {
+        let skx = ServerKeyExchangePayload::Ecdhe(EcdheServerKeyExchange {
             params: secdh,
             dss: DigitallySignedStruct::new(sigscheme, sig),
         });

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -11,7 +11,7 @@ use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
-use crate::msgs::handshake::{ClientECDHParams, HandshakeMessagePayload, HandshakePayload};
+use crate::msgs::handshake::{ClientEcdhParams, HandshakeMessagePayload, HandshakePayload};
 use crate::msgs::handshake::{NewSessionTicketPayload, SessionId};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -597,7 +597,7 @@ impl State<ServerConnectionData> for ExpectClientKx {
         // Complete key agreement, and set up encryption with the
         // resulting premaster secret.
         let peer_kx_params =
-            tls12::decode_ecdh_params::<ClientECDHParams>(cx.common, &client_kx.0)?;
+            tls12::decode_ecdh_params::<ClientEcdhParams>(cx.common, &client_kx.0)?;
         let secrets = ConnectionSecrets::from_key_exchange(
             self.server_kx,
             &peer_kx_params.public.0,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -40,7 +40,7 @@ mod client_hello {
     use crate::enums::SignatureScheme;
     use crate::msgs::enums::ECPointFormat;
     use crate::msgs::enums::{ClientCertificateType, Compression};
-    use crate::msgs::handshake::ServerECDHParams;
+    use crate::msgs::handshake::ServerEcdhParams;
     use crate::msgs::handshake::{CertificateRequestPayload, ClientSessionTicket, Random};
     use crate::msgs::handshake::{CertificateStatus, ECDHEServerKeyExchange};
     use crate::msgs::handshake::{ClientExtension, SessionId};
@@ -415,7 +415,7 @@ mod client_hello {
         let kx = selected_group
             .start()
             .map_err(|_| Error::FailedToGetRandomBytes)?;
-        let secdh = ServerECDHParams::new(&*kx);
+        let secdh = ServerEcdhParams::new(&*kx);
 
         let mut msg = Vec::new();
         msg.extend(randoms.client);

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -15,7 +15,7 @@ use crate::msgs::codec::Codec;
 use crate::msgs::enums::KeyUpdateRequest;
 use crate::msgs::handshake::HandshakeMessagePayload;
 use crate::msgs::handshake::HandshakePayload;
-use crate::msgs::handshake::{NewSessionTicketExtension, NewSessionTicketPayloadTLS13};
+use crate::msgs::handshake::{NewSessionTicketExtension, NewSessionTicketPayloadTls13};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 use crate::rand;
@@ -1125,7 +1125,7 @@ impl ExpectFinished {
             (id, stateful_lifetime)
         };
 
-        let mut payload = NewSessionTicketPayloadTLS13::new(lifetime, age_add, nonce, ticket);
+        let mut payload = NewSessionTicketPayloadTls13::new(lifetime, age_add, nonce, ticket);
 
         if config.max_early_data_size > 0 {
             if !stateless {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -730,7 +730,7 @@ mod client_hello {
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::CertificateRequest,
-                payload: HandshakePayload::CertificateRequestTLS13(cr),
+                payload: HandshakePayload::CertificateRequestTls13(cr),
             }),
         };
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -772,7 +772,7 @@ mod client_hello {
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::Certificate,
-                payload: HandshakePayload::CertificateTLS13(cert_body),
+                payload: HandshakePayload::CertificateTls13(cert_body),
             }),
         };
 
@@ -887,7 +887,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         let certp = require_handshake_msg!(
             m,
             HandshakeType::Certificate,
-            HandshakePayload::CertificateTLS13
+            HandshakePayload::CertificateTls13
         )?;
         self.transcript.add_message(&m);
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1145,7 +1145,7 @@ impl ExpectFinished {
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::NewSessionTicket,
-                payload: HandshakePayload::NewSessionTicketTLS13(payload),
+                payload: HandshakePayload::NewSessionTicketTls13(payload),
             }),
         };
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -52,7 +52,7 @@ mod client_hello {
     use crate::msgs::handshake::CertificateEntry;
     use crate::msgs::handshake::CertificateExtension;
     use crate::msgs::handshake::CertificatePayloadTls13;
-    use crate::msgs::handshake::CertificateRequestPayloadTLS13;
+    use crate::msgs::handshake::CertificateRequestPayloadTls13;
     use crate::msgs::handshake::CertificateStatus;
     use crate::msgs::handshake::ClientHelloPayload;
     use crate::msgs::handshake::HelloRetryExtension;
@@ -705,7 +705,7 @@ mod client_hello {
             return Ok(false);
         }
 
-        let mut cr = CertificateRequestPayloadTLS13 {
+        let mut cr = CertificateRequestPayloadTls13 {
             context: PayloadU8::empty(),
             extensions: Vec::new(),
         };

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -51,7 +51,7 @@ mod client_hello {
     use crate::msgs::handshake::CertReqExtension;
     use crate::msgs::handshake::CertificateEntry;
     use crate::msgs::handshake::CertificateExtension;
-    use crate::msgs::handshake::CertificatePayloadTLS13;
+    use crate::msgs::handshake::CertificatePayloadTls13;
     use crate::msgs::handshake::CertificateRequestPayloadTLS13;
     use crate::msgs::handshake::CertificateStatus;
     use crate::msgs::handshake::ClientHelloPayload;
@@ -767,7 +767,7 @@ mod client_hello {
             }
         }
 
-        let cert_body = CertificatePayloadTLS13::new(cert_entries);
+        let cert_body = CertificatePayloadTls13::new(cert_entries);
         let c = Message {
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::handshake(HandshakeMessagePayload {

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -320,18 +320,18 @@ mod tests {
     use super::*;
     use crate::common_state::{CommonState, Side};
     use crate::crypto::ring::kx_group::X25519;
-    use crate::msgs::handshake::{ClientEcdhParams, ServerECDHParams};
+    use crate::msgs::handshake::{ClientEcdhParams, ServerEcdhParams};
 
     #[test]
     fn server_ecdhe_remaining_bytes() {
         let key = X25519.start().unwrap();
-        let server_params = ServerECDHParams::new(&*key);
+        let server_params = ServerEcdhParams::new(&*key);
         let mut server_buf = Vec::new();
         server_params.encode(&mut server_buf);
         server_buf.push(34);
 
         let mut common = CommonState::new(Side::Client);
-        assert!(decode_ecdh_params::<ServerECDHParams>(&mut common, &server_buf).is_err());
+        assert!(decode_ecdh_params::<ServerEcdhParams>(&mut common, &server_buf).is_err());
     }
 
     #[test]

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -320,7 +320,7 @@ mod tests {
     use super::*;
     use crate::common_state::{CommonState, Side};
     use crate::crypto::ring::kx_group::X25519;
-    use crate::msgs::handshake::{ClientECDHParams, ServerECDHParams};
+    use crate::msgs::handshake::{ClientEcdhParams, ServerECDHParams};
 
     #[test]
     fn server_ecdhe_remaining_bytes() {
@@ -337,6 +337,6 @@ mod tests {
     #[test]
     fn client_ecdhe_invalid() {
         let mut common = CommonState::new(Side::Server);
-        assert!(decode_ecdh_params::<ClientECDHParams>(&mut common, &[34]).is_err());
+        assert!(decode_ecdh_params::<ClientEcdhParams>(&mut common, &[34]).is_err());
     }
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -949,9 +949,9 @@ fn server_cert_resolve_reduces_sigalgs_for_ecdsa_ciphersuite() {
     );
 }
 
-struct ServerCheckNoSNI {}
+struct ServerCheckNoSni {}
 
-impl ResolvesServerCert for ServerCheckNoSNI {
+impl ResolvesServerCert for ServerCheckNoSni {
     fn resolve(&self, client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
         assert!(client_hello.server_name().is_none());
 
@@ -963,7 +963,7 @@ impl ResolvesServerCert for ServerCheckNoSNI {
 fn client_with_sni_disabled_does_not_send_sni() {
     for kt in ALL_KEY_TYPES.iter() {
         let mut server_config = make_server_config(*kt);
-        server_config.cert_resolver = Arc::new(ServerCheckNoSNI {});
+        server_config.cert_resolver = Arc::new(ServerCheckNoSni {});
         let server_config = Arc::new(server_config);
 
         for version in rustls::ALL_VERSIONS {


### PR DESCRIPTION
This branch tidies up some remaining type names/enum variants that don't meet the [Rust naming conventions](https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case).

Instances in `enums.rs` are ignored with the intent that we want to exactly match upstream documentation in these cases.

The [`clippy::upper_case_acroynyms`](https://rust-lang.github.io/rust-clippy/rust-1.72.0/index.html#/upper_case_acronyms) linter is added to the `lib.rs` deny list, and a `.clippy.toml` is added to set the `upper-case-acronyms-aggressive: true` config option to enable linting on all camel case names.

Resolves https://github.com/rustls/rustls/issues/541