### PR TITLE
client: add `ClientHelloCamouflager` to reduce TLS fingerprinting risk

### DIFF
--- a/examples/src/bin/fingerprint-resist.rs
+++ b/examples/src/bin/fingerprint-resist.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use rustls::client::ClientHelloCamouflager;
 use rustls::internal::msgs::base::Payload;
-use rustls::internal::msgs::enums::{ECPointFormat, ExtensionType, PSKKeyExchangeMode};
+use rustls::internal::msgs::enums::{EcPointFormat, ExtensionType, PSKKeyExchangeMode};
 use rustls::internal::msgs::handshake::ClientExtension::*;
 use rustls::internal::msgs::handshake::{
     ClientExtension, ClientSessionTicket, ProtocolName, UnknownExtension,
@@ -85,7 +85,7 @@ fn main() {
                     NamedGroup::secp256r1,
                     NamedGroup::secp384r1,
                 ]),
-                EcPointFormats(vec![ECPointFormat::Uncompressed]),
+                EcPointFormats(vec![EcPointFormat::Uncompressed]),
                 SessionTicket(ClientSessionTicket::Request),
                 Protocols(vec![
                     // ProtocolName::from("h2".as_bytes().to_vec()),

--- a/examples/src/bin/fingerprint-resist.rs
+++ b/examples/src/bin/fingerprint-resist.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use rustls::client::ClientHelloCamouflager;
 use rustls::internal::msgs::base::Payload;
-use rustls::internal::msgs::enums::{EcPointFormat, ExtensionType, PSKKeyExchangeMode};
+use rustls::internal::msgs::enums::{EcPointFormat, ExtensionType, PskKeyExchangeMode};
 use rustls::internal::msgs::handshake::ClientExtension::*;
 use rustls::internal::msgs::handshake::{
     ClientExtension, ClientSessionTicket, ProtocolName, UnknownExtension,
@@ -110,7 +110,7 @@ fn main() {
                     payload: Payload::new(vec![]),
                 }),
                 keyshare,
-                PresharedKeyModes(vec![PSKKeyExchangeMode::PSK_DHE_KE]),
+                PresharedKeyModes(vec![PskKeyExchangeMode::PSK_DHE_KE]),
                 SupportedVersions(vec![
                     ProtocolVersion::Unknown(0x5a5a),
                     ProtocolVersion::TLSv1_3,

--- a/examples/src/bin/fingerprint-resist.rs
+++ b/examples/src/bin/fingerprint-resist.rs
@@ -1,0 +1,174 @@
+//! This is an example to show how to modify ClientHello to resist
+//! TLS fingerprinting techniques.
+
+use std::io::{stdout, Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+use rustls::client::ClientHelloCamouflager;
+use rustls::internal::msgs::base::Payload;
+use rustls::internal::msgs::enums::{ECPointFormat, ExtensionType, PSKKeyExchangeMode};
+use rustls::internal::msgs::handshake::ClientExtension::*;
+use rustls::internal::msgs::handshake::{
+    ClientExtension, ClientSessionTicket, ProtocolName, UnknownExtension,
+};
+use rustls::CipherSuite::*;
+use rustls::{CipherSuite, NamedGroup, ProtocolVersion};
+use rustls::{RootCertStore, SignatureScheme};
+
+fn main() {
+    let mut root_store = RootCertStore::empty();
+    root_store.extend(
+        webpki_roots::TLS_SERVER_ROOTS
+            .iter()
+            .cloned(),
+    );
+    let mut config = rustls::ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    config.alpn_protocols = vec!["http/1.1".as_bytes().to_vec()];
+
+    struct Chrome102;
+    impl ClientHelloCamouflager for Chrome102 {
+        fn transform_cipher_suites(&self, _cipher_suites: Vec<CipherSuite>) -> Vec<CipherSuite> {
+            vec![
+                CipherSuite::Unknown(0x0a0a), // GREASE
+                TLS13_AES_128_GCM_SHA256,
+                TLS13_AES_256_GCM_SHA384,
+                TLS13_CHACHA20_POLY1305_SHA256,
+                TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+                TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+                TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+                TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+                TLS_RSA_WITH_AES_128_GCM_SHA256,
+                TLS_RSA_WITH_AES_256_GCM_SHA384,
+                TLS_RSA_WITH_AES_128_CBC_SHA,
+                TLS_RSA_WITH_AES_256_CBC_SHA,
+            ]
+        }
+
+        fn transform_extensions(&self, extensions: Vec<ClientExtension>) -> Vec<ClientExtension> {
+            let sni = extensions
+                .iter()
+                .find(|ext| matches!(ext, ClientExtension::ServerName(_)))
+                .unwrap()
+                .clone();
+            let keyshare = extensions
+                .iter()
+                .find(|ext| matches!(ext, ClientExtension::KeyShare(_)))
+                .unwrap()
+                .clone();
+            vec![
+                ClientExtension::Unknown(UnknownExtension {
+                    typ: ExtensionType::Unknown(0x9a9a),
+                    payload: Payload::new(vec![]),
+                }),
+                sni,
+                // ExtendedMasterSecretRequest,
+                ClientExtension::Unknown(UnknownExtension {
+                    typ: ExtensionType::Unknown(23),
+                    payload: Payload::new(vec![]),
+                }),
+                ClientExtension::Unknown(UnknownExtension {
+                    typ: ExtensionType::RenegotiationInfo,
+                    payload: Payload::new(vec![0]),
+                }),
+                NamedGroups(vec![
+                    NamedGroup::Unknown(0x7a7a),
+                    NamedGroup::X25519,
+                    NamedGroup::secp256r1,
+                    NamedGroup::secp384r1,
+                ]),
+                EcPointFormats(vec![ECPointFormat::Uncompressed]),
+                SessionTicket(ClientSessionTicket::Request),
+                Protocols(vec![
+                    // ProtocolName::from("h2".as_bytes().to_vec()),
+                    ProtocolName::from("http/1.1".as_bytes().to_vec()),
+                ]),
+                ClientExtension::Unknown(UnknownExtension {
+                    typ: ExtensionType::StatusRequest,
+                    payload: Payload::new(vec![1, 0, 0, 0, 0]),
+                }),
+                SignatureAlgorithms(vec![
+                    SignatureScheme::ECDSA_NISTP256_SHA256,
+                    SignatureScheme::RSA_PSS_SHA256,
+                    SignatureScheme::RSA_PKCS1_SHA256,
+                    SignatureScheme::ECDSA_NISTP384_SHA384,
+                    SignatureScheme::RSA_PSS_SHA384,
+                    SignatureScheme::RSA_PKCS1_SHA384,
+                    SignatureScheme::RSA_PSS_SHA512,
+                    SignatureScheme::RSA_PKCS1_SHA512,
+                ]),
+                ClientExtension::Unknown(UnknownExtension {
+                    typ: ExtensionType::SCT,
+                    payload: Payload::new(vec![]),
+                }),
+                keyshare,
+                PresharedKeyModes(vec![PSKKeyExchangeMode::PSK_DHE_KE]),
+                SupportedVersions(vec![
+                    ProtocolVersion::Unknown(0x5a5a),
+                    ProtocolVersion::TLSv1_3,
+                    ProtocolVersion::TLSv1_2,
+                ]),
+                // compress_certificate, RFC 8879
+                ClientExtension::Unknown(UnknownExtension {
+                    typ: ExtensionType::Unknown(27),
+                    payload: Payload::new([0x1, 0x0, 0x2]),
+                }),
+                // Application Settings, not IANA assigned
+                ClientExtension::Unknown(UnknownExtension {
+                    typ: ExtensionType::Unknown(17513),
+                    payload: Payload::new([0x0, 0x3, 0x2, 68, 32]),
+                }),
+                ClientExtension::Unknown(UnknownExtension {
+                    typ: ExtensionType::Unknown(0x6a6a),
+                    payload: Payload::new(vec![0]),
+                }),
+                ClientExtension::Unknown(UnknownExtension {
+                    typ: ExtensionType::Padding,
+                    payload: Payload::new(vec![]),
+                }),
+            ]
+        }
+    }
+
+    config.client_hello_camouflager = Some(Arc::new(Chrome102));
+
+    // Allow using SSLKEYLOGFILE.
+    config.key_log = Arc::new(rustls::KeyLogFile::new());
+
+    let server_name = "tls.peet.ws".try_into().unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    let mut sock = TcpStream::connect("tls.peet.ws:443").unwrap();
+    let mut tls = rustls::Stream::new(&mut conn, &mut sock);
+    tls.write_all(
+        concat!(
+            "GET /api/all HTTP/1.1\r\n",
+            "Host: tls.peet.ws\r\n",
+            "Connection: close\r\n",
+            "Accept-Encoding: identity\r\n",
+            "\r\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    let ciphersuite = tls
+        .conn
+        .negotiated_cipher_suite()
+        .unwrap();
+    writeln!(
+        &mut std::io::stderr(),
+        "Current ciphersuite: {:?}",
+        ciphersuite.suite()
+    )
+    .unwrap();
+    let mut plaintext = Vec::new();
+    tls.read_to_end(&mut plaintext).unwrap();
+    stdout().write_all(&plaintext).unwrap();
+}

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -153,6 +153,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             key_log: Arc::new(NoKeyLog {}),
             enable_secret_extraction: false,
             enable_early_data: false,
+            client_hello_camouflager: None,
         }
     }
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -11,7 +11,7 @@ use crate::hash_hs::HandshakeHashBuffer;
 use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::enums::{Compression, ExtensionType};
-use crate::msgs::enums::{EcPointFormat, PSKKeyExchangeMode};
+use crate::msgs::enums::{EcPointFormat, PskKeyExchangeMode};
 use crate::msgs::handshake::ConvertProtocolNameList;
 use crate::msgs::handshake::{CertificateStatusRequest, ClientSessionTicket};
 use crate::msgs::handshake::{ClientExtension, HasServerExtensions};
@@ -255,7 +255,7 @@ fn emit_client_hello_for_retry(
     if support_tls13 {
         // We could support PSK_KE here too. Such connections don't
         // have forward secrecy, and are similar to TLS1.2 resumption.
-        let psk_modes = vec![PSKKeyExchangeMode::PSK_DHE_KE];
+        let psk_modes = vec![PskKeyExchangeMode::PSK_DHE_KE];
         exts.push(ClientExtension::PresharedKeyModes(psk_modes));
     }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -11,7 +11,7 @@ use crate::hash_hs::HandshakeHashBuffer;
 use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::enums::{Compression, ExtensionType};
-use crate::msgs::enums::{ECPointFormat, PSKKeyExchangeMode};
+use crate::msgs::enums::{EcPointFormat, PSKKeyExchangeMode};
 use crate::msgs::handshake::ConvertProtocolNameList;
 use crate::msgs::handshake::{CertificateStatusRequest, ClientSessionTicket};
 use crate::msgs::handshake::{ClientExtension, HasServerExtensions};
@@ -221,7 +221,7 @@ fn emit_client_hello_for_retry(
 
     let mut exts = vec![
         ClientExtension::SupportedVersions(supported_versions),
-        ClientExtension::EcPointFormats(ECPointFormat::SUPPORTED.to_vec()),
+        ClientExtension::EcPointFormats(EcPointFormat::SUPPORTED.to_vec()),
         ClientExtension::NamedGroups(
             config
                 .kx_groups
@@ -578,7 +578,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
         // If ECPointFormats extension is supplied by the server, it must contain
         // Uncompressed.  But it's allowed to be omitted.
         if let Some(point_fmts) = server_hello.get_ecpoints_extension() {
-            if !point_fmts.contains(&ECPointFormat::Uncompressed) {
+            if !point_fmts.contains(&EcPointFormat::Uncompressed) {
                 return Err(cx.common.send_fatal_alert(
                     AlertDescription::HandshakeFailure,
                     PeerMisbehaved::ServerHelloMustOfferUncompressedEcPoints,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -94,6 +94,10 @@ pub enum Error {
     /// The `max_fragment_size` value supplied in configuration was too small,
     /// or too large.
     BadMaxFragmentSize,
+
+    /// When the client with camouflaged ClientHello cannot handle the server's
+    /// response.
+    CamouflageSelected,
 }
 
 /// A corrupt TLS message payload that resulted in an error.
@@ -512,6 +516,9 @@ impl fmt::Display for Error {
             Self::FailedToGetRandomBytes => write!(f, "failed to get random bytes"),
             Self::BadMaxFragmentSize => {
                 write!(f, "the supplied max_fragment_size was too small or large")
+            }
+            Self::CamouflageSelected => {
+                write!(f, "peer selected camouflaged tls options")
             }
             Self::General(ref err) => write!(f, "unexpected error: {}", err),
         }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -380,15 +380,19 @@ pub mod internal {
             pub use crate::msgs::deframer::MessageDeframer;
         }
         pub mod enums {
-            pub use crate::msgs::enums::{AlertLevel, Compression, NamedGroup};
+            pub use crate::msgs::enums::{
+                AlertLevel, Compression, ECPointFormat, ExtensionType, NamedGroup,
+                PSKKeyExchangeMode,
+            };
         }
         pub mod fragmenter {
             pub use crate::msgs::fragmenter::MessageFragmenter;
         }
         pub mod handshake {
             pub use crate::msgs::handshake::{
-                ClientExtension, ClientHelloPayload, DistinguishedName, HandshakeMessagePayload,
-                HandshakePayload, KeyShareEntry, Random, SessionId,
+                ClientExtension, ClientHelloPayload, ClientSessionTicket, DistinguishedName,
+                HandshakeMessagePayload, HandshakePayload, KeyShareEntry, ProtocolName, Random,
+                SessionId, UnknownExtension,
             };
         }
         pub mod message {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -381,7 +381,7 @@ pub mod internal {
         }
         pub mod enums {
             pub use crate::msgs::enums::{
-                AlertLevel, Compression, ECPointFormat, ExtensionType, NamedGroup,
+                AlertLevel, Compression, EcPointFormat, ExtensionType, NamedGroup,
                 PSKKeyExchangeMode,
             };
         }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -382,7 +382,7 @@ pub mod internal {
         pub mod enums {
             pub use crate::msgs::enums::{
                 AlertLevel, Compression, EcPointFormat, ExtensionType, NamedGroup,
-                PSKKeyExchangeMode,
+                PskKeyExchangeMode,
             };
         }
         pub mod fragmenter {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -446,8 +446,9 @@ pub mod client {
     pub use crate::dns_name::InvalidDnsNameError;
     pub use builder::WantsClientCert;
     pub use client_conn::{
-        ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore,
-        ResolvesClientCert, Resumption, ServerName, Tls12Resumption, WriteEarlyData,
+        ClientConfig, ClientConnection, ClientConnectionData, ClientHelloCamouflager,
+        ClientSessionStore, ResolvesClientCert, Resumption, ServerName, Tls12Resumption,
+        WriteEarlyData,
     };
     pub use handy::ClientSessionMemoryCache;
 

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -77,7 +77,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U16
-    pub(crate) enum ExtensionType {
+    pub enum ExtensionType {
         ServerName => 0x0000,
         MaxFragmentLength => 0x0001,
         ClientCertificateUrl => 0x0002,

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -198,14 +198,14 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    pub enum ECPointFormat {
+    pub enum EcPointFormat {
         Uncompressed => 0x00,
         ANSIX962CompressedPrime => 0x01,
         ANSIX962CompressedChar2 => 0x02
     }
 }
 
-impl ECPointFormat {
+impl EcPointFormat {
     pub(crate) const SUPPORTED: [Self; 1] = [Self::Uncompressed];
 }
 
@@ -292,9 +292,9 @@ pub(crate) mod tests {
             NamedCurve::arbitrary_explicit_char2_curves,
         );
         test_enum16::<NamedGroup>(NamedGroup::secp256r1, NamedGroup::FFDHE8192);
-        test_enum8::<ECPointFormat>(
-            ECPointFormat::Uncompressed,
-            ECPointFormat::ANSIX962CompressedChar2,
+        test_enum8::<EcPointFormat>(
+            EcPointFormat::Uncompressed,
+            EcPointFormat::ANSIX962CompressedChar2,
         );
         test_enum8::<HeartbeatMode>(
             HeartbeatMode::PeerAllowedToSend,

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -237,7 +237,7 @@ enum_builder! {
     /// from the various RFCs covering TLS, and are listed by IANA.
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
-    pub enum PSKKeyExchangeMode {
+    pub enum PskKeyExchangeMode {
         PSK_KE => 0x00,
         PSK_DHE_KE => 0x01
     }
@@ -301,9 +301,9 @@ pub(crate) mod tests {
             HeartbeatMode::PeerNotAllowedToSend,
         );
         test_enum8::<ECCurveType>(ECCurveType::ExplicitPrime, ECCurveType::NamedCurve);
-        test_enum8::<PSKKeyExchangeMode>(
-            PSKKeyExchangeMode::PSK_KE,
-            PSKKeyExchangeMode::PSK_DHE_KE,
+        test_enum8::<PskKeyExchangeMode>(
+            PskKeyExchangeMode::PSK_KE,
+            PskKeyExchangeMode::PSK_DHE_KE,
         );
         test_enum8::<KeyUpdateRequest>(
             KeyUpdateRequest::UpdateNotRequested,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -11,7 +11,7 @@ use crate::log::warn;
 use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
 use crate::msgs::codec::{self, Codec, LengthPrefixedBuffer, ListLength, Reader, TlsListElement};
 use crate::msgs::enums::{
-    CertificateStatusType, ClientCertificateType, Compression, ECCurveType, ECPointFormat,
+    CertificateStatusType, ClientCertificateType, Compression, ECCurveType, EcPointFormat,
     ExtensionType, KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType,
 };
 use crate::verify::DigitallySignedStruct;
@@ -200,7 +200,7 @@ impl UnknownExtension {
     }
 }
 
-impl TlsListElement for ECPointFormat {
+impl TlsListElement for EcPointFormat {
     const SIZE_LEN: ListLength = ListLength::U8;
 }
 
@@ -540,7 +540,7 @@ impl TlsListElement for ProtocolVersion {
 
 #[derive(Clone, Debug)]
 pub enum ClientExtension {
-    EcPointFormats(Vec<ECPointFormat>),
+    EcPointFormats(Vec<EcPointFormat>),
     NamedGroups(Vec<NamedGroup>),
     SignatureAlgorithms(Vec<SignatureScheme>),
     ServerName(Vec<ServerName>),
@@ -690,7 +690,7 @@ pub enum ClientSessionTicket {
 
 #[derive(Clone, Debug)]
 pub enum ServerExtension {
-    EcPointFormats(Vec<ECPointFormat>),
+    EcPointFormats(Vec<EcPointFormat>),
     ServerNameAck,
     SessionTicketAck,
     RenegotiationInfo(PayloadU8),
@@ -900,7 +900,7 @@ impl ClientHelloPayload {
     }
 
     #[cfg(feature = "tls12")]
-    pub(crate) fn get_ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
+    pub(crate) fn get_ecpoints_extension(&self) -> Option<&[EcPointFormat]> {
         let ext = self.find_extension(ExtensionType::ECPointFormats)?;
         match *ext {
             ClientExtension::EcPointFormats(ref req) => Some(req),
@@ -1233,7 +1233,7 @@ impl ServerHelloPayload {
         }
     }
 
-    pub(crate) fn get_ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
+    pub(crate) fn get_ecpoints_extension(&self) -> Option<&[EcPointFormat]> {
         let ext = self.find_extension(ExtensionType::ECPointFormats)?;
         match *ext {
             ServerExtension::EcPointFormats(ref fmts) => Some(fmts),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -185,8 +185,8 @@ impl SessionId {
 
 #[derive(Clone, Debug)]
 pub struct UnknownExtension {
-    pub(crate) typ: ExtensionType,
-    pub(crate) payload: Payload,
+    pub typ: ExtensionType,
+    pub payload: Payload,
 }
 
 impl UnknownExtension {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -12,7 +12,7 @@ use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
 use crate::msgs::codec::{self, Codec, LengthPrefixedBuffer, ListLength, Reader, TlsListElement};
 use crate::msgs::enums::{
     CertificateStatusType, ClientCertificateType, Compression, ECCurveType, EcPointFormat,
-    ExtensionType, KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType,
+    ExtensionType, KeyUpdateRequest, NamedGroup, PskKeyExchangeMode, ServerNameType,
 };
 use crate::verify::DigitallySignedStruct;
 use crate::{rand, x509};
@@ -526,7 +526,7 @@ impl CertificateStatusRequest {
 
 // ---
 
-impl TlsListElement for PSKKeyExchangeMode {
+impl TlsListElement for PskKeyExchangeMode {
     const SIZE_LEN: ListLength = ListLength::U8;
 }
 
@@ -548,7 +548,7 @@ pub enum ClientExtension {
     Protocols(Vec<ProtocolName>),
     SupportedVersions(Vec<ProtocolVersion>),
     KeyShare(Vec<KeyShareEntry>),
-    PresharedKeyModes(Vec<PSKKeyExchangeMode>),
+    PresharedKeyModes(Vec<PskKeyExchangeMode>),
     PresharedKey(PresharedKeyOffer),
     Cookie(PayloadU16),
     ExtendedMasterSecretRequest,
@@ -979,7 +979,7 @@ impl ClientHelloPayload {
             .map_or(false, |ext| ext.get_type() == ExtensionType::PreSharedKey)
     }
 
-    pub(crate) fn get_psk_modes(&self) -> Option<&[PSKKeyExchangeMode]> {
+    pub(crate) fn get_psk_modes(&self) -> Option<&[PskKeyExchangeMode]> {
         let ext = self.find_extension(ExtensionType::PSKKeyExchangeModes)?;
         match *ext {
             ClientExtension::PresharedKeyModes(ref psk_modes) => Some(psk_modes),
@@ -987,7 +987,7 @@ impl ClientHelloPayload {
         }
     }
 
-    pub(crate) fn psk_mode_offered(&self, mode: PSKKeyExchangeMode) -> bool {
+    pub(crate) fn psk_mode_offered(&self, mode: PskKeyExchangeMode) -> bool {
         self.get_psk_modes()
             .map(|modes| modes.contains(&mode))
             .unwrap_or(false)

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -4,7 +4,7 @@ use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
 use crate::msgs::codec::{put_u16, Codec, Reader};
 use crate::msgs::enums::{
     ClientCertificateType, Compression, ECCurveType, EcPointFormat, ExtensionType,
-    KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType,
+    KeyUpdateRequest, NamedGroup, PskKeyExchangeMode, ServerNameType,
 };
 use crate::msgs::handshake::{
     CertReqExtension, CertificateEntry, CertificateExtension, CertificatePayloadTls13,
@@ -374,7 +374,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::Protocols(vec![ProtocolName::from(vec![0])]),
             ClientExtension::SupportedVersions(vec![ProtocolVersion::TLSv1_3]),
             ClientExtension::KeyShare(vec![KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3])]),
-            ClientExtension::PresharedKeyModes(vec![PSKKeyExchangeMode::PSK_DHE_KE]),
+            ClientExtension::PresharedKeyModes(vec![PskKeyExchangeMode::PSK_DHE_KE]),
             ClientExtension::PresharedKey(PresharedKeyOffer {
                 identities: vec![
                     PresharedKeyIdentity::new(vec![3, 4, 5], 123456),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -3,7 +3,7 @@ use crate::enums::{CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme}
 use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
 use crate::msgs::codec::{put_u16, Codec, Reader};
 use crate::msgs::enums::{
-    ClientCertificateType, Compression, ECCurveType, ECPointFormat, ExtensionType,
+    ClientCertificateType, Compression, ECCurveType, EcPointFormat, ExtensionType,
     KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType,
 };
 use crate::msgs::handshake::{
@@ -365,7 +365,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
         cipher_suites: vec![CipherSuite::TLS_NULL_WITH_NULL_NULL],
         compression_methods: vec![Compression::Null],
         extensions: vec![
-            ClientExtension::EcPointFormats(ECPointFormat::SUPPORTED.to_vec()),
+            ClientExtension::EcPointFormats(EcPointFormat::SUPPORTED.to_vec()),
             ClientExtension::NamedGroups(vec![NamedGroup::X25519]),
             ClientExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
             ClientExtension::make_sni(DnsNameRef::try_from("hello").unwrap()),
@@ -749,7 +749,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
         cipher_suite: CipherSuite::TLS_NULL_WITH_NULL_NULL,
         compression_method: Compression::Null,
         extensions: vec![
-            ServerExtension::EcPointFormats(ECPointFormat::SUPPORTED.to_vec()),
+            ServerExtension::EcPointFormats(EcPointFormat::SUPPORTED.to_vec()),
             ServerExtension::ServerNameAck,
             ServerExtension::SessionTicketAck,
             ServerExtension::RenegotiationInfo(PayloadU8(vec![0])),

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -38,7 +38,7 @@ pub(super) use client_hello::CompleteClientHelloHandling;
 mod client_hello {
     use crate::crypto::SupportedKxGroup;
     use crate::enums::SignatureScheme;
-    use crate::msgs::enums::ECPointFormat;
+    use crate::msgs::enums::EcPointFormat;
     use crate::msgs::enums::{ClientCertificateType, Compression};
     use crate::msgs::handshake::ServerEcdhParams;
     use crate::msgs::handshake::{CertificateRequestPayload, ClientSessionTicket, Random};
@@ -99,7 +99,7 @@ mod client_hello {
             trace!("namedgroups {:?}", groups_ext);
             trace!("ecpoints {:?}", ecpoints_ext);
 
-            if !ecpoints_ext.contains(&ECPointFormat::Uncompressed) {
+            if !ecpoints_ext.contains(&EcPointFormat::Uncompressed) {
                 return Err(cx.common.send_fatal_alert(
                     AlertDescription::IllegalParameter,
                     PeerIncompatible::UncompressedEcPointsRequired,
@@ -186,7 +186,7 @@ mod client_hello {
                     )
                 })?;
 
-            let ecpoint = ECPointFormat::SUPPORTED
+            let ecpoint = EcPointFormat::SUPPORTED
                 .iter()
                 .find(|format| ecpoints_ext.contains(format))
                 .cloned()
@@ -197,7 +197,7 @@ mod client_hello {
                     )
                 })?;
 
-            debug_assert_eq!(ecpoint, ECPointFormat::Uncompressed);
+            debug_assert_eq!(ecpoint, EcPointFormat::Uncompressed);
 
             let mut ocsp_response = server_key.get_ocsp();
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -47,7 +47,7 @@ mod client_hello {
     use crate::msgs::base::{Payload, PayloadU8};
     use crate::msgs::ccs::ChangeCipherSpecPayload;
     use crate::msgs::enums::NamedGroup;
-    use crate::msgs::enums::{Compression, PSKKeyExchangeMode};
+    use crate::msgs::enums::{Compression, PskKeyExchangeMode};
     use crate::msgs::handshake::CertReqExtension;
     use crate::msgs::handshake::CertificateEntry;
     use crate::msgs::handshake::CertificateExtension;
@@ -341,7 +341,7 @@ mod client_hello {
                 }
             }
 
-            if !client_hello.psk_mode_offered(PSKKeyExchangeMode::PSK_DHE_KE) {
+            if !client_hello.psk_mode_offered(PskKeyExchangeMode::PSK_DHE_KE) {
                 debug!("Client unwilling to resume, DHE_KE not offered");
                 self.send_tickets = 0;
                 chosen_psk_index = None;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -18,7 +18,7 @@ use rustls::client::{
 use rustls::crypto::ring::ALL_CIPHER_SUITES;
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
-use rustls::internal::msgs::enums::{AlertLevel, ECPointFormat};
+use rustls::internal::msgs::enums::{AlertLevel, EcPointFormat};
 use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
 use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert, WebPkiClientVerifier};
@@ -1257,7 +1257,7 @@ fn client_hello_camouflage() {
             ProtocolVersion::TLSv1_3,
             ProtocolVersion::TLSv1_2,
         ]),
-        ClientExtension::EcPointFormats(vec![ECPointFormat::Uncompressed]),
+        ClientExtension::EcPointFormats(vec![EcPointFormat::Uncompressed]),
     ];
     assert_eq!(
         vec![


### PR DESCRIPTION
There have been many discussions related to TLS fingerprinting, including #1421, #1501 and #1190. To get rid of this issue, a customizable modifier in `ClientConfig` is a viable approach. 

This design will replace the original cipher suites and extensions with user-defined values if `client_hello_camouflager` field is set in the config. This design will also use the original values constructed by rustls, in order to make users easily create their own masks.

This PR introduces little modification to the other part of rustls. If a user doesn't choose to use this feature, rustls should work the exactly same as the previous version. This PR also re-exports some structures, which are still public in stable 0.21 but removed in 0.22-beta.

The example included in this PR tries to pretend the traffic is sent by a Chrome 102 browser. The JA3 hash of the example is "cd08e31494f9531f560d64c695473da9", which can be found on many JA3 databases identified as Chrome.