### PR TITLE
crypto: fix nightly clippy get-first warning

### DIFF
--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -59,7 +59,7 @@ impl CertifiedKey {
     /// The end-entity certificate.
     pub fn end_entity_cert(&self) -> Result<&CertificateDer<'_>, Error> {
         self.cert
-            .get(0)
+            .first()
             .ok_or(Error::NoCertificatesPresented)
     }
 }


### PR DESCRIPTION
```
warning: accessing first element with `self.cert.get(0)`
  --> rustls/src/crypto/signer.rs:61:9
   |
61 | /         self.cert
62 | |             .get(0)
   | |___________________^ help: try: `self.cert.first()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
   = note: `#[warn(clippy::get_first)]` on by default
```