### PR TITLE
Add wall-time mode for CI benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ name = "rustls-ci-bench"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "byteorder",
  "clap",
  "fxhash",

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.73"
+async-trait = "0.1.74"
 byteorder = "1.4.3"
 clap = { version = "4.3.21", features = ["derive"] }
 fxhash = "0.2.1"

--- a/ci-bench/README.md
+++ b/ci-bench/README.md
@@ -1,14 +1,17 @@
 # CI Bench
 
-This crate is meant for CI benchmarking. It measures CPU instructions using `cachegrind`, outputs
-the results in CSV format and allows comparing results from multiple runs.
+This crate is meant for CI benchmarking. It has two modes of operation:
+
+1. Measure CPU instructions using `cachegrind`.
+2. Measure wall-time (runs each benchmark multiple times, leaving it to the caller to do statistical
+   analysis).
 
 ## Usage
 
 You can get detailed usage information through `cargo run --release -- --help`. Below are the most
 important bits.
 
-### Running all benchmarks
+### Running all benchmarks in instruction count mode
 
 _Note: this step requires having `valgrind` in your path._
 
@@ -37,7 +40,24 @@ are useful to report detailed instruction count differences when comparing two b
 subdirectory also contains log information from cachegrind itself (in `.log` files), which can be
 used to diagnose unexpected cachegrind crashes.
 
-### Comparing results
+### Running all benchmarks in wall-time mode
+
+Use `cargo run --release -- walltime --iterations-per-scenario 3` to print the CSV results to stdout
+(we use 3 iterations here for demonstration purposes, but recommend 100 iterations to deal with
+noise). The output should look like the following (one column per iteration):
+
+```csv
+handshake_no_resume_ring_1.2_rsa_aes,6035261,1714158,977368
+handshake_session_id_ring_1.2_rsa_aes,1537632,2445849,1766888
+handshake_tickets_ring_1.2_rsa_aes,1553743,2418286,1636431
+transfer_no_resume_ring_1.2_rsa_aes,10192862,10374258,8988854
+handshake_no_resume_ring_1.3_rsa_aes,1010150,1400602,936029
+...
+... rest omitted for brevity
+...
+```
+
+### Comparing results from an instruction count benchmark run
 
 Use `cargo run --release -- compare foo bar`. It will output a report using GitHub-flavored markdown
 (used by the CI itself to give feedback about PRs). We currently consider differences of 0.2% to be
@@ -62,17 +82,19 @@ with names like `transfer_no_resume_1.3_rsa_aes_client`.
 We have made an effort to heavily document the source code of the benchmarks. In addition to that,
 here are some high-level considerations that can help you hack on the crate.
 
-### Architecture
+### Environment configuration
 
