### PR TITLE
Clean up `rustls::internal` exports

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -9,7 +9,7 @@ use rustls::client::{ClientConfig, ClientConnection, Resumption, WebPkiServerVer
 use rustls::crypto::ring::{kx_group, Ticketer, ALL_KX_GROUPS};
 use rustls::crypto::SupportedKxGroup;
 use rustls::internal::msgs::codec::Codec;
-use rustls::internal::msgs::persist;
+use rustls::internal::msgs::persist::ServerSessionValue;
 use rustls::server::{ClientHello, ServerConfig, ServerConnection};
 use rustls::{
     self, client, server, sign, version, AlertDescription, CertificateError, Connection,
@@ -406,7 +406,7 @@ fn align_time() {
 
 impl server::StoresServerSessions for ServerCacheWithResumptionDelay {
     fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
-        let mut ssv = persist::ServerSessionValue::read_bytes(&value).unwrap();
+        let mut ssv = ServerSessionValue::read_bytes(&value).unwrap();
         ssv.creation_time_sec -= self.delay as u64;
 
         self.storage

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -62,9 +62,9 @@ mod server_hello {
             server_hello: &ServerHelloPayload,
             tls13_supported: bool,
         ) -> hs::NextStateOrError {
-            server_hello
-                .random
-                .write_slice(&mut self.randoms.server);
+            self.randoms
+                .server
+                .clone_from_slice(&server_hello.random.0[..]);
 
             // Look for TLS1.3 downgrade signal in server random
             // both the server random and TLS12_DOWNGRADE_SENTINEL are

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -7,8 +7,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: AlertDescription;
-    EnumVal{
+    pub enum AlertDescription {
         CloseNotify => 0x00,
         UnexpectedMessage => 0x0a,
         BadRecordMac => 0x14,
@@ -51,8 +50,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: HandshakeType;
-    EnumVal{
+    pub enum HandshakeType {
         HelloRequest => 0x00,
         ClientHello => 0x01,
         ServerHello => 0x02,
@@ -80,8 +78,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: ContentType;
-    EnumVal{
+    pub enum ContentType {
         ChangeCipherSpec => 0x14,
         Alert => 0x15,
         Handshake => 0x16,
@@ -95,8 +92,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U16
-    EnumName: ProtocolVersion;
-    EnumVal{
+    pub enum ProtocolVersion {
         SSLv2 => 0x0200,
         SSLv3 => 0x0300,
         TLSv1_0 => 0x0301,
@@ -114,8 +110,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U16
-    EnumName: CipherSuite;
-    EnumVal{
+    pub enum CipherSuite {
         TLS_NULL_WITH_NULL_NULL => 0x0000,
         TLS_RSA_WITH_NULL_MD5 => 0x0001,
         TLS_RSA_WITH_NULL_SHA => 0x0002,
@@ -500,8 +495,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U16
-    EnumName: SignatureScheme;
-    EnumVal{
+    pub enum SignatureScheme {
         RSA_PKCS1_SHA1 => 0x0201,
         ECDSA_SHA1_Legacy => 0x0203,
         RSA_PKCS1_SHA256 => 0x0401,
@@ -560,8 +554,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: SignatureAlgorithm;
-    EnumVal{
+    pub enum SignatureAlgorithm {
         Anonymous => 0x00,
         RSA => 0x01,
         DSA => 0x02,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -372,7 +372,7 @@ pub mod internal {
     /// Low-level TLS message parsing and encoding functions.
     pub mod msgs {
         pub mod base {
-            pub use crate::msgs::base::{Payload, PayloadU16};
+            pub use crate::msgs::base::Payload;
         }
         pub mod codec {
             pub use crate::msgs::codec::{Codec, Reader};

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -365,20 +365,43 @@ mod ticketer;
 mod versions;
 mod webpki;
 
-/// Internal classes which may be useful outside the library.
+/// Internal classes that are used in integration tests.
 /// The contents of this section DO NOT form part of the stable interface.
+#[allow(missing_docs)]
 pub mod internal {
     /// Low-level TLS message parsing and encoding functions.
     pub mod msgs {
-        pub use crate::msgs::*;
+        pub mod base {
+            pub use crate::msgs::base::{Payload, PayloadU16};
+        }
+        pub mod codec {
+            pub use crate::msgs::codec::{Codec, Reader};
+        }
+        pub mod deframer {
+            pub use crate::msgs::deframer::MessageDeframer;
+        }
+        pub mod enums {
+            pub use crate::msgs::enums::{AlertLevel, Compression, NamedGroup};
+        }
+        pub mod fragmenter {
+            pub use crate::msgs::fragmenter::MessageFragmenter;
+        }
+        pub mod handshake {
+            pub use crate::msgs::handshake::{
+                ClientExtension, ClientHelloPayload, DistinguishedName, HandshakeMessagePayload,
+                HandshakePayload, KeyShareEntry, Random, SessionId,
+            };
+        }
+        pub mod message {
+            pub use crate::msgs::message::{Message, MessagePayload, OpaqueMessage, PlainMessage};
+        }
+        pub mod persist {
+            pub use crate::msgs::persist::ServerSessionValue;
+        }
     }
-    /// Low-level TLS message decryption functions.
-    pub mod cipher {
-        pub use crate::crypto::cipher::MessageDecrypter;
-    }
-    /// Low-level TLS record layer functions.
+
     pub mod record_layer {
-        pub use crate::record_layer::{Decrypted, RecordLayer};
+        pub use crate::record_layer::RecordLayer;
     }
 }
 

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -135,10 +135,6 @@ impl PayloadU8 {
     pub(crate) fn empty() -> Self {
         Self(Vec::new())
     }
-
-    pub(crate) fn into_inner(self) -> Vec<u8> {
-        self.0
-    }
 }
 
 impl Codec for PayloadU8 {

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -57,10 +57,10 @@ impl fmt::Debug for Payload {
 
 /// An arbitrary, unknown-content, u24-length-prefixed payload
 #[derive(Clone, Eq, PartialEq)]
-pub struct PayloadU24(pub Vec<u8>);
+pub(crate) struct PayloadU24(pub(crate) Vec<u8>);
 
 impl PayloadU24 {
-    pub fn new(bytes: Vec<u8>) -> Self {
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }
 }
@@ -125,18 +125,18 @@ impl fmt::Debug for PayloadU16 {
 
 /// An arbitrary, unknown-content, u8-length-prefixed payload
 #[derive(Clone, Eq, PartialEq)]
-pub struct PayloadU8(pub Vec<u8>);
+pub struct PayloadU8(pub(crate) Vec<u8>);
 
 impl PayloadU8 {
-    pub fn new(bytes: Vec<u8>) -> Self {
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }
 
-    pub fn empty() -> Self {
+    pub(crate) fn empty() -> Self {
         Self(Vec::new())
     }
 
-    pub fn into_inner(self) -> Vec<u8> {
+    pub(crate) fn into_inner(self) -> Vec<u8> {
         self.0
     }
 }

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -126,7 +126,7 @@ impl Codec for u8 {
     }
 }
 
-pub fn put_u16(v: u16, out: &mut [u8]) {
+pub(crate) fn put_u16(v: u16, out: &mut [u8]) {
     let out: &mut [u8; 2] = (&mut out[..2]).try_into().unwrap();
     *out = u16::to_be_bytes(v);
 }
@@ -186,7 +186,7 @@ impl Codec for u32 {
     }
 }
 
-pub fn put_u64(v: u64, bytes: &mut [u8]) {
+pub(crate) fn put_u64(v: u64, bytes: &mut [u8]) {
     let bytes: &mut [u8; 8] = (&mut bytes[..8]).try_into().unwrap();
     *bytes = u64::to_be_bytes(v);
 }

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -438,11 +438,6 @@ pub struct Deframed {
     pub message: PlainMessage,
 }
 
-#[derive(Debug)]
-pub(crate) enum DeframerError {
-    HandshakePayloadSizeTooLarge,
-}
-
 const HEADER_SIZE: usize = 1 + 3;
 
 /// TLS allows for handshake messages of up to 16MB.  We

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -221,7 +221,7 @@ impl MessageDeframer {
 
     /// Allow pushing handshake messages directly into the buffer.
     #[cfg(feature = "quic")]
-    pub fn push(&mut self, version: ProtocolVersion, payload: &[u8]) -> Result<(), Error> {
+    pub(crate) fn push(&mut self, version: ProtocolVersion, payload: &[u8]) -> Result<(), Error> {
         if self.used > 0 && self.joining_hs.is_none() {
             return Err(Error::General(
                 "cannot push QUIC messages into unrelated connection".into(),
@@ -432,14 +432,14 @@ fn payload_size(buf: &[u8]) -> Result<Option<usize>, Error> {
 
 #[derive(Debug)]
 pub struct Deframed {
-    pub want_close_before_decrypt: bool,
-    pub aligned: bool,
-    pub trial_decryption_finished: bool,
+    pub(crate) want_close_before_decrypt: bool,
+    pub(crate) aligned: bool,
+    pub(crate) trial_decryption_finished: bool,
     pub message: PlainMessage,
 }
 
 #[derive(Debug)]
-pub enum DeframerError {
+pub(crate) enum DeframerError {
     HandshakePayloadSizeTooLarge,
 }
 

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -8,8 +8,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: HashAlgorithm;
-    EnumVal{
+    pub enum HashAlgorithm {
         NONE => 0x00,
         MD5 => 0x01,
         SHA1 => 0x02,
@@ -25,8 +24,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: ClientCertificateType;
-    EnumVal{
+    pub enum ClientCertificateType {
         RSASign => 0x01,
         DSSSign => 0x02,
         RSAFixedDH => 0x03,
@@ -45,8 +43,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: Compression;
-    EnumVal{
+    pub enum Compression {
         Null => 0x00,
         Deflate => 0x01,
         LSZ => 0x40
@@ -58,8 +55,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: AlertLevel;
-    EnumVal{
+    pub enum AlertLevel {
         Warning => 0x01,
         Fatal => 0x02
     }
@@ -70,8 +66,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: HeartbeatMessageType;
-    EnumVal{
+    pub enum HeartbeatMessageType {
         Request => 0x01,
         Response => 0x02
     }
@@ -82,8 +77,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U16
-    EnumName: ExtensionType;
-    EnumVal{
+    pub enum ExtensionType {
         ServerName => 0x0000,
         MaxFragmentLength => 0x0001,
         ClientCertificateUrl => 0x0002,
@@ -129,8 +123,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: ServerNameType;
-    EnumVal{
+    pub enum ServerNameType {
         HostName => 0x00
     }
 }
@@ -145,8 +138,7 @@ enum_builder! {
     /// Rustls supports. See [`crate::crypto::ring::kx_group`] for the list of supported
     /// elliptic curve groups.
     @U16
-    EnumName: NamedCurve;
-    EnumVal{
+    pub enum NamedCurve {
         sect163k1 => 0x0001,
         sect163r1 => 0x0002,
         sect163r2 => 0x0003,
@@ -187,8 +179,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U16
-    EnumName: NamedGroup;
-    EnumVal{
+    pub enum NamedGroup {
         secp256r1 => 0x0017,
         secp384r1 => 0x0018,
         secp521r1 => 0x0019,
@@ -207,8 +198,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: ECPointFormat;
-    EnumVal{
+    pub enum ECPointFormat {
         Uncompressed => 0x00,
         ANSIX962CompressedPrime => 0x01,
         ANSIX962CompressedChar2 => 0x02
@@ -224,8 +214,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: HeartbeatMode;
-    EnumVal{
+    pub enum HeartbeatMode {
         PeerAllowedToSend => 0x01,
         PeerNotAllowedToSend => 0x02
     }
@@ -236,8 +225,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: ECCurveType;
-    EnumVal{
+    pub enum ECCurveType {
         ExplicitPrime => 0x01,
         ExplicitChar2 => 0x02,
         NamedCurve => 0x03
@@ -249,8 +237,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: PSKKeyExchangeMode;
-    EnumVal{
+    pub enum PSKKeyExchangeMode {
         PSK_KE => 0x00,
         PSK_DHE_KE => 0x01
     }
@@ -261,8 +248,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: KeyUpdateRequest;
-    EnumVal{
+    pub enum KeyUpdateRequest {
         UpdateNotRequested => 0x00,
         UpdateRequested => 0x01
     }
@@ -273,8 +259,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    EnumName: CertificateStatusType;
-    EnumVal{
+    pub enum CertificateStatusType {
         OCSP => 0x01
     }
 }

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -24,7 +24,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    pub enum ClientCertificateType {
+    pub(crate) enum ClientCertificateType {
         RSASign => 0x01,
         DSSSign => 0x02,
         RSAFixedDH => 0x03,
@@ -66,7 +66,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    pub enum HeartbeatMessageType {
+    pub(crate) enum HeartbeatMessageType {
         Request => 0x01,
         Response => 0x02
     }
@@ -77,7 +77,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U16
-    pub enum ExtensionType {
+    pub(crate) enum ExtensionType {
         ServerName => 0x0000,
         MaxFragmentLength => 0x0001,
         ClientCertificateUrl => 0x0002,
@@ -123,7 +123,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    pub enum ServerNameType {
+    pub(crate) enum ServerNameType {
         HostName => 0x00
     }
 }
@@ -138,7 +138,7 @@ enum_builder! {
     /// Rustls supports. See [`crate::crypto::ring::kx_group`] for the list of supported
     /// elliptic curve groups.
     @U16
-    pub enum NamedCurve {
+    pub(crate) enum NamedCurve {
         sect163k1 => 0x0001,
         sect163r1 => 0x0002,
         sect163r2 => 0x0003,
@@ -206,7 +206,7 @@ enum_builder! {
 }
 
 impl ECPointFormat {
-    pub const SUPPORTED: [Self; 1] = [Self::Uncompressed];
+    pub(crate) const SUPPORTED: [Self; 1] = [Self::Uncompressed];
 }
 
 enum_builder! {
@@ -214,7 +214,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    pub enum HeartbeatMode {
+    pub(crate) enum HeartbeatMode {
         PeerAllowedToSend => 0x01,
         PeerNotAllowedToSend => 0x02
     }
@@ -225,7 +225,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    pub enum ECCurveType {
+    pub(crate) enum ECCurveType {
         ExplicitPrime => 0x01,
         ExplicitChar2 => 0x02,
         NamedCurve => 0x03

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -2,9 +2,9 @@ use crate::enums::ContentType;
 use crate::enums::ProtocolVersion;
 use crate::msgs::message::{BorrowedPlainMessage, PlainMessage};
 use crate::Error;
-pub const MAX_FRAGMENT_LEN: usize = 16384;
-pub const PACKET_OVERHEAD: usize = 1 + 2 + 2;
-pub const MAX_FRAGMENT_SIZE: usize = MAX_FRAGMENT_LEN + PACKET_OVERHEAD;
+pub(crate) const MAX_FRAGMENT_LEN: usize = 16384;
+pub(crate) const PACKET_OVERHEAD: usize = 1 + 2 + 2;
+pub(crate) const MAX_FRAGMENT_SIZE: usize = MAX_FRAGMENT_LEN + PACKET_OVERHEAD;
 
 pub struct MessageFragmenter {
     max_frag: usize,
@@ -32,7 +32,7 @@ impl MessageFragmenter {
 
     /// Enqueue borrowed fragments of (version, typ, payload) which
     /// are no longer than max_frag onto the `out` deque.
-    pub fn fragment_slice<'a>(
+    pub(crate) fn fragment_slice<'a>(
         &self,
         typ: ContentType,
         version: ProtocolVersion,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -916,6 +916,7 @@ impl ClientHelloPayload {
         }
     }
 
+    #[cfg(feature = "quic")]
     pub(crate) fn get_quic_params_extension(&self) -> Option<Vec<u8>> {
         let ext = self
             .find_extension(ExtensionType::TransportParameters)

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -101,11 +101,6 @@ impl Random {
         provider.fill_random(&mut data)?;
         Ok(Self(data))
     }
-
-    pub(crate) fn write_slice(&self, bytes: &mut [u8]) {
-        let buf = self.get_encoding();
-        bytes.copy_from_slice(&buf);
-    }
 }
 
 impl From<[u8; 32]> for Random {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -31,10 +31,10 @@ use std::collections;
 /// the `PayloadU8` or `PayloadU16` types. This is typically used for types where we don't need
 /// anything other than access to the underlying bytes.
 macro_rules! wrapped_payload(
-  ($(#[$comment:meta])* $name:ident, $inner:ident,) => {
+  ($(#[$comment:meta])* $vis:vis struct $name:ident, $inner:ident,) => {
     $(#[$comment])*
     #[derive(Clone, Debug)]
-    pub struct $name($inner);
+    $vis struct $name($inner);
 
     impl From<Vec<u8>> for $name {
         fn from(v: Vec<u8>) -> Self {
@@ -315,7 +315,7 @@ impl ConvertServerNameList for [ServerName] {
     }
 }
 
-wrapped_payload!(ProtocolName, PayloadU8,);
+wrapped_payload!(pub struct ProtocolName, PayloadU8,);
 
 impl TlsListElement for ProtocolName {
     const SIZE_LEN: ListLength = ListLength::U16;
@@ -417,7 +417,7 @@ impl TlsListElement for PresharedKeyIdentity {
     const SIZE_LEN: ListLength = ListLength::U16;
 }
 
-wrapped_payload!(PresharedKeyBinder, PayloadU8,);
+wrapped_payload!(pub struct PresharedKeyBinder, PayloadU8,);
 
 impl TlsListElement for PresharedKeyBinder {
     const SIZE_LEN: ListLength = ListLength::U16;
@@ -454,7 +454,7 @@ impl Codec for PresharedKeyOffer {
 }
 
 // --- RFC6066 certificate status request ---
-wrapped_payload!(ResponderId, PayloadU16,);
+wrapped_payload!(pub struct ResponderId, PayloadU16,);
 
 impl TlsListElement for ResponderId {
     const SIZE_LEN: ListLength = ListLength::U16;
@@ -1677,7 +1677,7 @@ wrapped_payload!(
     ///     println!("{}", x509_parser::x509::X509Name::from_der(&name.0)?.1);
     /// }
     /// ```
-    DistinguishedName,
+    pub struct DistinguishedName,
     PayloadU16,
 );
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -180,10 +180,6 @@ impl SessionId {
         }
     }
 
-    pub(crate) fn len(&self) -> usize {
-        self.len
-    }
-
     pub(crate) fn is_empty(&self) -> bool {
         self.len == 0
     }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1,6 +1,8 @@
 #![allow(non_camel_case_types)]
 
-use crate::crypto::{ActiveKeyExchange, CryptoProvider};
+#[cfg(feature = "tls12")]
+use crate::crypto::ActiveKeyExchange;
+use crate::crypto::CryptoProvider;
 use crate::dns_name::{DnsName, DnsNameRef};
 use crate::enums::{CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme};
 use crate::error::InvalidMessage;
@@ -175,6 +177,7 @@ impl SessionId {
         }
     }
 
+    #[cfg(feature = "tls12")]
     pub(crate) fn is_empty(&self) -> bool {
         self.len == 0
     }
@@ -784,6 +787,7 @@ impl ServerExtension {
         Self::Protocols(Vec::from_slices(proto))
     }
 
+    #[cfg(feature = "tls12")]
     pub(crate) fn make_empty_renegotiation_info() -> Self {
         let empty = Vec::new();
         Self::RenegotiationInfo(PayloadU8::new(empty))
@@ -895,6 +899,7 @@ impl ClientHelloPayload {
         }
     }
 
+    #[cfg(feature = "tls12")]
     pub(crate) fn get_ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
         let ext = self.find_extension(ExtensionType::ECPointFormats)?;
         match *ext {
@@ -923,6 +928,7 @@ impl ClientHelloPayload {
         }
     }
 
+    #[cfg(feature = "tls12")]
     pub(crate) fn get_ticket_extension(&self) -> Option<&ClientExtension> {
         self.find_extension(ExtensionType::SessionTicket)
     }
@@ -994,6 +1000,7 @@ impl ClientHelloPayload {
         }
     }
 
+    #[cfg(feature = "tls12")]
     pub(crate) fn ems_support_offered(&self) -> bool {
         self.find_extension(ExtensionType::ExtendedMasterSecret)
             .is_some()
@@ -1234,6 +1241,7 @@ impl ServerHelloPayload {
         }
     }
 
+    #[cfg(feature = "tls12")]
     pub(crate) fn ems_support_acked(&self) -> bool {
         self.find_extension(ExtensionType::ExtendedMasterSecret)
             .is_some()
@@ -1508,6 +1516,7 @@ pub(crate) struct ServerEcdhParams {
 }
 
 impl ServerEcdhParams {
+    #[cfg(feature = "tls12")]
     pub(crate) fn new(kx: &dyn ActiveKeyExchange) -> Self {
         Self {
             curve_params: EcParameters {
@@ -1578,6 +1587,7 @@ impl Codec for ServerKeyExchangePayload {
 }
 
 impl ServerKeyExchangePayload {
+    #[cfg(feature = "tls12")]
     pub(crate) fn unwrap_given_kxa(
         &self,
         kxa: KeyExchangeAlgorithm,
@@ -1847,6 +1857,7 @@ pub struct NewSessionTicketPayload {
 }
 
 impl NewSessionTicketPayload {
+    #[cfg(feature = "tls12")]
     pub(crate) fn new(lifetime_hint: u32, ticket: Vec<u8>) -> Self {
         Self {
             lifetime_hint,
@@ -2027,6 +2038,7 @@ impl CertificateStatus {
         }
     }
 
+    #[cfg(feature = "tls12")]
     pub(crate) fn into_inner(self) -> Vec<u8> {
         self.ocsp_response.0
     }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -358,16 +358,20 @@ impl ConvertProtocolNameList for Vec<ProtocolName> {
 // --- TLS 1.3 Key shares ---
 #[derive(Clone, Debug)]
 pub struct KeyShareEntry {
-    pub group: NamedGroup,
-    pub payload: PayloadU16,
+    pub(crate) group: NamedGroup,
+    pub(crate) payload: PayloadU16,
 }
 
 impl KeyShareEntry {
-    pub(crate) fn new(group: NamedGroup, payload: &[u8]) -> Self {
+    pub fn new(group: NamedGroup, payload: &[u8]) -> Self {
         Self {
             group,
             payload: PayloadU16::new(payload.to_vec()),
         }
+    }
+
+    pub fn group(&self) -> NamedGroup {
+        self.group
     }
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -74,7 +74,9 @@ fn accepts_short_sessionid() {
     let sess = SessionId::read(&mut rd).unwrap();
     println!("{:?}", sess);
 
+    #[cfg(feature = "tls12")]
     assert!(!sess.is_empty());
+    assert_ne!(sess, SessionId::empty());
     assert!(!rd.any_left());
 }
 
@@ -85,7 +87,9 @@ fn accepts_empty_sessionid() {
     let sess = SessionId::read(&mut rd).unwrap();
     println!("{:?}", sess);
 
+    #[cfg(feature = "tls12")]
     assert!(sess.is_empty());
+    assert_eq!(sess, SessionId::empty());
     assert!(!rd.any_left());
 }
 
@@ -520,6 +524,7 @@ fn client_get_namedgroups_extension() {
     });
 }
 
+#[cfg(feature = "tls12")]
 #[test]
 fn client_get_ecpoints_extension() {
     test_client_extension_getter(ExtensionType::ECPointFormats, |chp| {

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -75,7 +75,6 @@ fn accepts_short_sessionid() {
     println!("{:?}", sess);
 
     assert!(!sess.is_empty());
-    assert_eq!(sess.len(), 1);
     assert!(!rd.any_left());
 }
 
@@ -87,7 +86,6 @@ fn accepts_empty_sessionid() {
     println!("{:?}", sess);
 
     assert!(sess.is_empty());
-    assert_eq!(sess.len(), 0);
     assert!(!rd.any_left());
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -534,6 +534,7 @@ fn client_get_alpn_extension() {
     });
 }
 
+#[cfg(feature = "quic")]
 #[test]
 fn client_get_quic_params_extension() {
     test_client_extension_getter(ExtensionType::TransportParameters, |chp| {

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -67,6 +67,7 @@ macro_rules! enum_builder {
                 }
             }
 
+            #[allow(dead_code)] // generated irrespective if there are callers
             $enum_vis fn as_str(&self) -> Option<&'static str> {
                 match self {
                     $( $enum_name::$enum_var => Some(stringify!($enum_var))),*

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -3,18 +3,18 @@ macro_rules! enum_builder {
     (
     $(#[$comment:meta])*
     @U8
-        EnumName: $enum_name: ident;
-        EnumVal { $( $enum_var: ident => $enum_val: expr ),* }
+        $enum_vis:vis enum $enum_name:ident
+        { $( $enum_var: ident => $enum_val: expr ),* }
     ) => {
         $(#[$comment])*
         #[non_exhaustive]
         #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-        pub enum $enum_name {
+        $enum_vis enum $enum_name {
             $( $enum_var),*
             ,Unknown(u8)
         }
         impl $enum_name {
-            pub fn get_u8(&self) -> u8 {
+            $enum_vis fn get_u8(&self) -> u8 {
                 let x = self.clone();
                 match x {
                     $( $enum_name::$enum_var => $enum_val),*
@@ -48,18 +48,18 @@ macro_rules! enum_builder {
     (
     $(#[$comment:meta])*
     @U16
-        EnumName: $enum_name: ident;
-        EnumVal { $( $enum_var: ident => $enum_val: expr ),* }
+        $enum_vis:vis enum $enum_name:ident
+        { $( $enum_var: ident => $enum_val: expr ),* }
     ) => {
         $(#[$comment])*
         #[non_exhaustive]
         #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-        pub enum $enum_name {
+        $enum_vis enum $enum_name {
             $( $enum_var),*
             ,Unknown(u16)
         }
         impl $enum_name {
-            pub fn get_u16(&self) -> u16 {
+            $enum_vis fn get_u16(&self) -> u16 {
                 let x = self.clone();
                 match x {
                     $( $enum_name::$enum_var => $enum_val),*
@@ -67,7 +67,7 @@ macro_rules! enum_builder {
                 }
             }
 
-            pub fn as_str(&self) -> Option<&'static str> {
+            $enum_vis fn as_str(&self) -> Option<&'static str> {
                 match self {
                     $( $enum_name::$enum_var => Some(stringify!($enum_var))),*
                     ,$enum_name::Unknown(_) => None,

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -4,16 +4,16 @@
 #[macro_use]
 mod macros;
 
-pub mod alert;
-pub mod base;
-pub mod ccs;
-pub mod codec;
-pub mod deframer;
-pub mod enums;
-pub mod fragmenter;
-pub mod handshake;
-pub mod message;
-pub mod persist;
+pub(crate) mod alert;
+pub(crate) mod base;
+pub(crate) mod ccs;
+pub(crate) mod codec;
+pub(crate) mod deframer;
+pub(crate) mod enums;
+pub(crate) mod fragmenter;
+pub(crate) mod handshake;
+pub(crate) mod message;
+pub(crate) mod persist;
 
 #[cfg(test)]
 mod handshake_test;

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -252,8 +252,6 @@ static MAX_TICKET_LIFETIME: u32 = 7 * 24 * 60 * 60;
 static MAX_FRESHNESS_SKEW_MS: u32 = 60 * 1000;
 
 // --- Server types ---
-pub(crate) type ServerSessionKey = SessionId;
-
 #[derive(Debug)]
 pub struct ServerSessionValue {
     pub(crate) sni: Option<DnsName>,

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -4,6 +4,7 @@ use crate::error::InvalidMessage;
 use crate::msgs::base::{PayloadU16, PayloadU8};
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::handshake::CertificatePayload;
+#[cfg(feature = "tls12")]
 use crate::msgs::handshake::SessionId;
 #[cfg(feature = "tls12")]
 use crate::tls12::Tls12CipherSuite;
@@ -375,6 +376,7 @@ impl ServerSessionValue {
         }
     }
 
+    #[cfg(feature = "tls12")]
     pub(crate) fn set_extended_ms_used(&mut self) {
         self.extended_ms = true;
     }

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -224,11 +224,11 @@ impl RecordLayer {
 
 /// Result of decryption.
 #[derive(Debug)]
-pub struct Decrypted {
+pub(crate) struct Decrypted {
     /// Whether the peer appears to be getting close to encrypting too many messages with this key.
-    pub want_close_before_decrypt: bool,
+    pub(crate) want_close_before_decrypt: bool,
     /// The decrypted message.
-    pub plaintext: PlainMessage,
+    pub(crate) plaintext: PlainMessage,
 }
 
 #[cfg(test)]

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -16,7 +16,8 @@ use rustls::crypto::ring::ALL_CIPHER_SUITES;
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::enums::AlertLevel;
-use rustls::internal::msgs::message::PlainMessage;
+use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
+use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
 use rustls::server::{ClientHello, ResolvesServerCert, WebPkiClientVerifier};
 use rustls::ConnectionTrafficSecrets;
 use rustls::SupportedCipherSuite;
@@ -4505,11 +4506,6 @@ fn connection_types_are_not_huge() {
     assert_lt(mem::size_of::<ServerConnection>(), 1600);
     assert_lt(mem::size_of::<ClientConnection>(), 1600);
 }
-
-use rustls::internal::msgs::{
-    handshake::ClientExtension, handshake::HandshakePayload, message::Message,
-    message::MessagePayload,
-};
 
 #[test]
 fn test_server_rejects_duplicate_sni_names() {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3718,7 +3718,6 @@ mod test_quic {
         .unwrap();
 
         use rustls::crypto::ring::RING;
-        use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, NamedGroup};
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionId,
@@ -3747,10 +3746,10 @@ mod test_quic {
                     ClientExtension::SupportedVersions(vec![ProtocolVersion::TLSv1_3]),
                     ClientExtension::NamedGroups(vec![NamedGroup::X25519]),
                     ClientExtension::SignatureAlgorithms(vec![SignatureScheme::ED25519]),
-                    ClientExtension::KeyShare(vec![KeyShareEntry {
-                        group: NamedGroup::X25519,
-                        payload: PayloadU16::new(kx.as_ref().to_vec()),
-                    }]),
+                    ClientExtension::KeyShare(vec![KeyShareEntry::new(
+                        NamedGroup::X25519,
+                        kx.as_ref(),
+                    )]),
                 ],
             }),
         });
@@ -3773,7 +3772,6 @@ mod test_quic {
         let server_config = Arc::new(server_config);
 
         use rustls::crypto::ring::RING;
-        use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{Compression, NamedGroup};
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionId,
@@ -3808,10 +3806,10 @@ mod test_quic {
                 extensions: vec![
                     ClientExtension::NamedGroups(vec![NamedGroup::X25519]),
                     ClientExtension::SignatureAlgorithms(vec![SignatureScheme::ED25519]),
-                    ClientExtension::KeyShare(vec![KeyShareEntry {
-                        group: NamedGroup::X25519,
-                        payload: PayloadU16::new(kx.as_ref().to_vec()),
-                    }]),
+                    ClientExtension::KeyShare(vec![KeyShareEntry::new(
+                        NamedGroup::X25519,
+                        kx.as_ref(),
+                    )]),
                 ],
             }),
         });
@@ -4218,7 +4216,7 @@ fn test_client_rejects_hrr_with_varied_session_id() {
                     .get_keyshare_extension()
                     .expect("missing key share extension");
                 assert_eq!(keyshares.len(), 1);
-                assert_eq!(keyshares[0].group, rustls::NamedGroup::secp384r1);
+                assert_eq!(keyshares[0].group(), rustls::NamedGroup::secp384r1);
 
                 ch.session_id = different_session_id;
                 *encoded = Payload::new(parsed.get_encoding());


### PR DESCRIPTION
This is a tentative attempt to clean this up, starting by being precise about what parts are needed to run the existing tests we have. That has uncovered a few instances of unused code that were previously `pub`.