### PR TITLE
ci: move external types config to cargo metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,4 +329,4 @@ jobs:
       - run: cargo install --locked cargo-check-external-types
       - name: run cargo-check-external-types for rustls/
         working-directory: rustls/
-        run: cargo check-external-types --config external-types.toml
+        run: cargo check-external-types

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -57,3 +57,8 @@ required-features = ["ring"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "rustls_pki_types::*",
+]

--- a/rustls/external-types.toml
+++ b/rustls/external-types.toml
@@ -1,3 +1,0 @@
-allowed_external_types = [
-    "rustls_pki_types::*",
-]


### PR DESCRIPTION
As of [cargo-check-external-types v0.1.9](https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.1.9) the tool can read its configuration from the crate `Cargo.toml` metadata, removing the need for a standalone TOML file and the `--config` arg. This commit switches to that style of configuration.