### PR TITLE
implement the caller-side managed buffers (AKA `LlConnection`) API

### DIFF
--- a/examples/src/bin/llclient.rs
+++ b/examples/src/bin/llclient.rs
@@ -1,0 +1,196 @@
+use std::error::Error;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+use rustls::client::{ClientConnectionData, LlClientConnection};
+#[allow(unused_imports)]
+use rustls::version::{TLS12, TLS13};
+use rustls::{
+    AppDataRecord, ClientConfig, EncodeError, InsufficientSizeError, LlState, LlStatus,
+    MayEncryptAppData, RootCertStore,
+};
+
+const SERVER_NAME: &str = "example.com";
+const PORT: u16 = 443;
+const MAX_ITERATIONS: usize = 15;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let config = ClientConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(&[&TLS12])
+        // .with_protocol_versions(&[&TLS13])
+        .unwrap()
+        .with_root_certificates(build_root_store())
+        .with_no_client_auth();
+
+    let mut sock = TcpStream::connect(format!("{SERVER_NAME}:{PORT}"))?;
+    let mut conn = LlClientConnection::new(Arc::new(config), SERVER_NAME.try_into()?)?;
+
+    let mut incoming_tls = [0; 16 * 1024];
+    let mut incoming_used = 0;
+
+    let mut outgoing_tls = Vec::<u8>::new();
+    let mut outgoing_used = 0;
+
+    let mut open_connection = true;
+    let mut sent_request = false;
+    let mut received_response = false;
+
+    let mut iter_count = 0;
+    while open_connection {
+        let LlStatus { mut discard, state } =
+            conn.process_tls_records(&mut incoming_tls[..incoming_used])?;
+
+        match dbg!(state) {
+            LlState::AppDataAvailable(mut state) => {
+                while let Some(res) = state.next_record() {
+                    let AppDataRecord {
+                        discard: new_discard,
+                        payload,
+                    } = res?;
+                    discard += new_discard;
+
+                    println!("{}", core::str::from_utf8(payload)?);
+                    received_response = true;
+                }
+            }
+
+            LlState::MustEncodeTlsData(mut state) => {
+                let written = match state.encode(&mut outgoing_tls[outgoing_used..]) {
+                    Ok(written) => written,
+                    Err(EncodeError::InsufficientSize(InsufficientSizeError { required_size })) => {
+                        let new_len = outgoing_used + required_size;
+                        outgoing_tls.resize(new_len, 0);
+                        eprintln!("resized `outgoing_tls` buffer to {new_len}B");
+
+                        state
+                            .encode(&mut outgoing_tls[outgoing_used..])
+                            .expect("should not fail")
+                    }
+                    Err(e) => return Err(e.into()),
+                };
+
+                outgoing_used += written;
+            }
+
+            LlState::MustTransmitTlsData(mut state) => {
+                if let Some(mut may_encrypt) = state.may_encrypt() {
+                    make_http_request(
+                        &mut sent_request,
+                        &mut may_encrypt,
+                        &mut outgoing_tls,
+                        &mut outgoing_used,
+                    );
+                }
+
+                send_tls(&mut sock, &outgoing_tls, &mut outgoing_used)?;
+                state.done();
+            }
+
+            LlState::NeedsMoreTlsData { .. } => {
+                recv_tls(&mut sock, &mut incoming_tls, &mut incoming_used)?;
+            }
+
+            LlState::TrafficTransit(mut may_encrypt) => {
+                if make_http_request(
+                    &mut sent_request,
+                    &mut may_encrypt,
+                    &mut outgoing_tls,
+                    &mut outgoing_used,
+                ) {
+                    send_tls(&mut sock, &outgoing_tls, &mut outgoing_used)?;
+                    recv_tls(&mut sock, &mut incoming_tls, &mut incoming_used)?;
+                } else if !received_response {
+                    // this happens in the TLS 1.3 case. the app-data was sent in the preceding
+                    // `MustTransmitTlsData` state. the server should have already a response which
+                    // we can read out from the socket
+                    recv_tls(&mut sock, &mut incoming_tls, &mut incoming_used)?;
+                }
+            }
+
+            LlState::ConnectionClosed => {
+                open_connection = false;
+            }
+
+            // other states are not expected in this example
+            _ => unreachable!(),
+        }
+
+        if discard != 0 {
+            assert!(discard <= incoming_used);
+
+            incoming_tls.copy_within(discard..incoming_used, 0);
+            incoming_used -= discard;
+        }
+
+        iter_count += 1;
+        assert!(
+            iter_count < MAX_ITERATIONS,
+            "did not get a HTTP response within {MAX_ITERATIONS} iterations"
+        );
+    }
+
+    assert!(sent_request);
+    assert!(received_response);
+    assert_eq!(0, incoming_used);
+    assert_eq!(0, outgoing_used);
+
+    Ok(())
+}
+
+fn recv_tls(
+    sock: &mut TcpStream,
+    incoming_tls: &mut [u8],
+    incoming_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    let read = sock.read(&mut incoming_tls[*incoming_used..])?;
+    eprintln!("received {read}B of data");
+    *incoming_used += read;
+    Ok(())
+}
+
+fn send_tls(
+    sock: &mut TcpStream,
+    outgoing_tls: &[u8],
+    outgoing_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    sock.write_all(&outgoing_tls[..*outgoing_used])?;
+    eprintln!("sent {outgoing_used}B of data");
+    *outgoing_used = 0;
+    Ok(())
+}
+
+fn make_http_request(
+    sent_request: &mut bool,
+    may_encrypt: &mut MayEncryptAppData<'_, ClientConnectionData>,
+    outgoing_tls: &mut [u8],
+    outgoing_used: &mut usize,
+) -> bool {
+    if !*sent_request {
+        let written = may_encrypt
+            .encrypt(&build_http_request(), &mut outgoing_tls[*outgoing_used..])
+            .expect("encrypted request does not fit in `outgoing_tls`");
+        *outgoing_used += written;
+        *sent_request = true;
+        eprintln!("queued HTTP request");
+        true
+    } else {
+        false
+    }
+}
+
+fn build_root_store() -> RootCertStore {
+    let mut root_store = RootCertStore::empty();
+    root_store.extend(
+        webpki_roots::TLS_SERVER_ROOTS
+            .iter()
+            .cloned(),
+    );
+    root_store
+}
+
+fn build_http_request() -> Vec<u8> {
+    format!("GET / HTTP/1.1\r\nHost: {SERVER_NAME}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n").into_bytes()
+}

