### PR TITLE
Separate server hints list from accepted trust anchors

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -200,7 +200,7 @@ impl server::danger::ClientCertVerifier for DummyClientAuth {
         self.mandatory
     }
 
-    fn client_auth_root_subjects(&self) -> &[DistinguishedName] {
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
         &[]
     }
 
@@ -315,7 +315,7 @@ struct FixedSignatureSchemeClientCertResolver {
 impl client::ResolvesClientCert for FixedSignatureSchemeClientCertResolver {
     fn resolve(
         &self,
-        acceptable_issuers: &[&[u8]],
+        root_hint_subjects: &[&[u8]],
         sigschemes: &[SignatureScheme],
     ) -> Option<Arc<sign::CertifiedKey>> {
         if !sigschemes.contains(&self.scheme) {
@@ -323,7 +323,7 @@ impl client::ResolvesClientCert for FixedSignatureSchemeClientCertResolver {
         }
         let mut certkey = self
             .resolver
-            .resolve(acceptable_issuers, sigschemes)?;
+            .resolve(root_hint_subjects, sigschemes)?;
         Arc::make_mut(&mut certkey).key = Arc::new(FixedSignatureSchemeSigningKey {
             key: certkey.key.clone(),
             scheme: self.scheme,

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -86,20 +86,28 @@ pub trait ClientSessionStore: Send + Sync {
 /// A trait for the ability to choose a certificate chain and
 /// private key for the purposes of client authentication.
 pub trait ResolvesClientCert: Send + Sync {
-    /// With the server-supplied acceptable issuers in `acceptable_issuers`,
-    /// the server's supported signature schemes in `sigschemes`,
-    /// return a certificate chain and signing key to authenticate.
+    /// Resolve a client certificate chain/private key to use as the client's
+    /// identity.
     ///
-    /// `acceptable_issuers` is undecoded and unverified by the rustls
-    /// library, but it should be expected to contain a DER encodings
-    /// of X501 NAMEs.
+    /// `root_hint_subjects` is an optional list of certificate authority
+    /// subject distinguished names that the client can use to help
+    /// decide on a client certificate the server is likely to accept. If
+    /// the list is empty, the client should send whatever certificate it
+    /// has. The hints are expected to be DER-encoded X.500 distinguished names,
+    /// per [RFC 5280 A.1]. See [`crate::DistinguishedName`] for more information
+    /// on decoding with external crates like `x509-parser`.
     ///
-    /// Return None to continue the handshake without any client
+    /// `sigschemes` is the list of the [`SignatureScheme`]s the server
+    /// supports.
+    ///
+    /// Return `None` to continue the handshake without any client
     /// authentication.  The server may reject the handshake later
     /// if it requires authentication.
+    ///
+    /// [RFC 5280 A.1]: https://www.rfc-editor.org/rfc/rfc5280#appendix-A.1
     fn resolve(
         &self,
-        acceptable_issuers: &[&[u8]],
+        root_hint_subjects: &[&[u8]],
         sigschemes: &[SignatureScheme],
     ) -> Option<Arc<sign::CertifiedKey>>;
 

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -168,7 +168,7 @@ pub(super) struct FailResolveClientCert {}
 impl client::ResolvesClientCert for FailResolveClientCert {
     fn resolve(
         &self,
-        _acceptable_issuers: &[&[u8]],
+        _root_hint_subjects: &[&[u8]],
         _sigschemes: &[SignatureScheme],
     ) -> Option<Arc<sign::CertifiedKey>> {
         None
@@ -196,7 +196,7 @@ impl AlwaysResolvesClientCert {
 impl client::ResolvesClientCert for AlwaysResolvesClientCert {
     fn resolve(
         &self,
-        _acceptable_issuers: &[&[u8]],
+        _root_hint_subjects: &[&[u8]],
         _sigschemes: &[SignatureScheme],
     ) -> Option<Arc<sign::CertifiedKey>> {
         Some(Arc::clone(&self.0))

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -461,7 +461,7 @@ mod client_hello {
 
         let names = config
             .verifier
-            .client_auth_root_subjects()
+            .root_hint_subjects()
             .to_vec();
 
         let cr = CertificateRequestPayload {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -715,15 +715,13 @@ mod client_hello {
         cr.extensions
             .push(CertReqExtension::SignatureAlgorithms(schemes.to_vec()));
 
-        let names = config
-            .verifier
-            .root_hint_subjects()
-            .to_vec();
-
-        if !names.is_empty() {
-            cr.extensions
-                .push(CertReqExtension::AuthorityNames(names));
-        }
+        cr.extensions
+            .push(CertReqExtension::AuthorityNames(
+                config
+                    .verifier
+                    .root_hint_subjects()
+                    .to_vec(),
+            ));
 
         let m = Message {
             version: ProtocolVersion::TLSv1_3,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -717,7 +717,7 @@ mod client_hello {
 
         let names = config
             .verifier
-            .client_auth_root_subjects()
+            .root_hint_subjects()
             .to_vec();
 
         if !names.is_empty() {

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -167,8 +167,8 @@ pub trait ClientCertVerifier: Send + Sync {
     /// These hint values help the client pick a client certificate it believes the server will
     /// accept. The hints must be DER-encoded X.500 distinguished names, per [RFC 5280 A.1]. They
     /// are sent in the [`certificate_authorities`] extension of a [`CertificateRequest`] message
-    /// when [ClientCertVerifier::offer_client_auth] is true. If the return value is empty, no
-    /// CertificateRequest message will be sent.
+    /// when [ClientCertVerifier::offer_client_auth] is true. When an empty list is sent the client
+    /// should always provide a client certificate if it has one.
     ///
     /// Generally this list should contain the [`DistinguishedName`] of each root trust
     /// anchor in the root cert store that the server is configured to use for authenticating

--- a/rustls/src/webpki/anchors.rs
+++ b/rustls/src/webpki/anchors.rs
@@ -6,7 +6,7 @@ use webpki::extract_trust_anchor;
 use super::pki_error;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
-use crate::Error;
+use crate::{DistinguishedName, Error};
 
 /// A container for root certificates able to provide a root-of-trust
 /// for connection authentication.
@@ -75,6 +75,20 @@ impl RootCertStore {
                 .to_owned(),
         );
         Ok(())
+    }
+
+    /// Return the DER encoded [`DistinguishedName`] of each trust anchor subject in the root
+    /// cert store.
+    ///
+    /// Each [`DistinguishedName`] will be a DER-encoded X.500 distinguished name, per
+    /// [RFC 5280 A.1], including the outer `SEQUENCE`.
+    ///
+    /// [RFC 5280 A.1]: https://www.rfc-editor.org/rfc/rfc5280#appendix-A.1
+    pub fn subjects(&self) -> Vec<DistinguishedName> {
+        self.roots
+            .iter()
+            .map(|ta| DistinguishedName::in_sequence(ta.subject.as_ref()))
+            .collect()
     }
 
     /// Return true if there are no certificates.

--- a/rustls/src/webpki/anchors.rs
+++ b/rustls/src/webpki/anchors.rs
@@ -22,34 +22,6 @@ impl RootCertStore {
         Self { roots: Vec::new() }
     }
 
-    /// Return true if there are no certificates.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Say how many certificates are in the container.
-    pub fn len(&self) -> usize {
-        self.roots.len()
-    }
-
-    /// Add a single DER-encoded certificate to the store.
-    ///
-    /// This is suitable for a small set of root certificates that are expected to parse
-    /// successfully. For large collections of roots (for example from a system store) it
-    /// is expected that some of them might not be valid according to the rules rustls
-    /// implements. As long as a relatively limited number of certificates are affected,
-    /// this should not be a cause for concern. Use [`RootCertStore::add_parsable_certificates`]
-    /// in order to add as many valid roots as possible and to understand how many certificates
-    /// have been diagnosed as malformed.
-    pub fn add(&mut self, der: CertificateDer<'_>) -> Result<(), Error> {
-        self.roots.push(
-            extract_trust_anchor(&der)
-                .map_err(pki_error)?
-                .to_owned(),
-        );
-        Ok(())
-    }
-
     /// Parse the given DER-encoded certificates and add all that can be parsed
     /// in a best-effort fashion.
     ///
@@ -85,6 +57,34 @@ impl RootCertStore {
         );
 
         (valid_count, invalid_count)
+    }
+
+    /// Add a single DER-encoded certificate to the store.
+    ///
+    /// This is suitable for a small set of root certificates that are expected to parse
+    /// successfully. For large collections of roots (for example from a system store) it
+    /// is expected that some of them might not be valid according to the rules rustls
+    /// implements. As long as a relatively limited number of certificates are affected,
+    /// this should not be a cause for concern. Use [`RootCertStore::add_parsable_certificates`]
+    /// in order to add as many valid roots as possible and to understand how many certificates
+    /// have been diagnosed as malformed.
+    pub fn add(&mut self, der: CertificateDer<'_>) -> Result<(), Error> {
+        self.roots.push(
+            extract_trust_anchor(&der)
+                .map_err(pki_error)?
+                .to_owned(),
+        );
+        Ok(())
+    }
+
+    /// Return true if there are no certificates.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Say how many certificates are in the container.
+    pub fn len(&self) -> usize {
+        self.roots.len()
     }
 }
 

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -142,12 +142,7 @@ impl ClientCertVerifierBuilder {
             .supported_algs
             .ok_or(VerifierBuilderError::NoSupportedAlgorithms)?;
 
-        let root_hint_subjects = self
-            .roots
-            .roots
-            .iter()
-            .map(|ta| DistinguishedName::in_sequence(ta.subject.as_ref()))
-            .collect();
+        let root_hint_subjects = self.roots.subjects();
 
         Ok(Arc::new(WebPkiClientVerifier::new(
             self.roots,

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1255,13 +1255,13 @@ impl Drop for ClientCheckCertResolve {
 impl ResolvesClientCert for ClientCheckCertResolve {
     fn resolve(
         &self,
-        acceptable_issuers: &[&[u8]],
+        root_hint_subjects: &[&[u8]],
         sigschemes: &[SignatureScheme],
     ) -> Option<Arc<sign::CertifiedKey>> {
         self.query_count
             .fetch_add(1, Ordering::SeqCst);
 
-        if acceptable_issuers.is_empty() {
+        if root_hint_subjects.is_empty() {
             panic!("no issuers offered by server");
         }
 
@@ -1269,7 +1269,7 @@ impl ResolvesClientCert for ClientCheckCertResolve {
             panic!("no signature schemes shared by server");
         }
 
-        assert_eq!(acceptable_issuers, self.expect_issuers);
+        assert_eq!(root_hint_subjects, self.expect_issuers);
         assert_eq!(sigschemes, self.expect_sigschemes);
 
         None

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -166,7 +166,7 @@ impl ClientCertVerifier for MockClientVerifier {
         self.mandatory
     }
 
-    fn client_auth_root_subjects(&self) -> &[DistinguishedName] {
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
         &self.subjects
     }
 

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -150,11 +150,7 @@ impl MockClientVerifier {
     pub fn new(verified: fn() -> Result<ClientCertVerified, Error>, kt: KeyType) -> Self {
         Self {
             verified,
-            subjects: get_client_root_store(kt)
-                .roots
-                .iter()
-                .map(|ta| DistinguishedName::in_sequence(ta.subject.as_ref()))
-                .collect(),
+            subjects: get_client_root_store(kt).subjects(),
             mandatory: true,
             offered_schemes: None,
         }


### PR DESCRIPTION
This branch resolves https://github.com/rustls/rustls/issues/1549 by updating the default webpki client certificate verifier to allow configuring a server's client root certificate subject hints list separately from the subjects present in the root cert store used to verify client certificates. This is a useful capability in the presence of cross-signing when there are circumstances (described in #1549 and the updated rustdoc comments in this branch) where a server may want to hint to a client that it accepts a certificate with a given subject, without adding it to the server's trust store. 

See individual commit messages for more detail.