### PR TITLE
move sendable_plaintext from CommonState to ConnectionCommon

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -657,6 +657,8 @@ impl ConnectionCore<ClientConnectionData> {
         let mut cx = hs::ClientContext {
             common: &mut common_state,
             data: &mut data,
+            // `start_handshake` won't produce plaintext
+            sendable_plaintext: None,
         };
 
         let state = hs::start_handshake(name, extra_exts, config, &mut cx)?;

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1032,7 +1032,8 @@ impl State<ClientConnectionData> for ExpectFinished {
             emit_finished(&st.secrets, &mut st.transcript, cx.common);
         }
 
-        cx.common.start_traffic();
+        cx.common
+            .start_traffic(&mut cx.sendable_plaintext);
         Ok(Box::new(ExpectTraffic {
             secrets: st.secrets,
             _cert_verified: st.cert_verified,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -895,7 +895,8 @@ impl State<ClientConnectionData> for ExpectFinished {
         /* Now move to our application traffic keys. */
         cx.common.check_aligned_handshake()?;
         let key_schedule_traffic = key_schedule_pre_finished.into_traffic(cx.common);
-        cx.common.start_traffic();
+        cx.common
+            .start_traffic(&mut cx.sendable_plaintext);
 
         let st = ExpectTraffic {
             session_storage: Arc::clone(&st.config.resumption.store),

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -333,6 +333,11 @@ impl CommonState {
             return len;
         }
 
+        self.send_plain_non_buffering(data, limit)
+    }
+
+    fn send_plain_non_buffering(&mut self, data: &[u8], limit: Limit) -> usize {
+        debug_assert!(self.may_send_application_data);
         debug_assert!(self.record_layer.is_encrypting());
 
         if data.is_empty() {
@@ -409,7 +414,7 @@ impl CommonState {
         }
 
         while let Some(buf) = self.sendable_plaintext.pop() {
-            self.send_plain(&buf, Limit::No);
+            self.send_plain_non_buffering(&buf, Limit::No);
         }
     }
 

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -98,7 +98,7 @@ impl<Data> UnbufferedConnectionCommon<Data> {
                         }
                     };
 
-                match self.core.process_msg(msg, state) {
+                match self.core.process_msg(msg, state, None) {
                     Ok(new) => state = new,
 
                     Err(e) => {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -908,7 +908,8 @@ impl State<ServerConnectionData> for ExpectFinished {
             emit_finished(&self.secrets, &mut self.transcript, cx.common);
         }
 
-        cx.common.start_traffic();
+        cx.common
+            .start_traffic(&mut cx.sendable_plaintext);
         Ok(Box::new(ExpectTraffic {
             secrets: self.secrets,
             _fin_verified,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -442,7 +442,8 @@ mod client_hello {
                 // Application data can be sent immediately after Finished, in one
                 // flight.  However, if client auth is enabled, we don't want to send
                 // application data to an unauthenticated peer.
-                cx.common.start_outgoing_traffic();
+                cx.common
+                    .start_outgoing_traffic(&mut cx.sendable_plaintext);
             }
 
             if doing_client_auth {
@@ -1187,7 +1188,8 @@ impl State<ServerConnectionData> for ExpectFinished {
         }
 
         // Application data may now flow, even if we have client auth enabled.
-        cx.common.start_traffic();
+        cx.common
+            .start_traffic(&mut cx.sendable_plaintext);
 
         Ok(match cx.common.is_quic() {
             true => Box::new(ExpectQuicTraffic {


### PR DESCRIPTION
this is a refactor that follows up from #1583 and removes one of the 3 internal buffers in `CommonState` so that the `UnbufferedConnection` API does not inherit it.

breaking changes:

- `CommonState::set_buffer_limit` was moved into `ConnectionCommon`. this is technically a breaking change but users of the `set_buffer_limit` API through `ConnectionCommon` and `Connection` won't notice the change. in fact, none of the existing examples / tests required changes due to this "breaking" change

this PR is best reviewed on a commit by commit basis (do skip the PR1583 commits)