### PR TITLE
docs: create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Checklist**
+* [ ] I've searched the issue tracker for similar bugs.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Use one of the examples to connect to `....` 
+2. ...
+3. See error
+
+**Applicable Version(s)**
+A list of versions and platforms you've tested with.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/dependency-update.md
+++ b/.github/ISSUE_TEMPLATE/dependency-update.md
@@ -1,0 +1,33 @@
+---
+name: Dependency Update
+about: Request a dependency be updated
+title: Dependency update request
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Please note that we are only interested in **semver-incompatible** update requests. Updates to dependencies that are 
+semver-compatible can be done in dependent projects without needing changes in this repository.
+
+For example, if you are here because you believe Rustls is bringing in dependency `foo` at version `0.2.1` and
+you wish Rustls used `0.2.2` instead, you should not file an issue and instead should run `cargo update` in your
+dependent project. It would only be appropriate to file an issue if you require Rustls use `foo` at version `0.3.0+`.
+-->
+
+**Checklist**
+* [ ] I've searched the issue tracker for similar requests
+* [ ] I've confirmed my request is for a semver-incompatible update
+
+**Is your dependency update request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Checklist**
+* [ ] I've searched the issue tracker for similar requests
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Add Bug report, Feature request, and Dependency update issue templates to help prompt users into providing the information that will get them the best help. When a user creates a new issue they'll be asked to choose from one of these three templates, and will get a pre-populated new issue description based on their choice.

This is primarily motivated by the number of issues we see where folks are asking for semver compatible dependencies be updated (e.g. because they're trying to avoid multiple versions of a transitive dependency) without understanding they can use `cargo update` to pick up the required updates. This is a common source of confusion for folks new to the Rust ecosystem (I've certainly been confused about it myself in the past!).

My hope is that by having an explicit option for dependency update requests that itself has a checklist for steps like running `cargo update` we can cut down on the number of issues that get filed for this category of problem.