--- a/examples/src/bin/llserver.rs
+++ b/examples/src/bin/llserver.rs
@@ -1,0 +1,191 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::{self, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+
+use pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::{
+    server::LlServerConnection, AppDataRecord, EncodeError, InsufficientSizeError, LlState,
+    LlStatus, ServerConfig,
+};
+use rustls_pemfile::Item;
+
+const PORT: u16 = 1443;
+const MAX_ITERATIONS: usize = 20;
+const CERTFILE: &str = "localhost.pem";
+const PRIV_KEY_FILE: &str = "localhost-key.pem";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let config = Arc::new(
+        ServerConfig::builder()
+            .with_safe_defaults()
+            .with_no_client_auth()
+            .with_single_cert(load_certs()?, load_private_key()?)?,
+    );
+
+    let listener = TcpListener::bind(format!("[::]:{PORT}"))?;
+
+    for stream in listener.incoming() {
+        handle(stream?, &config)?;
+    }
+
+    Ok(())
+}
+
+fn handle(mut sock: TcpStream, config: &Arc<ServerConfig>) -> Result<(), Box<dyn Error>> {
+    dbg!(sock.peer_addr()?);
+
+    let mut conn = LlServerConnection::new(config.clone())?;
+
+    let mut incoming_tls = [0; 16 * 1024];
+    let mut incoming_used = 0;
+
+    let mut outgoing_tls = Vec::<u8>::new();
+    let mut outgoing_used = 0;
+
+    let mut open_connection = true;
+    let mut received_request = false;
+    let mut sent_response = false;
+
+    let mut iter_count = 0;
+    while open_connection {
+        let LlStatus { mut discard, state } =
+            conn.process_tls_records(&mut incoming_tls[..incoming_used])?;
+
+        match dbg!(state) {
+            LlState::AppDataAvailable(mut state) => {
+                while let Some(res) = state.next_record() {
+                    let AppDataRecord {
+                        discard: new_discard,
+                        payload,
+                    } = res?;
+                    discard += new_discard;
+
+                    println!("{}", core::str::from_utf8(payload)?);
+                    received_request = true;
+                }
+            }
+
+            LlState::MustEncodeTlsData(mut state) => {
+                let written = match state.encode(&mut outgoing_tls[outgoing_used..]) {
+                    Ok(written) => written,
+
+                    Err(EncodeError::InsufficientSize(InsufficientSizeError { required_size })) => {
+                        let new_len = outgoing_used + required_size;
+                        outgoing_tls.resize(new_len, 0);
+                        eprintln!("resized `outgoing_tls` buffer to {new_len}B");
+
+                        state
+                            .encode(&mut outgoing_tls[outgoing_used..])
+                            .expect("should not fail")
+                    }
+
+                    Err(e) => return Err(e.into()),
+                };
+
+                outgoing_used += written;
+            }
+
+            LlState::MustTransmitTlsData(mut state) => {
+                dbg!(state.may_encrypt().is_some());
+
+                send_tls(&mut sock, &outgoing_tls, &mut outgoing_used)?;
+                state.done();
+            }
+
+            LlState::NeedsMoreTlsData { .. } => {
+                recv_tls(&mut sock, &mut incoming_tls, &mut incoming_used)?;
+            }
+
+            LlState::TrafficTransit(mut state) => {
+                if !received_request {
+                    recv_tls(&mut sock, &mut incoming_tls, &mut incoming_used)?;
+                } else {
+                    let written = state
+                        .encrypt(build_http_response(), &mut outgoing_tls[outgoing_used..])
+                        .expect("encrypted request does not fit in `outgoing_tls`");
+                    outgoing_used += written;
+                    sent_response = true;
+
+                    let written = state
+                        .queue_close_notify(&mut outgoing_tls[outgoing_used..])
+                        .expect("encrypted close-notify does not fit in `outgoing_tls`");
+                    outgoing_used += written;
+                    open_connection = false;
+
+                    send_tls(&mut sock, &outgoing_tls, &mut outgoing_used)?;
+                }
+            }
+
+            _ => unreachable!(),
+        }
+
+        if discard != 0 {
+            assert!(discard <= incoming_used);
+
+            incoming_tls.copy_within(discard..incoming_used, 0);
+            incoming_used -= discard;
+        }
+
+        iter_count += 1;
+        assert!(
+            iter_count < MAX_ITERATIONS,
+            "did not get a HTTP response within {MAX_ITERATIONS} iterations"
+        );
+    }
+
+    assert!(received_request);
+    assert!(sent_response);
+    assert_eq!(0, incoming_used);
+    assert_eq!(0, outgoing_used);
+
+    Ok(())
+}
+
+fn recv_tls(
+    sock: &mut TcpStream,
+    incoming_tls: &mut [u8],
+    incoming_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    let read = sock.read(&mut incoming_tls[*incoming_used..])?;
+    eprintln!("received {read}B of data");
+    *incoming_used += read;
+    Ok(())
+}
+
+fn send_tls(
+    sock: &mut TcpStream,
+    outgoing_tls: &[u8],
+    outgoing_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    sock.write_all(&outgoing_tls[..*outgoing_used])?;
+    eprintln!("sent {outgoing_used}B of data");
+    *outgoing_used = 0;
+    Ok(())
+}
+
+fn build_http_response() -> &'static [u8] {
+    b"HTTP/1.0 200 OK\r\nConnection: close\r\n\r\nHello world from rustls llserver\r\n"
+}
+
+fn load_certs() -> Result<Vec<CertificateDer<'static>>, io::Error> {
+    let mut reader = BufReader::new(File::open(CERTFILE)?);
+    rustls_pemfile::certs(&mut reader).collect()
+}
+
+fn load_private_key() -> Result<PrivateKeyDer<'static>, io::Error> {
+    let mut reader = BufReader::new(File::open(PRIV_KEY_FILE)?);
+
+    loop {
+        match rustls_pemfile::read_one(&mut reader)? {
+            Some(Item::Pkcs1Key(key)) => return Ok(key.into()),
+            Some(Item::Pkcs8Key(key)) => return Ok(key.into()),
+            Some(Item::Sec1Key(key)) => return Ok(key.into()),
+            None => break,
+            _ => continue,
+        }
+    }
+
+    panic!("no keys found in {PRIV_KEY_FILE}")
+}

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,5 +1,5 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
-use crate::common_state::{CommonState, Protocol, Side};
+use crate::common_state::{CommonState, CommonState2, Protocol, Side};
 use crate::conn::{ConnectionCommon, ConnectionCore};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::dns_name::{DnsName, DnsNameRef, InvalidDnsNameError};
