### PR TITLE
v0.21.9 preparation

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.21.8"
+version = "0.21.9"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -197,7 +197,7 @@ impl<'a> io::Read for Reader<'a> {
     /// You may learn the number of bytes available at any time by inspecting
     /// the return of [`Connection::process_new_packets`].
     #[cfg(read_buf)]
-    fn read_buf(&mut self, mut cursor: io::BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, mut cursor: core::io::BorrowedCursor<'_>) -> io::Result<()> {
         let before = cursor.written();
         self.received_plaintext
             .read_buf(cursor.reborrow())?;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -305,6 +305,7 @@
 // is used to avoid needing `rustversion` to be compiled twice during
 // cross-compiling.
 #![cfg_attr(read_buf, feature(read_buf))]
+#![cfg_attr(read_buf, feature(core_io_borrowed_buf))]
 #![cfg_attr(bench, feature(test))]
 
 // Import `test` sysroot crate for `Bencher` definitions.

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -358,7 +358,7 @@ impl<'a> std::io::Read for ReadEarlyData<'a> {
     }
 
     #[cfg(read_buf)]
-    fn read_buf(&mut self, cursor: io::BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: core::io::BorrowedCursor<'_>) -> io::Result<()> {
         self.early_data.read_buf(cursor)
     }
 }
@@ -718,7 +718,7 @@ impl EarlyDataState {
     }
 
     #[cfg(read_buf)]
-    fn read_buf(&mut self, cursor: io::BorrowedCursor<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, cursor: core::io::BorrowedCursor<'_>) -> io::Result<()> {
         match self {
             Self::Accepted(ref mut received) => received.read_buf(cursor),
             _ => Err(io::Error::from(io::ErrorKind::BrokenPipe)),

--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -66,7 +66,7 @@ where
     }
 
     #[cfg(read_buf)]
-    fn read_buf(&mut self, cursor: std::io::BorrowedCursor<'_>) -> Result<()> {
+    fn read_buf(&mut self, cursor: core::io::BorrowedCursor<'_>) -> Result<()> {
         self.complete_prior_io()?;
 
         // We call complete_io() in a loop since a single call may read only
@@ -194,7 +194,7 @@ where
     }
 
     #[cfg(read_buf)]
-    fn read_buf(&mut self, cursor: std::io::BorrowedCursor<'_>) -> Result<()> {
+    fn read_buf(&mut self, cursor: core::io::BorrowedCursor<'_>) -> Result<()> {
         self.as_stream().read_buf(cursor)
     }
 }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -107,7 +107,7 @@ impl ChunkVecBuffer {
 
     #[cfg(read_buf)]
     /// Read data out of this object, writing it into `cursor`.
-    pub(crate) fn read_buf(&mut self, mut cursor: io::BorrowedCursor<'_>) -> io::Result<()> {
+    pub(crate) fn read_buf(&mut self, mut cursor: core::io::BorrowedCursor<'_>) -> io::Result<()> {
         while !self.is_empty() && cursor.capacity() > 0 {
             let chunk = self.chunks[0].as_slice();
             let used = std::cmp::min(chunk.len(), cursor.capacity());
@@ -167,7 +167,8 @@ mod test {
     #[cfg(read_buf)]
     #[test]
     fn read_buf() {
-        use std::{io::BorrowedBuf, mem::MaybeUninit};
+        use core::io::BorrowedBuf;
+        use core::mem::MaybeUninit;
 
         {
             let mut cvb = ChunkVecBuffer::new(None);

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -193,7 +193,8 @@ fn check_read_err(reader: &mut dyn io::Read, err_kind: io::ErrorKind) {
 
 #[cfg(read_buf)]
 fn check_read_buf(reader: &mut dyn io::Read, bytes: &[u8]) {
-    use std::{io::BorrowedBuf, mem::MaybeUninit};
+    use core::io::BorrowedBuf;
+    use std::mem::MaybeUninit;
 
     let mut buf = [MaybeUninit::<u8>::uninit(); 128];
     let mut buf: BorrowedBuf<'_> = buf.as_mut_slice().into();
@@ -203,7 +204,8 @@ fn check_read_buf(reader: &mut dyn io::Read, bytes: &[u8]) {
 
 #[cfg(read_buf)]
 fn check_read_buf_err(reader: &mut dyn io::Read, err_kind: io::ErrorKind) {
-    use std::{io::BorrowedBuf, mem::MaybeUninit};
+    use core::io::BorrowedBuf;
+    use std::mem::MaybeUninit;
 
     let mut buf = [MaybeUninit::<u8>::uninit(); 1];
     let mut buf: BorrowedBuf<'_> = buf.as_mut_slice().into();

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(read_buf, feature(read_buf))]
+#![cfg_attr(read_buf, feature(core_io_borrowed_buf))]
 //! Assorted public API tests.
 use std::cell::RefCell;
 use std::fmt;


### PR DESCRIPTION
## Description

This PR targets the `rel-0.21` feature branch, preparing a `0.21.9` release. It backports https://github.com/rustls/rustls/pull/1582 to fix build issues with downstream crates that were using the `read_buf` feature with Rust nightly (e.g. `rustls-ffi`).

## Proposed Release Notes

* Fixes using the (non-default) `read_buf` feature with Rust nightly newer than `nightly-2023-11-01` by opting in to the `core_io_borrowed_buf` feature and updated `BorrowedBuf`, `BorrowedCursor` types.