### PR TITLE
x509: reduce allocations for wrap_in_sequence

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -14,12 +14,12 @@ use crate::msgs::enums::{
     CertificateStatusType, ClientCertificateType, Compression, ECCurveType, ECPointFormat,
     ExtensionType, KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType,
 };
+use crate::rand;
 use crate::verify::DigitallySignedStruct;
-use crate::{rand, x509};
+use crate::x509::wrap_in_sequence;
 
 use pki_types::CertificateDer;
 
-use alloc::borrow::ToOwned;
 #[cfg(feature = "logging")]
 use alloc::string::String;
 use alloc::vec;
@@ -1702,9 +1702,7 @@ impl DistinguishedName {
     /// println!("{}", x509_parser::x509::X509Name::from_der(dn.as_ref())?.1);
     /// ```
     pub fn in_sequence(bytes: &[u8]) -> Self {
-        let mut wrapped = bytes.to_owned();
-        x509::wrap_in_sequence(&mut wrapped);
-        Self(PayloadU16::new(wrapped))
+        Self(PayloadU16::new(wrap_in_sequence(bytes)))
     }
 }
 

--- a/rustls/src/x509.rs
+++ b/rustls/src/x509.rs
@@ -2,27 +2,40 @@
 
 use alloc::vec::Vec;
 