@@ -707,7 +707,9 @@ impl ConnectionCore<ClientConnectionData> {
         let mut data = ClientConnectionData::new();
 
         let mut cx = hs::ClientContext {
-            common: &mut common_state,
+            common: CommonState2::Eager {
+                common_state: &mut common_state,
+            },
             data: &mut data,
         };
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "logging")]
 use crate::bs_debug;
 use crate::check::inappropriate_handshake_message;
-use crate::common_state::{CommonState, State};
+use crate::common_state::{CommonState2, State};
 use crate::conn::ConnectionRandoms;
 use crate::crypto::ActiveKeyExchange;
 use crate::enums::{AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion};
@@ -323,7 +323,7 @@ fn emit_client_hello_for_retry(
     if retryreq.is_some() {
         // send dummy CCS to fool middleboxes prior
         // to second client hello
-        tls13::emit_fake_ccs(&mut input.sent_tls13_fake_ccs, cx.common);
+        tls13::emit_fake_ccs(&mut input.sent_tls13_fake_ccs, &mut cx.common);
     }
 
     trace!("Sending ClientHello {:#?}", ch);
@@ -435,7 +435,7 @@ fn prepare_resumption<'a>(
 }
 
 pub(super) fn process_alpn_protocol(
-    common: &mut CommonState,
+    common: &mut CommonState2,
     config: &ClientConfig,
     proto: Option<&[u8]>,
 ) -> Result<(), Error> {
@@ -563,7 +563,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
 
         // Extract ALPN protocol
         if !cx.common.is_tls13() {
-            process_alpn_protocol(cx.common, config, server_hello.get_alpn_protocol())?;
+            process_alpn_protocol(&mut cx.common, config, server_hello.get_alpn_protocol())?;
         }
 
         // If ECPointFormats extension is supplied by the server, it must contain

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -200,6 +200,11 @@ impl CommonState2<'_> {
         }
     }
 
