### PR TITLE
add `encrypted_payload_len` to `MessageEncrypter`

### DIFF
--- a/provider-example/src/aead.rs
+++ b/provider-example/src/aead.rs
@@ -83,7 +83,7 @@ impl cipher::MessageEncrypter for Tls13Cipher {
         m: cipher::BorrowedPlainMessage,
         seq: u64,
     ) -> Result<cipher::OpaqueMessage, rustls::Error> {
-        let total_len = m.payload.len() + 1 + CHACHAPOLY1305_OVERHEAD;
+        let total_len = self.encrypted_payload_len(m.payload.len());
 
         // construct a TLSInnerPlaintext
         let mut payload = Vec::with_capacity(total_len);
@@ -103,6 +103,10 @@ impl cipher::MessageEncrypter for Tls13Cipher {
                     payload,
                 )
             })
+    }
+
+    fn encrypted_payload_len(&self, payload_len: usize) -> usize {
+        payload_len + 1 + CHACHAPOLY1305_OVERHEAD
     }
 }
 
@@ -132,7 +136,7 @@ impl cipher::MessageEncrypter for Tls12Cipher {
         m: cipher::BorrowedPlainMessage,
         seq: u64,
     ) -> Result<cipher::OpaqueMessage, rustls::Error> {
-        let total_len = m.payload.len() + CHACHAPOLY1305_OVERHEAD;
+        let total_len = self.encrypted_payload_len(m.payload.len());
 
         let mut payload = Vec::with_capacity(total_len);
         payload.extend_from_slice(m.payload);
@@ -144,6 +148,10 @@ impl cipher::MessageEncrypter for Tls12Cipher {
             .encrypt_in_place(&nonce, &aad, &mut payload)
             .map_err(|_| rustls::Error::EncryptError)
             .map(|_| cipher::OpaqueMessage::new(m.typ, m.version, payload))
+    }
+
+    fn encrypted_payload_len(&self, payload_len: usize) -> usize {
+        payload_len + CHACHAPOLY1305_OVERHEAD
     }
 }
 

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -132,6 +132,10 @@ pub trait MessageEncrypter: Send + Sync {
     /// Encrypt the given TLS message `msg`, using the sequence number
     /// `seq which can be used to derive a unique [`Nonce`].
     fn encrypt(&self, msg: BorrowedPlainMessage, seq: u64) -> Result<OpaqueMessage, Error>;
+
+    /// Return the length of the ciphertext that results from encrypting plaintext of
+    /// length `payload_len`
+    fn encrypted_payload_len(&self, payload_len: usize) -> usize;
 }
 
 impl dyn MessageEncrypter {
@@ -299,6 +303,10 @@ struct InvalidMessageEncrypter {}
 impl MessageEncrypter for InvalidMessageEncrypter {
     fn encrypt(&self, _m: BorrowedPlainMessage, _seq: u64) -> Result<OpaqueMessage, Error> {
         Err(Error::EncryptError)
+    }
+
+    fn encrypted_payload_len(&self, payload_len: usize) -> usize {
+        payload_len
     }
 }
 

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -266,8 +266,8 @@ impl MessageEncrypter for GcmMessageEncrypter {
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
 
-        let total_len = msg.payload.len() + self.enc_key.algorithm().tag_len();
-        let mut payload = Vec::with_capacity(GCM_EXPLICIT_NONCE_LEN + total_len);
+        let total_len = self.encrypted_payload_len(msg.payload.len());
+        let mut payload = Vec::with_capacity(total_len);
         payload.extend_from_slice(&nonce.as_ref()[4..]);
         payload.extend_from_slice(msg.payload);
 
@@ -277,6 +277,10 @@ impl MessageEncrypter for GcmMessageEncrypter {
             .map_err(|_| Error::EncryptError)?;
 
         Ok(OpaqueMessage::new(msg.typ, msg.version, payload))
+    }
+
+    fn encrypted_payload_len(&self, payload_len: usize) -> usize {
+        payload_len + GCM_EXPLICIT_NONCE_LEN + self.enc_key.algorithm().tag_len()
     }
 }
 
@@ -335,7 +339,7 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).0);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
 
-        let total_len = msg.payload.len() + self.enc_key.algorithm().tag_len();
+        let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut buf = Vec::with_capacity(total_len);
         buf.extend_from_slice(msg.payload);
 
@@ -344,6 +348,10 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
             .map_err(|_| Error::EncryptError)?;
 
         Ok(OpaqueMessage::new(msg.typ, msg.version, buf))
+    }
+
+    fn encrypted_payload_len(&self, payload_len: usize) -> usize {
+        payload_len + self.enc_key.algorithm().tag_len()
     }
 }
 

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -181,7 +181,7 @@ struct Tls13MessageDecrypter {
 
 impl MessageEncrypter for Tls13MessageEncrypter {
     fn encrypt(&self, msg: BorrowedPlainMessage, seq: u64) -> Result<OpaqueMessage, Error> {
-        let total_len = msg.payload.len() + 1 + self.enc_key.algorithm().tag_len();
+        let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = Vec::with_capacity(total_len);
         payload.extend_from_slice(msg.payload);
         msg.typ.encode(&mut payload);
@@ -197,6 +197,10 @@ impl MessageEncrypter for Tls13MessageEncrypter {
             ProtocolVersion::TLSv1_2,
             payload,
         ))
+    }
+
+    fn encrypted_payload_len(&self, payload_len: usize) -> usize {
+        payload_len + 1 + self.enc_key.algorithm().tag_len()
     }
 }
 


### PR DESCRIPTION
The `LlConnection` API proposed in RFC #1420 returns an error when the user attempts to encrypt app-data that won't fit in the provided buffer. To perform this check is necessary to compute the size of the resulting TLS record(s) without performing any encryption or encoding as that would be expensive in the retry cases where the end-user will call the `encrypt` API twice. To compute the size, `MessageEncrypter` implementations need to provide the post-encryption size.

This has been send as a separate PR from #1578 because it's a semver breaking change and it would be good to get it into the 0.22 release.

I'm submitting @pvdrz 's implementation as it but would it make sense to have `MessageEncrypter` report the encryption overhead (e.g. `fn encryption_overhead(&self) -> usize`), which appears to be constant in all in-tree implementations, instead?