### PR TITLE
crypto: add HPKE module and traits, provider-example impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +171,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -401,6 +432,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +452,15 @@ dependencies = [
  "generic-array",
  "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -439,6 +491,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +527,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -495,10 +569,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -533,6 +642,16 @@ checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -619,6 +738,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -628,8 +748,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -643,6 +775,17 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -680,6 +823,12 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
@@ -737,12 +886,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -763,6 +921,49 @@ dependencies = [
  "libc",
  "match_cfg",
  "winapi",
+]
+
+[[package]]
+name = "hpke-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be3c089364da994102385ce2bed54c7e86e190da41e0125e0213f2c061786395"
+dependencies = [
+ "hpke-rs-crypto",
+ "log",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-crypto"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc863a0678d194f682f20790336ea8ef4ddc748abab61a9533ac5aa1e9d27d9"
+dependencies = [
+ "getrandom",
+ "rand",
+ "serde",
+ "serde_json",
+ "tls_codec",
+]
+
+[[package]]
+name = "hpke-rs-rust-crypto"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c0b07cafc144f03466bf2692db1616134152a6f49afc42e86c929b756876dd"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "getrandom",
+ "hkdf",
+ "hpke-rs-crypto",
+ "p256",
+ "p384",
+ "rand",
+ "rand_chacha",
+ "sha2",
+ "x25519-dalek-ng",
 ]
 
 [[package]]
@@ -1082,6 +1283,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1417,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1448,15 @@ checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7dbe9ed3b56368bd99483eb32fe9c17fdd3730aebadc906918ce78d54c7eeb4"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1348,6 +1594,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,7 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -1536,12 +1792,18 @@ dependencies = [
  "chacha20poly1305",
  "der",
  "env_logger",
+ "hex",
  "hmac",
+ "hpke-rs",
+ "hpke-rs-crypto",
+ "hpke-rs-rust-crypto",
  "rand_core",
  "rsa",
  "rustls 0.22.0-alpha.4",
  "rustls-pki-types",
  "rustls-webpki 0.102.0-alpha.6",
+ "serde",
+ "serde_json",
  "sha2",
  "webpki-roots 0.26.0-alpha.1",
  "x25519-dalek",
@@ -1576,6 +1838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1857,20 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring 0.17.5",
  "untrusted 0.9.0",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1618,6 +1900,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,7 +1918,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1636,11 +1929,11 @@ checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
 ]
 
@@ -1702,6 +1995,12 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -1775,6 +2074,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1e621cbf57f36f5b51ebf366b57ba153be7fed133182a9513e443ecdf506e"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3226440488120aabe7e7cc80292634a68e541c407d97b66eceaae787454dae25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -2138,6 +2458,18 @@ dependencies = [
  "curve25519-dalek",
  "rand_core",
  "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek-ng"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7074de8999662970c3c4c8f7f30925028dd8f4ca31ad4c055efa9cdf2ec326"
+dependencies = [
+ "curve25519-dalek-ng",
+ "rand",
+ "rand_core",
  "zeroize",
 ]
 

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -11,6 +11,9 @@ chacha20poly1305 = "0.10.0"
 der = "0.7.0"
 env_logger = "0.10"
 hmac = "0.12.0"
+hpke-rs = "0.1.0"
+hpke-rs-crypto = "0.1.2"
+hpke-rs-rust-crypto = "0.1.2"
 pki-types = { package = "rustls-pki-types", version = "0.2.0" }
 rand_core = "0.6.0"
 rustls = { path = "../rustls", default-features = false, features = ["logging", "tls12"] }
@@ -19,3 +22,8 @@ sha2 = "0.10.0"
 webpki = { package = "rustls-webpki", version = "0.102.0-alpha.1", default-features = false, features = ["alloc", "std"] }
 webpki-roots = "0.26.0-alpha.1"
 x25519-dalek = "2"