+    #[cfg(feature = "quic")]
+    pub(crate) fn missing_extension(&mut self, why: PeerMisbehaved) -> Error {
+        self.send_fatal_alert(AlertDescription::MissingExtension, why)
+    }
+
     fn send_warning_alert(&mut self, desc: AlertDescription) {
         warn!("Sending warning alert {:?}", desc);
         self.send_warning_alert_no_log(desc);
@@ -565,11 +570,6 @@ impl CommonState {
 
     fn take_received_plaintext(&mut self, bytes: Payload) {
         self.received_plaintext.append(bytes.0);
-    }
-
-    #[cfg(feature = "quic")]
-    pub(crate) fn missing_extension(&mut self, why: PeerMisbehaved) -> Error {
-        self.send_fatal_alert(AlertDescription::MissingExtension, why)
     }
 
     pub(crate) fn process_alert(&mut self, alert: &AlertMessagePayload) -> Result<(), Error> {

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -756,7 +756,7 @@ impl<Data> ConnectionCore<Data> {
 
 pub(crate) struct LlConnectionCore<Data> {
     pub(crate) common_state: LlCommonState,
-    data: Data,
+    pub(crate) data: Data,
     pub(crate) deferred_actions: LlDeferredActions,
     message_deframer: LlMessageDeframer,
     pub(crate) state: Result<Box<dyn State<Data>>, Error>,

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1,4 +1,4 @@
-use crate::common_state::{CommonState, Context, IoState, State};
+use crate::common_state::{CommonState, CommonState2, Context, IoState, State};
 use crate::enums::{AlertDescription, ContentType};
 use crate::error::{Error, PeerMisbehaved};
 #[cfg(feature = "logging")]
@@ -571,7 +571,9 @@ impl<Data> ConnectionCommon<Data> {
 impl<'a, Data> From<&'a mut ConnectionCommon<Data>> for Context<'a, Data> {
     fn from(conn: &'a mut ConnectionCommon<Data>) -> Self {
         Self {
-            common: &mut conn.core.common_state,
+            common: CommonState2::Eager {
+                common_state: &mut conn.core.common_state,
+            },
             data: &mut conn.core.data,
         }
     }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -359,6 +359,7 @@ mod builder;
 mod enums;
 mod key_log;
 mod key_log_file;
+mod ll;
 mod suites;
 mod ticketer;
 mod versions;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -422,9 +422,9 @@ pub use crate::error::{
 pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;
 pub use crate::ll::{
-    AppDataAvailable, AppDataRecord, EncodeError, EncryptError, InsufficientSizeError,
-    LlConnectionCommon, LlState, LlStatus, MayEncryptAppData, MustEncodeTlsData,
-    MustTransmitTlsData,
+    AppDataAvailable, AppDataRecord, EarlyDataError, EncodeError, EncryptError,
+    InsufficientSizeError, LlConnectionCommon, LlState, LlStatus, MayEncryptAppData,
+    MustEncodeTlsData, MustTransmitTlsData,
 };
 pub use crate::msgs::enums::NamedGroup;
 pub use crate::msgs::handshake::DistinguishedName;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -421,6 +421,11 @@ pub use crate::error::{
 };
 pub use crate::key_log::{KeyLog, NoKeyLog};
 pub use crate::key_log_file::KeyLogFile;
+pub use crate::ll::{
+    AppDataAvailable, AppDataRecord, EncodeError, EncryptError, InsufficientSizeError,
+    LlConnectionCommon, LlState, LlStatus, MayEncryptAppData, MustEncodeTlsData,
+    MustTransmitTlsData,
+};
 pub use crate::msgs::enums::NamedGroup;
 pub use crate::msgs::handshake::DistinguishedName;
 pub use crate::stream::{Stream, StreamOwned};
@@ -448,7 +453,8 @@ pub mod client {
     pub use builder::WantsClientCert;
     pub use client_conn::{
         ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore,
-        ResolvesClientCert, Resumption, ServerName, Tls12Resumption, WriteEarlyData,
+        LlClientConnection, ResolvesClientCert, Resumption, ServerName, Tls12Resumption,
+        WriteEarlyData,
     };
     pub use handy::ClientSessionMemoryCache;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -495,7 +495,8 @@ pub mod server {
     pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
     pub use server_conn::StoresServerSessions;
     pub use server_conn::{
-        Accepted, Acceptor, ReadEarlyData, ServerConfig, ServerConnection, ServerConnectionData,
+        Accepted, Acceptor, LlServerConnection, ReadEarlyData, ServerConfig, ServerConnection,
+        ServerConnectionData,
     };
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
 

--- a/rustls/src/ll.rs
+++ b/rustls/src/ll.rs
@@ -1,0 +1,29 @@
+//! Low-level Connection API
+
+use alloc::collections::VecDeque;
+
+use crate::crypto::cipher::OpaqueMessage;
+use crate::msgs::base::Payload;
+
+#[derive(Default)]
+pub(crate) struct LlDeferredActions {
+    inner: VecDeque<LlDeferredAction>,
+}
+
+impl LlDeferredActions {
+    pub(crate) fn queue_tls_message(&mut self, m: OpaqueMessage) {
+        self.inner
+            .push_back(LlDeferredAction::QueueTlsMessage { m });
+    }
+
+    pub(crate) fn take_received_plaintext(&mut self, bytes: Payload) {
+        self.inner
+            .push_back(LlDeferredAction::ReceivedPlainText { bytes });
+    }
+}
+
+#[allow(dead_code)]
+enum LlDeferredAction {
+    QueueTlsMessage { m: OpaqueMessage },
+    ReceivedPlainText { bytes: Payload },
+}

--- a/rustls/src/ll.rs
+++ b/rustls/src/ll.rs
@@ -385,6 +385,17 @@ impl<Data> MayEncryptAppData<'_, Data> {
             .common_state
             .eager_send_some_plaintext(application_data, outgoing_tls)
     }
+
+    /// Queues a close_notify warning alert in `outgoing_tls`
+    ///
+    /// returns the number of bytes that were written into `outgoing_tls`, or an error if
+    /// the provided buffer was too small. in the error case, `outgoing_tls` is not modified
+    pub fn queue_close_notify(&mut self, outgoing_tls: &mut [u8]) -> Result<usize, EncryptError> {
+        self.conn
+            .core
+            .common_state
+            .eager_send_close_notify(outgoing_tls)
+    }
 }
 
 #[derive(Default)]

--- a/rustls/src/ll.rs
+++ b/rustls/src/ll.rs
@@ -1,9 +1,391 @@
 //! Low-level Connection API
 
 use alloc::collections::VecDeque;
+use core::num::NonZeroUsize;
+use core::{fmt, mem};
 
+use crate::conn::LlConnectionCore;
 use crate::crypto::cipher::OpaqueMessage;
 use crate::msgs::base::Payload;
+use crate::Error;
+
+/// Interface shared by client and server connections.
+pub struct LlConnectionCommon<Data> {
+    core: LlConnectionCore<Data>,
+    wants_write: bool,
+}
+
+impl<Data> From<LlConnectionCore<Data>> for LlConnectionCommon<Data> {
+    fn from(core: LlConnectionCore<Data>) -> Self {
+        Self {
+            core,
+            wants_write: false,
+        }
+    }
+}
+
+impl<Data> LlConnectionCommon<Data> {
+    /// Processes TLS records in the `incoming_tls` buffer
+    pub fn process_tls_records<'c, 'i>(
+        &'c mut self,
+        incoming_tls: &'i mut [u8],
+    ) -> Result<LlStatus<'c, 'i, Data>, Error> {
+        let mut discard = 0;
+
+        let ll_state = 'outer: loop {
+            // process deferred actions that may have been produced by `State::handle` in the
+            // last iteration of this loop
+            while let Some(action) = self.core.deferred_actions.pop() {
+                match action {
+                    LlDeferredAction::QueueTlsMessage { m } => {
+                        break 'outer MustEncodeTlsData::new(self, m).into()
+                    }
+                    LlDeferredAction::ReceivedPlainText { bytes } => {
+                        break 'outer AppDataAvailable::new(self, incoming_tls, bytes).into();
+                    }
+                }
+            }
+
+            if let Some((new_discard, message)) = self
+                .core
+                .deframe(&mut incoming_tls[discard..])?
+            {
+                discard += new_discard;
+
+                let mut state =
+                    match mem::replace(&mut self.core.state, Err(Error::HandshakeNotComplete)) {
+                        Ok(state) => state,
+                        Err(e) => {
+                            self.core.state = Err(e.clone());
+                            return Err(e);
+                        }
+                    };
+
+                match self.core.process_msg(message, state) {
+                    Ok(new) => state = new,
+                    Err(e) => {
+                        self.core.state = Err(e.clone());
+                        return Err(e);
+                    }
+                }
+
+                self.core.state = Ok(state);
+            } else if self.wants_write {
+                let may_send_application_data = self
+                    .core
+                    .common_state
+                    .may_send_application_data;
+
+                break MustTransmitTlsData {
+                    conn: self,
+                    may_send_application_data,
+                }
+                .into();
+            } else if self
+                .core
+                .common_state
+                .has_received_close_notify
+            {
+                break LlState::ConnectionClosed;
+            } else if self
+                .core
+                .common_state
+                .may_send_application_data
+            {
+                break LlState::TrafficTransit(MayEncryptAppData { conn: self });
+            } else {
+                break LlState::NeedsMoreTlsData { num_bytes: None };
+            }
+        };
+
+        Ok(LlStatus {
+            discard,
+            state: ll_state,
+        })
+    }
+}
+
+/// The current status of the `LlConnection*`
+#[must_use]
+pub struct LlStatus<'c, 'i, Data> {
+    /// number of bytes that must be discarded from the *front* of `incoming_tls` *after* handling
+    /// `state` and *before* the next `process_tls_records` call
+    pub discard: usize,
+
+    /// the current state of the handshake process
+    pub state: LlState<'c, 'i, Data>,
+}
+
+/// The current state of the `LlConnection*`
+#[non_exhaustive] // for forwards compatibility; to support caller-side certificate verification
+pub enum LlState<'c, 'i, Data> {
+    /// One, or more, application data record is available
+    AppDataAvailable(AppDataAvailable<'c, 'i, Data>),
+
+    /// A Handshake record must be encoded into the `outgoing_tls` buffer
+    MustEncodeTlsData(MustEncodeTlsData<'c, Data>),
+
+    /// TLS records related to the handshake have been placed in the `outgoing_tls` buffer and must
+    /// be transmitted to continue with the handshake process
+    MustTransmitTlsData(MustTransmitTlsData<'c, Data>),
+
+    /// More TLS data needs to be added to the `incoming_tls` buffer to continue with the handshake
+    NeedsMoreTlsData {
+        /// number of bytes required to complete a TLS record. `None` indicates that
+        /// no information is available
+        num_bytes: Option<NonZeroUsize>,
+    },
+
+    /// Handshake is complete.
+    TrafficTransit(MayEncryptAppData<'c, Data>),
+
+    /// Connection has been closed.
+    ConnectionClosed,
+}
+
+impl<Data> fmt::Debug for LlState<'_, '_, Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AppDataAvailable(..) => f
+                .debug_tuple("AppDataAvailable")
+                .finish(),
+            Self::MustEncodeTlsData(..) => f
+                .debug_tuple("MustEncodeTlsData")
+                .finish(),
+            Self::MustTransmitTlsData(..) => f
+                .debug_tuple("MustTransmitTlsData")
+                .finish(),
+            Self::NeedsMoreTlsData { num_bytes } => f
+                .debug_struct("NeedsMoreTlsData")
+                .field("num_bytes", num_bytes)
+                .finish(),
+            Self::TrafficTransit(..) => f.debug_tuple("TrafficTransit").finish(),
+            Self::ConnectionClosed => write!(f, "ConnectionClosed"),
+        }
+    }
+}
+
+impl<'c, 'i, Data> From<MustTransmitTlsData<'c, Data>> for LlState<'c, 'i, Data> {
+    fn from(v: MustTransmitTlsData<'c, Data>) -> Self {
+        Self::MustTransmitTlsData(v)
+    }
+}
+
+impl<'c, 'i, Data> From<MustEncodeTlsData<'c, Data>> for LlState<'c, 'i, Data> {
+    fn from(v: MustEncodeTlsData<'c, Data>) -> Self {
+        Self::MustEncodeTlsData(v)
+    }
+}
+
+impl<'c, 'i, Data> From<AppDataAvailable<'c, 'i, Data>> for LlState<'c, 'i, Data> {
+    fn from(v: AppDataAvailable<'c, 'i, Data>) -> Self {
+        Self::AppDataAvailable(v)
+    }
+}
+
+/// Application-data is available
+pub struct AppDataAvailable<'c, 'i, Data> {
+    _conn: &'c mut LlConnectionCommon<Data>,
+    // for forwards compatibility; to support in-place decryption in the future
+    _incoming_tls: &'i mut [u8],
+    payload: Payload,
+    taken: bool,
+}
+
+impl<'c, 'i, Data> AppDataAvailable<'c, 'i, Data> {
+    fn new(
+        _conn: &'c mut LlConnectionCommon<Data>,
+        _incoming_tls: &'i mut [u8],
+        payload: Payload,
+    ) -> Self {
+        Self {
+            _conn,
+            _incoming_tls,
+            payload,
+            taken: false,
+        }
+    }
+
+    /// decrypts and returns the next available app-data record
+    // TODO deprecate in favor of `Iterator` implementation, which requires in-place decryption
+    pub fn next_record(&mut self) -> Option<Result<AppDataRecord, Error>> {
+        if self.taken {
+            None
+        } else {
+            self.taken = true;
+            Some(Ok(AppDataRecord {
+                discard: 0,
+                payload: &self.payload.0,
+            }))
+        }
+    }
+
+    /// returns the payload size of the next app-data record *without* decrypting it
+    ///
+    /// returns `None` if there are no more app-data records
+    pub fn peek_len(&self) -> Option<NonZeroUsize> {
+        if self.taken {
+            None
+        } else {
+            NonZeroUsize::new(self.payload.0.len())
+        }
+    }
+}
+
+/// A decrypted application-data record
+pub struct AppDataRecord<'i> {
+    /// Number of additional bytes to discard from the front of `incoming_tls` before the next
+    /// call to `process_tls_records`
+    pub discard: usize,
+
+    /// The payload of the app-data record
+    pub payload: &'i [u8],
+}
+
+/// A handshake record must be encoded
+pub struct MustEncodeTlsData<'c, Data> {
+    conn: &'c mut LlConnectionCommon<Data>,
+    message: Option<OpaqueMessage>,
+}
+
+impl<'c, Data> MustEncodeTlsData<'c, Data> {
+    fn new(conn: &'c mut LlConnectionCommon<Data>, message: OpaqueMessage) -> Self {
+        Self {
+            conn,
+            message: Some(message),
+        }
+    }
+
+    /// Encodes a handshake record into the `outgoing_tls` buffer
+    ///
+    /// returns the number of bytes that were written into `outgoing_tls`, or an error if
+    /// the provided buffer was too small. in the error case, `outgoing_tls` is not modified
+    pub fn encode(&mut self, outgoing_tls: &mut [u8]) -> Result<usize, EncodeError> {
+        let Some(message) = self.message.take() else {
+            return Err(EncodeError::AlreadyEncoded);
+        };
+
+        let required_size = message.encode_len();
+
+        if required_size > outgoing_tls.len() {
+            self.message = Some(message);
+            Err(InsufficientSizeError { required_size }.into())
+        } else {
+            let bytes = message.encode();
+            let written = bytes.len();
+
+            debug_assert_eq!(required_size, written);
+
+            outgoing_tls[..written].copy_from_slice(&bytes);
+
+            self.conn.wants_write = true;
+
+            Ok(written)
+        }
+    }
+}
+
+/// Errors that may arise when encoding a handshake record
+#[derive(Debug)]
+pub enum EncodeError {
+    /// Provided buffer was too small
+    InsufficientSize(InsufficientSizeError),
+
+    /// The handshake record has already been encoded; do not call `encode` again
+    AlreadyEncoded,
+}
+
+impl From<InsufficientSizeError> for EncodeError {
+    fn from(v: InsufficientSizeError) -> Self {
+        Self::InsufficientSize(v)
+    }
+}
+
+impl fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InsufficientSize(InsufficientSizeError { required_size }) => write!(
+                f,
+                "cannot encode due to insufficient size, {} bytes are required",
+                required_size
+            ),
+            Self::AlreadyEncoded => "cannot encode, data has already been encoded".fmt(f),
+        }
+    }
+}
+
+/// Errors that may arise when encrypting application data
+#[derive(Debug)]
+pub enum EncryptError {
+    /// Provided buffer was too small
+    InsufficientSize(InsufficientSizeError),
+
+    /// Encrypter has been exhausted
+    EncryptExhausted,
+}
+
+impl From<InsufficientSizeError> for EncryptError {
+    fn from(v: InsufficientSizeError) -> Self {
+        Self::InsufficientSize(v)
+    }
+}
+
+/// Provided buffer was too small
+#[derive(Debug)]
+pub struct InsufficientSizeError {
+    /// buffer must be at least this size
+    pub required_size: usize,
+}
+
+impl std::error::Error for EncodeError {}
+
+/// Previously encoded TLS data must be transmitted
+pub struct MustTransmitTlsData<'c, Data> {
+    conn: &'c mut LlConnectionCommon<Data>,
+    may_send_application_data: bool,
+}
+
+impl<Data> MustTransmitTlsData<'_, Data> {
+    /// signals the `LlConnection*` API that the TLS data has been transmitted
+    pub fn done(self) {
+        self.conn.wants_write = false;
+    }
+
+    /// returns an adapter that allows encrypting app-data before transmitting the already encoded
+    /// TLS data
+    ///
+    /// IF allowed by the protocol
+    // XXX unclear if this stage can be reached in practice
+    pub fn may_encrypt(&mut self) -> Option<MayEncryptAppData<Data>> {
+        if self.may_send_application_data {
+            Some(MayEncryptAppData { conn: self.conn })
+        } else {
+            None
+        }
+    }
+}
+
+/// Allows encrypting app-data
+pub struct MayEncryptAppData<'c, Data> {
+    conn: &'c mut LlConnectionCommon<Data>,
+}
+
+impl<Data> MayEncryptAppData<'_, Data> {
+    /// Encrypts `application_data` into the `outgoing_tls` buffer
+    ///
+    /// returns the number of bytes that were written into `outgoing_tls`, or an error if
+    /// the provided buffer was too small. in the error case, `outgoing_tls` is not modified
+    pub fn encrypt(
+        &mut self,
+        application_data: &[u8],
+        outgoing_tls: &mut [u8],
+    ) -> Result<usize, EncryptError> {
+        self.conn
+            .core
+            .common_state
+            .eager_send_some_plaintext(application_data, outgoing_tls)
+    }
+}
 
 #[derive(Default)]
 pub(crate) struct LlDeferredActions {
@@ -20,9 +402,12 @@ impl LlDeferredActions {
         self.inner
             .push_back(LlDeferredAction::ReceivedPlainText { bytes });
     }
+
+    fn pop(&mut self) -> Option<LlDeferredAction> {
+        self.inner.pop_front()
+    }
 }
 
