### PR TITLE
lib: export crate::error::OtherError

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -440,7 +440,7 @@ pub use crate::enums::{
     SignatureScheme,
 };
 pub use crate::error::{
-    CertRevocationListError, CertificateError, Error, InvalidMessage, PeerIncompatible,
+    CertRevocationListError, CertificateError, Error, InvalidMessage, OtherError, PeerIncompatible,
     PeerMisbehaved,
 };
 pub use crate::key_log::{KeyLog, NoKeyLog};


### PR DESCRIPTION
Recently the `error::Error` enum was updated with a `Error::Other` variant that holds an `error::OtherError` instance (https://github.com/rustls/rustls/pull/1575). We neglected to export the `OtherError` type, so this variant ends up opaque. This commit exports the type so that crate-external users can instantiate an `Error::Other` variant as needed. I wasn't able to use this new error type in https://github.com/rustls/rustls/pull/1589 for unrelated reasons, but bumped into this oversight when considering it.