### PR TITLE
More general error used in trait `SupportedKxGroup` & new variant in `Error`

### DIFF
--- a/provider-example/src/kx.rs
+++ b/provider-example/src/kx.rs
@@ -34,7 +34,7 @@ pub const ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[&X25519 as &dyn SupportedK
 pub struct X25519;
 
 impl crypto::SupportedKxGroup for X25519 {
-    fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::crypto::GetRandomFailed> {
+    fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::Error> {
         let priv_key = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
         Ok(Box::new(KeyExchange {
             pub_key: (&priv_key).into(),

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -59,7 +59,7 @@ pub trait SupportedKxGroup: Send + Sync + Debug {
     /// # Errors
     ///
     /// This can fail if the random source fails during ephemeral key generation.
-    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, GetRandomFailed>;
+    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error>;
 
     /// Named group the SupportedKxGroup operates in.
     fn name(&self) -> NamedGroup;

--- a/rustls/src/crypto/ring/kx.rs
+++ b/rustls/src/crypto/ring/kx.rs
@@ -22,7 +22,7 @@ struct KxGroup {
 }
 
 impl SupportedKxGroup for KxGroup {
-    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, GetRandomFailed> {
+    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
         let rng = SystemRandom::new();
         let priv_key = EphemeralPrivateKey::generate(self.agreement_algorithm, &rng)
             .map_err(|_| GetRandomFailed)?;


### PR DESCRIPTION
This PR:
- Add a new variant named `Other` in `Error` to express any other error. The main intention for this is to use it to hold errors throw from underlying custom crypto provider or PKI provider.
  A new unit struct `OtherError` is added to properly implement `PartialEq`.
- Use `Error` instead of `GetRandomFailed` in trait `SupportedKxGroup`, so that underlying crypto provider could throw errors other than RNG related errors.
- Fix #1569 