-#[allow(dead_code)]
 enum LlDeferredAction {
     QueueTlsMessage { m: OpaqueMessage },
     ReceivedPlainText { bytes: Payload },

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -379,6 +379,273 @@ impl MessageDeframer {
     }
 }
 
+/// A low-level version of `MessageDeframer` that does not maintains an internal buffer. instead, it
+/// operates on a caller-provided buffer
+#[allow(dead_code)]
+#[derive(Default)]
+pub(crate) struct LlMessageDeframer {
+    /// Set if the peer is not talking TLS, but some other
+    /// protocol.  The caller should abort the connection, because
+    /// the deframer cannot recover.
+    last_error: Option<Error>,
+
+    /// If we're in the middle of joining a handshake payload, this is the metadata.
+    joining_hs: Option<HandshakePayloadMeta>,
+
+    /// Tracks how many bytes must be removed from the front of the caller-provided buffer
+    discard: usize,
+}
+
+#[allow(dead_code)]
+impl LlMessageDeframer {
+    // TODO share code between this and `MessageDeframer::pop`
+    pub(crate) fn pop(
+        &mut self,
+        record_layer: &mut RecordLayer,
+        negotiated_version: Option<ProtocolVersion>,
+        buf: &mut [u8],
+    ) -> Result<Option<LlDeframed>, Error> {
+        if let Some(last_err) = self.last_error.clone() {
+            return Err(last_err);
+        } else if buf.is_empty() {
+            return Ok(None);
+        }
+
+        // We loop over records we've received but not processed yet.
+        // For records that decrypt as `Handshake`, we keep the current state of the joined
+        // handshake message payload in `self.joining_hs`, appending to it as we see records.
+        let expected_len = loop {
+            let start = match &self.joining_hs {
+                Some(meta) => {
+                    match meta.expected_len {
+                        // We're joining a handshake payload, and we've seen the full payload.
+                        Some(len) if len <= meta.payload.len() => break len,
+                        // Not enough data, and we can't parse any more out of the buffer (QUIC).
+                        _ if meta.quic => return Ok(None),
+                        // Try parsing some more of the encrypted buffered data.
+                        _ => meta.message.end,
+                    }
+                }
+                None => 0,
+            };
+
+            // Does our `buf` contain a full message?  It does if it is big enough to
+            // contain a header, and that header has a length which falls within `buf`.
+            // If so, deframe it and place the message onto the frames output queue.
+            let mut rd = codec::Reader::init(&buf[start..]);
+            let m = match OpaqueMessage::read(&mut rd) {
+                Ok(m) => m,
+                Err(msg_err) => {
+                    let err_kind = match msg_err {
+                        MessageError::TooShortForHeader | MessageError::TooShortForLength => {
+                            return Ok(None)
+                        }
+                        MessageError::InvalidEmptyPayload => InvalidMessage::InvalidEmptyPayload,
+                        MessageError::MessageTooLarge => InvalidMessage::MessageTooLarge,
+                        MessageError::InvalidContentType => InvalidMessage::InvalidContentType,
+                        MessageError::UnknownProtocolVersion => {
+                            InvalidMessage::UnknownProtocolVersion
+                        }
+                    };
+
+                    return Err(self.set_err(err_kind));
+                }
+            };
+
+            // Return CCS messages and early plaintext alerts immediately without decrypting.
+            let end = start + rd.used();
+            let version_is_tls13 = matches!(negotiated_version, Some(ProtocolVersion::TLSv1_3));
+            let allowed_plaintext = match m.typ {
+                // CCS messages are always plaintext.
+                ContentType::ChangeCipherSpec => true,
+                // Alerts are allowed to be plaintext if-and-only-if:
+                // * The negotiated protocol version is TLS 1.3. - In TLS 1.2 it is unambiguous when
+                //   keying changes based on the CCS message. Only TLS 1.3 requires these heuristics.
+                // * We have not yet decrypted any messages from the peer - if we have we don't
+                //   expect any plaintext.
+                // * The payload size is indicative of a plaintext alert message.
+                ContentType::Alert
+                    if version_is_tls13
+                        && !record_layer.has_decrypted()
+                        && m.payload().len() <= 2 =>
+                {
+                    true
+                }
+                // In other circumstances, we expect all messages to be encrypted.
+                _ => false,
+            };
+            if self.joining_hs.is_none() && allowed_plaintext {
+                // This is unencrypted. We check the contents later.
+                self.discard(end);
+                let deframed = Deframed {
+                    want_close_before_decrypt: false,
+                    aligned: true,
+                    trial_decryption_finished: false,
+                    message: m.into_plain_message(),
+                };
+                return Ok(Some(LlDeframed {
+                    deframed,
+                    discard: self.take_discard(),
+                }));
+            }
+
+            // Decrypt the encrypted message (if necessary).
+            let msg = match record_layer.decrypt_incoming(m) {
+                Ok(Some(decrypted)) => {
+                    let Decrypted {
+                        want_close_before_decrypt,
+                        plaintext,
+                    } = decrypted;
+                    debug_assert!(!want_close_before_decrypt);
+                    plaintext
+                }
+                // This was rejected early data, discard it. If we currently have a handshake
+                // payload in progress, this counts as interleaved, so we error out.
+                Ok(None) if self.joining_hs.is_some() => {
+                    return Err(self.set_err(
+                        PeerMisbehaved::RejectedEarlyDataInterleavedWithHandshakeMessage,
+                    ));
+                }
+                Ok(None) => {
+                    self.discard(end);
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+
+            if self.joining_hs.is_some() && msg.typ != ContentType::Handshake {
+                // "Handshake messages MUST NOT be interleaved with other record
+                // types.  That is, if a handshake message is split over two or more
+                // records, there MUST NOT be any other records between them."
+                // https://www.rfc-editor.org/rfc/rfc8446#section-5.1
+                return Err(self.set_err(PeerMisbehaved::MessageInterleavedWithHandshakeMessage));
+            }
+
+            // If it's not a handshake message, just return it -- no joining necessary.
+            if msg.typ != ContentType::Handshake {
+                let end = start + rd.used();
+                self.discard(end);
+                let deframed = Deframed {
+                    want_close_before_decrypt: false,
+                    aligned: true,
+                    trial_decryption_finished: false,
+                    message: msg,
+                };
+                return Ok(Some(LlDeframed {
+                    deframed,
+                    discard: self.take_discard(),
+                }));
+            }
+
+            // If we don't know the payload size yet or if the payload size is larger
+            // than the currently buffered payload, we need to wait for more data.
+            match self.append_hs(msg.version, &msg.payload.0, end, false, buf)? {
+                HandshakePayloadState::Blocked => return Ok(None),
+                HandshakePayloadState::Complete(len) => break len,
+                HandshakePayloadState::Continue => continue,
+            }
+        };
+
+        let meta = self.joining_hs.as_mut().unwrap(); // safe after calling `append_hs()`
+
+        // We can now wrap the complete handshake payload in a `PlainMessage`, to be returned.
+        let message = PlainMessage {
+            typ: ContentType::Handshake,
+            version: meta.version,
+            payload: Payload::new(&buf[meta.payload.start..meta.payload.start + expected_len]),
+        };
+
+        // But before we return, update the `joining_hs` state to skip past this payload.
+        if meta.payload.len() > expected_len {
+            // If we have another (beginning of) a handshake payload left in the buffer, update
+            // the payload start to point past the payload we're about to yield, and update the
+            // `expected_len` to match the state of that remaining payload.
+            meta.payload.start += expected_len;
+            meta.expected_len = payload_size(&buf[meta.payload.start..meta.payload.end])?;
+        } else {
+            // Otherwise, we've yielded the last handshake payload in the buffer, so we can
+            // discard all of the bytes that we're previously buffered as handshake data.
+            let end = meta.message.end;
+            self.joining_hs = None;
+            self.discard(end);
+        }
+
+        let deframed = Deframed {
+            want_close_before_decrypt: false,
+            aligned: self.joining_hs.is_none(),
+            trial_decryption_finished: true,
+            message,
+        };
+        Ok(Some(LlDeframed {
+            deframed,
+            discard: self.take_discard(),
+        }))
+    }
+
+    fn append_hs(
+        &mut self,
+        version: ProtocolVersion,
+        payload: &[u8],
+        end: usize,
+        quic: bool,
+        buf: &mut [u8],
+    ) -> Result<HandshakePayloadState, Error> {
+        let meta = match &mut self.joining_hs {
+            Some(_meta) => {
+                // currently untested
+                todo!()
+            }
+            None => {
+                // We've found a new handshake message here.
+                // Write it into the buffer and create the metadata.
+
+                let expected_len = payload_size(payload)?;
+                let dst = &mut buf[..payload.len()];
+                dst.copy_from_slice(payload);
+                self.joining_hs
+                    .insert(HandshakePayloadMeta {
+                        message: Range { start: 0, end },
+                        payload: Range {
+                            start: 0,
+                            end: payload.len(),
+                        },
+                        version,
+                        expected_len,
+                        quic,
+                    })
+            }
+        };
+
+        Ok(match meta.expected_len {
+            Some(len) if len <= meta.payload.len() => HandshakePayloadState::Complete(len),
+            _ => match buf.len() > meta.message.end {
+                true => HandshakePayloadState::Continue,
+                false => HandshakePayloadState::Blocked,
+            },
+        })
+    }
+
+    fn set_err(&mut self, err: impl Into<Error>) -> Error {
+        let err = err.into();
+        self.last_error = Some(err.clone());
+        err
+    }
+
+    fn discard(&mut self, taken: usize) {
+        self.discard += taken;
+    }
+
+    fn take_discard(&mut self) -> usize {
+        core::mem::take(&mut self.discard)
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct LlDeframed {
+    pub(crate) deframed: Deframed,
+    pub(crate) discard: usize,
+}
+
 enum HandshakePayloadState {
     /// Waiting for more data.
     Blocked,

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -165,6 +165,15 @@ impl OpaqueMessage {
         buf
     }
 
+    pub fn encode_len(&self) -> usize {
+        let typ = 1;
+        let version = 2;
+        let payload_len = 2;
+        let payload = self.payload.0.len();
+
+        typ + version + payload_len + payload
+    }
+
     /// Force conversion into a plaintext message.
     ///
     /// This should only be used for messages that are known to be in plaintext. Otherwise, the

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroU64;
+
 use crate::crypto::cipher::{MessageDecrypter, MessageEncrypter};
 use crate::error::Error;
 use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
@@ -202,6 +204,13 @@ impl RecordLayer {
 
     pub(crate) fn write_seq(&self) -> u64 {
         self.write_seq
+    }
+
+    /// Returns the number of remaining write sequences
+    pub(crate) fn remaining_write_seq(&self) -> Option<NonZeroU64> {
+        SEQ_SOFT_LIMIT
+            .checked_sub(self.write_seq)
+            .and_then(NonZeroU64::new)
     }
 
     pub(crate) fn read_seq(&self) -> u64 {


### PR DESCRIPTION
this is a WIP implementation of RFC #1420 

currently only the `LlClientConnection` API has been minimally implemented but it's able to interact with, for example, `example.com` using either TLS 1.2 or TLS 1.3.

I'm putting this up now because I'd like feedback on the approach. I have aimed for maximal code reuse (though there a few places that could use a bit more code reuse) and my approach has been to reuse the existing `State::handle` machinery to implement the `LlConnection` API.

Arguably that's not the most performant option because, for example, the current implementation does memcpy and allocations when encoding / decoding TLS records (see `Codec`) so the `LlConnection` API ends up inheriting those.

However, it is, I believe, the fastest approach towards landing the public API. Further performance improvements can be done without breaking the public API (I believe the `#[non_exhaustive]` attribute on `LlState` should let us extend it without incurring in semver breaking changes and any required change in traits like `Codec` and `State` won't be public facing).

This PR is best reviewed on a commit-by-commit basis

TODO list
- [ ] add size checking to `encrypt` method (depends on PR #1579  )
- [x] complete `LlMessageDeframer::append_hs`
- [x] add and test `LlServerConnection`
- [x] add support for early data
- add support for caller-side certificate-verification (to be done in a separate PR)
- perform decryption in-place (to be done in a separate PR)