### PR TITLE
[2/3] implement the caller-side managed buffers API (take 2)

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Check unbuffered client 
         run: cargo run --locked --bin unbuffered-client
 
+      - name: Check unbuffered tokio client 
+        run: cargo run --locked --bin unbuffered-async-client
+
+      - name: Check unbuffered async-std client 
+        run: cargo run --locked --bin unbuffered-async-client --features=async-std
+
       # Test the server_acceptor binary builds - we invoke with --help since it
       # will run a server process that doesn't exit when invoked with no args
       - name: Check server acceptor

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Check simple 0rtt client
         run: cargo run --locked --bin simple_0rtt_client
 
+      - name: Check unbuffered client 
+        run: cargo run --locked --bin unbuffered-client
+
       # Test the server_acceptor binary builds - we invoke with --help since it
       # will run a server process that doesn't exit when invoked with no args
       - name: Check server acceptor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,161 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 4.0.0",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.2.0",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.1",
+ "futures-lite 2.1.0",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4353121d5644cdf2beb5726ab752e79a8db1ebb52031770ec47db31d245526"
+dependencies = [
+ "async-channel 2.1.1",
+ "async-executor",
+ "async-io 2.2.1",
+ "async-lock 3.2.0",
+ "blocking",
+ "futures-lite 2.1.0",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6d3b15875ba253d1110c740755e246537483f152fa334f91abd7fe84c88b3ff"
+dependencies = [
+ "async-lock 3.2.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.1.0",
+ "parking",
+ "polling 3.3.1",
+ "rustix 0.38.28",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
+dependencies = [
+ "event-listener 4.0.0",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 1.13.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,8 +278,14 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.40",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -216,7 +377,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.40",
  "which",
 ]
 
@@ -240,6 +401,28 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel 2.1.1",
+ "async-lock 3.2.0",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite 2.1.0",
+ "piper",
+ "tracing",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
@@ -354,7 +537,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -377,6 +560,15 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -481,7 +673,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -588,7 +780,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -619,6 +811,48 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"
@@ -677,6 +911,34 @@ name = "futures-io"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-sink"
@@ -755,6 +1017,18 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -998,12 +1272,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.5",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1022,7 +1316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
 
@@ -1040,6 +1334,24 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1086,6 +1398,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
@@ -1105,6 +1423,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-cache"
@@ -1281,6 +1602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1671,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1707,36 @@ name = "platforms"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.28",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "poly1305"
@@ -1412,7 +1780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1626,6 +1994,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
@@ -1633,7 +2015,7 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.12",
  "windows-sys 0.52.0",
 ]
 
@@ -1698,6 +2080,7 @@ dependencies = [
 name = "rustls-examples"
 version = "0.0.1"
 dependencies = [
+ "async-std",
  "docopt",
  "env_logger",
  "log",
@@ -1708,6 +2091,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_derive",
+ "tokio",
  "webpki-roots 0.26.0",
 ]
 
@@ -1852,7 +2236,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1910,6 +2294,16 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
@@ -1954,6 +2348,17 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
@@ -1989,7 +2394,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2037,8 +2442,20 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.5",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2084,7 +2501,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -2163,16 +2580,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "value-bag"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.40",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.40",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -2198,7 +2703,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.28",
 ]
 
 [[package]]
@@ -2418,5 +2923,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.40",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,6 +7,7 @@ description = "Rustls example code and tests."
 publish = false
 
 [dependencies]
+async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 docopt = "~1.1"
 env_logger = "0.10"
 log = { version = "0.4.4" }
@@ -17,4 +18,5 @@ rustls = { path = "../rustls", features = [ "logging" ]}
 rustls-pemfile = "2"
 serde = "1.0"
 serde_derive = "1.0"
+tokio = { version = "1.34.0", features = ["io-util", "macros", "net", "rt"]}
 webpki-roots = "0.26"

--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -66,9 +66,9 @@ async fn converse(
     let mut iter_count = 0;
     while open_connection {
         let UnbufferedStatus { mut discard, state } =
-            conn.process_tls_records(&mut incoming_tls[..incoming_used])?;
+            conn.process_tls_records(&mut incoming_tls[..incoming_used]);
 
-        match dbg!(state) {
+        match dbg!(state.unwrap()) {
             ConnectionState::ReadTraffic(mut state) => {
                 while let Some(res) = state.next_record() {
                     let AppDataRecord {

--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -1,0 +1,263 @@
+use std::error::Error;
+use std::sync::Arc;
+
+#[cfg(feature = "async-std")]
+use async_std::io::{ReadExt, WriteExt};
+#[cfg(feature = "async-std")]
+use async_std::net::TcpStream;
+use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
+use rustls::unbuffered::{
+    AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,
+    UnbufferedStatus, WriteTraffic,
+};
+#[allow(unused_imports)]
+use rustls::version::{TLS12, TLS13};
+use rustls::{ClientConfig, RootCertStore};
+#[cfg(not(feature = "async-std"))]
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(not(feature = "async-std"))]
+use tokio::net::TcpStream;
+
+const SERVER_NAME: &str = "example.com";
+const PORT: u16 = 443;
+
+const KB: usize = 1024;
+const INCOMING_TLS_BUFSIZE: usize = 16 * KB;
+const OUTGOING_TLS_INITIAL_BUFSIZE: usize = KB;
+
+const MAX_ITERATIONS: usize = 20;
+
+#[cfg_attr(not(feature = "async-std"), tokio::main(flavor = "current_thread"))]
+#[cfg_attr(feature = "async-std", async_std::main)]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    };
+
+    let config = ClientConfig::builder_with_protocol_versions(&[&TLS13])
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    let config = Arc::new(config);
+
+    let mut incoming_tls = [0; INCOMING_TLS_BUFSIZE];
+    let mut outgoing_tls = vec![0; OUTGOING_TLS_INITIAL_BUFSIZE];
+
+    converse(&config, &mut incoming_tls, &mut outgoing_tls).await?;
+
+    Ok(())
+}
+
+async fn converse(
+    config: &Arc<ClientConfig>,
+    incoming_tls: &mut [u8],
+    outgoing_tls: &mut Vec<u8>,
+) -> Result<(), Box<dyn Error>> {
+    let mut conn = UnbufferedClientConnection::new(Arc::clone(config), SERVER_NAME.try_into()?)?;
+    let mut sock = TcpStream::connect(format!("{SERVER_NAME}:{PORT}")).await?;
+
+    let mut incoming_used = 0;
+    let mut outgoing_used = 0;
+
+    let mut open_connection = true;
+    let mut sent_request = false;
+    let mut received_response = false;
+
+    let mut iter_count = 0;
+    while open_connection {
+        let UnbufferedStatus { mut discard, state } =
+            conn.process_tls_records(&mut incoming_tls[..incoming_used])?;
+
+        match dbg!(state) {
+            ConnectionState::ReadTraffic(mut state) => {
+                while let Some(res) = state.next_record() {
+                    let AppDataRecord {
+                        discard: new_discard,
+                        payload,
+                    } = res?;
+                    discard += new_discard;
+
+                    if payload.starts_with(b"HTTP") {
+                        let response = core::str::from_utf8(payload)?;
+                        let header = response
+                            .lines()
+                            .next()
+                            .unwrap_or(response);
+
+                        println!("{header}");
+                    } else {
+                        println!("(.. continued HTTP response ..)");
+                    }
+
+                    received_response = true;
+                }
+            }
+
+            ConnectionState::EncodeTlsData(mut state) => {
+                try_or_resize_and_retry(
+                    |out_buffer| state.encode(out_buffer),
+                    |e| {
+                        if let EncodeError::InsufficientSize(is) = &e {
+                            Ok(*is)
+                        } else {
+                            Err(e.into())
+                        }
+                    },
+                    outgoing_tls,
+                    &mut outgoing_used,
+                )?;
+            }
+
+            ConnectionState::TransmitTlsData(mut state) => {
+                if let Some(mut may_encrypt) = state.may_encrypt_app_data() {
+                    encrypt_http_request(
+                        &mut sent_request,
+                        &mut may_encrypt,
+                        outgoing_tls,
+                        &mut outgoing_used,
+                    );
+                }
+
+                send_tls(&mut sock, outgoing_tls, &mut outgoing_used).await?;
+                state.done();
+            }
+
+            ConnectionState::BlockedHandshake { .. } => {
+                recv_tls(&mut sock, incoming_tls, &mut incoming_used).await?;
+            }
+
+            ConnectionState::WriteTraffic(mut may_encrypt) => {
+                if encrypt_http_request(
+                    &mut sent_request,
+                    &mut may_encrypt,
+                    outgoing_tls,
+                    &mut outgoing_used,
+                ) {
+                    send_tls(&mut sock, outgoing_tls, &mut outgoing_used).await?;
+                    recv_tls(&mut sock, incoming_tls, &mut incoming_used).await?;
+                } else if !received_response {
+                    // this happens in the TLS 1.3 case. the app-data was sent in the preceding
+                    // `TransmitTlsData` state. the server should have already written a
+                    // response which we can read out from the socket
+                    recv_tls(&mut sock, incoming_tls, &mut incoming_used).await?;
+                } else {
+                    try_or_resize_and_retry(
+                        |out_buffer| may_encrypt.queue_close_notify(out_buffer),
+                        |e| {
+                            if let EncryptError::InsufficientSize(is) = &e {
+                                Ok(*is)
+                            } else {
+                                Err(e.into())
+                            }
+                        },
+                        outgoing_tls,
+                        &mut outgoing_used,
+                    )?;
+                    send_tls(&mut sock, outgoing_tls, &mut outgoing_used).await?;
+                    open_connection = false;
+                }
+            }
+
+            ConnectionState::Closed => {
+                open_connection = false;
+            }
+
+            // other states are not expected in this example
+            _ => unreachable!(),
+        }
+
+        if discard != 0 {
+            assert!(discard <= incoming_used);
+
+            incoming_tls.copy_within(discard..incoming_used, 0);
+            incoming_used -= discard;
+
+            eprintln!("discarded {discard}B from `incoming_tls`");
+        }
+
+        iter_count += 1;
+        assert!(
+            iter_count < MAX_ITERATIONS,
+            "did not get a HTTP response within {MAX_ITERATIONS} iterations"
+        );
+    }
+
+    assert!(sent_request);
+    assert!(received_response);
+    assert_eq!(0, incoming_used);
+    assert_eq!(0, outgoing_used);
+
+    Ok(())
+}
+
+fn try_or_resize_and_retry<E>(
+    mut f: impl FnMut(&mut [u8]) -> Result<usize, E>,
+    map_err: impl FnOnce(E) -> Result<InsufficientSizeError, Box<dyn Error>>,
+    outgoing_tls: &mut Vec<u8>,
+    outgoing_used: &mut usize,
+) -> Result<usize, Box<dyn Error>>
+where
+    E: Error + 'static,
+{
+    let written = match f(&mut outgoing_tls[*outgoing_used..]) {
+        Ok(written) => written,
+
+        Err(e) => {
+            let InsufficientSizeError { required_size } = map_err(e)?;
+            let new_len = *outgoing_used + required_size;
+            outgoing_tls.resize(new_len, 0);
+            eprintln!("resized `outgoing_tls` buffer to {new_len}B");
+
+            f(&mut outgoing_tls[*outgoing_used..])?
+        }
+    };
+
+    *outgoing_used += written;
+
+    Ok(written)
+}
+
+async fn recv_tls(
+    sock: &mut TcpStream,
+    incoming_tls: &mut [u8],
+    incoming_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    let read = sock
+        .read(&mut incoming_tls[*incoming_used..])
+        .await?;
+    eprintln!("received {read}B of data");
+    *incoming_used += read;
+    Ok(())
+}
+
+async fn send_tls(
+    sock: &mut TcpStream,
+    outgoing_tls: &[u8],
+    outgoing_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    sock.write_all(&outgoing_tls[..*outgoing_used])
+        .await?;
+    eprintln!("sent {outgoing_used}B of data");
+    *outgoing_used = 0;
+    Ok(())
+}
+
+fn encrypt_http_request(
+    sent_request: &mut bool,
+    may_encrypt: &mut WriteTraffic<'_, ClientConnectionData>,
+    outgoing_tls: &mut [u8],
+    outgoing_used: &mut usize,
+) -> bool {
+    if !*sent_request {
+        let request = format!("GET / HTTP/1.1\r\nHost: {SERVER_NAME}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n").into_bytes();
+        let written = may_encrypt
+            .encrypt(&request, &mut outgoing_tls[*outgoing_used..])
+            .expect("encrypted request does not fit in `outgoing_tls`");
+        *outgoing_used += written;
+        *sent_request = true;
+        eprintln!("queued HTTP request");
+        true
+    } else {
+        false
+    }
+}

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -1,0 +1,255 @@
+//! This is a simple client using rustls' unbuffered API. Meaning that the application layer must
+//! handle the buffers required to receive, process and send TLS data.
+
+use std::error::Error;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
+use rustls::unbuffered::{
+    AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,
+    UnbufferedStatus, WriteTraffic,
+};
+#[allow(unused_imports)]
+use rustls::version::{TLS12, TLS13};
+use rustls::{ClientConfig, RootCertStore};
+
+const SERVER_NAME: &str = "example.com";
+const PORT: u16 = 443;
+
+const KB: usize = 1024;
+const INCOMING_TLS_BUFSIZE: usize = 16 * KB;
+const OUTGOING_TLS_INITIAL_BUFSIZE: usize = KB;
+
+const MAX_ITERATIONS: usize = 20;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    };
+
+    let config = ClientConfig::builder_with_protocol_versions(&[&TLS13])
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    let config = Arc::new(config);
+
+    let mut incoming_tls = [0; INCOMING_TLS_BUFSIZE];
+    let mut outgoing_tls = vec![0; OUTGOING_TLS_INITIAL_BUFSIZE];
+
+    converse(&config, &mut incoming_tls, &mut outgoing_tls)?;
+
+    Ok(())
+}
+
+fn converse(
+    config: &Arc<ClientConfig>,
+    incoming_tls: &mut [u8],
+    outgoing_tls: &mut Vec<u8>,
+) -> Result<(), Box<dyn Error>> {
+    let mut conn = UnbufferedClientConnection::new(Arc::clone(config), SERVER_NAME.try_into()?)?;
+    let mut sock = TcpStream::connect(format!("{SERVER_NAME}:{PORT}"))?;
+
+    let mut incoming_used = 0;
+    let mut outgoing_used = 0;
+
+    let mut open_connection = true;
+    let mut sent_request = false;
+    let mut received_response = false;
+
+    let mut iter_count = 0;
+    while open_connection {
+        let UnbufferedStatus { mut discard, state } =
+            conn.process_tls_records(&mut incoming_tls[..incoming_used])?;
+
+        match dbg!(state) {
+            ConnectionState::ReadTraffic(mut state) => {
+                while let Some(res) = state.next_record() {
+                    let AppDataRecord {
+                        discard: new_discard,
+                        payload,
+                    } = res?;
+                    discard += new_discard;
+
+                    if payload.starts_with(b"HTTP") {
+                        let response = core::str::from_utf8(payload)?;
+                        let header = response
+                            .lines()
+                            .next()
+                            .unwrap_or(response);
+
+                        println!("{header}");
+                    } else {
+                        println!("(.. continued HTTP response ..)");
+                    }
+
+                    received_response = true;
+                }
+            }
+
+            ConnectionState::EncodeTlsData(mut state) => {
+                try_or_resize_and_retry(
+                    |out_buffer| state.encode(out_buffer),
+                    |e| {
+                        if let EncodeError::InsufficientSize(is) = &e {
+                            Ok(*is)
+                        } else {
+                            Err(e.into())
+                        }
+                    },
+                    outgoing_tls,
+                    &mut outgoing_used,
+                )?;
+            }
+
+            ConnectionState::TransmitTlsData(mut state) => {
+                if let Some(mut may_encrypt) = state.may_encrypt_app_data() {
+                    encrypt_http_request(
+                        &mut sent_request,
+                        &mut may_encrypt,
+                        outgoing_tls,
+                        &mut outgoing_used,
+                    );
+                }
+
+                send_tls(&mut sock, outgoing_tls, &mut outgoing_used)?;
+                state.done();
+            }
+
+            ConnectionState::BlockedHandshake { .. } => {
+                recv_tls(&mut sock, incoming_tls, &mut incoming_used)?;
+            }
+
+            ConnectionState::WriteTraffic(mut may_encrypt) => {
+                if encrypt_http_request(
+                    &mut sent_request,
+                    &mut may_encrypt,
+                    outgoing_tls,
+                    &mut outgoing_used,
+                ) {
+                    send_tls(&mut sock, outgoing_tls, &mut outgoing_used)?;
+                    recv_tls(&mut sock, incoming_tls, &mut incoming_used)?;
+                } else if !received_response {
+                    // this happens in the TLS 1.3 case. the app-data was sent in the preceding
+                    // `TransmitTlsData` state. the server should have already written a
+                    // response which we can read out from the socket
+                    recv_tls(&mut sock, incoming_tls, &mut incoming_used)?;
+                } else {
+                    try_or_resize_and_retry(
+                        |out_buffer| may_encrypt.queue_close_notify(out_buffer),
+                        |e| {
+                            if let EncryptError::InsufficientSize(is) = &e {
+                                Ok(*is)
+                            } else {
+                                Err(e.into())
+                            }
+                        },
+                        outgoing_tls,
+                        &mut outgoing_used,
+                    )?;
+                    send_tls(&mut sock, outgoing_tls, &mut outgoing_used)?;
+                    open_connection = false;
+                }
+            }
+
+            ConnectionState::Closed => {
+                open_connection = false;
+            }
+
+            // other states are not expected in this example
+            _ => unreachable!(),
+        }
+
+        if discard != 0 {
+            assert!(discard <= incoming_used);
+
+            incoming_tls.copy_within(discard..incoming_used, 0);
+            incoming_used -= discard;
+
+            eprintln!("discarded {discard}B from `incoming_tls`");
+        }
+
+        iter_count += 1;
+        assert!(
+            iter_count < MAX_ITERATIONS,
+            "did not get a HTTP response within {MAX_ITERATIONS} iterations"
+        );
+    }
+
+    assert!(sent_request);
+    assert!(received_response);
+    assert_eq!(0, incoming_used);
+    assert_eq!(0, outgoing_used);
+
+    Ok(())
+}
+
+fn try_or_resize_and_retry<E>(
+    mut f: impl FnMut(&mut [u8]) -> Result<usize, E>,
+    map_err: impl FnOnce(E) -> Result<InsufficientSizeError, Box<dyn Error>>,
+    outgoing_tls: &mut Vec<u8>,
+    outgoing_used: &mut usize,
+) -> Result<usize, Box<dyn Error>>
+where
+    E: Error + 'static,
+{
+    let written = match f(&mut outgoing_tls[*outgoing_used..]) {
+        Ok(written) => written,
+
+        Err(e) => {
+            let InsufficientSizeError { required_size } = map_err(e)?;
+            let new_len = *outgoing_used + required_size;
+            outgoing_tls.resize(new_len, 0);
+            eprintln!("resized `outgoing_tls` buffer to {new_len}B");
+
+            f(&mut outgoing_tls[*outgoing_used..])?
+        }
+    };
+
+    *outgoing_used += written;
+
+    Ok(written)
+}
+
+fn recv_tls(
+    sock: &mut TcpStream,
+    incoming_tls: &mut [u8],
+    incoming_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    let read = sock.read(&mut incoming_tls[*incoming_used..])?;
+    eprintln!("received {read}B of data");
+    *incoming_used += read;
+    Ok(())
+}
+
+fn send_tls(
+    sock: &mut TcpStream,
+    outgoing_tls: &[u8],
+    outgoing_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    sock.write_all(&outgoing_tls[..*outgoing_used])?;
+    eprintln!("sent {outgoing_used}B of data");
+    *outgoing_used = 0;
+    Ok(())
+}
+
+fn encrypt_http_request(
+    sent_request: &mut bool,
+    may_encrypt: &mut WriteTraffic<'_, ClientConnectionData>,
+    outgoing_tls: &mut [u8],
+    outgoing_used: &mut usize,
+) -> bool {
+    if !*sent_request {
+        let request = format!("GET / HTTP/1.1\r\nHost: {SERVER_NAME}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n").into_bytes();
+        let written = may_encrypt
+            .encrypt(&request, &mut outgoing_tls[*outgoing_used..])
+            .expect("encrypted request does not fit in `outgoing_tls`");
+        *outgoing_used += written;
+        *sent_request = true;
+        eprintln!("queued HTTP request");
+        true
+    } else {
+        false
+    }
+}

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -70,9 +70,9 @@ fn converse(
     let mut iter_count = 0;
     while open_connection {
         let UnbufferedStatus { mut discard, state } =
-            conn.process_tls_records(&mut incoming_tls[..incoming_used])?;
+            conn.process_tls_records(&mut incoming_tls[..incoming_used]);
 
-        match dbg!(state) {
+        match dbg!(state.unwrap()) {
             ConnectionState::ReadTraffic(mut state) => {
                 while let Some(res) = state.next_record() {
                     let AppDataRecord {

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
+use rustls::client::{ClientConnectionData, EarlyDataError, UnbufferedClientConnection};
 use rustls::unbuffered::{
     AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,
     UnbufferedStatus, WriteTraffic,
@@ -23,28 +23,36 @@ const INCOMING_TLS_BUFSIZE: usize = 16 * KB;
 const OUTGOING_TLS_INITIAL_BUFSIZE: usize = KB;
 
 const MAX_ITERATIONS: usize = 20;
+const SEND_EARLY_DATA: bool = false;
+const EARLY_DATA: &[u8] = b"hello";
 
 fn main() -> Result<(), Box<dyn Error>> {
     let root_store = RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.into(),
     };
 
-    let config = ClientConfig::builder_with_protocol_versions(&[&TLS13])
+    let mut config = ClientConfig::builder_with_protocol_versions(&[&TLS13])
         .with_root_certificates(root_store)
         .with_no_client_auth();
+    config.enable_early_data = SEND_EARLY_DATA;
 
     let config = Arc::new(config);
 
     let mut incoming_tls = [0; INCOMING_TLS_BUFSIZE];
     let mut outgoing_tls = vec![0; OUTGOING_TLS_INITIAL_BUFSIZE];
 
-    converse(&config, &mut incoming_tls, &mut outgoing_tls)?;
+    converse(&config, false, &mut incoming_tls, &mut outgoing_tls)?;
+    if SEND_EARLY_DATA {
+        eprintln!("---- second connection ----");
+        converse(&config, true, &mut incoming_tls, &mut outgoing_tls)?;
+    }
 
     Ok(())
 }
 
 fn converse(
     config: &Arc<ClientConfig>,
+    send_early_data: bool,
     incoming_tls: &mut [u8],
     outgoing_tls: &mut Vec<u8>,
 ) -> Result<(), Box<dyn Error>> {
@@ -57,6 +65,7 @@ fn converse(
     let mut open_connection = true;
     let mut sent_request = false;
     let mut received_response = false;
+    let mut sent_early_data = false;
 
     let mut iter_count = 0;
     while open_connection {
@@ -104,6 +113,21 @@ fn converse(
             }
 
             ConnectionState::TransmitTlsData(mut state) => {
+                if let Some(mut may_encrypt_early_data) = state.may_encrypt_early_data() {
+                    let written = try_or_resize_and_retry(
+                        |out_buffer| may_encrypt_early_data.encrypt(EARLY_DATA, out_buffer),
+                        |e| match &e {
+                            EarlyDataError::Encrypt(EncryptError::InsufficientSize(is)) => Ok(*is),
+                            _ => Err(e.into()),
+                        },
+                        outgoing_tls,
+                        &mut outgoing_used,
+                    )?;
+
+                    eprintln!("queued {written}B of early data");
+                    sent_early_data = true;
+                }
+
                 if let Some(mut may_encrypt) = state.may_encrypt_app_data() {
                     encrypt_http_request(
                         &mut sent_request,
@@ -179,6 +203,7 @@ fn converse(
 
     assert!(sent_request);
     assert!(received_response);
+    assert_eq!(send_early_data, sent_early_data);
     assert_eq!(0, incoming_used);
     assert_eq!(0, outgoing_used);
 

--- a/examples/src/bin/unbuffered-server.rs
+++ b/examples/src/bin/unbuffered-server.rs
@@ -1,0 +1,258 @@
+use std::error::Error;
+use std::fs::File;
+use std::io::{self, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+
+use pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::UnbufferedServerConnection;
+use rustls::unbuffered::{
+    AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,
+    UnbufferedStatus,
+};
+use rustls::ServerConfig;
+use rustls_pemfile::Item;
+
+const KB: usize = 1024;
+const INCOMING_TLS_BUFSIZE: usize = 16 * KB;
+const OUTGOING_TLS_INITIAL_BUFSIZE: usize = 0;
+const MAX_EARLY_DATA_SIZE: Option<u32> = Some(128);
+const MAX_FRAGMENT_SIZE: Option<usize> = None;
+
+const PORT: u16 = 1443;
+const MAX_ITERATIONS: usize = 30;
+const CERTFILE: &str = match option_env!("CERTFILE") {
+    Some(certfile) => certfile,
+    None => "localhost.pem",
+};
+const PRIV_KEY_FILE: &str = match option_env!("PRIV_KEY_FILE") {
+    Some(priv_key_file) => priv_key_file,
+    None => "localhost-key.pem",
+};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(load_certs()?, load_private_key()?)?;
+
+    if let Some(max_early_data_size) = MAX_EARLY_DATA_SIZE {
+        config.max_early_data_size = max_early_data_size;
+    }
+
+    config.max_fragment_size = MAX_FRAGMENT_SIZE;
+
+    let config = Arc::new(config);
+
+    let listener = TcpListener::bind(format!("[::]:{PORT}"))?;
+
+    let mut incoming_tls = [0; INCOMING_TLS_BUFSIZE];
+    let mut outgoing_tls = vec![0; OUTGOING_TLS_INITIAL_BUFSIZE];
+    for stream in listener.incoming() {
+        handle(stream?, &config, &mut incoming_tls, &mut outgoing_tls)?;
+    }
+
+    Ok(())
+}
+
+fn handle(
+    mut sock: TcpStream,
+    config: &Arc<ServerConfig>,
+    incoming_tls: &mut [u8],
+    outgoing_tls: &mut Vec<u8>,
+) -> Result<(), Box<dyn Error>> {
+    eprintln!("\n---- new client ----");
+
+    dbg!(sock.peer_addr()?);
+
+    let mut conn = UnbufferedServerConnection::new(config.clone())?;
+
+    let mut incoming_used = 0;
+    let mut outgoing_used = 0;
+
+    let mut open_connection = true;
+    let mut received_request = false;
+    let mut sent_response = false;
+
+    let mut iter_count = 0;
+    while open_connection {
+        let UnbufferedStatus { mut discard, state } =
+            conn.process_tls_records(&mut incoming_tls[..incoming_used])?;
+
+        match dbg!(state) {
+            ConnectionState::ReadTraffic(mut state) => {
+                while let Some(res) = state.next_record() {
+                    let AppDataRecord {
+                        discard: new_discard,
+                        payload,
+                    } = res?;
+                    discard += new_discard;
+
+                    if payload.starts_with(b"GET") {
+                        let response = core::str::from_utf8(payload)?;
+                        let header = response
+                            .lines()
+                            .next()
+                            .unwrap_or(response);
+
+                        println!("{header}");
+                    } else {
+                        println!("(.. continued HTTP request ..)");
+                    }
+
+                    received_request = true;
+                }
+            }
+
+            ConnectionState::EncodeTlsData(mut state) => {
+                try_or_resize_and_retry(
+                    |out_buffer| state.encode(out_buffer),
+                    |e| {
+                        if let EncodeError::InsufficientSize(is) = &e {
+                            Ok(*is)
+                        } else {
+                            Err(e.into())
+                        }
+                    },
+                    outgoing_tls,
+                    &mut outgoing_used,
+                )?;
+            }
+
+            ConnectionState::TransmitTlsData(state) => {
+                send_tls(&mut sock, outgoing_tls, &mut outgoing_used)?;
+                state.done();
+            }
+
+            ConnectionState::BlockedHandshake { .. } => {
+                recv_tls(&mut sock, incoming_tls, &mut incoming_used)?;
+            }
+
+            ConnectionState::WriteTraffic(mut state) => {
+                if !received_request {
+                    recv_tls(&mut sock, incoming_tls, &mut incoming_used)?;
+                } else {
+                    let map_err = |e| {
+                        if let EncryptError::InsufficientSize(is) = &e {
+                            Ok(*is)
+                        } else {
+                            Err(e.into())
+                        }
+                    };
+
+                    let http_response = b"HTTP/1.0 200 OK\r\nConnection: close\r\n\r\nHello world from rustls unbuffered server\r\n";
+                    try_or_resize_and_retry(
+                        |out_buffer| state.encrypt(http_response, out_buffer),
+                        map_err,
+                        outgoing_tls,
+                        &mut outgoing_used,
+                    )?;
+                    sent_response = true;
+
+                    try_or_resize_and_retry(
+                        |out_buffer| state.queue_close_notify(out_buffer),
+                        map_err,
+                        outgoing_tls,
+                        &mut outgoing_used,
+                    )?;
+                    open_connection = false;
+
+                    send_tls(&mut sock, outgoing_tls, &mut outgoing_used)?;
+                }
+            }
+
+            _ => unreachable!(),
+        }
+
+        if discard != 0 {
+            assert!(discard <= incoming_used);
+
+            incoming_tls.copy_within(discard..incoming_used, 0);
+            incoming_used -= discard;
+
+            eprintln!("discarded {discard}B from `incoming_tls`");
+        }
+
+        iter_count += 1;
+        assert!(
+            iter_count < MAX_ITERATIONS,
+            "did not get a HTTP response within {MAX_ITERATIONS} iterations"
+        );
+    }
+
+    assert!(received_request);
+    assert!(sent_response);
+    assert_eq!(0, incoming_used);
+    assert_eq!(0, outgoing_used);
+
+    Ok(())
+}
+
+fn try_or_resize_and_retry<E>(
+    mut f: impl FnMut(&mut [u8]) -> Result<usize, E>,
+    map_err: impl FnOnce(E) -> Result<InsufficientSizeError, Box<dyn Error>>,
+    outgoing_tls: &mut Vec<u8>,
+    outgoing_used: &mut usize,
+) -> Result<usize, Box<dyn Error>>
+where
+    E: Error + 'static,
+{
+    let written = match f(&mut outgoing_tls[*outgoing_used..]) {
+        Ok(written) => written,
+
+        Err(e) => {
+            let InsufficientSizeError { required_size } = map_err(e)?;
+            let new_len = *outgoing_used + required_size;
+            outgoing_tls.resize(new_len, 0);
+            eprintln!("resized `outgoing_tls` buffer to {new_len}B");
+
+            f(&mut outgoing_tls[*outgoing_used..])?
+        }
+    };
+
+    *outgoing_used += written;
+
+    Ok(written)
+}
+
+fn recv_tls(
+    sock: &mut TcpStream,
+    incoming_tls: &mut [u8],
+    incoming_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    let read = sock.read(&mut incoming_tls[*incoming_used..])?;
+    eprintln!("received {read}B of data");
+    *incoming_used += read;
+    Ok(())
+}
+
+fn send_tls(
+    sock: &mut TcpStream,
+    outgoing_tls: &[u8],
+    outgoing_used: &mut usize,
+) -> Result<(), Box<dyn Error>> {
+    sock.write_all(&outgoing_tls[..*outgoing_used])?;
+    eprintln!("sent {outgoing_used}B of data");
+    *outgoing_used = 0;
+    Ok(())
+}
+
+fn load_certs() -> Result<Vec<CertificateDer<'static>>, io::Error> {
+    let mut reader = BufReader::new(File::open(CERTFILE)?);
+    rustls_pemfile::certs(&mut reader).collect()
+}
+
+fn load_private_key() -> Result<PrivateKeyDer<'static>, io::Error> {
+    let mut reader = BufReader::new(File::open(PRIV_KEY_FILE)?);
+
+    loop {
+        match rustls_pemfile::read_one(&mut reader)? {
+            Some(Item::Pkcs1Key(key)) => return Ok(key.into()),
+            Some(Item::Pkcs8Key(key)) => return Ok(key.into()),
+            Some(Item::Sec1Key(key)) => return Ok(key.into()),
+            None => break,
+            _ => continue,
+        }
+    }
+
+    panic!("no keys found in {PRIV_KEY_FILE}")
+}

--- a/examples/src/bin/unbuffered-server.rs
+++ b/examples/src/bin/unbuffered-server.rs
@@ -76,9 +76,9 @@ fn handle(
     let mut iter_count = 0;
     while open_connection {
         let UnbufferedStatus { mut discard, state } =
-            conn.process_tls_records(&mut incoming_tls[..incoming_used])?;
+            conn.process_tls_records(&mut incoming_tls[..incoming_used]);
 
-        match dbg!(state) {
+        match dbg!(state.unwrap()) {
             ConnectionState::ReadTraffic(mut state) => {
                 while let Some(res) = state.next_record() {
                     let AppDataRecord {

--- a/examples/src/bin/unbuffered-server.rs
+++ b/examples/src/bin/unbuffered-server.rs
@@ -103,6 +103,20 @@ fn handle(
                 }
             }
 
+            ConnectionState::ReadEarlyData(mut state) => {
+                while let Some(res) = state.next_record() {
+                    let AppDataRecord {
+                        discard: new_discard,
+                        payload,
+                    } = res?;
+                    discard += new_discard;
+
+                    println!("early data: {:?}", core::str::from_utf8(payload));
+
+                    received_request = true;
+                }
+            }
+
             ConnectionState::EncodeTlsData(mut state) => {
                 try_or_resize_and_retry(
                     |out_buffer| state.encode(out_buffer),

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,6 +1,6 @@
 use crate::builder::ConfigBuilder;
 use crate::common_state::{CommonState, Protocol, Side};
-use crate::conn::{ConnectionCommon, ConnectionCore};
+use crate::conn::{ConnectionCommon, ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
@@ -660,6 +660,37 @@ impl ConnectionCore<ClientConnectionData> {
 
     pub(crate) fn is_early_data_accepted(&self) -> bool {
         self.data.early_data.is_accepted()
+    }
+}
+
+/// Unbuffered version of `ClientConnection`
+///
+/// See the [`crate::unbuffered`] module docs for more details
+pub struct UnbufferedClientConnection {
+    inner: UnbufferedConnectionCommon<ClientConnectionData>,
+}
+
+impl UnbufferedClientConnection {
+    /// Make a new ClientConnection. `config` controls how we behave in the TLS protocol, `name` is
+    /// the name of the server we want to talk to.
+    pub fn new(config: Arc<ClientConfig>, name: ServerName<'static>) -> Result<Self, Error> {
+        Ok(Self {
+            inner: ConnectionCore::for_client(config, name, Vec::new(), Protocol::Tcp)?.into(),
+        })
+    }
+}
+
+impl Deref for UnbufferedClientConnection {
+    type Target = UnbufferedConnectionCommon<ClientConnectionData>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for UnbufferedClientConnection {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
     }
 }
 

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -15,6 +15,7 @@ use crate::suites::PartiallyExtractedSecrets;
 use crate::suites::SupportedCipherSuite;
 #[cfg(feature = "tls12")]
 use crate::tls12::ConnectionSecrets;
+use crate::unbuffered::{EncryptError, InsufficientSizeError};
 use crate::vecbuf::ChunkVecBuffer;
 
 use alloc::boxed::Box;
@@ -184,6 +185,49 @@ impl CommonState {
     pub(crate) fn send_some_plaintext(&mut self, data: &[u8]) -> usize {
         self.perhaps_write_key_update();
         self.send_plain(data, Limit::Yes)
+    }
+
+    pub(crate) fn eager_send_some_plaintext(
+        &mut self,
+        plaintext: &[u8],
+        outgoing_tls: &mut [u8],
+    ) -> Result<usize, EncryptError> {
+        if plaintext.is_empty() {
+            return Ok(0);
+        }
+
+        let fragments = self.message_fragmenter.fragment_slice(
+            ContentType::ApplicationData,
+            ProtocolVersion::TLSv1_2,
+            plaintext,
+        );
+
+        let remaining_encryptions = self
+            .record_layer
+            .remaining_write_seq()
+            .ok_or(EncryptError::EncryptExhausted)?;
+
+        if fragments.len() as u64 > remaining_encryptions.get() {
+            return Err(EncryptError::EncryptExhausted);
+        }
+
+        self.check_required_size(
+            outgoing_tls,
+            self.queued_key_update_message
+                .as_deref(),
+            fragments,
+        )?;
+
+        let fragments = self.message_fragmenter.fragment_slice(
+            ContentType::ApplicationData,
+            ProtocolVersion::TLSv1_2,
+            plaintext,
+        );
+
+        let opt_msg = self.queued_key_update_message.take();
+        let written = self.write_fragments(outgoing_tls, opt_msg, fragments);
+
+        Ok(written)
     }
 
     pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
@@ -493,9 +537,86 @@ impl CommonState {
         self.send_warning_alert_no_log(AlertDescription::CloseNotify);
     }
 
+    pub(crate) fn eager_send_close_notify(
+        &mut self,
+        outgoing_tls: &mut [u8],
+    ) -> Result<usize, EncryptError> {
+        debug_assert!(self.record_layer.is_encrypting());
+
+        let m = Message::build_alert(AlertLevel::Warning, AlertDescription::CloseNotify).into();
+
+        let iter = self
+            .message_fragmenter
+            .fragment_message(&m);
+
+        self.check_required_size(outgoing_tls, None, iter)?;
+
+        debug!("Sending warning alert {:?}", AlertDescription::CloseNotify);
+
+        let iter = self
+            .message_fragmenter
+            .fragment_message(&m);
+
+        let written = self.write_fragments(outgoing_tls, None, iter);
+
+        Ok(written)
+    }
+
     fn send_warning_alert_no_log(&mut self, desc: AlertDescription) {
         let m = Message::build_alert(AlertLevel::Warning, desc);
         self.send_msg(m, self.record_layer.is_encrypting());
+    }
+
+    fn check_required_size<'a>(
+        &self,
+        outgoing_tls: &mut [u8],
+        opt_msg: Option<&[u8]>,
+        fragments: impl Iterator<Item = BorrowedPlainMessage<'a>>,
+    ) -> Result<(), EncryptError> {
+        let mut required_size = 0;
+        if let Some(message) = opt_msg {
+            required_size += message.len();
+        }
+
+        for m in fragments {
+            required_size += m.encoded_len(&self.record_layer);
+        }
+
+        if required_size > outgoing_tls.len() {
+            return Err(EncryptError::InsufficientSize(InsufficientSizeError {
+                required_size,
+            }));
+        }
+
+        Ok(())
+    }
+
+    fn write_fragments<'a>(
+        &mut self,
+        outgoing_tls: &mut [u8],
+        opt_msg: Option<Vec<u8>>,
+        fragments: impl Iterator<Item = BorrowedPlainMessage<'a>>,
+    ) -> usize {
+        let mut written = 0;
+
+        if let Some(message) = opt_msg {
+            let len = message.len();
+            outgoing_tls[written..written + len].copy_from_slice(&message);
+            written += len;
+        }
+
+        for m in fragments {
+            let em = self
+                .record_layer
+                .encrypt_outgoing(m)
+                .encode();
+
+            let len = em.len();
+            outgoing_tls[written..written + len].copy_from_slice(&em);
+            written += len;
+        }
+
+        written
     }
 
     pub(crate) fn set_max_fragment_size(&mut self, new: Option<usize>) -> Result<(), Error> {

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -182,12 +182,12 @@ impl CommonState {
     ///
     /// If internal buffers are too small, this function will not accept
     /// all the data.
-    pub(crate) fn send_some_plaintext(&mut self, data: &[u8]) -> usize {
+    pub(crate) fn buffer_plaintext(&mut self, data: &[u8]) -> usize {
         self.perhaps_write_key_update();
         self.send_plain(data, Limit::Yes)
     }
 
-    pub(crate) fn eager_send_some_plaintext(
+    pub(crate) fn write_plaintext(
         &mut self,
         plaintext: &[u8],
         outgoing_tls: &mut [u8],

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -15,6 +15,8 @@ use core::mem;
 use core::ops::{Deref, DerefMut};
 use std::io;
 
+pub(crate) mod unbuffered;
+
 /// A client or server connection.
 #[derive(Debug)]
 pub enum Connection {
@@ -616,6 +618,21 @@ impl<Data> From<ConnectionCore<Data>> for ConnectionCommon<Data> {
         Self {
             core,
             deframer_buffer: DeframerVecBuffer::default(),
+        }
+    }
+}
+
+/// Interface shared by unbuffered client and server connections.
+pub struct UnbufferedConnectionCommon<Data> {
+    pub(crate) core: ConnectionCore<Data>,
+    wants_write: bool,
+}
+
+impl<Data> From<ConnectionCore<Data>> for UnbufferedConnectionCommon<Data> {
+    fn from(core: ConnectionCore<Data>) -> Self {
+        Self {
+            core,
+            wants_write: false,
         }
     }
 }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -244,13 +244,13 @@ pub(crate) trait PlaintextSink {
 
 impl<T> PlaintextSink for ConnectionCommon<T> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        Ok(self.send_some_plaintext(buf))
+        Ok(self.buffer_plaintext(buf))
     }
 
     fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
         let mut sz = 0;
         for buf in bufs {
-            sz += self.send_some_plaintext(buf);
+            sz += self.buffer_plaintext(buf);
         }
         Ok(sz)
     }

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -1,0 +1,438 @@
+//! Unbuffered connection API
+
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
+use core::{fmt, mem};
+use std::error::Error as StdError;
+
+use super::UnbufferedConnectionCommon;
+use crate::msgs::deframer::DeframerSliceBuffer;
+use crate::Error;
+
+impl<Data> UnbufferedConnectionCommon<Data> {
+    /// Processes the TLS records in `incoming_tls` buffer until a new [`UnbufferedStatus`] is
+    /// reached.
+    pub fn process_tls_records<'c, 'i>(
+        &'c mut self,
+        incoming_tls: &'i mut [u8],
+    ) -> Result<UnbufferedStatus<'c, 'i, Data>, Error> {
+        let mut buffer = DeframerSliceBuffer::new(incoming_tls);
+
+        let (discard, state) = loop {
+            if let Some(chunk) = self
+                .core
+                .common_state
+                .received_plaintext
+                .pop()
+            {
+                break (
+                    buffer.pending_discard(),
+                    ReadTraffic::new(self, incoming_tls, chunk).into(),
+                );
+            }
+
+            if let Some(chunk) = self
+                .core
+                .common_state
+                .sendable_tls
+                .pop()
+            {
+                break (
+                    buffer.pending_discard(),
+                    EncodeTlsData::new(self, chunk).into(),
+                );
+            }
+
+            if let Some(msg) = self.core.deframe(None, &mut buffer)? {
+                let mut state =
+                    match mem::replace(&mut self.core.state, Err(Error::HandshakeNotComplete)) {
+                        Ok(state) => state,
+                        Err(e) => {
+                            self.core.state = Err(e.clone());
+                            return Err(e);
+                        }
+                    };
+
+                match self.core.process_msg(msg, state) {
+                    Ok(new) => state = new,
+
+                    Err(e) => {
+                        self.core.state = Err(e.clone());
+                        return Err(e);
+                    }
+                }
+
+                self.core.state = Ok(state);
+            } else if self.wants_write {
+                break (
+                    buffer.pending_discard(),
+                    TransmitTlsData { conn: self }.into(),
+                );
+            } else if self
+                .core
+                .common_state
+                .has_received_close_notify
+            {
+                break (buffer.pending_discard(), ConnectionState::Closed);
+            } else if self
+                .core
+                .common_state
+                .may_send_application_data
+            {
+                break (
+                    buffer.pending_discard(),
+                    ConnectionState::WriteTraffic(WriteTraffic { conn: self }),
+                );
+            } else {
+                break (buffer.pending_discard(), ConnectionState::BlockedHandshake);
+            }
+        };
+
+        Ok(UnbufferedStatus { discard, state })
+    }
+}
+
+/// The current status of the `UnbufferedConnection*`
+#[must_use]
+pub struct UnbufferedStatus<'c, 'i, Data> {
+    /// Number of bytes to discard
+    ///
+    /// After the `state` field of this object has been handled, `discard` bytes must be
+    /// removed from the *front* of the `incoming_tls` buffer that was passed to
+    /// the [`UnbufferedConnectionCommon::process_tls_records`] call that returned this object.
+    ///
+    /// This discard operation MUST happen *before*
+    /// [`UnbufferedConnectionCommon::process_tls_records`] is called again.
+    pub discard: usize,
+
+    /// The current state of the handshake process
+    ///
+    /// This value MUST be handled prior to calling
+    /// [`UnbufferedConnectionCommon::process_tls_records`] again. See the documentation on the
+    /// variants of [`ConnectionState`] for more details.
+    pub state: ConnectionState<'c, 'i, Data>,
+}
+
+/// The state of the [`UnbufferedConnectionCommon`] object
+#[non_exhaustive] // for forwards compatibility; to support caller-side certificate verification
+pub enum ConnectionState<'c, 'i, Data> {
+    /// One, or more, application data records are available
+    ///
+    /// See [`ReadTraffic`] for more details on how to use the enclosed object to access
+    /// the received data.
+    ReadTraffic(ReadTraffic<'c, 'i, Data>),
+
+    /// Connection has been cleanly closed by the peer
+    Closed,
+
+    /// A Handshake record is ready for encoding
+    ///
+    /// Call [`EncodeTlsData::encode`] on the enclosed object, providing an `outgoing_tls`
+    /// buffer to store the encoding
+    EncodeTlsData(EncodeTlsData<'c, Data>),
+
+    /// Previously encoded handshake records need to be transmitted
+    ///
+    /// Transmit the contents of the `outgoing_tls` buffer that was passed to previous
+    /// [`EncodeTlsData::encode`] calls to the peer.
+    ///
+    /// After transmitting the contents, call [`TransmitTlsData::done`] on the enclosed object.
+    /// The transmitted contents MUST not be sent to the peer more than once so they SHOULD be
+    /// discarded at this point.
+    ///
+    /// At some stages of the handshake process, it's possible to send application-data alongside
+    /// handshake records. Call [`TransmitTlsData::may_encrypt_app_data`] on the enclosed
+    /// object to probe if that's allowed.
+    TransmitTlsData(TransmitTlsData<'c, Data>),
+
+    /// More TLS data is needed to continue with the handshake
+    ///
+    /// Request more data from the peer and append the contents to the `incoming_tls` buffer that
+    /// was passed to [`UnbufferedConnectionCommon::process_tls_records`].
+    BlockedHandshake,
+
+    /// The handshake process has been completed.
+    ///
+    /// [`WriteTraffic::encrypt`] can be called on the enclosed object to encrypt application
+    /// data into an `outgoing_tls` buffer. Similarly, [`WriteTraffic::queue_close_notify`] can
+    /// be used to encrypt a close_notify alert message into a buffer to signal the peer that the
+    /// connection is being closed. Data written into `outgoing_buffer` by either method MAY be
+    /// transmitted to the peer during this state.
+    ///
+    /// Once this state has been reached, data MAY be requested from the peer and appended to an
+    /// `incoming_tls` buffer that will be passed to a future
+    /// [`UnbufferedConnectionCommon::process_tls_records`] invocation. When enough data has been
+    /// appended to `incoming_tls`, [`UnbufferedConnectionCommon::process_tls_records`] will yield
+    /// the [`ConnectionState::ReadTraffic`] state.
+    WriteTraffic(WriteTraffic<'c, Data>),
+}
+
+impl<'c, 'i, Data> From<ReadTraffic<'c, 'i, Data>> for ConnectionState<'c, 'i, Data> {
+    fn from(v: ReadTraffic<'c, 'i, Data>) -> Self {
+        Self::ReadTraffic(v)
+    }
+}
+
+impl<'c, 'i, Data> From<EncodeTlsData<'c, Data>> for ConnectionState<'c, 'i, Data> {
+    fn from(v: EncodeTlsData<'c, Data>) -> Self {
+        Self::EncodeTlsData(v)
+    }
+}
+
+impl<'c, 'i, Data> From<TransmitTlsData<'c, Data>> for ConnectionState<'c, 'i, Data> {
+    fn from(v: TransmitTlsData<'c, Data>) -> Self {
+        Self::TransmitTlsData(v)
+    }
+}
+
+impl<Data> fmt::Debug for ConnectionState<'_, '_, Data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReadTraffic(..) => f.debug_tuple("ReadTraffic").finish(),
+
+            Self::Closed => write!(f, "Closed"),
+
+            Self::EncodeTlsData(..) => f.debug_tuple("EncodeTlsData").finish(),
+
+            Self::TransmitTlsData(..) => f
+                .debug_tuple("TransmitTlsData")
+                .finish(),
+
+            Self::BlockedHandshake => f
+                .debug_struct("BlockedHandshake")
+                .finish(),
+
+            Self::WriteTraffic(..) => f.debug_tuple("WriteTraffic").finish(),
+        }
+    }
+}
+
+/// Application data is available
+pub struct ReadTraffic<'c, 'i, Data> {
+    _conn: &'c mut UnbufferedConnectionCommon<Data>,
+    // for forwards compatibility; to support in-place decryption in the future
+    _incoming_tls: &'i mut [u8],
+    chunk: Vec<u8>,
+    taken: bool,
+}
+
+impl<'c, 'i, Data> ReadTraffic<'c, 'i, Data> {
+    fn new(
+        _conn: &'c mut UnbufferedConnectionCommon<Data>,
+        _incoming_tls: &'i mut [u8],
+        chunk: Vec<u8>,
+    ) -> Self {
+        Self {
+            _conn,
+            _incoming_tls,
+            chunk,
+            taken: false,
+        }
+    }
+
+    /// Decrypts and returns the next available app-data record
+    // TODO deprecate in favor of `Iterator` implementation, which requires in-place decryption
+    pub fn next_record(&mut self) -> Option<Result<AppDataRecord, Error>> {
+        if self.taken {
+            None
+        } else {
+            self.taken = true;
+            Some(Ok(AppDataRecord {
+                discard: 0,
+                payload: &self.chunk,
+            }))
+        }
+    }
+
+    /// Returns the payload size of the next app-data record *without* decrypting it
+    ///
+    /// Returns `None` if there are no more app-data records
+    pub fn peek_len(&self) -> Option<NonZeroUsize> {
+        if self.taken {
+            None
+        } else {
+            NonZeroUsize::new(self.chunk.len())
+        }
+    }
+}
+
+/// A decrypted application-data record
+pub struct AppDataRecord<'i> {
+    /// Number of additional bytes to discard
+    ///
+    /// This number MUST be added to the value of [`UnbufferedStatus.discard`] *prior* to the
+    /// discard operation. See [`UnbufferedStatus.discard`] for more details
+    pub discard: usize,
+
+    /// The payload of the app-data record
+    pub payload: &'i [u8],
+}
+
+/// Allows encrypting app-data
+pub struct WriteTraffic<'c, Data> {
+    conn: &'c mut UnbufferedConnectionCommon<Data>,
+}
+
+impl<Data> WriteTraffic<'_, Data> {
+    /// Encrypts `application_data` into the `outgoing_tls` buffer
+    ///
+    /// Returns the number of bytes that were written into `outgoing_tls`, or an error if
+    /// the provided buffer is too small. In the error case, `outgoing_tls` is not modified
+    pub fn encrypt(
+        &mut self,
+        application_data: &[u8],
+        outgoing_tls: &mut [u8],
+    ) -> Result<usize, EncryptError> {
+        self.conn
+            .core
+            .common_state
+            .eager_send_some_plaintext(application_data, outgoing_tls)
+    }
+
+    /// Encrypts a close_notify warning alert in `outgoing_tls`
+    ///
+    /// Returns the number of bytes that were written into `outgoing_tls`, or an error if
+    /// the provided buffer is too small. In the error case, `outgoing_tls` is not modified
+    pub fn queue_close_notify(&mut self, outgoing_tls: &mut [u8]) -> Result<usize, EncryptError> {
+        self.conn
+            .core
+            .common_state
+            .eager_send_close_notify(outgoing_tls)
+    }
+}
+
+/// A handshake record must be encoded
+pub struct EncodeTlsData<'c, Data> {
+    conn: &'c mut UnbufferedConnectionCommon<Data>,
+    chunk: Option<Vec<u8>>,
+}
+
+impl<'c, Data> EncodeTlsData<'c, Data> {
+    fn new(conn: &'c mut UnbufferedConnectionCommon<Data>, chunk: Vec<u8>) -> Self {
+        Self {
+            conn,
+            chunk: Some(chunk),
+        }
+    }
+
+    /// Encodes a handshake record into the `outgoing_tls` buffer
+    ///
+    /// Returns the number of bytes that were written into `outgoing_tls`, or an error if
+    /// the provided buffer is too small. In the error case, `outgoing_tls` is not modified
+    pub fn encode(&mut self, outgoing_tls: &mut [u8]) -> Result<usize, EncodeError> {
+        let chunk = match self.chunk.take() {
+            Some(chunk) => chunk,
+            None => return Err(EncodeError::AlreadyEncoded),
+        };
+
+        let required_size = chunk.len();
+
+        if required_size > outgoing_tls.len() {
+            self.chunk = Some(chunk);
+            Err(InsufficientSizeError { required_size }.into())
+        } else {
+            let written = chunk.len();
+            outgoing_tls[..written].copy_from_slice(&chunk);
+
+            self.conn.wants_write = true;
+
+            Ok(written)
+        }
+    }
+}
+
+/// Previously encoded TLS data must be transmitted
+pub struct TransmitTlsData<'c, Data> {
+    conn: &'c mut UnbufferedConnectionCommon<Data>,
+}
+
+impl<Data> TransmitTlsData<'_, Data> {
+    /// Signals that the previously encoded TLS data has been transmitted
+    pub fn done(self) {
+        self.conn.wants_write = false;
+    }
+
+    /// Returns an adapter that allows encrypting application data
+    ///
+    /// If allowed at this stage of the handshake process
+    pub fn may_encrypt_app_data(&mut self) -> Option<WriteTraffic<Data>> {
+        if self
+            .conn
+            .core
+            .common_state
+            .may_send_application_data
+        {
+            Some(WriteTraffic { conn: self.conn })
+        } else {
+            None
+        }
+    }
+}
+
+/// Errors that may arise when encoding a handshake record
+#[derive(Debug)]
+pub enum EncodeError {
+    /// Provided buffer was too small
+    InsufficientSize(InsufficientSizeError),
+
+    /// The handshake record has already been encoded; do not call `encode` again
+    AlreadyEncoded,
+}
+
+impl From<InsufficientSizeError> for EncodeError {
+    fn from(v: InsufficientSizeError) -> Self {
+        Self::InsufficientSize(v)
+    }
+}
+
+impl fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InsufficientSize(InsufficientSizeError { required_size }) => write!(
+                f,
+                "cannot encode due to insufficient size, {} bytes are required",
+                required_size
+            ),
+            Self::AlreadyEncoded => "cannot encode, data has already been encoded".fmt(f),
+        }
+    }
+}
+
+impl StdError for EncodeError {}
+
+/// Errors that may arise when encrypting application data
+#[derive(Debug)]
+pub enum EncryptError {
+    /// Provided buffer was too small
+    InsufficientSize(InsufficientSizeError),
+
+    /// Encrypter has been exhausted
+    EncryptExhausted,
+}
+
+impl From<InsufficientSizeError> for EncryptError {
+    fn from(v: InsufficientSizeError) -> Self {
+        Self::InsufficientSize(v)
+    }
+}
+
+impl fmt::Display for EncryptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InsufficientSize(InsufficientSizeError { required_size }) => write!(
+                f,
+                "cannot encrypt due to insufficient size, {required_size} bytes are required"
+            ),
+            Self::EncryptExhausted => f.write_str("encrypter has been exhausted"),
+        }
+    }
+}
+
+impl StdError for EncryptError {}
+
+/// Provided buffer was too small
+#[derive(Clone, Copy, Debug)]
+pub struct InsufficientSizeError {
+    /// buffer must be at least this size
+    pub required_size: usize,
+}

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -126,6 +126,7 @@ impl<Data> UnbufferedConnectionCommon<Data> {
 
 /// The current status of the `UnbufferedConnection*`
 #[must_use]
+#[derive(Debug)]
 pub struct UnbufferedStatus<'c, 'i, Data> {
     /// Number of bytes to discard
     ///

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -286,7 +286,7 @@ impl<Data> WriteTraffic<'_, Data> {
         self.conn
             .core
             .common_state
-            .eager_send_some_plaintext(application_data, outgoing_tls)
+            .write_plaintext(application_data, outgoing_tls)
     }
 
     /// Encrypts a close_notify warning alert in `outgoing_tls`

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -423,6 +423,39 @@ pub mod internal {
     }
 }
 
+/// Unbuffered connection API
+///
+/// This is an alternative to the [`crate::ConnectionCommon`] API that does not internally buffer
+/// TLS nor plaintext data. Instead those buffers are managed by the API user so they have
+/// control over when and how to allocate, resize and dispose of them.
+///
+/// This API is lower level than the `ConnectionCommon` API and is built around a state machine
+/// interface where the API user must handle each state to advance and complete the
+/// handshake process.
+///
+/// Like the `ConnectionCommon` API, no IO happens internally so all IO must be handled by the API
+/// user. Unlike the `ConnectionCommon` API, this API does not make use of the [`std::io::Read`] and
+/// [`std::io::Write`] traits so it's usable in no-std context.
+///
+/// The entry points into this API are [`crate::client::UnbufferedClientConnection::new`],
+/// [`crate::server::UnbufferedServerConnection::new`] and
+/// [`unbuffered::UnbufferedConnectionCommon::process_tls_records`]. The state machine API is
+/// documented in [`unbuffered::ConnectionState`].
+///
+/// # Examples
+///
+/// [`unbuffered-client`] and [`unbuffered-server`] are examples that fully exercise the API in
+/// std, non-async context.
+///
+/// [`unbuffered-client`]: https://github.com/rustls/rustls/blob/main/examples/src/bin/unbuffererd-client.rs
+pub mod unbuffered {
+    pub use crate::conn::unbuffered::{
+        AppDataRecord, ConnectionState, EncodeError, EncodeTlsData, EncryptError,
+        InsufficientSizeError, ReadTraffic, TransmitTlsData, UnbufferedStatus, WriteTraffic,
+    };
+    pub use crate::conn::UnbufferedConnectionCommon;
+}
+
 // Have a (non-public) "test provider" mod which supplies
 // tests that need part of a *ring*-compatible provider module.
 #[cfg(all(any(test, bench), not(feature = "ring"), feature = "aws_lc_rs"))]
@@ -469,7 +502,8 @@ pub mod client {
     pub use builder::WantsClientCert;
     pub use client_conn::{
         ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore,
-        ResolvesClientCert, Resumption, Tls12Resumption, WriteEarlyData,
+        ResolvesClientCert, Resumption, Tls12Resumption, UnbufferedClientConnection,
+        WriteEarlyData,
     };
     pub use handy::ClientSessionMemoryCache;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -448,6 +448,7 @@ pub mod internal {
 /// std, non-async context.
 ///
 /// [`unbuffered-client`]: https://github.com/rustls/rustls/blob/main/examples/src/bin/unbuffererd-client.rs
+/// [`unbuffered-server`]: https://github.com/rustls/rustls/blob/main/examples/src/bin/unbuffererd-server.rs
 pub mod unbuffered {
     pub use crate::conn::unbuffered::{
         AppDataRecord, ConnectionState, EncodeError, EncodeTlsData, EncryptError,
@@ -546,6 +547,7 @@ pub mod server {
     pub use server_conn::StoresServerSessions;
     pub use server_conn::{
         Accepted, Acceptor, ReadEarlyData, ServerConfig, ServerConnection, ServerConnectionData,
+        UnbufferedServerConnection,
     };
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -452,7 +452,8 @@ pub mod internal {
 pub mod unbuffered {
     pub use crate::conn::unbuffered::{
         AppDataRecord, ConnectionState, EncodeError, EncodeTlsData, EncryptError,
-        InsufficientSizeError, ReadTraffic, TransmitTlsData, UnbufferedStatus, WriteTraffic,
+        InsufficientSizeError, ReadEarlyData, ReadTraffic, TransmitTlsData, UnbufferedStatus,
+        WriteTraffic,
     };
     pub use crate::conn::UnbufferedConnectionCommon;
 }
@@ -502,7 +503,7 @@ pub mod client {
 
     pub use builder::WantsClientCert;
     pub use client_conn::{
-        ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore,
+        ClientConfig, ClientConnection, ClientConnectionData, ClientSessionStore, EarlyDataError,
         ResolvesClientCert, Resumption, Tls12Resumption, UnbufferedClientConnection,
         WriteEarlyData,
     };

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -37,7 +37,7 @@ impl MessageFragmenter {
         typ: ContentType,
         version: ProtocolVersion,
         payload: &'a [u8],
-    ) -> impl Iterator<Item = BorrowedPlainMessage<'a>> + 'a {
+    ) -> impl Iterator<Item = BorrowedPlainMessage<'a>> + ExactSizeIterator + 'a {
         payload
             .chunks(self.max_frag)
             .map(move |c| BorrowedPlainMessage {

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -1,6 +1,7 @@
 use crate::enums::ProtocolVersion;
 use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
+use crate::internal::record_layer::RecordLayer;
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
@@ -348,6 +349,10 @@ impl<'a> BorrowedPlainMessage<'a> {
             typ: self.typ,
             payload: Payload(self.payload.to_vec()),
         }
+    }
+
+    pub fn encoded_len(&self, record_layer: &RecordLayer) -> usize {
+        OpaqueMessage::HEADER_SIZE as usize + record_layer.encrypted_len(self.payload.len())
     }
 }
 

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroU64;
+
 use crate::crypto::cipher::{MessageDecrypter, MessageEncrypter};
 use crate::error::Error;
 use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
@@ -204,8 +206,20 @@ impl RecordLayer {
         self.write_seq
     }
 
+    /// Returns the number of remaining write sequences
+    pub(crate) fn remaining_write_seq(&self) -> Option<NonZeroU64> {
+        SEQ_SOFT_LIMIT
+            .checked_sub(self.write_seq)
+            .and_then(NonZeroU64::new)
+    }
+
     pub(crate) fn read_seq(&self) -> u64 {
         self.read_seq
+    }
+
+    pub(crate) fn encrypted_len(&self, payload_len: usize) -> usize {
+        self.message_encrypter
+            .encrypted_payload_len(payload_len)
     }
 
     fn doing_trial_decryption(&mut self, requested: usize) -> bool {

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -597,6 +597,12 @@ impl DerefMut for UnbufferedServerConnection {
     }
 }
 
+impl UnbufferedConnectionCommon<ServerConnectionData> {
+    pub(crate) fn pop_early_data(&mut self) -> Option<Vec<u8>> {
+        self.core.data.early_data.pop()
+    }
+}
+
 /// Handle a server-side connection before configuration is available.
 ///
 /// `Acceptor` allows the caller to choose a [`ServerConfig`] after reading
@@ -815,6 +821,13 @@ impl EarlyDataState {
 
     pub(super) fn was_rejected(&self) -> bool {
         matches!(self, Self::Rejected)
+    }
+
+    fn pop(&mut self) -> Option<Vec<u8>> {
+        match self {
+            Self::Accepted(ref mut received) => received.pop(),
+            _ => None,
+        }
     }
 
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1,0 +1,193 @@
+#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+use std::sync::Arc;
+
+use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
+use rustls::server::{ServerConnectionData, UnbufferedServerConnection};
+use rustls::unbuffered::{ConnectionState, UnbufferedConnectionCommon, UnbufferedStatus};
+
+use crate::common::*;
+
+mod common;
+
+#[test]
+fn handshake() {
+    for version in rustls::ALL_VERSIONS {
+        let server_config = make_server_config(KeyType::Rsa);
+        let client_config = make_client_config_with_versions(KeyType::Rsa, &[version]);
+
+        let mut client =
+            UnbufferedClientConnection::new(Arc::new(client_config), server_name("localhost"))
+                .unwrap();
+        let mut server = UnbufferedServerConnection::new(Arc::new(server_config)).unwrap();
+        let mut buffers = BothBuffers::default();
+
+        let mut count = 0;
+        let mut client_handshake_done = false;
+        let mut server_handshake_done = false;
+        while !client_handshake_done || !server_handshake_done {
+            match advance_client(&mut client, &mut buffers.client) {
+                State::EncodedTlsData => {}
+                State::TransmitTlsData => buffers.client_send(),
+                State::BlockedHandshake => buffers.server_send(),
+                State::WriteTraffic => client_handshake_done = true,
+            }
+
+            match advance_server(&mut server, &mut buffers.server) {
+                State::EncodedTlsData => {}
+                State::TransmitTlsData => buffers.server_send(),
+                State::BlockedHandshake => buffers.client_send(),
+                State::WriteTraffic => server_handshake_done = true,
+            }
+
+            count += 1;
+
+            assert!(count <= 100, "handshake {version:?} was not completed");
+        }
+    }
+}
+
+#[derive(Debug)]
+enum State {
+    EncodedTlsData,
+    BlockedHandshake,
+    WriteTraffic,
+    TransmitTlsData,
+}
+
+fn advance_client(
+    conn: &mut UnbufferedConnectionCommon<ClientConnectionData>,
+    buffers: &mut Buffers,
+) -> State {
+    let UnbufferedStatus { discard, state } = conn
+        .process_tls_records(buffers.incoming.filled())
+        .unwrap();
+
+    let state = handle_state(state, &mut buffers.outgoing);
+    buffers.incoming.discard(discard);
+
+    state
+}
+
+fn advance_server(
+    conn: &mut UnbufferedConnectionCommon<ServerConnectionData>,
+    buffers: &mut Buffers,
+) -> State {
+    let UnbufferedStatus { discard, state } = conn
+        .process_tls_records(buffers.incoming.filled())
+        .unwrap();
+
+    let state = handle_state(state, &mut buffers.outgoing);
+    buffers.incoming.discard(discard);
+
+    state
+}
+
+fn handle_state<Data>(state: ConnectionState<'_, '_, Data>, outgoing: &mut Buffer) -> State {
+    match state {
+        ConnectionState::EncodeTlsData(mut state) => {
+            let written = state
+                .encode(outgoing.unfilled())
+                .unwrap();
+            outgoing.advance(written);
+
+            State::EncodedTlsData
+        }
+
+        ConnectionState::TransmitTlsData(state) => {
+            // this should be called *after* the data has been transmitted but it's easier to
+            // do it in reverse
+            state.done();
+            State::TransmitTlsData
+        }
+
+        ConnectionState::BlockedHandshake { .. } => State::BlockedHandshake,
+
+        ConnectionState::WriteTraffic(_) => State::WriteTraffic,
+
+        _ => unreachable!(),
+    }
+}
+
+#[derive(Default)]
+struct BothBuffers {
+    client: Buffers,
+    server: Buffers,
+}
+
+impl BothBuffers {
+    fn client_send(&mut self) {
+        let client_data = self.client.outgoing.filled();
+        let num_bytes = client_data.len();
+        if num_bytes == 0 {
+            return;
+        }
+        self.server.incoming.append(client_data);
+        self.client.outgoing.clear();
+        eprintln!("client sent {num_bytes}B");
+    }
+
+    fn server_send(&mut self) {
+        let server_data = self.server.outgoing.filled();
+        let num_bytes = server_data.len();
+        if num_bytes == 0 {
+            return;
+        }
+        self.client.incoming.append(server_data);
+        self.server.outgoing.clear();
+        eprintln!("server sent {num_bytes}B");
+    }
+}
+
+#[derive(Default)]
+struct Buffers {
+    incoming: Buffer,
+    outgoing: Buffer,
+}
+
+struct Buffer {
+    inner: Vec<u8>,
+    used: usize,
+}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Self {
+            inner: vec![0; 16 * 1024],
+            used: 0,
+        }
+    }
+}
+
+impl Buffer {
+    fn advance(&mut self, num_bytes: usize) {
+        self.used += num_bytes;
+    }
+
+    fn append(&mut self, bytes: &[u8]) {
+        let num_bytes = bytes.len();
+        self.unfilled()[..num_bytes].copy_from_slice(bytes);
+        self.advance(num_bytes)
+    }
+
+    fn clear(&mut self) {
+        self.used = 0;
+    }
+
+    fn discard(&mut self, discard: usize) {
+        if discard != 0 {
+            assert!(discard <= self.used);
+
+            self.inner
+                .copy_within(discard..self.used, 0);
+            self.used -= discard;
+        }
+    }
+
+    fn filled(&mut self) -> &mut [u8] {
+        &mut self.inner[..self.used]
+    }
+
+    fn unfilled(&mut self) -> &mut [u8] {
+        &mut self.inner[self.used..]
+    }
+}

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -21,38 +21,38 @@ fn tls12_handshake() {
     assert_eq!(
         client_transcript,
         vec![
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "WriteTraffic"
+            "Ok(EncodeTlsData)",
+            "Ok(TransmitTlsData)",
+            "Ok(BlockedHandshake)",
+            "Ok(BlockedHandshake)",
+            "Ok(BlockedHandshake)",
+            "Ok(BlockedHandshake)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(TransmitTlsData)",
+            "Ok(BlockedHandshake)",
+            "Ok(BlockedHandshake)",
+            "Ok(WriteTraffic)"
         ],
         "client transcript mismatch"
     );
     assert_eq!(
         server_transcript,
         vec![
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "WriteTraffic"
+            "Ok(BlockedHandshake)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(TransmitTlsData)",
+            "Ok(BlockedHandshake)",
+            "Ok(BlockedHandshake)",
+            "Ok(BlockedHandshake)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(TransmitTlsData)",
+            "Ok(WriteTraffic)"
         ],
         "server transcript mismatch"
     );
@@ -64,42 +64,42 @@ fn tls13_handshake() {
     assert_eq!(
         client_transcript,
         vec![
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "WriteTraffic",
-            "WriteTraffic",
-            "WriteTraffic",
-            "WriteTraffic",
-            "WriteTraffic"
+            "Ok(EncodeTlsData)",
+            "Ok(TransmitTlsData)",
+            "Ok(BlockedHandshake)",
+            "Ok(EncodeTlsData)",
+            "Ok(TransmitTlsData)",
+            "Ok(BlockedHandshake)",
+            "Ok(BlockedHandshake)",
+            "Ok(BlockedHandshake)",
+            "Ok(EncodeTlsData)",
+            "Ok(TransmitTlsData)",
+            "Ok(WriteTraffic)",
+            "Ok(WriteTraffic)",
+            "Ok(WriteTraffic)",
+            "Ok(WriteTraffic)",
+            "Ok(WriteTraffic)"
         ],
         "client transcript mismatch"
     );
     assert_eq!(
         server_transcript,
         vec![
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "WriteTraffic"
+            "Ok(BlockedHandshake)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(TransmitTlsData)",
+            "Ok(BlockedHandshake)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(EncodeTlsData)",
+            "Ok(TransmitTlsData)",
+            "Ok(WriteTraffic)"
         ],
         "server transcript mismatch"
     );
@@ -600,15 +600,13 @@ fn advance_client(
     actions: Actions,
     transcript: Option<&mut Vec<String>>,
 ) -> State {
-    let UnbufferedStatus { discard, state } = conn
-        .process_tls_records(buffers.incoming.filled())
-        .unwrap();
+    let UnbufferedStatus { discard, state } = conn.process_tls_records(buffers.incoming.filled());
 
     if let Some(transcript) = transcript {
         transcript.push(format!("{:?}", state));
     }
 
-    let state = match state {
+    let state = match state.unwrap() {
         ConnectionState::TransmitTlsData(mut state) => {
             let mut sent_early_data = false;
             if let Some(early_data) = actions.early_data_to_send {
@@ -649,15 +647,13 @@ fn advance_server(
     actions: Actions,
     transcript: Option<&mut Vec<String>>,
 ) -> State {
-    let UnbufferedStatus { discard, state } = conn
-        .process_tls_records(buffers.incoming.filled())
-        .unwrap();
+    let UnbufferedStatus { discard, state } = conn.process_tls_records(buffers.incoming.filled());
 
     if let Some(transcript) = transcript {
         transcript.push(format!("{:?}", state));
     }
 
-    let state = match state {
+    let state = match state.unwrap() {
         ConnectionState::ReadEarlyData(mut state) => {
             let mut records = vec![];
 
@@ -897,12 +893,10 @@ fn server_receives_handshake_byte_by_byte() {
     let (mut client, mut server) = make_connection_pair(&TLS13);
 
     let mut client_hello_buffer = vec![0u8; 1024];
-    let UnbufferedStatus { discard, state } = client
-        .process_tls_records(&mut [])
-        .unwrap();
+    let UnbufferedStatus { discard, state } = client.process_tls_records(&mut []);
 
     assert_eq!(discard, 0);
-    match state {
+    match state.unwrap() {
         ConnectionState::EncodeTlsData(mut inner) => {
             let wr = inner
                 .encode(&mut client_hello_buffer)
@@ -915,18 +909,16 @@ fn server_receives_handshake_byte_by_byte() {
     println!("client hello: {:?}", client_hello_buffer);
 
     for prefix in 0..client_hello_buffer.len() - 1 {
-        let UnbufferedStatus { discard, state } = server
-            .process_tls_records(&mut client_hello_buffer[..prefix])
-            .unwrap();
+        let UnbufferedStatus { discard, state } =
+            server.process_tls_records(&mut client_hello_buffer[..prefix]);
         println!("prefix {prefix:?}: ({discard:?}, {state:?}");
-        assert!(matches!(state, ConnectionState::BlockedHandshake));
+        assert!(matches!(state.unwrap(), ConnectionState::BlockedHandshake));
     }
 
-    let UnbufferedStatus { discard, state } = server
-        .process_tls_records(&mut client_hello_buffer[..])
-        .unwrap();
+    let UnbufferedStatus { discard, state } =
+        server.process_tls_records(&mut client_hello_buffer[..]);
 
-    assert!(matches!(state, ConnectionState::EncodeTlsData(_)));
+    assert!(matches!(state.unwrap(), ConnectionState::EncodeTlsData(_)));
     assert_eq!(client_hello_buffer.len(), discard);
 }
 
@@ -935,21 +927,20 @@ fn server_receives_incorrect_first_handshake_message() {
     let (_, mut server) = make_connection_pair(&TLS13);
 
     let mut junk_buffer = [0x16, 0x3, 0x1, 0x0, 0x4, 0xff, 0x0, 0x0, 0x0];
+    let junk_buffer_len = junk_buffer.len();
 
-    let err = server
-        .process_tls_records(&mut junk_buffer[..])
-        .unwrap_err();
+    let UnbufferedStatus { discard, state } = server.process_tls_records(&mut junk_buffer[..]);
 
+    assert_eq!(discard, junk_buffer_len);
     assert_eq!(
-        format!("{err:?}"),
-        "InappropriateHandshakeMessage { expect_types: [ClientHello], got_type: Unknown(255) }"
+        format!("{state:?}"),
+        "Err(InappropriateHandshakeMessage { expect_types: [ClientHello], got_type: Unknown(255) })"
     );
 
-    let UnbufferedStatus { discard, state } = server
-        .process_tls_records(&mut junk_buffer[..])
-        .unwrap();
+    let UnbufferedStatus { discard, state } = server.process_tls_records(&mut []);
+    assert_eq!(discard, 0);
 
-    match state {
+    match state.unwrap() {
         ConnectionState::EncodeTlsData(mut inner) => {
             let mut alert_buffer = [0u8; 7];
             let wr = inner.encode(&mut alert_buffer).unwrap();
@@ -958,9 +949,4 @@ fn server_receives_incorrect_first_handshake_message() {
         }
         _ => panic!("unexpected alert sending state"),
     };
-
-    // XXX: error should be fused here.
-    let err = server
-        .process_tls_records(&mut junk_buffer[..])
-        .unwrap_err();
 }

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
 use rustls::server::{ServerConnectionData, UnbufferedServerConnection};
 use rustls::unbuffered::{
-    ConnectionState, WriteTraffic, UnbufferedConnectionCommon, UnbufferedStatus,
+    ConnectionState, UnbufferedConnectionCommon, UnbufferedStatus, WriteTraffic,
 };
+use rustls::version::TLS13;
 
 use crate::common::*;
 
@@ -27,6 +28,7 @@ fn handshake() {
                 State::EncodedTlsData => {}
                 State::TransmitTlsData {
                     sent_app_data: false,
+                    sent_early_data: false,
                 } => buffers.client_send(),
                 State::BlockedHandshake => buffers.server_send(),
                 State::WriteTraffic {
@@ -39,6 +41,7 @@ fn handshake() {
                 State::EncodedTlsData => {}
                 State::TransmitTlsData {
                     sent_app_data: false,
+                    sent_early_data: false,
                 } => buffers.server_send(),
                 State::BlockedHandshake => buffers.client_send(),
                 State::WriteTraffic {
@@ -68,6 +71,7 @@ fn app_data_client_to_server() {
 
         let mut client_actions = Actions {
             app_data_to_send: Some(expected),
+            ..NO_ACTIONS
         };
         let mut received_app_data = vec![];
         let mut count = 0;
@@ -76,7 +80,10 @@ fn app_data_client_to_server() {
         while !client_handshake_done || !server_handshake_done {
             match advance_client(&mut client, &mut buffers.client, client_actions) {
                 State::EncodedTlsData => {}
-                State::TransmitTlsData { sent_app_data } => {
+                State::TransmitTlsData {
+                    sent_app_data,
+                    sent_early_data: false,
+                } => {
                     buffers.client_send();
 
                     if sent_app_data {
@@ -99,6 +106,7 @@ fn app_data_client_to_server() {
                 State::EncodedTlsData => {}
                 State::TransmitTlsData {
                     sent_app_data: false,
+                    sent_early_data: false,
                 } => buffers.server_send(),
                 State::BlockedHandshake => buffers.client_send(),
                 State::ReceivedAppData { records } => {
@@ -139,6 +147,7 @@ fn app_data_server_to_client() {
 
         let mut server_actions = Actions {
             app_data_to_send: Some(expected),
+            ..NO_ACTIONS
         };
         let mut received_app_data = vec![];
         let mut count = 0;
@@ -149,6 +158,7 @@ fn app_data_server_to_client() {
                 State::EncodedTlsData => {}
                 State::TransmitTlsData {
                     sent_app_data: false,
+                    sent_early_data: false,
                 } => buffers.client_send(),
                 State::BlockedHandshake => buffers.server_send(),
                 State::WriteTraffic {
@@ -162,7 +172,10 @@ fn app_data_server_to_client() {
 
             match advance_server(&mut server, &mut buffers.server, server_actions) {
                 State::EncodedTlsData => {}
-                State::TransmitTlsData { sent_app_data } => {
+                State::TransmitTlsData {
+                    sent_app_data,
+                    sent_early_data: false,
+                } => {
                     buffers.server_send();
                     if sent_app_data {
                         server_actions.app_data_to_send = None;
@@ -197,22 +210,113 @@ fn app_data_server_to_client() {
     }
 }
 
+#[test]
+fn early_data() {
+    let expected: &[_] = b"hello";
+
+    let mut server_config = make_server_config(KeyType::Rsa);
+    server_config.max_early_data_size = 128;
+    let server_config = Arc::new(server_config);
+
+    let mut client_config = make_client_config_with_versions(KeyType::Rsa, &[&TLS13]);
+    client_config.enable_early_data = true;
+    let client_config = Arc::new(client_config);
+
+    for conn_count in 0..2 {
+        eprintln!("----");
+        let mut client =
+            UnbufferedClientConnection::new(client_config.clone(), server_name("localhost"))
+                .unwrap();
+        let mut server = UnbufferedServerConnection::new(server_config.clone()).unwrap();
+        let mut buffers = BothBuffers::default();
+
+        let mut client_actions = Actions {
+            early_data_to_send: Some(expected),
+            ..NO_ACTIONS
+        };
+        let mut received_early_data = vec![];
+        let mut count = 0;
+        let mut client_handshake_done = false;
+        let mut server_handshake_done = false;
+        while !client_handshake_done || !server_handshake_done {
+            match advance_client(&mut client, &mut buffers.client, client_actions) {
+                State::EncodedTlsData => {}
+                State::TransmitTlsData {
+                    sent_app_data: false,
+                    sent_early_data,
+                } => {
+                    buffers.client_send();
+
+                    if sent_early_data {
+                        client_actions.early_data_to_send = None;
+                    }
+                }
+                State::BlockedHandshake => buffers.server_send(),
+                State::WriteTraffic {
+                    sent_app_data: false,
+                } => client_handshake_done = true,
+                state => unreachable!("{state:?}"),
+            }
+
+            match advance_server(&mut server, &mut buffers.server, NO_ACTIONS) {
+                State::EncodedTlsData => {}
+                State::TransmitTlsData {
+                    sent_app_data: false,
+                    sent_early_data: false,
+                } => buffers.server_send(),
+                State::BlockedHandshake => buffers.client_send(),
+                State::WriteTraffic {
+                    sent_app_data: false,
+                } => server_handshake_done = true,
+                State::ReceivedEarlyData { records } => {
+                    received_early_data.extend(records);
+                }
+                state => unreachable!("{state:?}"),
+            }
+
+            count += 1;
+
+            assert!(count <= MAX_ITERATIONS, "handshake was not completed");
+        }
+
+        // early data is not exchanged on the first server interaction
+        if conn_count == 1 {
+            assert!(client_actions
+                .early_data_to_send
+                .is_none());
+            assert_eq!([expected], received_early_data.as_slice());
+        }
+    }
+}
+
 #[derive(Debug)]
 enum State {
     EncodedTlsData,
-    TransmitTlsData { sent_app_data: bool },
+    TransmitTlsData {
+        sent_app_data: bool,
+        sent_early_data: bool,
+    },
     BlockedHandshake,
-    ReceivedAppData { records: Vec<Vec<u8>> },
-    WriteTraffic { sent_app_data: bool },
+    ReceivedAppData {
+        records: Vec<Vec<u8>>,
+    },
+    ReceivedEarlyData {
+        records: Vec<Vec<u8>>,
+    },
+    WriteTraffic {
+        sent_app_data: bool,
+    },
 }
 
 const NO_ACTIONS: Actions = Actions {
     app_data_to_send: None,
+    early_data_to_send: None,
 };
 
 #[derive(Clone, Copy, Debug)]
 struct Actions<'a> {
     app_data_to_send: Option<&'a [u8]>,
+    early_data_to_send: Option<&'a [u8]>,
 }
 
 fn advance_client(
@@ -224,7 +328,27 @@ fn advance_client(
         .process_tls_records(buffers.incoming.filled())
         .unwrap();
 
-    let state = handle_state(state, &mut buffers.outgoing, actions);
+    let state = match state {
+        ConnectionState::TransmitTlsData(mut state) => {
+            let mut sent_early_data = false;
+            if let Some(early_data) = actions.early_data_to_send {
+                if let Some(mut state) = state.may_encrypt_early_data() {
+                    let written = state
+                        .encrypt(early_data, buffers.outgoing.unfilled())
+                        .unwrap();
+                    buffers.outgoing.advance(written);
+                    sent_early_data = true;
+                }
+            }
+            state.done();
+            State::TransmitTlsData {
+                sent_app_data: false,
+                sent_early_data,
+            }
+        }
+
+        state => handle_state(state, &mut buffers.outgoing, actions),
+    };
     buffers.incoming.discard(discard);
 
     state
@@ -239,7 +363,19 @@ fn advance_server(
         .process_tls_records(buffers.incoming.filled())
         .unwrap();
 
-    let state = handle_state(state, &mut buffers.outgoing, actions);
+    let state = match state {
+        ConnectionState::ReadEarlyData(mut state) => {
+            let mut records = vec![];
+
+            while let Some(res) = state.next_record() {
+                records.push(res.unwrap().payload.to_vec());
+            }
+
+            State::ReceivedEarlyData { records }
+        }
+
+        state => handle_state(state, &mut buffers.outgoing, actions),
+    };
     buffers.incoming.discard(discard);
 
     state
@@ -272,7 +408,10 @@ fn handle_state<Data>(
             // this should be called *after* the data has been transmitted but it's easier to
             // do it in reverse
             state.done();
-            State::TransmitTlsData { sent_app_data }
+            State::TransmitTlsData {
+                sent_app_data,
+                sent_early_data: false,
+            }
         }
 
         ConnectionState::BlockedHandshake { .. } => State::BlockedHandshake,


### PR DESCRIPTION
supersedes #1578 ~~but I'm not closing that one just yet because this one is still WIP~~

I took a different approach and tried to first move the buffers out from `CommonState` into `ConnectionCommon` to implement `ConnectionCommon` on top of `UnbufferedConnectionCommon` ; that turned out to be a non-trivial exercise. Then I tried the same "unbuffering" exercise with `MessageDeframer` and that turned out to be relatively straightforward. That's when I realized that as a more incremental step we can implement `UnbufferedConnectionCommon` on top of the current, buffered `CommonState` while still achieving the goal of not depending on IO traits or anything else from the `std` crate. So that's what this PR does (I haven't finished moving the server and early data stuff over from #1578 )

I did some renaming while copying over bits from #1578 