### PR TITLE
Reduce allocation counts in a couple of places

### DIFF
--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -24,7 +24,6 @@ macro_rules! require_handshake_msg(
 );
 
 /// Like require_handshake_msg, but moves the payload out of $m.
-#[cfg(feature = "tls12")]
 macro_rules! require_handshake_msg_move(
   ( $m:expr, $handshake_type:path, $payload_type:path ) => (
     match $m.payload {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1448,12 +1448,11 @@ impl CertificatePayloadTls13 {
             .unwrap_or_default()
     }
 
-    pub(crate) fn convert(&self) -> CertificatePayload {
-        let mut ret = Vec::new();
-        for entry in &self.entries {
-            ret.push(entry.cert.clone());
-        }
-        ret
+    pub(crate) fn convert(self) -> CertificatePayload {
+        self.entries
+            .into_iter()
+            .map(|e| e.cert)
+            .collect()
     }
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -881,12 +881,12 @@ struct ExpectCertificate {
 
 impl State<ServerConnectionData> for ExpectCertificate {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
-        let certp = require_handshake_msg!(
+        self.transcript.add_message(&m);
+        let certp = require_handshake_msg_move!(
             m,
             HandshakeType::Certificate,
             HandshakePayload::CertificateTls13
         )?;
-        self.transcript.add_message(&m);
 
         // We don't send any CertificateRequest extensions, so any extensions
         // here are illegal.

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -122,8 +122,8 @@ impl ChunkVecBuffer {
     fn consume(&mut self, mut used: usize) {
         while let Some(mut buf) = self.chunks.pop_front() {
             if used < buf.len() {
-                self.chunks
-                    .push_front(buf.split_off(used));
+                buf.drain(..used);
+                self.chunks.push_front(buf);
                 break;
             } else {
                 used -= buf.len();


### PR DESCRIPTION
Messing around with heaptrack in #1563, I identified a couple of places with relatively high allocation counts when running `simpleclient` (modified to do several connections in a row).

In CertificatePayloadTls13::convert, we were unnecessarily doing a clone. Fixed this by converting that function to take `self`, and the two callsites to use `require_handshake_msg_move!` instead of `require_handshake_msg!`.

In `ChunkVecBuffer::consume`, when a chunk is partially consumed, we were calling [Vec::split_off](https://doc.rust-lang.org/nightly/std/vec/struct.Vec.html#method.split_off), which always "Returns a newly allocated vector." Instead, use [Vec::drain](https://doc.rust-lang.org/nightly/std/vec/struct.Vec.html#method.drain), which reuses the current allocation.

In local testing, the change to `ChunkVecBuffer::consume` appeared to reduce allocations by almost 10%. I'll be curious to see if the CI run shows actual runtime performance.