+
+[dev-dependencies]
+hex = "0.4.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -1,0 +1,97 @@
+use std::fmt::{Debug, Formatter};
+
+use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
+use hpke_rs_crypto::HpkeCrypto;
+use hpke_rs_rust_crypto::HpkeRustCrypto;
+
+use rustls::crypto::hpke::{
+    EncapsulatedSecret, Hpke, HpkePrivateKey, HpkeProvider, HpkePublicKey, HpkeSuite,
+};
+use rustls::Error;
+
+pub static HPKE_PROVIDER: &'static dyn HpkeProvider = &HpkeRsProvider {};
+
+/// A Rustls HPKE provider backed by hpke-rs.
+#[derive(Debug)]
+struct HpkeRsProvider {}
+
+impl HpkeProvider for HpkeRsProvider {
+    fn start(&self, suite: &HpkeSuite) -> Result<Box<dyn Hpke>, Error> {
+        Ok(Box::new(HpkeRs(hpke_rs::Hpke::new(
+            hpke_rs::Mode::Base,
+            KemAlgorithm::try_from(suite.kem.get_u16()).map_err(general_err)?,
+            KdfAlgorithm::try_from(suite.sym.kdf_id.get_u16()).map_err(general_err)?,
+            AeadAlgorithm::try_from(suite.sym.aead_id.get_u16()).map_err(general_err)?,
+        ))))
+    }
+
+    fn supports_suite(&self, suite: &HpkeSuite) -> bool {
+        let kem = KemAlgorithm::try_from(suite.kem.get_u16()).ok();
+        let kdf = KdfAlgorithm::try_from(suite.sym.kdf_id.get_u16()).ok();
+        let aead = AeadAlgorithm::try_from(suite.sym.aead_id.get_u16()).ok();
+        match (kem, kdf, aead) {
+            (Some(kem), Some(kdf), Some(aead)) => {
+                HpkeRustCrypto::supports_kem(kem).is_ok()
+                    && HpkeRustCrypto::supports_kdf(kdf).is_ok()
+                    && HpkeRustCrypto::supports_aead(aead).is_ok()
+            }
+            _ => false,
+        }
+    }
+}
+
+struct HpkeRs(hpke_rs::Hpke<HpkeRustCrypto>);
+
+impl Debug for HpkeRs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HpkeRsHpke").finish()
+    }
+}
+
+impl Hpke for HpkeRs {
+    fn seal(
+        &mut self,
+        pk_r: &HpkePublicKey,
+        info: &[u8],
+        aad: &[u8],
+        plaintext: &[u8],
+    ) -> Result<(EncapsulatedSecret, Vec<u8>), Error> {
+        let pk_r = hpke_rs::HpkePublicKey::new(pk_r.0.clone());
+        let (enc, ciphertext) = self
+            .0
+            .seal(&pk_r, info, aad, plaintext, None, None, None)
+            .map_err(general_err)?;
+        Ok((EncapsulatedSecret(enc.to_vec()), ciphertext))
+    }
+
+    fn open(
+        &mut self,
+        enc: &EncapsulatedSecret,
+        sk_r: &HpkePrivateKey,
+        info: &[u8],
+        aad: &[u8],
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>, Error> {
+        let sk_r = hpke_rs::HpkePrivateKey::new(sk_r.secret_bytes().to_vec());
+        self.0
+            .open(
+                enc.0.as_slice(),
+                &sk_r,
+                info,
+                aad,
+                ciphertext,
+                None,
+                None,
+                None,
+            )
+            .map_err(general_err)
+    }
+}
+
+// TODO(XXX): Switch to using `Error::Other(Error::OtherError(err))` once a hpke-rs release
+//   with https://github.com/franziskuskiefer/hpke-rs/pull/44 is available.
+fn general_err(err: impl Debug) -> Error {
+    // Presently hpke_rs::HpkeError does not implement std::error::Error, so we use Debug
+    // and create a general error.
+    Error::General(format!("{:?}", err))
+}

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -4,8 +4,11 @@ use std::sync::Arc;
 mod aead;
 mod hash;
 mod hmac;
+mod hpke;
 mod kx;
 mod verify;
+
+pub use hpke::HPKE_PROVIDER;
 
 pub static PROVIDER: &'static dyn rustls::crypto::CryptoProvider = &Provider;
 

--- a/provider-example/tests/hpke.rs
+++ b/provider-example/tests/hpke.rs
@@ -1,0 +1,88 @@
+use std::fs::File;
+
+use serde::Deserialize;
+
+use rustls::crypto::hpke::{HpkePrivateKey, HpkePublicKey, HpkeSuite};
+use rustls::internal::msgs::enums::{HpkeAead, HpkeKdf, HpkeKem};
+use rustls::internal::msgs::handshake::HpkeSymmetricCipherSuite;
+use rustls_provider_example::HPKE_PROVIDER;
+
+/// Confirm opne/seal operations work using using the test vectors from [RFC 9180 Appendix A].
+///
+/// [RFC 9180 Appendix A]: https://www.rfc-editor.org/rfc/rfc9180#TestVectors
+#[test]
+fn check_test_vectors() {
+    for (idx, vec) in test_vectors().into_iter().enumerate() {
+        if !vec.applicable() {
+            println!("skipping inapplicable vector {idx}");
+            continue;
+        }
+
+        println!("testing vector {idx}");
+        let mut hpke = HPKE_PROVIDER
+            .start(&vec.suite())
+            .unwrap();
+        let pk_r = HpkePublicKey(hex::decode(vec.pk_rm).unwrap());
+        let sk_r = HpkePrivateKey::from(hex::decode(vec.sk_rm).unwrap());
+        let info = hex::decode(vec.info).unwrap();
+
+        for enc in vec.encryptions {
+            let aad = hex::decode(enc.aad).unwrap();
+            let pt = hex::decode(enc.pt).unwrap();
+
+            let (enc, ciphertext) = hpke
+                .seal(&pk_r, &info, &aad, &pt)
+                .unwrap();
+
+            let plaintext = hpke
+                .open(&enc, &sk_r, &info, &aad, &ciphertext)
+                .unwrap();
+            assert_eq!(plaintext, pt);
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct TestVector {
+    mode: u8,
+    kem_id: u16,
+    kdf_id: u16,
+    aead_id: u16,
+    info: String,
+    #[serde(rename(deserialize = "pkRm"))]
+    pk_rm: String,
+    #[serde(rename(deserialize = "skRm"))]
+    sk_rm: String,
+    encryptions: Vec<TestEncryption>,
+}
+
+#[derive(Deserialize, Debug)]
+struct TestEncryption {
+    aad: String,
+    pt: String,
+}
+
+impl TestVector {
+    fn suite(&self) -> HpkeSuite {
+        HpkeSuite {
+            kem: HpkeKem::from(self.kem_id),
+            sym: HpkeSymmetricCipherSuite {
+                kdf_id: HpkeKdf::from(self.kdf_id),
+                aead_id: HpkeAead::from(self.aead_id),
+            },
+        }
+    }
+
+    fn applicable(&self) -> bool {
+        // Only base mode test vectors for supported suites are applicable.
+        self.mode == 0 && HPKE_PROVIDER.supports_suite(&self.suite())
+    }
+}
+
+fn test_vectors() -> Vec<TestVector> {
+    serde_json::from_reader(
+        &mut File::open("tests/rfc-9180-test-vectors.json")
+            .expect("failed to open test vectors data file"),
+    )
+    .expect("failed to deserialize test vectors")
+}

--- a/rustls/src/crypto/hpke.rs
+++ b/rustls/src/crypto/hpke.rs
@@ -1,0 +1,98 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::fmt::Debug;
+
+use crate::msgs::enums::HpkeKem;
+use crate::msgs::handshake::HpkeSymmetricCipherSuite;
+use crate::Error;
+
+/// A provider for [RFC 9180] Hybrid Public Key Encryption (HPKE) in base mode.
+///
+/// At a minimum each provider must support the [HPKE ciphersuite profile] required for
+/// encrypted client hello (ECH):
+///  * KEM: DHKEM(X25519, HKDF-SHA256)
+///  * symmetric ciphersuite:  AES-128-GCM w/ HKDF-SHA256
+///
+/// [RFC 9180]: <https://www.rfc-editor.org/rfc/rfc9180.html>
+/// [HPKE ciphersuite profile]: <https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-17#section-9>
+pub trait HpkeProvider: Debug + Send + Sync + 'static {
+    /// Start setting up to use HPKE in base mode with the chosen suite.
+    ///
+    /// May return an error if the suite is unsupported by the provider.
+    fn start(&self, suite: &HpkeSuite) -> Result<Box<dyn Hpke>, Error>;
+
+    /// Does the provider support the given [HpkeSuite]?
+    fn supports_suite(&self, suite: &HpkeSuite) -> bool;
+}
+
+/// An HPKE suite, specifying a key encapsulation mechanism and a symmetric cipher suite.
+pub struct HpkeSuite {
+    /// The choice of HPKE key encapsulation mechanism.
+    pub kem: HpkeKem,
+
+    /// The choice of HPKE symmetric cipher suite.
+    ///
+    /// This combines a choice of authenticated encryption with additional data (AEAD) algorithm
+    /// and a key derivation function (KDF).
+    pub sym: HpkeSymmetricCipherSuite,
+}
+
+/// An HPKE instance that can be used for base-mode single-shot encryption and decryption.
+pub trait Hpke: Debug + Send + Sync {
+    /// Seal the provided `plaintext` to the recipient public key `pk_r` with application supplied
+    /// `info`, and additional data `aad`.
+    ///
+    /// Returns ciphertext that can be used with [Self::open] by the recipient to recover plaintext
+    /// using the same `info` and `aad` and the private key corresponding to `pk_r`.
+    fn seal(
+        &mut self,
+        pk_r: &HpkePublicKey,
+        info: &[u8],
+        aad: &[u8],
+        plaintext: &[u8],
+    ) -> Result<(EncapsulatedSecret, Vec<u8>), Error>;
+
+    /// Open the provided `ciphertext` using the encapsulated secret `enc`, with application
+    /// supplied `info`, and additional data `aad`.
+    ///
+    /// Returns plaintext if  the `info` and `aad` match those used with [Self::seal], and
+    /// decryption with `sk_r` succeeds.
+    fn open(
+        &mut self,
+        enc: &EncapsulatedSecret,
+        sk_r: &HpkePrivateKey,
+        info: &[u8],
+        aad: &[u8],
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>, Error>;
+}
+
+/// An HPKE public key.
+pub struct HpkePublicKey(pub Vec<u8>);
+
+/// An HPKE private key.
+pub struct HpkePrivateKey(Vec<u8>);
+
+impl HpkePrivateKey {
+    /// Return the private key bytes.
+    pub fn secret_bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl From<Vec<u8>> for HpkePrivateKey {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
+/// An HPKE key pair, made of a matching public and private key.
+pub struct HpkeKeyPair {
+    /// A HPKE public key.
+    pub public_key: HpkePublicKey,
+    /// A HPKE private key.
+    pub private_key: HpkePrivateKey,
+}
+
+/// An encapsulated secret returned from setting up a sender or receiver context.
+pub struct EncapsulatedSecret(pub Vec<u8>);

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -37,6 +37,9 @@ pub mod tls12;
 /// Cryptography specific to TLS1.3.
 pub mod tls13;
 
+/// Hybrid public key encryption (RFC 9180).
+pub mod hpke;
+
 pub use crate::rand::GetRandomFailed;
 
 pub use crate::msgs::handshake::KeyExchangeAlgorithm;


### PR DESCRIPTION
This branch introduces a trait for a hybrid public key encryption (HPKE) provider. HPKE is specified in [RFC 9180](https://www.rfc-editor.org/rfc/rfc9180), and is a pre-requisite for implementing [encrypted client hello (ECH)](https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-17). Implementations of these traits can use the cryptographic provider of their choice to provide HPKE using existing primitives from the crypto provider.

We've tailored the HPKE trait in Rustls to just what is required for ECH, e.g. it doesn't support modes other than the unauthenticated 'base' mode, and it only offers the "single-shot" APIs.

Demonstration of implementing the traits is achieved using [hpke-rs](https://github.com/franziskuskiefer/hpke-rs) with the rust-crypto backend.  Separately we expect to implement a HPKE provider using the *ring* crypto provider for proper ECH support. 

Since the HPKE traits are not yet used in Rustls a unit test of the provider-example HPKE provider based on the RFC 9180 test vectors is added to prevent bitrot and ensure the traits are workable. Likely in the future we will want to move this test logic somewhere outside of the provider-example crate and use it to test the other HPKE provider implementations.