-pub(crate) fn wrap_in_asn1_len(bytes: &mut Vec<u8>) {
+pub(crate) fn asn1_wrap(tag: u8, bytes: &[u8]) -> Vec<u8> {
     let len = bytes.len();
 
     if len <= 0x7f {
-        bytes.insert(0, len as u8);
+        // Short form
+        let mut ret = Vec::with_capacity(2 + len);
+        ret.push(tag);
+        ret.push(len as u8);
+        ret.extend_from_slice(bytes);
+        ret
     } else {
-        bytes.insert(0, 0x80u8);
-        let mut left = len;
-        while left > 0 {
-            let byte = (left & 0xff) as u8;
-            bytes.insert(1, byte);
-            bytes[0] += 1;
-            left >>= 8;
-        }
+        // Long form
+        let size = len.to_be_bytes();
+        let leading_zero_bytes = size
+            .iter()
+            .position(|&x| x != 0)
+            .unwrap_or(size.len());
+        assert!(leading_zero_bytes < size.len());
+        let encoded_bytes = size.len() - leading_zero_bytes;
+
+        let mut ret = Vec::with_capacity(2 + encoded_bytes + len);
+        ret.push(tag);
+
+        ret.push(0x80 + encoded_bytes as u8);
+        ret.extend_from_slice(&size[leading_zero_bytes..]);
+
+        ret.extend_from_slice(bytes);
+        ret
     }
 }
 
 /// Prepend stuff to `bytes` to put it in a DER SEQUENCE.
-pub(crate) fn wrap_in_sequence(bytes: &mut Vec<u8>) {
-    wrap_in_asn1_len(bytes);
-    bytes.insert(0, DER_SEQUENCE_TAG);
+pub(crate) fn wrap_in_sequence(bytes: &[u8]) -> Vec<u8> {
+    asn1_wrap(DER_SEQUENCE_TAG, bytes)
 }
 
 const DER_SEQUENCE_TAG: u8 = 0x30;
@@ -33,68 +46,65 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let mut val = Vec::new();
-        wrap_in_sequence(&mut val);
-        assert_eq!(vec![0x30, 0x00], val);
+        assert_eq!(vec![0x30, 0x00], wrap_in_sequence(&[]));
     }
 
     #[test]
     fn test_small() {
-        let mut val = Vec::new();
-        val.insert(0, 0x00);
-        val.insert(1, 0x11);
-        val.insert(2, 0x22);
-        val.insert(3, 0x33);
-        wrap_in_sequence(&mut val);
-        assert_eq!(vec![0x30, 0x04, 0x00, 0x11, 0x22, 0x33], val);
+        assert_eq!(
+            vec![0x30, 0x04, 0x00, 0x11, 0x22, 0x33],
+            wrap_in_sequence(&[0x00, 0x11, 0x22, 0x33])
+        );
     }
 
     #[test]
     fn test_medium() {
         let mut val = Vec::new();
         val.resize(255, 0x12);
-        wrap_in_sequence(&mut val);
-        assert_eq!(vec![0x30, 0x81, 0xff, 0x12, 0x12, 0x12], val[..6].to_vec());
+        assert_eq!(
+            vec![0x30, 0x81, 0xff, 0x12, 0x12, 0x12],
+            wrap_in_sequence(&val)[..6]
+        );
     }
 
     #[test]
     fn test_large() {
         let mut val = Vec::new();
         val.resize(4660, 0x12);
-        wrap_in_sequence(&mut val);
-        assert_eq!(vec![0x30, 0x82, 0x12, 0x34, 0x12, 0x12], val[..6].to_vec());
+        wrap_in_sequence(&val);
+        assert_eq!(
+            vec![0x30, 0x82, 0x12, 0x34, 0x12, 0x12],
+            wrap_in_sequence(&val)[..6]
+        );
     }
 
     #[test]
     fn test_huge() {
         let mut val = Vec::new();
         val.resize(0xffff, 0x12);
-        wrap_in_sequence(&mut val);
-        assert_eq!(vec![0x30, 0x82, 0xff, 0xff, 0x12, 0x12], val[..6].to_vec());
-        assert_eq!(val.len(), 0xffff + 4);
+        let result = wrap_in_sequence(&val);
+        assert_eq!(vec![0x30, 0x82, 0xff, 0xff, 0x12, 0x12], result[..6]);
+        assert_eq!(result.len(), 0xffff + 4);
     }
 
     #[test]
     fn test_gigantic() {
         let mut val = Vec::new();
         val.resize(0x100000, 0x12);
-        wrap_in_sequence(&mut val);
-        assert_eq!(
-            vec![0x30, 0x83, 0x10, 0x00, 0x00, 0x12, 0x12],
-            val[..7].to_vec()
-        );
-        assert_eq!(val.len(), 0x100000 + 5);
+        let result = wrap_in_sequence(&val);
+        assert_eq!(vec![0x30, 0x83, 0x10, 0x00, 0x00, 0x12, 0x12], result[..7]);
+        assert_eq!(result.len(), 0x100000 + 5);
     }
 
     #[test]
     fn test_ludicrous() {
         let mut val = Vec::new();
         val.resize(0x1000000, 0x12);
-        wrap_in_sequence(&mut val);
+        let result = wrap_in_sequence(&val);
         assert_eq!(
             vec![0x30, 0x84, 0x01, 0x00, 0x00, 0x00, 0x12, 0x12],
-            val[..8].to_vec()
+            result[..8]
         );
-        assert_eq!(val.len(), 0x1000000 + 6);
+        assert_eq!(result.len(), 0x1000000 + 6);
     }
 }


### PR DESCRIPTION
Instead of taking a `Vec<u8>` and inserting bytes at the beginning, take a `&[u8]` and return a new vector containing those bytes plus a tag and a length.

This isn't the perfect approach for all situations, but for one of the main places we call wrap_in_sequence (DistinguishedName::in_sequence), it's optimal because the input is `&[u8]`, meaning we can't write to a previously existing `Vec<u8>` (which would potentially save allocations by using excess capacity at the end of the Vec).

In the process, change the one call site for `wrap_in_asn1_len` to call the new `asn1_wrap` function instead, which encodes a tag and length at the same time, reducing reallocations and copies.

This has a slight secondary benefit: the resulting Vec is exactly sized to what it holds, instead of following the doubling approach and possibly over-allocating. This saves a handful of bytes in a long-lived data structure.

Fixes #1562