-An important goal of this benchmarking setup is that it should run with minimum noise on
-standard GitHub Actions runners. We achieve that by measuring CPU instructions using `cachegrind`,
-which runs fine on the cloud (contrary to hardware instruction counters). This is the same
-approach used by the [iai](https://crates.io/crates/iai) benchmarking crate, but we needed more
-flexibility and have therefore rolled our own setup.
+An important goal of this benchmarking setup is that it should run with minimal noise. Measuring CPU
+instructions using `cachegrind` yields excellent results, regardless of your environment. The
+wall-time benchmarks, however, require a more elaborate benchmarking environment: running them on a
+laptop is too noisy, but running them on a carefully configured bare-metal server yields accurate
+measurements (up to 1% resolution, according to our tests).
+
+### Instruction count mode
 
 Using `cachegrind` has some architectural consequences because it operates at the process level
-(i.e. it can count CPU instructions for a whole process, but not for a single function). The
-most important consequences are:
+(i.e. it can count CPU instructions for a whole process, but not for a single function). The most
+important consequences when running in instruction count mode are:
 
 - Since we want to measure server and client instruction counts separately, the benchmark runner
   spawns two child processes for each benchmark (one for the client, one for the server) and pipes
@@ -85,18 +107,36 @@ most important consequences are:
   subtracted from it. We are currently using this to subtract the handshake instructions from the
   data transfer benchmark.
 
-### Debugging
-
-If you need to debug the crate, here are a few tricks that might help:
+If you need to debug benchmarks in instruction count mode, here are a few tricks that might help:
 
 - For printf debugging, you should use `eprintln!`, because child processes use stdio as the
   transport for the TLS connection (i.e. if you print something to stdout, you won't even see it
   _and_ the other side of the connection will choke on it).
 - When using a proper debugger, remember that each side of the connection runs as a child process.
-  If necessary, you can tweak the code to ensure both sides of the connection run on the parent
-  process (e.g. by starting each side on its own thread and having them communicate through TCP).
-  This should require little effort, because the TLS transport layer is encapsulated and generic
-  over `Read` and `Write`.
+
+### Wall-time mode
+
+To increase determinism, it is important that wall-time mode benchmarks run in a single process and
+thread. All IO is done in-memory and there is no complex setup like in the case of the instruction
+counting mode. Because of this, the easiest way to debug the crate is by running the benchmarks in
+wall-time mode.
+
+### Code reuse between benchmarking modes
+
+Originally, we only supported the instruction count mode, implemented using blocking IO. Even though
+the code was generic over the `Reader` and `Writer`, it could not be reused for the wall-time mode
+because it was blocking (e.g. if the client side of the connection is waiting for a read, the thread
+is blocked and the server never gets a chance to write).
+
+The solution was to:
+
+1. Rewrite the IO code to use async / await.
+2. Keep using blocking operations under the hood in instruction-count mode, disguised as `Future`s
+   that complete after a single `poll`. This way we avoid using an async runtime, which could
+   introduce non-determinism.
+3. Use non-blocking operations under the hood in wall-time mode, which simulate IO through shared
+   in-memory buffers. The server and client `Future`s are polled in turns, so again we we avoid
+   pulling in an async runtime and keep things as deterministic as possible.
 
 ### Why measure CPU instructions
 

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -153,8 +153,7 @@ fn main() -> anyhow::Result<()> {
             let mut stdout = unsafe { File::from_raw_fd(stdout_lock.as_raw_fd()) };
 
             let handshake_buf = &mut [0u8; DEFAULT_BUFFER_SIZE];
-            let resumption_kind = black_box(bench.kind.resumption_kind());
-            let params = black_box(&bench.params);
+            let resumption_kind = bench.kind.resumption_kind();
             let io = StepperIo {
                 reader: &mut stdin,
                 writer: &mut stdout,
@@ -166,7 +165,10 @@ fn main() -> anyhow::Result<()> {
                         run_bench(
                             ServerSideStepper {
                                 io,
-                                config: ServerSideStepper::make_config(params, resumption_kind),
+                                config: ServerSideStepper::make_config(
+                                    &bench.params,
+                                    resumption_kind,
+                                ),
                             },
                             bench.kind,
                         )
@@ -177,7 +179,10 @@ fn main() -> anyhow::Result<()> {
                             ClientSideStepper {
                                 io,
                                 resumption_kind,
-                                config: ClientSideStepper::make_config(params, resumption_kind),
+                                config: ClientSideStepper::make_config(
+                                    &bench.params,
+                                    resumption_kind,
+                                ),
                             },
                             bench.kind,
                         )

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -40,7 +40,7 @@ mod cachegrind;
 mod util;
 
 /// The size in bytes of the plaintext sent in the transfer benchmark
-const TRANSFER_PLAINTEXT_SIZE: usize = 1024 * 1024;
+const TRANSFER_PLAINTEXT_SIZE: usize = 1024 * 1024 * 10; // 10 MB
 
 /// The amount of times a resumed handshake should be executed during benchmarking.
 ///

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -71,10 +71,10 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Command {
-    /// Run all benchmarks and prints the measured CPU instruction counts in CSV format
+    /// Run all benchmarks and print the measured CPU instruction counts in CSV format
     RunAll {
-        #[arg(short, long)]
-        output_dir: Option<PathBuf>,
+        #[arg(short, long, default_value = "target/ci-bench")]
+        output_dir: PathBuf,
     },
     /// Run a single benchmark at the provided index (used by the bench runner to start each benchmark in its own process)
     RunSingle { index: u32, side: Side },
@@ -115,7 +115,6 @@ fn main() -> anyhow::Result<()> {
     match cli.command {
         Command::RunAll { output_dir } => {
             let executable = std::env::args().next().unwrap();
-            let output_dir = output_dir.unwrap_or("target/ci-bench".into());
             let results = run_all(executable, output_dir.clone(), &benchmarks)?;
 
             // Output results in CSV (note: not using a library here to avoid extra dependencies)

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::hint::black_box;
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::mem;
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Context;
+use async_trait::async_trait;
 use clap::{Parser, Subcommand, ValueEnum};
 use fxhash::FxHashMap;
 use itertools::Itertools;
@@ -26,6 +27,7 @@ use crate::benchmark::{
     ResumptionKind,
 };
 use crate::cachegrind::CachegrindRunner;
+use crate::util::async_io::{self, AsyncRead, AsyncWrite};
 use crate::util::transport::{
     read_handshake_message, read_plaintext_to_end_bounded, send_handshake_message,
     write_all_plaintext_bounded,
@@ -150,26 +152,32 @@ fn main() -> anyhow::Result<()> {
                 writer: &mut stdout,
                 handshake_buf,
             };
-            let result = match side {
-                Side::Server => run_bench(
-                    ServerSideStepper {
-                        io,
-                        config: ServerSideStepper::make_config(params, resumption_kind),
-                    },
-                    bench.kind,
-                ),
-                Side::Client => run_bench(
-                    ClientSideStepper {
-                        io,
-                        resumption_kind,
-                        config: ClientSideStepper::make_config(params, resumption_kind),
-                    },
-                    bench.kind,
-                ),
-            };
-
-            result
-                .with_context(|| format!("{} crashed for {} side", bench.name(), side.as_str()))?;
+            async_io::block_on_single_poll(async {
+                match side {
+                    Side::Server => {
+                        run_bench(
+                            ServerSideStepper {
+                                io,
+                                config: ServerSideStepper::make_config(params, resumption_kind),
+                            },
+                            bench.kind,
+                        )
+                        .await
+                    }
+                    Side::Client => {
+                        run_bench(
+                            ClientSideStepper {
+                                io,
+                                resumption_kind,
+                                config: ClientSideStepper::make_config(params, resumption_kind),
+                            },
+                            bench.kind,
+                        )
+                        .await
+                    }
+                }
+            })
+            .with_context(|| format!("{} crashed for {} side", bench.name(), side.as_str()))?;
 
             // Prevent stdin / stdout from being closed
             mem::forget(stdin);
@@ -374,18 +382,19 @@ pub fn run_all(
 /// Drives the different steps in a benchmark.
 ///
 /// See [`run_bench`] for specific details on how it is used.
+#[async_trait(?Send)]
 trait BenchStepper {
     type Endpoint;
 
-    fn handshake(&mut self) -> anyhow::Result<Self::Endpoint>;
-    fn sync_before_resumed_handshake(&mut self) -> anyhow::Result<()>;
-    fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()>;
+    async fn handshake(&mut self) -> anyhow::Result<Self::Endpoint>;
+    async fn sync_before_resumed_handshake(&mut self) -> anyhow::Result<()>;
+    async fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()>;
 }
 
 /// Stepper fields necessary for IO
 struct StepperIo<'a> {
-    reader: &'a mut dyn Read,
-    writer: &'a mut dyn Write,
+    reader: &'a mut dyn AsyncRead,
+    writer: &'a mut dyn AsyncWrite,
     handshake_buf: &'a mut [u8],
 }
 
@@ -424,20 +433,21 @@ impl ClientSideStepper<'_> {
     }
 }
 
+#[async_trait(?Send)]
 impl BenchStepper for ClientSideStepper<'_> {
     type Endpoint = ClientConnection;
 
-    fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
+    async fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
         let server_name = "localhost".try_into().unwrap();
         let mut client = ClientConnection::new(self.config.clone(), server_name).unwrap();
         client.set_buffer_limit(None);
 
         loop {
-            send_handshake_message(&mut client, self.io.writer, self.io.handshake_buf)?;
+            send_handshake_message(&mut client, self.io.writer, self.io.handshake_buf).await?;
             if !client.is_handshaking() && !client.wants_write() {
                 break;
             }
-            read_handshake_message(&mut client, self.io.reader, self.io.handshake_buf)?;
+            read_handshake_message(&mut client, self.io.reader, self.io.handshake_buf).await?;
         }
 
         // Session ids and tickets are no longer part of the handshake in TLS 1.3, so we need to
@@ -445,23 +455,23 @@ impl BenchStepper for ClientSideStepper<'_> {
         if self.resumption_kind != ResumptionKind::No
             && client.protocol_version().unwrap() == ProtocolVersion::TLSv1_3
         {
-            read_handshake_message(&mut client, self.io.reader, self.io.handshake_buf)?;
+            read_handshake_message(&mut client, self.io.reader, self.io.handshake_buf).await?;
         }
 
         Ok(client)
     }
 
-    fn sync_before_resumed_handshake(&mut self) -> anyhow::Result<()> {
+    async fn sync_before_resumed_handshake(&mut self) -> anyhow::Result<()> {
         // The client syncs by receiving a single byte (we assert that it matches the `42` byte sent
         // by the server, just to be sure)
         let buf = &mut [0];
-        self.io.reader.read_exact(buf)?;
+        self.io.reader.read_exact(buf).await?;
         assert_eq!(buf[0], 42);
         Ok(())
     }
 
-    fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()> {
-        let total_plaintext_read = read_plaintext_to_end_bounded(endpoint, self.io.reader)?;
+    async fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()> {
+        let total_plaintext_read = read_plaintext_to_end_bounded(endpoint, self.io.reader).await?;
         assert_eq!(total_plaintext_read, TRANSFER_PLAINTEXT_SIZE);
         Ok(())
     }
@@ -498,37 +508,38 @@ impl ServerSideStepper<'_> {
     }
 }
 
+#[async_trait(?Send)]
 impl BenchStepper for ServerSideStepper<'_> {
     type Endpoint = ServerConnection;
 
-    fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
+    async fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
         let mut server = ServerConnection::new(self.config.clone()).unwrap();
         server.set_buffer_limit(None);
 
         while server.is_handshaking() {
-            read_handshake_message(&mut server, self.io.reader, self.io.handshake_buf)?;
-            send_handshake_message(&mut server, self.io.writer, self.io.handshake_buf)?;
+            read_handshake_message(&mut server, self.io.reader, self.io.handshake_buf).await?;
+            send_handshake_message(&mut server, self.io.writer, self.io.handshake_buf).await?;
         }
 
         Ok(server)
     }
 
-    fn sync_before_resumed_handshake(&mut self) -> anyhow::Result<()> {
+    async fn sync_before_resumed_handshake(&mut self) -> anyhow::Result<()> {
         // The server syncs by sending a single byte
-        self.io.writer.write_all(&[42])?;
-        self.io.writer.flush()?;
+        self.io.writer.write_all(&[42]).await?;
+        self.io.writer.flush().await?;
         Ok(())
     }
 
-    fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()> {
-        write_all_plaintext_bounded(endpoint, self.io.writer, TRANSFER_PLAINTEXT_SIZE)?;
+    async fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()> {
+        write_all_plaintext_bounded(endpoint, self.io.writer, TRANSFER_PLAINTEXT_SIZE).await?;
         Ok(())
     }
 }
 
 /// Runs the benchmark using the provided stepper
-fn run_bench<T: BenchStepper>(mut stepper: T, kind: BenchmarkKind) -> anyhow::Result<()> {
-    let mut endpoint = stepper.handshake()?;
+async fn run_bench<T: BenchStepper>(mut stepper: T, kind: BenchmarkKind) -> anyhow::Result<()> {
+    let mut endpoint = stepper.handshake().await?;
 
     match kind {
         BenchmarkKind::Handshake(ResumptionKind::No) => {
@@ -544,12 +555,16 @@ fn run_bench<T: BenchStepper>(mut stepper: T, kind: BenchmarkKind) -> anyhow::Re
                 // connection and be ready for a new handshake, otherwise the client will start a
                 // handshake before the server is ready and the bytes will be fed to the old
                 // connection!)
-                stepper.sync_before_resumed_handshake()?;
-                stepper.handshake()?;
+                stepper
+                    .sync_before_resumed_handshake()
+                    .await?;
+                stepper.handshake().await?;
             }
         }
         BenchmarkKind::Transfer => {
-            stepper.transmit_data(&mut endpoint)?;
+            stepper
+                .transmit_data(&mut endpoint)
+                .await?;
         }
     }
 

--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -39,9 +39,12 @@ pub mod async_io {
     //! Async IO building blocks required for sharing code between the instruction count and
     //! wall-time benchmarks
 
+    use std::cell::{Cell, RefCell};
+    use std::collections::VecDeque;
     use std::fs::File;
     use std::future::Future;
-    use std::pin::pin;
+    use std::pin::{pin, Pin};
+    use std::rc::Rc;
     use std::task::{Poll, RawWaker, RawWakerVTable, Waker};
     use std::{io, ptr, task};
 
@@ -67,6 +70,61 @@ pub mod async_io {
             Poll::Pending => {
                 panic!("the provided future did not finish after one poll!")
             }
+        }
+    }
+
+    /// Block on two futures that are run concurrently and return their results.
+    ///
+    /// Useful when measuring wall-time, because the server and the client side of the connection
+    /// run in a single process _and_ thread to minimize noise. Each side of the connection runs
+    /// inside its own future and they are polled in turns.
+    ///
+    /// Using this together with blocking futures can lead to deadlocks (i.e. when one of the
+    /// futures is blocked while it waits on a message from the other).
+    pub fn block_on_concurrent(
+        x: impl Future<Output = anyhow::Result<()>>,
+        y: impl Future<Output = anyhow::Result<()>>,
+    ) -> (anyhow::Result<()>, anyhow::Result<()>) {
+        let mut x = pin!(x);
+        let mut y = pin!(y);
+
+        // The futures won't complete right away, but since there are only two of them we can poll
+        // them in turns without a more complex waking mechanism.
+        let waker = noop_waker();
+        let mut ctx = task::Context::from_waker(&waker);
+
+        let mut x_output = None;
+        let mut y_output = None;
+
+        // Fuel makes sure we can exit a potential infinite loop if the futures are endlessly
+        // waiting on each other due to a bug (e.g. a read without a corresponding write)
+        let mut fuel = 1_000;
+        loop {
+            let futures_done = x_output.is_some() && y_output.is_some();
+            if futures_done || fuel == 0 {
+                break;
+            }
+
+            fuel -= 1;
+
+            if x_output.is_none() {
+                match x.as_mut().poll(&mut ctx) {
+                    Poll::Ready(output) => x_output = Some(output),
+                    Poll::Pending => {}
+                }
+            }
+
+            if y_output.is_none() {
+                match y.as_mut().poll(&mut ctx) {
+                    Poll::Ready(output) => y_output = Some(output),
+                    Poll::Pending => {}
+                }
+            }
+        }
+
+        match (x_output, y_output) {
+            (Some(x_output), Some(y_output)) => (x_output, y_output),
+            _ => panic!("at least one of the futures seems to be stuck"),
         }
     }
 
@@ -112,6 +170,219 @@ pub mod async_io {
 
         async fn flush(&mut self) -> io::Result<()> {
             io::Write::flush(self)
+        }
+    }
+
+    /// Creates an unidirectional byte pipe of the given capacity, suitable for async reading and
+    /// writing
+    pub fn async_pipe(capacity: usize) -> (AsyncSender, AsyncReceiver) {
+        let open = Rc::new(Cell::new(true));
+        let buf = Rc::new(RefCell::new(VecDeque::with_capacity(capacity)));
+        (
+            AsyncSender {
+                inner: AsyncPipeSide {
+                    open: open.clone(),
+                    buf: buf.clone(),
+                },
+            },
+            AsyncReceiver {
+                inner: AsyncPipeSide { open, buf },
+            },
+        )
+    }
+
+    /// The sender end of an asynchronous byte pipe
+    pub struct AsyncSender {
+        inner: AsyncPipeSide,
+    }
+
+    /// The receiver end of an asynchronous byte pipe
+    pub struct AsyncReceiver {
+        inner: AsyncPipeSide,
+    }
+
+    struct AsyncPipeSide {
+        open: Rc<Cell<bool>>,
+        buf: Rc<RefCell<VecDeque<u8>>>,
+    }
+
+    impl Drop for AsyncPipeSide {
+        fn drop(&mut self) {
+            self.open.set(false);
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl AsyncRead for AsyncReceiver {
+        async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            AsyncPipeReadFuture {
+                reader: self,
+                user_buf: buf,
+            }
+            .await
+        }
+
+        async fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+            let mut read = 0;
+            while read < buf.len() {
+                read += self.read(&mut buf[read..]).await?;
+            }
+
+            Ok(())
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl AsyncWrite for AsyncSender {
+        async fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+            AsyncPipeWriteFuture {
+                writer: self,
+                user_buf: buf,
+            }
+            .await
+        }
+
+        async fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct AsyncPipeReadFuture<'a> {
+        reader: &'a AsyncReceiver,
+        user_buf: &'a mut [u8],
+    }
+
+    impl<'a> Future for AsyncPipeReadFuture<'a> {
+        type Output = io::Result<usize>;
+
+        fn poll(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
+            let inner_buf = &mut self.reader.inner.buf.borrow_mut();
+            if inner_buf.is_empty() {
+                return if self.reader.inner.open.get() {
+                    // Wait for data to arrive, or EOF
+                    Poll::Pending
+                } else {
+                    // EOF
+                    Poll::Ready(Ok(0))
+                };
+            }
+
+            let bytes_to_write = inner_buf.len().min(self.user_buf.len());
+
+            // This is a convoluted way to copy the bytes from the inner buffer into the user's
+            // buffer
+            let (first_half, second_half) = inner_buf.as_slices();
+            let bytes_to_write_from_first_half = first_half.len().min(bytes_to_write);
+            let bytes_to_write_from_second_half =
+                bytes_to_write.saturating_sub(bytes_to_write_from_first_half);
+            self.user_buf[..bytes_to_write_from_first_half]
+                .copy_from_slice(&first_half[..bytes_to_write_from_first_half]);
+            self.user_buf[bytes_to_write_from_first_half..bytes_to_write]
+                .copy_from_slice(&second_half[..bytes_to_write_from_second_half]);
+
+            inner_buf.drain(..bytes_to_write);
+
+            Poll::Ready(Ok(bytes_to_write))
+        }
+    }
+
+    struct AsyncPipeWriteFuture<'a> {
+        writer: &'a AsyncSender,
+        user_buf: &'a [u8],
+    }
+
+    impl<'a> Future for AsyncPipeWriteFuture<'a> {
+        type Output = io::Result<()>;
+
+        fn poll(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
+            if !self.writer.inner.open.get() {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "channel was closed",
+                )));
+            }
+
+            let mut pipe_buf = self.writer.inner.buf.borrow_mut();
+            let capacity_left = pipe_buf.capacity() - pipe_buf.len();
+            let bytes_to_write = self.user_buf.len().min(capacity_left);
+            pipe_buf.extend(&self.user_buf[..bytes_to_write]);
+
+            if self.user_buf.len() > capacity_left {
+                self.user_buf = &self.user_buf[bytes_to_write..];
+
+                // Continue writing later once capacity is available
+                Poll::Pending
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn test_block_on_concurrent_minimal_capacity() {
+            test_block_on_concurrent(1);
+        }
+
+        #[test]
+        fn test_block_on_concurrent_enough_capacity() {
+            test_block_on_concurrent(100);
+        }
+
+        fn test_block_on_concurrent(capacity: usize) {
+            let (mut server_writer, mut client_reader) = async_pipe(capacity);
+            let (mut client_writer, mut server_reader) = async_pipe(capacity);
+
+            let client = async {
+                client_writer
+                    .write_all(b"hello")
+                    .await
+                    .unwrap();
+
+                let mut buf = [0; 2];
+                client_reader
+                    .read_exact(&mut buf)
+                    .await
+                    .unwrap();
+                assert_eq!(&buf, b"42");
+
+                client_writer
+                    .write_all(b"bye bye")
+                    .await
+                    .unwrap();
+
+                Ok(())
+            };
+
+            let server = async {
+                let mut buf = [0; 5];
+                server_reader
+                    .read_exact(&mut buf)
+                    .await
+                    .unwrap();
+                assert_eq!(&buf, b"hello");
+
+                server_writer
+                    .write_all(b"42")
+                    .await
+                    .unwrap();
+
+                let mut buf = [0; 7];
+                server_reader
+                    .read_exact(&mut buf)
+                    .await
+                    .unwrap();
+                assert_eq!(&buf, b"bye bye");
+
+                Ok(())
+            };
+
+            let (client_result, server_result) = block_on_concurrent(client, server);
+            client_result.unwrap();
+            server_result.unwrap();
         }
     }
 }


### PR DESCRIPTION
_See updated readme for details (or follow commit by commit)_

I have tested that the wall-time mode results in low noise in the following way:

1. Do 30 benchmark runs, each with 100 iterations per scenario.
2. Use the results to calculate the noise thresholds (for each scenario, we take the _median_ runtime of the 100 iterations, and use that as the result for a given run).
3. Using the calculated noise thresholds, look at the diffs between the runs, and check whether any of them exceeds the noise threshold.
4. Results: no false positives across the 29 diffs 🎉; most noise thresholds below 2%; no thresholds above 5%.

Open questions:

- Should we attempt to distinguish the time spent in the server from the time spent in the client? I'm not sure it would be viable (because of timer resolution), so I haven't tried to implement it (and if we do, I'll need to double-check that it doesn't result in noisy measurements).
- Should we scrape the command to do comparisons once we switch to the bare-metal bench runner? I'm assuming we will want to do that (the current version of the bench runner contains an improved version of the comparison code from the `ci-bench` crate). For that reason, I didn't implement a comparison for two runs of the wall-time benchmarks.