### PR TITLE
make the decode / decrypt pipeline non-allocating (groundwork)

### DIFF
--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -27,7 +27,7 @@ fuzz_target!(|data: &[u8]| {
         Message::try_from(PlainMessage {
             typ: msg.typ,
             version: msg.version,
-            payload: Payload(msg.payload.to_vec()),
+            payload: Payload::Owned(msg.payload.to_vec()),
         })
         .ok();
     }

--- a/fuzz/fuzzers/persist.rs
+++ b/fuzz/fuzzers/persist.rs
@@ -8,7 +8,7 @@ use rustls::internal::msgs::persist;
 
 fn try_type<T>(data: &[u8])
 where
-    T: Codec,
+    T: for<'a> Codec<'a>,
 {
     let mut rdr = Reader::init(data);
 

--- a/provider-example/src/aead.rs
+++ b/provider-example/src/aead.rs
@@ -1,8 +1,11 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
+use chacha20poly1305::aead::Buffer;
 use chacha20poly1305::{AeadInPlace, KeyInit, KeySizeUser};
-use rustls::crypto::cipher::{self, AeadKey, Iv, UnsupportedOperationError, NONCE_LEN};
+use rustls::crypto::cipher::{
+    self, AeadKey, BorrowedPayload, Iv, UnsupportedOperationError, NONCE_LEN,
+};
 use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};
 
 pub struct Chacha20Poly1305;
@@ -114,17 +117,17 @@ impl cipher::MessageEncrypter for Tls13Cipher {
 }
 
 impl cipher::MessageDecrypter for Tls13Cipher {
-    fn decrypt(
+    fn decrypt<'a>(
         &mut self,
-        mut m: cipher::OpaqueMessage,
+        mut m: cipher::BorrowedOpaqueMessage<'a>,
         seq: u64,
-    ) -> Result<cipher::PlainMessage, rustls::Error> {
-        let payload = m.payload_mut();
+    ) -> Result<cipher::BorrowedPlainMessage<'a>, rustls::Error> {
+        let payload = &mut m.payload;
         let nonce = chacha20poly1305::Nonce::from(cipher::Nonce::new(&self.1, seq).0);
         let aad = cipher::make_tls13_aad(payload.len());
 
         self.0
-            .decrypt_in_place(&nonce, &aad, payload)
+            .decrypt_in_place(&nonce, &aad, &mut BufferAdapter(payload))
             .map_err(|_| rustls::Error::DecryptError)?;
 
         m.into_tls13_unpadded_message()
@@ -159,12 +162,12 @@ impl cipher::MessageEncrypter for Tls12Cipher {
 }
 
 impl cipher::MessageDecrypter for Tls12Cipher {
-    fn decrypt(
+    fn decrypt<'a>(
         &mut self,
-        mut m: cipher::OpaqueMessage,
+        mut m: cipher::BorrowedOpaqueMessage<'a>,
         seq: u64,
-    ) -> Result<cipher::PlainMessage, rustls::Error> {
-        let payload = m.payload();
+    ) -> Result<cipher::BorrowedPlainMessage<'a>, rustls::Error> {
+        let payload = &m.payload;
         let nonce = chacha20poly1305::Nonce::from(cipher::Nonce::new(&self.1, seq).0);
         let aad = cipher::make_tls12_aad(
             seq,
@@ -173,9 +176,9 @@ impl cipher::MessageDecrypter for Tls12Cipher {
             payload.len() - CHACHAPOLY1305_OVERHEAD,
         );
 
-        let payload = m.payload_mut();
+        let payload = &mut m.payload;
         self.0
-            .decrypt_in_place(&nonce, &aad, payload)
+            .decrypt_in_place(&nonce, &aad, &mut BufferAdapter(payload))
             .map_err(|_| rustls::Error::DecryptError)?;
 
         Ok(m.into_plain_message())
@@ -183,3 +186,27 @@ impl cipher::MessageDecrypter for Tls12Cipher {
 }
 
 const CHACHAPOLY1305_OVERHEAD: usize = 16;
+
+struct BufferAdapter<'a, 'p>(&'a mut BorrowedPayload<'p>);
+
+impl AsRef<[u8]> for BufferAdapter<'_, '_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+impl AsMut<[u8]> for BufferAdapter<'_, '_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0
+    }
+}
+
+impl Buffer for BufferAdapter<'_, '_> {
+    fn extend_from_slice(&mut self, _: &[u8]) -> chacha20poly1305::aead::Result<()> {
+        unreachable!("not used by `AeadInPlace::decrypt_in_place`")
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
+    }
+}

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -11,15 +11,26 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 #[derive(Debug)]
-pub(super) struct ServerCertDetails {
-    pub(super) cert_chain: CertificateChain,
+pub(super) struct ServerCertDetails<'a> {
+    pub(super) cert_chain: CertificateChain<'a>,
     pub(super) ocsp_response: Vec<u8>,
 }
 
-impl ServerCertDetails {
-    pub(super) fn new(cert_chain: CertificateChain, ocsp_response: Vec<u8>) -> Self {
+impl<'a> ServerCertDetails<'a> {
+    pub(super) fn new(cert_chain: CertificateChain<'a>, ocsp_response: Vec<u8>) -> Self {
         Self {
             cert_chain,
+            ocsp_response,
+        }
+    }
+
+    pub(super) fn into_owned(self) -> ServerCertDetails<'static> {
+        let Self {
+            cert_chain,
+            ocsp_response,
+        } = self;
+        ServerCertDetails {
+            cert_chain: cert_chain.into_owned(),
             ocsp_response,
         }
     }

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -195,7 +195,7 @@ pub(super) struct AlwaysResolvesClientCert(Arc<sign::CertifiedKey>);
 impl AlwaysResolvesClientCert {
     pub(super) fn new(
         private_key: Arc<dyn sign::SigningKey>,
-        chain: CertificateChain,
+        chain: CertificateChain<'static>,
     ) -> Result<Self, Error> {
         Ok(Self(Arc::new(sign::CertifiedKey::new(
             chain.0,

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1009,15 +1009,15 @@ impl State<ClientConnectionData> for ExpectFinished {
 
         // Constant-time verification of this is relatively unimportant: they only
         // get one chance.  But it can't hurt.
-        let _fin_verified = match ConstantTimeEq::ct_eq(&expect_verify_data[..], &finished.0).into()
-        {
-            true => verify::FinishedMessageVerified::assertion(),
-            false => {
-                return Err(cx
-                    .common
-                    .send_fatal_alert(AlertDescription::DecryptError, Error::DecryptError));
-            }
-        };
+        let _fin_verified =
+            match ConstantTimeEq::ct_eq(&expect_verify_data[..], finished.bytes()).into() {
+                true => verify::FinishedMessageVerified::assertion(),
+                false => {
+                    return Err(cx
+                        .common
+                        .send_fatal_alert(AlertDescription::DecryptError, Error::DecryptError));
+                }
+            };
 
         // Hash this message too.
         st.transcript.add_message(&m);

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -129,7 +129,12 @@ mod server_hello {
 
                     // Since we're resuming, we verified the certificate and
                     // proof of possession in the prior session.
-                    cx.common.peer_certificates = Some(resuming.server_cert_chain().clone());
+                    cx.common.peer_certificates = Some(
+                        resuming
+                            .server_cert_chain()
+                            .clone()
+                            .into_owned(),
+                    );
                     let cert_verified = verify::ServerCertVerified::assertion();
                     let sig_verified = verify::HandshakeSignatureValid::assertion();
 
@@ -245,7 +250,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
     }
 }
 
-struct ExpectCertificateStatusOrServerKx {
+struct ExpectCertificateStatusOrServerKx<'m> {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
@@ -254,11 +259,11 @@ struct ExpectCertificateStatusOrServerKx {
     using_ems: bool,
     transcript: HandshakeHash,
     suite: &'static Tls12CipherSuite,
-    server_cert_chain: CertificateChain,
+    server_cert_chain: CertificateChain<'m>,
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
+impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx<'_> {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -320,11 +325,22 @@ impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
+        Box::new(ExpectCertificateStatusOrServerKx {
+            config: self.config,
+            resuming_session: self.resuming_session,
+            session_id: self.session_id,
+            server_name: self.server_name,
+            randoms: self.randoms,
+            using_ems: self.using_ems,
+            transcript: self.transcript,
+            suite: self.suite,
+            server_cert_chain: self.server_cert_chain.into_owned(),
+            must_issue_new_ticket: self.must_issue_new_ticket,
+        })
     }
 }
 
-struct ExpectCertificateStatus {
+struct ExpectCertificateStatus<'a> {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
@@ -333,11 +349,11 @@ struct ExpectCertificateStatus {
     using_ems: bool,
     transcript: HandshakeHash,
     suite: &'static Tls12CipherSuite,
-    server_cert_chain: CertificateChain,
+    server_cert_chain: CertificateChain<'a>,
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateStatus {
+impl State<ClientConnectionData> for ExpectCertificateStatus<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -376,11 +392,22 @@ impl State<ClientConnectionData> for ExpectCertificateStatus {
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
+        Box::new(ExpectCertificateStatus {
+            config: self.config,
+            resuming_session: self.resuming_session,
+            session_id: self.session_id,
+            server_name: self.server_name,
+            randoms: self.randoms,
+            using_ems: self.using_ems,
+            transcript: self.transcript,
+            suite: self.suite,
+            server_cert_chain: self.server_cert_chain.into_owned(),
+            must_issue_new_ticket: self.must_issue_new_ticket,
+        })
     }
 }
 
-struct ExpectServerKx {
+struct ExpectServerKx<'a> {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
@@ -389,11 +416,11 @@ struct ExpectServerKx {
     using_ems: bool,
     transcript: HandshakeHash,
     suite: &'static Tls12CipherSuite,
-    server_cert: ServerCertDetails,
+    server_cert: ServerCertDetails<'a>,
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectServerKx {
+impl State<ClientConnectionData> for ExpectServerKx<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -444,13 +471,24 @@ impl State<ClientConnectionData> for ExpectServerKx {
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
+        Box::new(ExpectServerKx {
+            config: self.config,
+            resuming_session: self.resuming_session,
+            session_id: self.session_id,
+            server_name: self.server_name,
+            randoms: self.randoms,
+            using_ems: self.using_ems,
+            transcript: self.transcript,
+            suite: self.suite,
+            server_cert: self.server_cert.into_owned(),
+            must_issue_new_ticket: self.must_issue_new_ticket,
+        })
     }
 }
 
 fn emit_certificate(
     transcript: &mut HandshakeHash,
-    cert_chain: CertificateChain,
+    cert_chain: CertificateChain<'static>,
     common: &mut CommonState,
 ) {
     let cert = Message {
@@ -556,7 +594,7 @@ impl ServerKxDetails {
 // --- Either a CertificateRequest, or a ServerHelloDone. ---
 // Existence of the CertificateRequest tells us the server is asking for
 // client auth.  Otherwise we go straight to ServerHelloDone.
-struct ExpectServerDoneOrCertReq {
+struct ExpectServerDoneOrCertReq<'a> {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
@@ -565,12 +603,12 @@ struct ExpectServerDoneOrCertReq {
     using_ems: bool,
     transcript: HandshakeHash,
     suite: &'static Tls12CipherSuite,
-    server_cert: ServerCertDetails,
+    server_cert: ServerCertDetails<'a>,
     server_kx: ServerKxDetails,
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectServerDoneOrCertReq {
+impl State<ClientConnectionData> for ExpectServerDoneOrCertReq<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -625,11 +663,23 @@ impl State<ClientConnectionData> for ExpectServerDoneOrCertReq {
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
+        Box::new(ExpectServerDoneOrCertReq {
+            config: self.config,
+            resuming_session: self.resuming_session,
+            session_id: self.session_id,
+            server_name: self.server_name,
+            randoms: self.randoms,
+            using_ems: self.using_ems,
+            transcript: self.transcript,
+            suite: self.suite,
+            server_cert: self.server_cert.into_owned(),
+            server_kx: self.server_kx,
+            must_issue_new_ticket: self.must_issue_new_ticket,
+        })
     }
 }
 
-struct ExpectCertificateRequest {
+struct ExpectCertificateRequest<'a> {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
@@ -638,12 +688,12 @@ struct ExpectCertificateRequest {
     using_ems: bool,
     transcript: HandshakeHash,
     suite: &'static Tls12CipherSuite,
-    server_cert: ServerCertDetails,
+    server_cert: ServerCertDetails<'a>,
     server_kx: ServerKxDetails,
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateRequest {
+impl State<ClientConnectionData> for ExpectCertificateRequest<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -693,11 +743,23 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
+        Box::new(ExpectCertificateRequest {
+            config: self.config,
+            resuming_session: self.resuming_session,
+            session_id: self.session_id,
+            server_name: self.server_name,
+            randoms: self.randoms,
+            using_ems: self.using_ems,
+            transcript: self.transcript,
+            suite: self.suite,
+            server_cert: self.server_cert.into_owned(),
+            server_kx: self.server_kx,
+            must_issue_new_ticket: self.must_issue_new_ticket,
+        })
     }
 }
 
-struct ExpectServerDone {
+struct ExpectServerDone<'a> {
     config: Arc<ClientConfig>,
     resuming_session: Option<persist::Tls12ClientSessionValue>,
     session_id: SessionId,
@@ -706,13 +768,13 @@ struct ExpectServerDone {
     using_ems: bool,
     transcript: HandshakeHash,
     suite: &'static Tls12CipherSuite,
-    server_cert: ServerCertDetails,
+    server_cert: ServerCertDetails<'a>,
     server_kx: ServerKxDetails,
     client_auth: Option<ClientAuthDetails>,
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectServerDone {
+impl State<ClientConnectionData> for ExpectServerDone<'_> {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -811,7 +873,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
                         .send_cert_verify_error_alert(err)
                 })?
         };
-        cx.common.peer_certificates = Some(st.server_cert.cert_chain);
+        cx.common.peer_certificates = Some(st.server_cert.cert_chain.into_owned());
 
         // 4.
         if let Some(client_auth) = &st.client_auth {
@@ -906,7 +968,20 @@ impl State<ClientConnectionData> for ExpectServerDone {
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
+        Box::new(ExpectServerDone {
+            config: self.config,
+            resuming_session: self.resuming_session,
+            session_id: self.session_id,
+            server_name: self.server_name,
+            randoms: self.randoms,
+            using_ems: self.using_ems,
+            transcript: self.transcript,
+            suite: self.suite,
+            server_cert: self.server_cert.into_owned(),
+            server_kx: self.server_kx,
+            client_auth: self.client_auth,
+            must_issue_new_ticket: self.must_issue_new_ticket,
+        })
     }
 }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -61,7 +61,7 @@ mod server_hello {
             suite: &'static Tls12CipherSuite,
             server_hello: &ServerHelloPayload,
             tls13_supported: bool,
-        ) -> hs::NextStateOrError {
+        ) -> hs::NextStateOrError<'static> {
             self.randoms
                 .server
                 .clone_from_slice(&server_hello.random.0[..]);
@@ -194,11 +194,14 @@ struct ExpectCertificate {
 }
 
 impl State<ClientConnectionData> for ExpectCertificate {
-    fn handle(
+    fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
-        m: Message,
-    ) -> hs::NextStateOrError {
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         self.transcript.add_message(&m);
         let server_cert_chain = require_handshake_msg_move!(
             m,
@@ -236,6 +239,10 @@ impl State<ClientConnectionData> for ExpectCertificate {
             }))
         }
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 struct ExpectCertificateStatusOrServerKx {
@@ -252,7 +259,14 @@ struct ExpectCertificateStatusOrServerKx {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         match m.payload {
             MessagePayload::Handshake {
                 parsed:
@@ -304,6 +318,10 @@ impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
             )),
         }
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 struct ExpectCertificateStatus {
@@ -320,11 +338,14 @@ struct ExpectCertificateStatus {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateStatus {
-    fn handle(
+    fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
-        m: Message,
-    ) -> hs::NextStateOrError {
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         self.transcript.add_message(&m);
         let server_cert_ocsp_response = require_handshake_msg_move!(
             m,
@@ -353,6 +374,10 @@ impl State<ClientConnectionData> for ExpectCertificateStatus {
             must_issue_new_ticket: self.must_issue_new_ticket,
         }))
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 struct ExpectServerKx {
@@ -369,7 +394,14 @@ struct ExpectServerKx {
 }
 
 impl State<ClientConnectionData> for ExpectServerKx {
-    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let opaque_kx = require_handshake_msg!(
             m,
             HandshakeType::ServerKeyExchange,
@@ -409,6 +441,10 @@ impl State<ClientConnectionData> for ExpectServerKx {
             server_kx,
             must_issue_new_ticket: self.must_issue_new_ticket,
         }))
+    }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
     }
 }
 
@@ -535,7 +571,14 @@ struct ExpectServerDoneOrCertReq {
 }
 
 impl State<ClientConnectionData> for ExpectServerDoneOrCertReq {
-    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         if matches!(
             m.payload,
             MessagePayload::Handshake {
@@ -580,6 +623,10 @@ impl State<ClientConnectionData> for ExpectServerDoneOrCertReq {
             .handle(cx, m)
         }
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 struct ExpectCertificateRequest {
@@ -597,11 +644,14 @@ struct ExpectCertificateRequest {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateRequest {
-    fn handle(
+    fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
-        m: Message,
-    ) -> hs::NextStateOrError {
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let certreq = require_handshake_msg!(
             m,
             HandshakeType::CertificateRequest,
@@ -641,6 +691,10 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             must_issue_new_ticket: self.must_issue_new_ticket,
         }))
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 struct ExpectServerDone {
@@ -659,7 +713,14 @@ struct ExpectServerDone {
 }
 
 impl State<ClientConnectionData> for ExpectServerDone {
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         match m.payload {
             MessagePayload::Handshake {
                 parsed:
@@ -843,6 +904,10 @@ impl State<ClientConnectionData> for ExpectServerDone {
             }))
         }
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 struct ExpectNewTicket {
@@ -859,11 +924,14 @@ struct ExpectNewTicket {
 }
 
 impl State<ClientConnectionData> for ExpectNewTicket {
-    fn handle(
+    fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
-        m: Message,
-    ) -> hs::NextStateOrError {
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         self.transcript.add_message(&m);
 
         let nst = require_handshake_msg_move!(
@@ -886,6 +954,10 @@ impl State<ClientConnectionData> for ExpectNewTicket {
             sig_verified: self.sig_verified,
         }))
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 // -- Waiting for their CCS --
@@ -904,7 +976,14 @@ struct ExpectCcs {
 }
 
 impl State<ClientConnectionData> for ExpectCcs {
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         match m.payload {
             MessagePayload::ChangeCipherSpec(..) => {}
             payload => {
@@ -936,6 +1015,10 @@ impl State<ClientConnectionData> for ExpectCcs {
             cert_verified: self.cert_verified,
             sig_verified: self.sig_verified,
         }))
+    }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
     }
 }
 
@@ -996,7 +1079,14 @@ impl ExpectFinished {
 }
 
 impl State<ClientConnectionData> for ExpectFinished {
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let mut st = *self;
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
@@ -1053,6 +1143,10 @@ impl State<ClientConnectionData> for ExpectFinished {
                 .remove_tls12_session(&self.server_name);
         }
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 // -- Traffic transit state --
@@ -1064,7 +1158,14 @@ struct ExpectTraffic {
 }
 
 impl State<ClientConnectionData> for ExpectTraffic {
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx
                 .common
@@ -1093,5 +1194,9 @@ impl State<ClientConnectionData> for ExpectTraffic {
     fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
         self.secrets
             .extract_secrets(Side::Client)
+    }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
     }
 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -77,7 +77,7 @@ pub(super) fn handle_server_hello(
     hello: ClientHelloDetails,
     our_key_share: Box<dyn ActiveKeyExchange>,
     mut sent_tls13_fake_ccs: bool,
-) -> hs::NextStateOrError {
+) -> hs::NextStateOrError<'static> {
     validate_server_hello(cx.common, server_hello)?;
 
     let their_key_share = server_hello
@@ -380,7 +380,14 @@ struct ExpectEncryptedExtensions {
 }
 
 impl State<ClientConnectionData> for ExpectEncryptedExtensions {
-    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let exts = require_handshake_msg!(
             m,
             HandshakeType::EncryptedExtensions,
@@ -456,6 +463,10 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
             }))
         }
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 struct ExpectCertificateOrCertReq {
@@ -468,7 +479,14 @@ struct ExpectCertificateOrCertReq {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         match m.payload {
             MessagePayload::Handshake {
                 parsed:
@@ -513,6 +531,10 @@ impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
             )),
         }
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 // TLS1.3 version of CertificateRequest handling.  We then move to expecting the server
@@ -528,7 +550,14 @@ struct ExpectCertificateRequest {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateRequest {
-    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let certreq = &require_handshake_msg!(
             m,
             HandshakeType::CertificateRequest,
@@ -584,6 +613,10 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             client_auth: Some(client_auth),
         }))
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 struct ExpectCertificate {
@@ -597,7 +630,14 @@ struct ExpectCertificate {
 }
 
 impl State<ClientConnectionData> for ExpectCertificate {
-    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         self.transcript.add_message(&m);
         let cert_chain = require_handshake_msg_move!(
             m,
@@ -635,6 +675,10 @@ impl State<ClientConnectionData> for ExpectCertificate {
             client_auth: self.client_auth,
         }))
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 // --- TLS1.3 CertificateVerify ---
@@ -650,7 +694,14 @@ struct ExpectCertificateVerify {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateVerify {
-    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let cert_verify = require_handshake_msg!(
             m,
             HandshakeType::CertificateVerify,
@@ -709,6 +760,10 @@ impl State<ClientConnectionData> for ExpectCertificateVerify {
             cert_verified,
             sig_verified,
         }))
+    }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
     }
 }
 
@@ -817,7 +872,14 @@ struct ExpectFinished {
 }
 
 impl State<ClientConnectionData> for ExpectFinished {
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let mut st = *self;
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
@@ -915,6 +977,10 @@ impl State<ClientConnectionData> for ExpectFinished {
             false => Box::new(st),
         })
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 // -- Traffic transit state (TLS1.3) --
@@ -1010,7 +1076,14 @@ impl ExpectTraffic {
 }
 
 impl State<ClientConnectionData> for ExpectTraffic {
-    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx
                 .common
@@ -1057,12 +1130,23 @@ impl State<ClientConnectionData> for ExpectTraffic {
         self.key_schedule
             .extract_secrets(Side::Client)
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 struct ExpectQuicTraffic(ExpectTraffic);
 
 impl State<ClientConnectionData> for ExpectQuicTraffic {
-    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ClientContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let nst = require_handshake_msg!(
             m,
             HandshakeType::NewSessionTicket,
@@ -1081,5 +1165,9 @@ impl State<ClientConnectionData> for ExpectQuicTraffic {
     ) -> Result<(), Error> {
         self.0
             .export_keying_material(output, label, context)
+    }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
     }
 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -682,18 +682,18 @@ impl State<ClientConnectionData> for ExpectCertificate {
 }
 
 // --- TLS1.3 CertificateVerify ---
-struct ExpectCertificateVerify {
+struct ExpectCertificateVerify<'a> {
     config: Arc<ClientConfig>,
     server_name: ServerName<'static>,
     randoms: ConnectionRandoms,
     suite: &'static Tls13CipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
-    server_cert: ServerCertDetails,
+    server_cert: ServerCertDetails<'a>,
     client_auth: Option<ClientAuthDetails>,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateVerify {
+impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -746,7 +746,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify {
                     .send_cert_verify_error_alert(err)
             })?;
 
-        cx.common.peer_certificates = Some(self.server_cert.cert_chain);
+        cx.common.peer_certificates = Some(self.server_cert.cert_chain.into_owned());
         self.transcript.add_message(&m);
 
         Ok(Box::new(ExpectFinished {
@@ -763,7 +763,16 @@ impl State<ClientConnectionData> for ExpectCertificateVerify {
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
+        Box::new(ExpectCertificateVerify {
+            config: self.config,
+            server_name: self.server_name,
+            randoms: self.randoms,
+            suite: self.suite,
+            transcript: self.transcript,
+            key_schedule: self.key_schedule,
+            server_cert: self.server_cert.into_owned(),
+            client_auth: self.client_auth,
+        })
     }
 }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -827,7 +827,8 @@ impl State<ClientConnectionData> for ExpectFinished {
             .key_schedule
             .sign_server_finish(&handshake_hash);
 
-        let fin = match ConstantTimeEq::ct_eq(expect_verify_data.as_ref(), &finished.0).into() {
+        let fin = match ConstantTimeEq::ct_eq(expect_verify_data.as_ref(), finished.bytes()).into()
+        {
             true => verify::FinishedMessageVerified::assertion(),
             false => {
                 return Err(cx

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -39,7 +39,7 @@ pub struct CommonState {
     pub(crate) has_received_close_notify: bool,
     pub(crate) has_seen_eof: bool,
     pub(crate) received_middlebox_ccs: u8,
-    pub(crate) peer_certificates: Option<CertificateChain>,
+    pub(crate) peer_certificates: Option<CertificateChain<'static>>,
     message_fragmenter: MessageFragmenter,
     pub(crate) received_plaintext: ChunkVecBuffer,
     pub(crate) sendable_tls: ChunkVecBuffer,

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -428,7 +428,8 @@ impl CommonState {
     }
 
     pub(crate) fn take_received_plaintext(&mut self, bytes: Payload) {
-        self.received_plaintext.append(bytes.0);
+        self.received_plaintext
+            .append(bytes.into_vec());
     }
 
     #[cfg(feature = "tls12")]

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1,11 +1,12 @@
 use crate::common_state::{CommonState, Context, IoState, State, DEFAULT_BUFFER_LIMIT};
+use crate::crypto::cipher::BorrowedPlainMessage;
 use crate::enums::{AlertDescription, ContentType};
 use crate::error::{Error, PeerMisbehaved};
 #[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::msgs::deframer::{Deframed, DeframerSliceBuffer, DeframerVecBuffer, MessageDeframer};
 use crate::msgs::handshake::Random;
-use crate::msgs::message::{Message, MessagePayload, PlainMessage};
+use crate::msgs::message::{Message, MessagePayload};
 use crate::suites::{ExtractedSecrets, PartiallyExtractedSecrets};
 use crate::vecbuf::ChunkVecBuffer;
 
@@ -336,11 +337,11 @@ impl ConnectionRandoms {
 
 // --- Common (to client and server) connection functions ---
 
-fn is_valid_ccs(msg: &PlainMessage) -> bool {
+fn is_valid_ccs(msg: &BorrowedPlainMessage) -> bool {
     // We passthrough ChangeCipherSpec messages in the deframer without decrypting them.
     // Note: this is prior to the record layer, so is unencrypted. See
     // third paragraph of section 5 in RFC8446.
-    msg.typ == ContentType::ChangeCipherSpec && msg.payload.bytes() == [0x01]
+    msg.typ == ContentType::ChangeCipherSpec && msg.payload == [0x01]
 }
 
 /// Interface shared by client and server connections.
@@ -474,7 +475,8 @@ impl<Data> ConnectionCommon<Data> {
         let mut deframer_buffer = self.deframer_buffer.borrow();
         let res = self
             .core
-            .deframe(None, &mut deframer_buffer);
+            .deframe(None, &mut deframer_buffer)
+            .map(|opt| opt.map(|m| m.into_owned()));
         let discard = deframer_buffer.pending_discard();
         self.deframer_buffer.discard(discard);
 
@@ -772,11 +774,11 @@ impl<Data> ConnectionCore<Data> {
     }
 
     /// Pull a message out of the deframer and send any messages that need to be sent as a result.
-    fn deframe(
+    fn deframe<'b>(
         &mut self,
         state: Option<&dyn State<Data>>,
-        deframer_buffer: &mut DeframerSliceBuffer,
-    ) -> Result<Option<PlainMessage>, Error> {
+        deframer_buffer: &mut DeframerSliceBuffer<'b>,
+    ) -> Result<Option<BorrowedPlainMessage<'b>>, Error> {
         match self.message_deframer.pop(
             &mut self.common_state.record_layer,
             self.common_state.negotiated_version,
@@ -799,7 +801,7 @@ impl<Data> ConnectionCore<Data> {
                 }
 
                 self.common_state.aligned_handshake = aligned;
-                Ok(Some(message.into_owned()))
+                Ok(Some(message))
             }
             Ok(None) => Ok(None),
             Err(err @ Error::InvalidMessage(_)) => {
@@ -831,7 +833,7 @@ impl<Data> ConnectionCore<Data> {
 
     fn process_msg(
         &mut self,
-        msg: PlainMessage,
+        msg: BorrowedPlainMessage,
         state: Box<dyn State<Data>>,
         sendable_plaintext: Option<&mut ChunkVecBuffer>,
     ) -> Result<Box<dyn State<Data>>, Error> {
@@ -860,7 +862,7 @@ impl<Data> ConnectionCore<Data> {
         }
 
         // Now we can fully parse the message payload.
-        let msg = match Message::try_from(msg) {
+        let msg = match Message::try_from(msg.into_owned()) {
             Ok(msg) => msg,
             Err(err) => {
                 return Err(self

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -340,7 +340,7 @@ fn is_valid_ccs(msg: &PlainMessage) -> bool {
     // We passthrough ChangeCipherSpec messages in the deframer without decrypting them.
     // Note: this is prior to the record layer, so is unencrypted. See
     // third paragraph of section 5 in RFC8446.
-    msg.typ == ContentType::ChangeCipherSpec && msg.payload.0 == [0x01]
+    msg.typ == ContentType::ChangeCipherSpec && msg.payload.bytes() == [0x01]
 }
 
 /// Interface shared by client and server connections.

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -471,16 +471,16 @@ impl<Data> ConnectionCommon<Data> {
     ///
     /// This is a shortcut to the `process_new_packets()` -> `process_msg()` ->
     /// `process_handshake_messages()` path, specialized for the first handshake message.
-    pub(crate) fn first_handshake_message(&mut self) -> Result<Option<Message>, Error> {
+    pub(crate) fn first_handshake_message(&mut self) -> Result<Option<Message<'static>>, Error> {
         let mut deframer_buffer = self.deframer_buffer.borrow();
         let res = self
             .core
             .deframe(None, &mut deframer_buffer)
-            .map(|opt| opt.map(|m| m.into_owned()));
+            .map(|opt| opt.map(|pm| Message::try_from(pm).map(|m| m.into_owned())));
         let discard = deframer_buffer.pending_discard();
         self.deframer_buffer.discard(discard);
 
-        match res?.map(Message::try_from) {
+        match res? {
             Some(Ok(msg)) => Ok(Some(msg)),
             Some(Err(err)) => Err(self.send_fatal_alert(AlertDescription::DecodeError, err)),
             None => Ok(None),
@@ -862,7 +862,7 @@ impl<Data> ConnectionCore<Data> {
         }
 
         // Now we can fully parse the message payload.
-        let msg = match Message::try_from(msg.into_owned()) {
+        let msg = match Message::try_from(msg) {
             Ok(msg) => msg,
             Err(err) => {
                 return Err(self

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -127,7 +127,11 @@ pub struct KeyBlockShape {
 pub trait MessageDecrypter: Send + Sync {
     /// Decrypt the given TLS message `msg`, using the sequence number
     /// `seq` which can be used to derive a unique [`Nonce`].
-    fn decrypt(&mut self, msg: OpaqueMessage, seq: u64) -> Result<PlainMessage, Error>;
+    fn decrypt<'a>(
+        &mut self,
+        msg: BorrowedOpaqueMessage<'a>,
+        seq: u64,
+    ) -> Result<BorrowedPlainMessage<'a>, Error>;
 }
 
 /// Objects with this trait can encrypt TLS messages.
@@ -317,7 +321,11 @@ impl MessageEncrypter for InvalidMessageEncrypter {
 struct InvalidMessageDecrypter {}
 
 impl MessageDecrypter for InvalidMessageDecrypter {
-    fn decrypt(&mut self, _m: OpaqueMessage, _seq: u64) -> Result<PlainMessage, Error> {
+    fn decrypt<'a>(
+        &mut self,
+        _m: BorrowedOpaqueMessage<'a>,
+        _seq: u64,
+    ) -> Result<BorrowedPlainMessage<'a>, Error> {
         Err(Error::DecryptError)
     }
 }

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -7,7 +7,9 @@ use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::Error;
 pub use crate::msgs::base::BorrowedPayload;
 use crate::msgs::codec;
-pub use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
+pub use crate::msgs::message::{
+    BorrowedOpaqueMessage, BorrowedPlainMessage, OpaqueMessage, PlainMessage,
+};
 use crate::suites::ConnectionTrafficSecrets;
 
 use zeroize::Zeroize;

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -5,6 +5,7 @@ use std::error::Error as StdError;
 
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::Error;
+pub use crate::msgs::base::BorrowedPayload;
 use crate::msgs::codec;
 pub use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 use crate::suites::ConnectionTrafficSecrets;

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -1,13 +1,13 @@
 use crate::crypto::cipher::{
-    make_tls12_aad, AeadKey, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter, Nonce,
-    Tls12AeadAlgorithm, UnsupportedOperationError, NONCE_LEN,
+    make_tls12_aad, AeadKey, BorrowedOpaqueMessage, Iv, KeyBlockShape, MessageDecrypter,
+    MessageEncrypter, Nonce, Tls12AeadAlgorithm, UnsupportedOperationError, NONCE_LEN,
 };
 use crate::crypto::tls12::PrfUsingHmac;
 use crate::crypto::KeyExchangeAlgorithm;
 use crate::enums::{CipherSuite, SignatureScheme};
 use crate::error::Error;
 use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
-use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
+use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage};
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls12::Tls12CipherSuite;
 
@@ -237,8 +237,12 @@ const GCM_EXPLICIT_NONCE_LEN: usize = 8;
 const GCM_OVERHEAD: usize = GCM_EXPLICIT_NONCE_LEN + 16;
 
 impl MessageDecrypter for GcmMessageDecrypter {
-    fn decrypt(&mut self, mut msg: OpaqueMessage, seq: u64) -> Result<PlainMessage, Error> {
-        let payload = msg.payload();
+    fn decrypt<'a>(
+        &mut self,
+        mut msg: BorrowedOpaqueMessage<'a>,
+        seq: u64,
+    ) -> Result<BorrowedPlainMessage<'a>, Error> {
+        let payload = &msg.payload;
         if payload.len() < GCM_OVERHEAD {
             return Err(Error::DecryptError);
         }
@@ -257,7 +261,7 @@ impl MessageDecrypter for GcmMessageDecrypter {
             payload.len() - GCM_OVERHEAD,
         ));
 
-        let payload = msg.payload_mut();
+        let payload = &mut msg.payload;
         let plain_len = self
             .dec_key
             .open_within(nonce, aad, payload, GCM_EXPLICIT_NONCE_LEN..)
@@ -315,8 +319,12 @@ struct ChaCha20Poly1305MessageDecrypter {
 const CHACHAPOLY1305_OVERHEAD: usize = 16;
 
 impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
-    fn decrypt(&mut self, mut msg: OpaqueMessage, seq: u64) -> Result<PlainMessage, Error> {
-        let payload = msg.payload();
+    fn decrypt<'a>(
+        &mut self,
+        mut msg: BorrowedOpaqueMessage<'a>,
+        seq: u64,
+    ) -> Result<BorrowedPlainMessage<'a>, Error> {
+        let payload = &msg.payload;
 
         if payload.len() < CHACHAPOLY1305_OVERHEAD {
             return Err(Error::DecryptError);
@@ -330,7 +338,7 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
             payload.len() - CHACHAPOLY1305_OVERHEAD,
         ));
 
-        let payload = msg.payload_mut();
+        let payload = &mut msg.payload;
         let plain_len = self
             .dec_key
             .open_in_place(nonce, aad, payload)

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -3,14 +3,14 @@ use alloc::vec::Vec;
 
 use crate::crypto;
 use crate::crypto::cipher::{
-    make_tls13_aad, AeadKey, Iv, MessageDecrypter, MessageEncrypter, Nonce, Tls13AeadAlgorithm,
-    UnsupportedOperationError,
+    make_tls13_aad, AeadKey, BorrowedOpaqueMessage, Iv, MessageDecrypter, MessageEncrypter, Nonce,
+    Tls13AeadAlgorithm, UnsupportedOperationError,
 };
 use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use crate::enums::{CipherSuite, ContentType, ProtocolVersion};
 use crate::error::Error;
 use crate::msgs::codec::Codec;
-use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
+use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage};
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls13::Tls13CipherSuite;
 
@@ -207,8 +207,12 @@ impl MessageEncrypter for Tls13MessageEncrypter {
 }
 
 impl MessageDecrypter for Tls13MessageDecrypter {
-    fn decrypt(&mut self, mut msg: OpaqueMessage, seq: u64) -> Result<PlainMessage, Error> {
-        let payload = msg.payload_mut();
+    fn decrypt<'a>(
+        &mut self,
+        mut msg: BorrowedOpaqueMessage<'a>,
+        seq: u64,
+    ) -> Result<BorrowedPlainMessage<'a>, Error> {
+        let payload = &mut msg.payload;
         if payload.len() < self.dec_key.algorithm().tag_len() {
             return Err(Error::DecryptError);
         }

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -36,7 +36,7 @@ impl HandshakeHashBuffer {
     pub(crate) fn add_message(&mut self, m: &Message) {
         if let MessagePayload::Handshake { encoded, .. } = &m.payload {
             self.buffer
-                .extend_from_slice(&encoded.0);
+                .extend_from_slice(encoded.bytes());
         }
     }
 
@@ -98,7 +98,7 @@ impl HandshakeHash {
     /// Hash/buffer a handshake message.
     pub(crate) fn add_message(&mut self, m: &Message) -> &mut Self {
         if let MessagePayload::Handshake { encoded, .. } = &m.payload {
-            self.update_raw(&encoded.0);
+            self.update_raw(encoded.bytes());
         }
         self
     }

--- a/rustls/src/msgs/alert.rs
+++ b/rustls/src/msgs/alert.rs
@@ -11,7 +11,7 @@ pub struct AlertMessagePayload {
     pub description: AlertDescription,
 }
 
-impl Codec for AlertMessagePayload {
+impl Codec<'_> for AlertMessagePayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.level.encode(bytes);
         self.description.encode(bytes);

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -57,8 +57,38 @@ impl<'a> DerefMut for BorrowedPayload<'a> {
 }
 
 impl<'a> BorrowedPayload<'a> {
+    #[cfg(test)]
+    pub(crate) fn new(bytes: &'a mut [u8]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn truncate(&mut self, len: usize) {
+        if len >= self.len() {
+            return;
+        }
+
+        self.0 = core::mem::take(&mut self.0)
+            .split_at_mut(len)
+            .0;
+    }
+
     pub(crate) fn read(r: &mut ReaderMut<'a>) -> Self {
         Self(r.rest())
+    }
+
+    pub(crate) fn into_inner(self) -> &'a mut [u8] {
+        self.0
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<u8> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let len = self.len();
+        let last = self[len - 1];
+        self.truncate(len - 1);
+        Some(last)
     }
 }
 

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -57,7 +57,6 @@ impl<'a> DerefMut for BorrowedPayload<'a> {
 }
 
 impl<'a> BorrowedPayload<'a> {
-    #[allow(dead_code)] // TODO(@cpu): remove in "introduce and expose BorrowedOpaqueMessage"
     pub(crate) fn read(r: &mut ReaderMut<'a>) -> Self {
         Self(r.rest())
     }

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -18,7 +18,7 @@ pub enum Payload<'a> {
     Owned(Vec<u8>),
 }
 
-impl<'a> Codec<'a> for Payload<'static> {
+impl<'a> Codec<'a> for Payload<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(self.bytes());
     }
@@ -35,11 +35,20 @@ impl<'a> Payload<'a> {
             Self::Owned(bytes) => bytes,
         }
     }
+
+    pub fn into_owned(self) -> Payload<'static> {
+        Payload::Owned(self.into_vec())
+    }
+
     pub fn into_vec(self) -> Vec<u8> {
         match self {
             Self::Borrowed(bytes) => bytes.to_vec(),
             Self::Owned(bytes) => bytes,
         }
+    }
+
+    pub fn read(r: &mut Reader<'a>) -> Self {
+        Self::Borrowed(r.rest())
     }
 }
 
@@ -50,10 +59,6 @@ impl Payload<'static> {
 
     pub fn empty() -> Self {
         Self::Borrowed(&[])
-    }
-
-    pub fn read(r: &mut Reader) -> Self {
-        Self::Owned(r.rest().to_vec())
     }
 }
 

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -4,9 +4,12 @@ use crate::msgs::codec::{Codec, Reader};
 
 use alloc::vec::Vec;
 use core::fmt;
+use core::ops::{Deref, DerefMut};
 
 use pki_types::CertificateDer;
 use zeroize::Zeroize;
+
+use super::codec::ReaderMut;
 
 /// An externally length'd payload
 #[derive(Clone, Eq, PartialEq)]
@@ -33,6 +36,30 @@ impl Payload {
 
     pub fn read(r: &mut Reader) -> Self {
         Self(r.rest().to_vec())
+    }
+}
+
+/// Non-owning version of [`Payload`]
+pub struct BorrowedPayload<'a>(&'a mut [u8]);
+
+impl Deref for BorrowedPayload<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl<'a> DerefMut for BorrowedPayload<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0
+    }
+}
+
+impl<'a> BorrowedPayload<'a> {
+    #[allow(dead_code)] // TODO(@cpu): remove in "introduce and expose BorrowedOpaqueMessage"
+    pub(crate) fn read(r: &mut ReaderMut<'a>) -> Self {
+        Self(r.rest())
     }
 }
 

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -115,16 +115,16 @@ impl<'a> BorrowedPayload<'a> {
     }
 }
 
-impl<'a> Codec<'_> for CertificateDer<'a> {
+impl<'a> Codec<'a> for CertificateDer<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         codec::u24(self.as_ref().len() as u32).encode(bytes);
         bytes.extend(self.as_ref());
     }
 
-    fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
+    fn read(r: &mut Reader<'a>) -> Result<Self, InvalidMessage> {
         let len = codec::u24::read(r)?.0 as usize;
         let mut sub = r.sub(len)?;
-        let body = sub.rest().to_vec();
+        let body = sub.rest();
         Ok(Self::from(body))
     }
 }

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -15,7 +15,7 @@ use super::codec::ReaderMut;
 #[derive(Clone, Eq, PartialEq)]
 pub struct Payload(pub Vec<u8>);
 
-impl Codec for Payload {
+impl Codec<'_> for Payload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(&self.0);
     }
@@ -92,7 +92,7 @@ impl<'a> BorrowedPayload<'a> {
     }
 }
 
-impl<'a> Codec for CertificateDer<'a> {
+impl<'a> Codec<'_> for CertificateDer<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         codec::u24(self.as_ref().len() as u32).encode(bytes);
         bytes.extend(self.as_ref());
@@ -122,7 +122,7 @@ impl PayloadU24 {
     }
 }
 
-impl Codec for PayloadU24 {
+impl Codec<'_> for PayloadU24 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         codec::u24(self.0.len() as u32).encode(bytes);
         bytes.extend_from_slice(&self.0);
@@ -161,7 +161,7 @@ impl PayloadU16 {
     }
 }
 
-impl Codec for PayloadU16 {
+impl Codec<'_> for PayloadU16 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         Self::encode_slice(&self.0, bytes);
     }
@@ -199,7 +199,7 @@ impl PayloadU8 {
     }
 }
 
-impl Codec for PayloadU8 {
+impl Codec<'_> for PayloadU8 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         (self.0.len() as u8).encode(bytes);
         bytes.extend_from_slice(&self.0);

--- a/rustls/src/msgs/ccs.rs
+++ b/rustls/src/msgs/ccs.rs
@@ -6,7 +6,7 @@ use crate::msgs::codec::{Codec, Reader};
 #[derive(Debug)]
 pub struct ChangeCipherSpecPayload;
 
-impl Codec for ChangeCipherSpecPayload {
+impl Codec<'_> for ChangeCipherSpecPayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         1u8.encode(bytes);
     }

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -19,7 +19,7 @@ pub struct Reader<'a> {
 impl<'a> Reader<'a> {
     /// Creates a new Reader of the provided `bytes` slice with
     /// the initial cursor position of zero.
-    pub fn init(bytes: &[u8]) -> Reader {
+    pub fn init(bytes: &'a [u8]) -> Self {
         Reader {
             buffer: bytes,
             cursor: 0,
@@ -29,7 +29,7 @@ impl<'a> Reader<'a> {
     /// Attempts to create a new Reader on a sub section of this
     /// readers bytes by taking a slice of the provided `length`
     /// will return None if there is not enough bytes
-    pub fn sub(&mut self, length: usize) -> Result<Reader, InvalidMessage> {
+    pub fn sub(&mut self, length: usize) -> Result<Self, InvalidMessage> {
         match self.take(length) {
             Some(bytes) => Ok(Reader::init(bytes)),
             None => Err(InvalidMessage::MessageTooShort),
@@ -40,7 +40,7 @@ impl<'a> Reader<'a> {
     /// that appear after the cursor position.
     ///
     /// Moves the cursor to the end of the buffer length.
-    pub fn rest(&mut self) -> &[u8] {
+    pub fn rest(&mut self) -> &'a [u8] {
         let rest = &self.buffer[self.cursor..];
         self.cursor = self.buffer.len();
         rest
@@ -50,7 +50,7 @@ impl<'a> Reader<'a> {
     /// cursor position of `length` if there is not enough
     /// bytes remaining after the cursor to take the length
     /// then None is returned instead.
-    pub fn take(&mut self, length: usize) -> Option<&[u8]> {
+    pub fn take(&mut self, length: usize) -> Option<&'a [u8]> {
         if self.left() < length {
             return None;
         }

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -92,7 +92,6 @@ pub(crate) struct ReaderMut<'a> {
     used: usize,
 }
 
-#[allow(dead_code)] // TODO(@cpu): remove in "introduce and expose BorrowedOpaqueMessage"
 impl<'a> ReaderMut<'a> {
     pub(crate) fn init(bytes: &'a mut [u8]) -> Self {
         Self {
@@ -124,6 +123,7 @@ impl<'a> ReaderMut<'a> {
         Some(taken)
     }
 
+    #[allow(dead_code)] // TODO(@cpu): Remove in "use BorrowedOpaqueMessage in MessageDeframer".
     pub(crate) fn used(&self) -> usize {
         self.used
     }

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -123,7 +123,6 @@ impl<'a> ReaderMut<'a> {
         Some(taken)
     }
 
-    #[allow(dead_code)] // TODO(@cpu): Remove in "use BorrowedOpaqueMessage in MessageDeframer".
     pub(crate) fn used(&self) -> usize {
         self.used
     }

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -865,7 +865,7 @@ mod tests {
         let mut rl = RecordLayer::new();
         let m = d.pop_message(&mut rl, None);
         assert_eq!(m.typ, ContentType::ApplicationData);
-        assert_eq!(m.payload.0.len(), 0);
+        assert_eq!(m.payload.bytes().len(), 0);
         assert!(!d.has_pending());
         assert!(d.last_error.is_none());
     }

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -384,7 +384,7 @@ pub(crate) mod tests {
         );
     }
 
-    pub(crate) fn test_enum8<T: Codec>(first: T, last: T) {
+    pub(crate) fn test_enum8<T: for<'a> Codec<'a>>(first: T, last: T) {
         let first_v = get8(&first);
         let last_v = get8(&last);
 
@@ -398,7 +398,7 @@ pub(crate) mod tests {
         }
     }
 
-    pub(crate) fn test_enum16<T: Codec>(first: T, last: T) {
+    pub(crate) fn test_enum16<T: for<'a> Codec<'a>>(first: T, last: T) {
         let first_v = get16(&first);
         let last_v = get16(&last);
 
@@ -412,13 +412,13 @@ pub(crate) mod tests {
         }
     }
 
-    fn get8<T: Codec>(enum_value: &T) -> u8 {
+    fn get8<T: for<'a> Codec<'a>>(enum_value: &T) -> u8 {
         let enc = enum_value.get_encoding();
         assert_eq!(enc.len(), 1);
         enc[0]
     }
 
-    fn get16<T: Codec>(enum_value: &T) -> u16 {
+    fn get16<T: for<'a> Codec<'a>>(enum_value: &T) -> u16 {
         let enc = enum_value.get_encoding();
         assert_eq!(enc.len(), 2);
         (enc[0] as u16 >> 8) | (enc[1] as u16)

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -27,7 +27,7 @@ impl MessageFragmenter {
         &self,
         msg: &'a PlainMessage,
     ) -> impl Iterator<Item = BorrowedPlainMessage<'a>> + 'a {
-        self.fragment_slice(msg.typ, msg.version, &msg.payload.0)
+        self.fragment_slice(msg.typ, msg.version, msg.payload.bytes())
     }
 
     /// Enqueue borrowed fragments of (version, typ, payload) which

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -185,7 +185,7 @@ impl SessionId {
 #[derive(Clone, Debug)]
 pub struct UnknownExtension {
     pub(crate) typ: ExtensionType,
-    pub(crate) payload: Payload,
+    pub(crate) payload: Payload<'static>,
 }
 
 impl UnknownExtension {
@@ -214,7 +214,7 @@ impl TlsListElement for SignatureScheme {
 #[derive(Clone, Debug)]
 pub(crate) enum ServerNamePayload {
     HostName(DnsName<'static>),
-    Unknown(Payload),
+    Unknown(Payload<'static>),
 }
 
 impl ServerNamePayload {
@@ -483,7 +483,7 @@ impl Codec<'_> for OcspCertificateStatusRequest {
 #[derive(Clone, Debug)]
 pub enum CertificateStatusRequest {
     Ocsp(OcspCertificateStatusRequest),
-    Unknown((CertificateStatusType, Payload)),
+    Unknown((CertificateStatusType, Payload<'static>)),
 }
 
 impl Codec<'_> for CertificateStatusRequest {
@@ -684,7 +684,7 @@ impl ClientExtension {
 #[derive(Clone, Debug)]
 pub enum ClientSessionTicket {
     Request,
-    Offer(Payload),
+    Offer(Payload<'static>),
 }
 
 #[derive(Clone, Debug)]
@@ -1588,7 +1588,7 @@ impl Codec<'_> for EcdheServerKeyExchange {
 #[derive(Debug)]
 pub enum ServerKeyExchangePayload {
     Ecdhe(EcdheServerKeyExchange),
-    Unknown(Payload),
+    Unknown(Payload<'static>),
 }
 
 impl Codec<'_> for ServerKeyExchangePayload {
@@ -1613,7 +1613,7 @@ impl ServerKeyExchangePayload {
         kxa: KeyExchangeAlgorithm,
     ) -> Option<EcdheServerKeyExchange> {
         if let Self::Unknown(ref unk) = *self {
-            let mut rd = Reader::init(&unk.0);
+            let mut rd = Reader::init(unk.bytes());
 
             let result = match kxa {
                 KeyExchangeAlgorithm::ECDHE => EcdheServerKeyExchange::read(&mut rd),
@@ -2076,15 +2076,15 @@ pub enum HandshakePayload {
     CertificateVerify(DigitallySignedStruct),
     ServerHelloDone,
     EndOfEarlyData,
-    ClientKeyExchange(Payload),
+    ClientKeyExchange(Payload<'static>),
     NewSessionTicket(NewSessionTicketPayload),
     NewSessionTicketTls13(NewSessionTicketPayloadTls13),
     EncryptedExtensions(Vec<ServerExtension>),
     KeyUpdate(KeyUpdateRequest),
-    Finished(Payload),
+    Finished(Payload<'static>),
     CertificateStatus(CertificateStatus),
-    MessageHash(Payload),
-    Unknown(Payload),
+    MessageHash(Payload<'static>),
+    Unknown(Payload<'static>),
 }
 
 impl HandshakePayload {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -194,7 +194,7 @@ impl UnknownExtension {
     }
 
     fn read(typ: ExtensionType, r: &mut Reader) -> Self {
-        let payload = Payload::read(r);
+        let payload = Payload::read(r).into_owned();
         Self { typ, payload }
     }
 }
@@ -265,7 +265,7 @@ impl Codec<'_> for ServerName {
 
         let payload = match typ {
             ServerNameType::HostName => ServerNamePayload::read_hostname(r)?,
-            _ => ServerNamePayload::Unknown(Payload::read(r)),
+            _ => ServerNamePayload::Unknown(Payload::read(r).into_owned()),
         };
 
         Ok(Self { typ, payload })
@@ -506,7 +506,7 @@ impl Codec<'_> for CertificateStatusRequest {
                 Ok(Self::Ocsp(ocsp_req))
             }
             _ => {
-                let data = Payload::read(r);
+                let data = Payload::read(r).into_owned();
                 Ok(Self::Unknown((typ, data)))
             }
         }
@@ -622,7 +622,7 @@ impl Codec<'_> for ClientExtension {
             ExtensionType::ServerName => Self::ServerName(Vec::read(&mut sub)?),
             ExtensionType::SessionTicket => {
                 if sub.any_left() {
-                    let contents = Payload::read(&mut sub);
+                    let contents = Payload::read(&mut sub).into_owned();
                     Self::SessionTicket(ClientSessionTicket::Offer(contents))
                 } else {
                     Self::SessionTicket(ClientSessionTicket::Request)
@@ -1602,7 +1602,7 @@ impl Codec<'_> for ServerKeyExchangePayload {
     fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         // read as Unknown, fully parse when we know the
         // KeyExchangeAlgorithm
-        Ok(Self::Unknown(Payload::read(r)))
+        Ok(Self::Unknown(Payload::read(r).into_owned()))
     }
 }
 
@@ -2184,7 +2184,7 @@ impl HandshakeMessagePayload {
                 HandshakePayload::ServerHelloDone
             }
             HandshakeType::ClientKeyExchange => {
-                HandshakePayload::ClientKeyExchange(Payload::read(&mut sub))
+                HandshakePayload::ClientKeyExchange(Payload::read(&mut sub).into_owned())
             }
             HandshakeType::CertificateRequest if vers == ProtocolVersion::TLSv1_3 => {
                 let p = CertificateRequestPayloadTls13::read(&mut sub)?;
@@ -2215,7 +2215,9 @@ impl HandshakeMessagePayload {
                 sub.expect_empty("EndOfEarlyData")?;
                 HandshakePayload::EndOfEarlyData
             }
-            HandshakeType::Finished => HandshakePayload::Finished(Payload::read(&mut sub)),
+            HandshakeType::Finished => {
+                HandshakePayload::Finished(Payload::read(&mut sub).into_owned())
+            }
             HandshakeType::CertificateStatus => {
                 HandshakePayload::CertificateStatus(CertificateStatus::read(&mut sub)?)
             }
@@ -2227,7 +2229,7 @@ impl HandshakeMessagePayload {
                 // not legal on wire
                 return Err(InvalidMessage::UnexpectedMessage("HelloRetryRequest"));
             }
-            _ => HandshakePayload::Unknown(Payload::read(&mut sub)),
+            _ => HandshakePayload::Unknown(Payload::read(&mut sub).into_owned()),
         };
 
         sub.expect_empty("HandshakeMessagePayload")

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -51,7 +51,7 @@ macro_rules! wrapped_payload(
         }
     }
 
-    impl Codec for $name {
+    impl Codec<'_> for $name {
         fn encode(&self, bytes: &mut Vec<u8>) {
             self.0.encode(bytes);
         }
@@ -79,7 +79,7 @@ static HELLO_RETRY_REQUEST_RANDOM: Random = Random([
 
 static ZERO_RANDOM: Random = Random([0u8; 32]);
 
-impl Codec for Random {
+impl Codec<'_> for Random {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(&self.0);
     }
@@ -138,7 +138,7 @@ impl PartialEq for SessionId {
     }
 }
 
-impl Codec for SessionId {
+impl Codec<'_> for SessionId {
     fn encode(&self, bytes: &mut Vec<u8>) {
         debug_assert!(self.len <= 32);
         bytes.push(self.len as u8);
@@ -254,7 +254,7 @@ pub struct ServerName {
     pub(crate) payload: ServerNamePayload,
 }
 
-impl Codec for ServerName {
+impl Codec<'_> for ServerName {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.typ.encode(bytes);
         self.payload.encode(bytes);
@@ -368,7 +368,7 @@ impl KeyShareEntry {
     }
 }
 
-impl Codec for KeyShareEntry {
+impl Codec<'_> for KeyShareEntry {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.group.encode(bytes);
         self.payload.encode(bytes);
@@ -398,7 +398,7 @@ impl PresharedKeyIdentity {
     }
 }
 
-impl Codec for PresharedKeyIdentity {
+impl Codec<'_> for PresharedKeyIdentity {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.identity.encode(bytes);
         self.obfuscated_ticket_age.encode(bytes);
@@ -438,7 +438,7 @@ impl PresharedKeyOffer {
     }
 }
 
-impl Codec for PresharedKeyOffer {
+impl Codec<'_> for PresharedKeyOffer {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.identities.encode(bytes);
         self.binders.encode(bytes);
@@ -465,7 +465,7 @@ pub struct OcspCertificateStatusRequest {
     pub(crate) extensions: PayloadU16,
 }
 
-impl Codec for OcspCertificateStatusRequest {
+impl Codec<'_> for OcspCertificateStatusRequest {
     fn encode(&self, bytes: &mut Vec<u8>) {
         CertificateStatusType::OCSP.encode(bytes);
         self.responder_ids.encode(bytes);
@@ -486,7 +486,7 @@ pub enum CertificateStatusRequest {
     Unknown((CertificateStatusType, Payload)),
 }
 
-impl Codec for CertificateStatusRequest {
+impl Codec<'_> for CertificateStatusRequest {
     fn encode(&self, bytes: &mut Vec<u8>) {
         match self {
             Self::Ocsp(ref r) => r.encode(bytes),
@@ -582,7 +582,7 @@ impl ClientExtension {
     }
 }
 
-impl Codec for ClientExtension {
+impl Codec<'_> for ClientExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.ext_type().encode(bytes);
 
@@ -726,7 +726,7 @@ impl ServerExtension {
     }
 }
 
-impl Codec for ServerExtension {
+impl Codec<'_> for ServerExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.ext_type().encode(bytes);
 
@@ -803,7 +803,7 @@ pub struct ClientHelloPayload {
     pub extensions: Vec<ClientExtension>,
 }
 
-impl Codec for ClientHelloPayload {
+impl Codec<'_> for ClientHelloPayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.client_version.encode(bytes);
         self.random.encode(bytes);
@@ -1029,7 +1029,7 @@ impl HelloRetryExtension {
     }
 }
 
-impl Codec for HelloRetryExtension {
+impl Codec<'_> for HelloRetryExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.ext_type().encode(bytes);
 
@@ -1073,7 +1073,7 @@ pub struct HelloRetryRequest {
     pub(crate) extensions: Vec<HelloRetryExtension>,
 }
 
-impl Codec for HelloRetryRequest {
+impl Codec<'_> for HelloRetryRequest {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.legacy_version.encode(bytes);
         HELLO_RETRY_REQUEST_RANDOM.encode(bytes);
@@ -1168,7 +1168,7 @@ pub struct ServerHelloPayload {
     pub(crate) extensions: Vec<ServerExtension>,
 }
 
-impl Codec for ServerHelloPayload {
+impl Codec<'_> for ServerHelloPayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.legacy_version.encode(bytes);
         self.random.encode(bytes);
@@ -1257,7 +1257,7 @@ impl ServerHelloPayload {
 #[derive(Clone, Default, Debug)]
 pub struct CertificateChain(pub Vec<CertificateDer<'static>>);
 
-impl Codec for CertificateChain {
+impl Codec<'_> for CertificateChain {
     fn encode(&self, bytes: &mut Vec<u8>) {
         Vec::encode(&self.0, bytes)
     }
@@ -1305,7 +1305,7 @@ impl CertificateExtension {
     }
 }
 
-impl Codec for CertificateExtension {
+impl Codec<'_> for CertificateExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.ext_type().encode(bytes);
 
@@ -1344,7 +1344,7 @@ pub(crate) struct CertificateEntry {
     pub(crate) exts: Vec<CertificateExtension>,
 }
 
-impl Codec for CertificateEntry {
+impl Codec<'_> for CertificateEntry {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.cert.encode(bytes);
         self.exts.encode(bytes);
@@ -1405,7 +1405,7 @@ pub struct CertificatePayloadTls13 {
     pub(crate) entries: Vec<CertificateEntry>,
 }
 
-impl Codec for CertificatePayloadTls13 {
+impl Codec<'_> for CertificatePayloadTls13 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.context.encode(bytes);
         self.entries.encode(bytes);
@@ -1492,7 +1492,7 @@ pub(crate) struct EcParameters {
     pub(crate) named_group: NamedGroup,
 }
 
-impl Codec for EcParameters {
+impl Codec<'_> for EcParameters {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.curve_type.encode(bytes);
         self.named_group.encode(bytes);
@@ -1518,7 +1518,7 @@ pub(crate) struct ClientEcdhParams {
     pub(crate) public: PayloadU8,
 }
 
-impl Codec for ClientEcdhParams {
+impl Codec<'_> for ClientEcdhParams {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.public.encode(bytes);
     }
@@ -1548,7 +1548,7 @@ impl ServerEcdhParams {
     }
 }
 
-impl Codec for ServerEcdhParams {
+impl Codec<'_> for ServerEcdhParams {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.curve_params.encode(bytes);
         self.public.encode(bytes);
@@ -1571,7 +1571,7 @@ pub struct EcdheServerKeyExchange {
     pub(crate) dss: DigitallySignedStruct,
 }
 
-impl Codec for EcdheServerKeyExchange {
+impl Codec<'_> for EcdheServerKeyExchange {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.params.encode(bytes);
         self.dss.encode(bytes);
@@ -1591,7 +1591,7 @@ pub enum ServerKeyExchangePayload {
     Unknown(Payload),
 }
 
-impl Codec for ServerKeyExchangePayload {
+impl Codec<'_> for ServerKeyExchangePayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         match *self {
             Self::Ecdhe(ref x) => x.encode(bytes),
@@ -1737,7 +1737,7 @@ pub struct CertificateRequestPayload {
     pub(crate) canames: Vec<DistinguishedName>,
 }
 
-impl Codec for CertificateRequestPayload {
+impl Codec<'_> for CertificateRequestPayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.certtypes.encode(bytes);
         self.sigschemes.encode(bytes);
@@ -1779,7 +1779,7 @@ impl CertReqExtension {
     }
 }
 
-impl Codec for CertReqExtension {
+impl Codec<'_> for CertReqExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.ext_type().encode(bytes);
 
@@ -1826,7 +1826,7 @@ pub struct CertificateRequestPayloadTls13 {
     pub(crate) extensions: Vec<CertReqExtension>,
 }
 
-impl Codec for CertificateRequestPayloadTls13 {
+impl Codec<'_> for CertificateRequestPayloadTls13 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.context.encode(bytes);
         self.extensions.encode(bytes);
@@ -1884,7 +1884,7 @@ impl NewSessionTicketPayload {
     }
 }
 
-impl Codec for NewSessionTicketPayload {
+impl Codec<'_> for NewSessionTicketPayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.lifetime_hint.encode(bytes);
         self.ticket.encode(bytes);
@@ -1917,7 +1917,7 @@ impl NewSessionTicketExtension {
     }
 }
 
-impl Codec for NewSessionTicketExtension {
+impl Codec<'_> for NewSessionTicketExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.ext_type().encode(bytes);
 
@@ -1997,7 +1997,7 @@ impl NewSessionTicketPayloadTls13 {
     }
 }
 
-impl Codec for NewSessionTicketPayloadTls13 {
+impl Codec<'_> for NewSessionTicketPayloadTls13 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.lifetime.encode(bytes);
         self.age_add.encode(bytes);
@@ -2031,7 +2031,7 @@ pub struct CertificateStatus {
     pub(crate) ocsp_response: PayloadU24,
 }
 
-impl Codec for CertificateStatus {
+impl Codec<'_> for CertificateStatus {
     fn encode(&self, bytes: &mut Vec<u8>) {
         CertificateStatusType::OCSP.encode(bytes);
         self.ocsp_response.encode(bytes);
@@ -2120,7 +2120,7 @@ pub struct HandshakeMessagePayload {
     pub payload: HandshakePayload,
 }
 
-impl Codec for HandshakeMessagePayload {
+impl Codec<'_> for HandshakeMessagePayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         // output type, length, and encoded payload
         match self.typ {
@@ -2277,7 +2277,7 @@ pub struct HpkeSymmetricCipherSuite {
     pub aead_id: HpkeAead,
 }
 
-impl Codec for HpkeSymmetricCipherSuite {
+impl Codec<'_> for HpkeSymmetricCipherSuite {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.kdf_id.encode(bytes);
         self.aead_id.encode(bytes);
@@ -2303,7 +2303,7 @@ pub struct HpkeKeyConfig {
     pub symmetric_cipher_suites: Vec<HpkeSymmetricCipherSuite>,
 }
 
-impl Codec for HpkeKeyConfig {
+impl Codec<'_> for HpkeKeyConfig {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.config_id.encode(bytes);
         self.kem_id.encode(bytes);
@@ -2330,7 +2330,7 @@ pub struct EchConfigContents {
     pub extensions: PayloadU16,
 }
 
-impl Codec for EchConfigContents {
+impl Codec<'_> for EchConfigContents {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.key_config.encode(bytes);
         self.maximum_name_length.encode(bytes);
@@ -2359,7 +2359,7 @@ pub struct EchConfig {
     pub contents: EchConfigContents,
 }
 
-impl Codec for EchConfig {
+impl Codec<'_> for EchConfig {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.version.encode(bytes);
         let mut contents = Vec::with_capacity(128);

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -370,7 +370,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
             ClientExtension::make_sni(&DnsName::try_from("hello").unwrap()),
             ClientExtension::SessionTicket(ClientSessionTicket::Request),
-            ClientExtension::SessionTicket(ClientSessionTicket::Offer(Payload(vec![]))),
+            ClientExtension::SessionTicket(ClientSessionTicket::Offer(Payload::Borrowed(&[]))),
             ClientExtension::Protocols(vec![ProtocolName::from(vec![0])]),
             ClientExtension::SupportedVersions(vec![ProtocolVersion::TLSv1_3]),
             ClientExtension::KeyShare(vec![KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3])]),
@@ -391,7 +391,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::TransportParameters(vec![1, 2, 3]),
             ClientExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload::Borrowed(&[1, 2, 3]),
             }),
         ],
     }
@@ -497,7 +497,7 @@ fn test_client_extension_getter(typ: ExtensionType, getter: fn(&ClientHelloPaylo
 
     chp.extensions = vec![ClientExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload::Borrowed(&[]),
     })];
     assert!(!getter(&chp));
 }
@@ -612,7 +612,7 @@ fn test_helloretry_extension_getter(typ: ExtensionType, getter: fn(&HelloRetryRe
 
     hrr.extensions = vec![HelloRetryExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload::Borrowed(&[]),
     })];
     assert!(!getter(&hrr));
 }
@@ -681,7 +681,7 @@ fn test_server_extension_getter(typ: ExtensionType, getter: fn(&ServerHelloPaylo
 
     shp.extensions = vec![ServerExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload::Borrowed(&[]),
     })];
     assert!(!getter(&shp));
 }
@@ -724,7 +724,7 @@ fn test_cert_extension_getter(typ: ExtensionType, getter: fn(&CertificateEntry) 
 
     ce.exts = vec![CertificateExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload::Borrowed(&[]),
     })];
     assert!(!getter(&ce));
 }
@@ -757,7 +757,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
             ServerExtension::TransportParameters(vec![1, 2, 3]),
             ServerExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload::Borrowed(&[1, 2, 3]),
             }),
         ],
     }
@@ -784,7 +784,7 @@ fn get_sample_helloretryrequest() -> HelloRetryRequest {
             HelloRetryExtension::SupportedVersions(ProtocolVersion::TLSv1_2),
             HelloRetryExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload::Borrowed(&[1, 2, 3]),
             }),
         ],
     }
@@ -801,7 +801,7 @@ fn get_sample_certificatepayloadtls13() -> CertificatePayloadTls13 {
                 }),
                 CertificateExtension::Unknown(UnknownExtension {
                     typ: ExtensionType::Unknown(12345),
-                    payload: Payload(vec![1, 2, 3]),
+                    payload: Payload::Borrowed(&[1, 2, 3]),
                 }),
             ],
         }],
@@ -822,7 +822,7 @@ fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
 }
 
 fn get_sample_serverkeyexchangepayload_unknown() -> ServerKeyExchangePayload {
-    ServerKeyExchangePayload::Unknown(Payload(vec![1, 2, 3]))
+    ServerKeyExchangePayload::Unknown(Payload::Borrowed(&[1, 2, 3]))
 }
 
 fn get_sample_certificaterequestpayload() -> CertificateRequestPayload {
@@ -841,7 +841,7 @@ fn get_sample_certificaterequestpayloadtls13() -> CertificateRequestPayloadTls13
             CertReqExtension::AuthorityNames(vec![DistinguishedName::from(vec![1, 2, 3])]),
             CertReqExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload::Borrowed(&[1, 2, 3]),
             }),
         ],
     }
@@ -862,7 +862,7 @@ fn get_sample_newsessionticketpayloadtls13() -> NewSessionTicketPayloadTls13 {
         ticket: PayloadU16(vec![4, 5, 6]),
         exts: vec![NewSessionTicketExtension::Unknown(UnknownExtension {
             typ: ExtensionType::Unknown(12345),
-            payload: Payload(vec![1, 2, 3]),
+            payload: Payload::Borrowed(&[1, 2, 3]),
         })],
     }
 }
@@ -923,7 +923,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::ClientKeyExchange,
-            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::ClientKeyExchange(Payload::Borrowed(&[1, 2, 3])),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
@@ -943,7 +943,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Finished,
-            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Finished(Payload::Borrowed(&[1, 2, 3])),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::CertificateStatus,
@@ -951,7 +951,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Unknown(99),
-            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Unknown(Payload::Borrowed(&[1, 2, 3])),
         },
     ]
 }
@@ -1060,7 +1060,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::ClientKeyExchange,
-            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::ClientKeyExchange(Payload::Borrowed(&[1, 2, 3])),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
@@ -1082,7 +1082,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Finished,
-            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Finished(Payload::Borrowed(&[1, 2, 3])),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::CertificateStatus,
@@ -1090,7 +1090,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Unknown(99),
-            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Unknown(Payload::Borrowed(&[1, 2, 3])),
         },
     ]
 }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -877,7 +877,7 @@ fn get_sample_certificatestatus() -> CertificateStatus {
     }
 }
 
-fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
+fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload<'static>> {
     vec![
         HandshakeMessagePayload {
             typ: HandshakeType::HelloRequest,
@@ -1007,7 +1007,7 @@ fn can_detect_truncation_of_all_tls12_handshake_payloads() {
     }
 }
 
-fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
+fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload<'static>> {
     vec![
         HandshakeMessagePayload {
             typ: HandshakeType::HelloRequest,

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -22,7 +22,7 @@ macro_rules! enum_builder {
                 }
             }
         }
-        impl Codec for $enum_name {
+        impl Codec<'_> for $enum_name {
             // NOTE(allow) fully qualified Vec is only needed in no-std mode
             #[allow(unused_qualifications)]
             fn encode(&self, bytes: &mut alloc::vec::Vec<u8>) {
@@ -75,7 +75,7 @@ macro_rules! enum_builder {
                 }
             }
         }
-        impl Codec for $enum_name {
+        impl Codec<'_> for $enum_name {
             // NOTE(allow) fully qualified Vec is only needed in no-std mode
             #[allow(unused_qualifications)]
             fn encode(&self, bytes: &mut alloc::vec::Vec<u8>) {

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -19,7 +19,7 @@ use super::codec::ReaderMut;
 pub enum MessagePayload<'a> {
     Alert(AlertMessagePayload),
     Handshake {
-        parsed: HandshakeMessagePayload,
+        parsed: HandshakeMessagePayload<'a>,
         encoded: Payload<'a>,
     },
     ChangeCipherSpec(ChangeCipherSpecPayload),
@@ -36,7 +36,7 @@ impl<'a> MessagePayload<'a> {
         }
     }
 
-    pub fn handshake(parsed: HandshakeMessagePayload) -> Self {
+    pub fn handshake(parsed: HandshakeMessagePayload<'a>) -> Self {
         Self::Handshake {
             encoded: Payload::new(parsed.get_encoding()),
             parsed,
@@ -79,7 +79,7 @@ impl<'a> MessagePayload<'a> {
         match self {
             Alert(x) => Alert(x),
             Handshake { parsed, encoded } => Handshake {
-                parsed,
+                parsed: parsed.into_owned(),
                 encoded: encoded.into_owned(),
             },
             ChangeCipherSpec(x) => ChangeCipherSpec(x),

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -20,17 +20,17 @@ pub enum MessagePayload {
     Alert(AlertMessagePayload),
     Handshake {
         parsed: HandshakeMessagePayload,
-        encoded: Payload,
+        encoded: Payload<'static>,
     },
     ChangeCipherSpec(ChangeCipherSpecPayload),
-    ApplicationData(Payload),
+    ApplicationData(Payload<'static>),
 }
 
 impl MessagePayload {
     pub fn encode(&self, bytes: &mut Vec<u8>) {
         match self {
             Self::Alert(x) => x.encode(bytes),
-            Self::Handshake { encoded, .. } => bytes.extend(&encoded.0),
+            Self::Handshake { encoded, .. } => bytes.extend(encoded.bytes()),
             Self::ChangeCipherSpec(x) => x.encode(bytes),
             Self::ApplicationData(x) => x.encode(bytes),
         }
@@ -46,9 +46,9 @@ impl MessagePayload {
     pub fn new(
         typ: ContentType,
         vers: ProtocolVersion,
-        payload: Payload,
+        payload: Payload<'static>,
     ) -> Result<Self, InvalidMessage> {
-        let mut r = Reader::init(&payload.0);
+        let mut r = Reader::init(payload.bytes());
         match typ {
             ContentType::ApplicationData => Ok(Self::ApplicationData(payload)),
             ContentType::Alert => AlertMessagePayload::read(&mut r).map(MessagePayload::Alert),
@@ -90,7 +90,7 @@ impl MessagePayload {
 pub struct OpaqueMessage {
     pub typ: ContentType,
     pub version: ProtocolVersion,
-    payload: Payload,
+    payload: Payload<'static>,
 }
 
 impl OpaqueMessage {
@@ -107,12 +107,15 @@ impl OpaqueMessage {
 
     /// Access the message payload as a slice.
     pub fn payload(&self) -> &[u8] {
-        &self.payload.0
+        self.payload.bytes()
     }
 
     /// Access the message payload as a mutable `Vec<u8>`.
     pub fn payload_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.payload.0
+        match &mut self.payload {
+            Payload::Borrowed(_) => unreachable!("due to how constructor works"),
+            Payload::Owned(bytes) => bytes,
+        }
     }
 
     /// `MessageError` allows callers to distinguish between valid prefixes (might
@@ -136,7 +139,7 @@ impl OpaqueMessage {
         let mut buf = Vec::new();
         self.typ.encode(&mut buf);
         self.version.encode(&mut buf);
-        (self.payload.0.len() as u16).encode(&mut buf);
+        (self.payload.bytes().len() as u16).encode(&mut buf);
         self.payload.encode(&mut buf);
         buf
     }
@@ -291,7 +294,7 @@ impl From<Message> for PlainMessage {
             _ => {
                 let mut buf = Vec::new();
                 msg.payload.encode(&mut buf);
-                Payload(buf)
+                Payload::Owned(buf)
             }
         };
 
@@ -311,7 +314,7 @@ impl From<Message> for PlainMessage {
 pub struct PlainMessage {
     pub typ: ContentType,
     pub version: ProtocolVersion,
-    pub payload: Payload,
+    pub payload: Payload<'static>,
 }
 
 impl PlainMessage {
@@ -327,7 +330,7 @@ impl PlainMessage {
         BorrowedPlainMessage {
             version: self.version,
             typ: self.typ,
-            payload: &self.payload.0,
+            payload: self.payload.bytes(),
         }
     }
 }
@@ -402,7 +405,7 @@ impl<'a> BorrowedPlainMessage<'a> {
         OpaqueMessage {
             version: self.version,
             typ: self.typ,
-            payload: Payload(self.payload.to_vec()),
+            payload: Payload::Owned(self.payload.to_vec()),
         }
     }
 

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -213,6 +213,19 @@ impl<'a> BorrowedOpaqueMessage<'a> {
             payload,
         })
     }
+
+    pub(crate) fn into_owned(self) -> OpaqueMessage {
+        let Self {
+            typ,
+            version,
+            payload,
+        } = self;
+        OpaqueMessage {
+            typ,
+            version,
+            payload: Payload::new(&*payload),
+        }
+    }
 }
 
 fn read_opaque_message_header(

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -126,7 +126,7 @@ impl OpaqueMessage {
         let mut sub = r
             .sub(len as usize)
             .map_err(|_| MessageError::TooShortForLength)?;
-        let payload = Payload::read(&mut sub);
+        let payload = Payload::read(&mut sub).into_owned();
 
         Ok(Self {
             typ,

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -410,7 +410,7 @@ impl<'a> BorrowedPlainMessage<'a> {
         OpaqueMessage::HEADER_SIZE as usize + record_layer.encrypted_len(self.payload.len())
     }
 
-    pub(crate) fn into_owned(self) -> PlainMessage {
+    pub fn into_owned(self) -> PlainMessage {
         let Self {
             typ,
             version,

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -100,7 +100,7 @@ fn construct_all_types() {
 
 #[test]
 fn debug_payload() {
-    assert_eq!("01020304", format!("{:?}", Payload(vec![1, 2, 3, 4])));
+    assert_eq!("01020304", format!("{:?}", Payload::new(vec![1, 2, 3, 4])));
     assert_eq!("01020304", format!("{:?}", PayloadU8(vec![1, 2, 3, 4])));
     assert_eq!("01020304", format!("{:?}", PayloadU16(vec![1, 2, 3, 4])));
     assert_eq!("01020304", format!("{:?}", PayloadU24(vec![1, 2, 3, 4])));

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -264,7 +264,7 @@ pub struct ServerSessionValue {
     freshness: Option<bool>,
 }
 
-impl Codec for ServerSessionValue {
+impl Codec<'_> for ServerSessionValue {
     fn encode(&self, bytes: &mut Vec<u8>) {
         if let Some(ref sni) = self.sni {
             1u8.encode(bytes);

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -2,7 +2,7 @@ use core::num::NonZeroU64;
 
 use crate::crypto::cipher::{BorrowedOpaqueMessage, MessageDecrypter, MessageEncrypter};
 use crate::error::Error;
-use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
+use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage};
 
 #[cfg(feature = "logging")]
 use crate::log::trace;
@@ -60,14 +60,14 @@ impl RecordLayer {
     /// `encr` is a decoded message allegedly received from the peer.
     /// If it can be decrypted, its decryption is returned.  Otherwise,
     /// an error is returned.
-    pub(crate) fn decrypt_incoming(
+    pub(crate) fn decrypt_incoming<'a>(
         &mut self,
-        encr: BorrowedOpaqueMessage<'_>,
-    ) -> Result<Option<Decrypted>, Error> {
+        encr: BorrowedOpaqueMessage<'a>,
+    ) -> Result<Option<Decrypted<'a>>, Error> {
         if self.decrypt_state != DirectionState::Active {
             return Ok(Some(Decrypted {
                 want_close_before_decrypt: false,
-                plaintext: encr.into_plain_message().into_owned(),
+                plaintext: encr.into_plain_message(),
             }));
         }
 
@@ -93,7 +93,7 @@ impl RecordLayer {
                 }
                 Ok(Some(Decrypted {
                     want_close_before_decrypt,
-                    plaintext: plaintext.into_owned(),
+                    plaintext,
                 }))
             }
             Err(Error::DecryptError) if self.doing_trial_decryption(encrypted_len) => {
@@ -238,11 +238,11 @@ impl RecordLayer {
 
 /// Result of decryption.
 #[derive(Debug)]
-pub(crate) struct Decrypted {
+pub(crate) struct Decrypted<'a> {
     /// Whether the peer appears to be getting close to encrypting too many messages with this key.
     pub(crate) want_close_before_decrypt: bool,
     /// The decrypted message.
-    pub(crate) plaintext: PlainMessage,
+    pub(crate) plaintext: BorrowedPlainMessage<'a>,
 }
 
 #[cfg(test)]

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -110,7 +110,10 @@ pub(super) struct AlwaysResolvesChain(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesChain {
     /// Creates an `AlwaysResolvesChain`, using the supplied key and certificate chain.
-    pub(super) fn new(private_key: Arc<dyn sign::SigningKey>, chain: CertificateChain) -> Self {
+    pub(super) fn new(
+        private_key: Arc<dyn sign::SigningKey>,
+        chain: CertificateChain<'static>,
+    ) -> Self {
         Self(Arc::new(sign::CertifiedKey::new(chain.0, private_key)))
     }
 
@@ -119,7 +122,7 @@ impl AlwaysResolvesChain {
     /// If non-empty, the given OCSP response is attached.
     pub(super) fn new_with_extras(
         private_key: Arc<dyn sign::SigningKey>,
-        chain: CertificateChain,
+        chain: CertificateChain<'static>,
         ocsp: Vec<u8>,
     ) -> Self {
         let mut r = Self::new(private_key, chain);

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -31,8 +31,8 @@ use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-pub(super) type NextState = Box<dyn State<ServerConnectionData>>;
-pub(super) type NextStateOrError = Result<NextState, Error>;
+pub(super) type NextState<'a> = Box<dyn State<ServerConnectionData> + 'a>;
+pub(super) type NextStateOrError<'a> = Result<NextState<'a>, Error>;
 pub(super) type ServerContext<'a> = crate::common_state::Context<'a, ServerConnectionData>;
 
 pub(super) fn can_resume(
@@ -243,7 +243,7 @@ impl ExpectClientHello {
         client_hello: &ClientHelloPayload,
         m: &Message,
         cx: &mut ServerContext<'_>,
-    ) -> NextStateOrError {
+    ) -> NextStateOrError<'static> {
         let tls13_enabled = self
             .config
             .supports_version(ProtocolVersion::TLSv1_3);
@@ -426,9 +426,20 @@ impl ExpectClientHello {
 }
 
 impl State<ServerConnectionData> for ExpectClientHello {
-    fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ServerContext<'_>,
+        m: Message<'m>,
+    ) -> NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let (client_hello, sig_schemes) = process_client_hello(&m, self.done_retry, cx)?;
         self.with_certified_key(sig_schemes, client_hello, &m, cx)
+    }
+
+    fn into_owned(self: Box<Self>) -> NextState<'static> {
+        self
     }
 }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -727,7 +727,7 @@ impl Acceptor {
 /// Contains the state required to resume the connection through [`Accepted::into_connection()`].
 pub struct Accepted {
     connection: ConnectionCommon<ServerConnectionData>,
-    message: Message,
+    message: Message<'static>,
     sig_schemes: Vec<SignatureScheme>,
 }
 
@@ -770,7 +770,7 @@ impl Accepted {
         })
     }
 
-    fn client_hello_payload(message: &Message) -> &ClientHelloPayload {
+    fn client_hello_payload<'a>(message: &'a Message) -> &'a ClientHelloPayload {
         match &message.payload {
             crate::msgs::message::MessagePayload::Handshake { parsed, .. } => match &parsed.payload
             {

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -846,10 +846,10 @@ impl EarlyDataState {
     }
 
     pub(super) fn take_received_plaintext(&mut self, bytes: Payload) -> bool {
-        let available = bytes.0.len();
+        let available = bytes.bytes().len();
         match self {
             Self::Accepted(ref mut received) if received.apply_limit(available) == available => {
-                received.append(bytes.0);
+                received.append(bytes.into_vec());
                 true
             }
             _ => false,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -785,12 +785,19 @@ impl Accepted {
 struct Accepting;
 
 impl State<ServerConnectionData> for Accepting {
-    fn handle(
+    fn handle<'m>(
         self: Box<Self>,
         _cx: &mut hs::ServerContext<'_>,
-        _m: Message,
-    ) -> Result<Box<dyn State<ServerConnectionData>>, Error> {
+        _m: Message<'m>,
+    ) -> Result<Box<dyn State<ServerConnectionData> + 'm>, Error>
+    where
+        Self: 'm,
+    {
         Err(Error::General("unreachable state".into()))
+    }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
     }
 }
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -75,7 +75,7 @@ mod client_hello {
             client_hello: &ClientHelloPayload,
             sigschemes_ext: Vec<SignatureScheme>,
             tls13_enabled: bool,
-        ) -> hs::NextStateOrError {
+        ) -> hs::NextStateOrError<'static> {
             // -- TLS1.2 only from hereon in --
             self.transcript.add_message(chm);
 
@@ -276,7 +276,7 @@ mod client_hello {
             client_hello: &ClientHelloPayload,
             id: &SessionId,
             resumedata: persist::ServerSessionValue,
-        ) -> hs::NextStateOrError {
+        ) -> hs::NextStateOrError<'static> {
             debug!("Resuming connection");
 
             if resumedata.extended_ms && !self.using_ems {
@@ -522,7 +522,14 @@ struct ExpectCertificate {
 }
 
 impl State<ServerConnectionData> for ExpectCertificate {
-    fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ServerContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         self.transcript.add_message(&m);
         let cert_chain = require_handshake_msg_move!(
             m,
@@ -575,6 +582,10 @@ impl State<ServerConnectionData> for ExpectCertificate {
             send_ticket: self.send_ticket,
         }))
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 // --- Process client's KeyExchange ---
@@ -591,7 +602,14 @@ struct ExpectClientKx {
 }
 
 impl State<ServerConnectionData> for ExpectClientKx {
-    fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ServerContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let client_kx = require_handshake_msg!(
             m,
             HandshakeType::ClientKeyExchange,
@@ -644,6 +662,10 @@ impl State<ServerConnectionData> for ExpectClientKx {
             }))
         }
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 // --- Process client's certificate proof ---
@@ -658,7 +680,14 @@ struct ExpectCertificateVerify {
 }
 
 impl State<ServerConnectionData> for ExpectCertificateVerify {
-    fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ServerContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let rc = {
             let sig = require_handshake_msg!(
                 m,
@@ -707,6 +736,10 @@ impl State<ServerConnectionData> for ExpectCertificateVerify {
             send_ticket: self.send_ticket,
         }))
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 // --- Process client's ChangeCipherSpec ---
@@ -721,7 +754,14 @@ struct ExpectCcs {
 }
 
 impl State<ServerConnectionData> for ExpectCcs {
-    fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ServerContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         match m.payload {
             MessagePayload::ChangeCipherSpec(..) => {}
             payload => {
@@ -748,6 +788,10 @@ impl State<ServerConnectionData> for ExpectCcs {
             resuming: self.resuming,
             send_ticket: self.send_ticket,
         }))
+    }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
     }
 }
 
@@ -853,7 +897,14 @@ struct ExpectFinished {
 }
 
 impl State<ServerConnectionData> for ExpectFinished {
-    fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        mut self: Box<Self>,
+        cx: &mut ServerContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
 
@@ -918,6 +969,10 @@ impl State<ServerConnectionData> for ExpectFinished {
             _fin_verified,
         }))
     }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
+    }
 }
 
 // --- Process traffic ---
@@ -929,7 +984,14 @@ struct ExpectTraffic {
 impl ExpectTraffic {}
 
 impl State<ServerConnectionData> for ExpectTraffic {
-    fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle<'m>(
+        self: Box<Self>,
+        cx: &mut ServerContext<'_>,
+        m: Message<'m>,
+    ) -> hs::NextStateOrError<'m>
+    where
+        Self: 'm,
+    {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx
                 .common
@@ -958,5 +1020,9 @@ impl State<ServerConnectionData> for ExpectTraffic {
     fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
         self.secrets
             .extract_secrets(Side::Server)
+    }
+
+    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
+        self
     }
 }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -856,8 +856,8 @@ impl State<ServerConnectionData> for ExpectAndSkipRejectedEarlyData {
          *  up to the configured max_early_data_size."
          * (RFC8446, 14.2.10) */
         if let MessagePayload::ApplicationData(ref skip_data) = m.payload {
-            if skip_data.0.len() <= self.skip_data_left {
-                self.skip_data_left -= skip_data.0.len();
+            if skip_data.bytes().len() <= self.skip_data_left {
+                self.skip_data_left -= skip_data.bytes().len();
                 return Ok(self);
             }
         }
@@ -1158,7 +1158,8 @@ impl State<ServerConnectionData> for ExpectFinished {
             .key_schedule
             .sign_client_finish(&handshake_hash, cx.common);
 
-        let fin = match ConstantTimeEq::ct_eq(expect_verify_data.as_ref(), &finished.0[..]).into() {
+        let fin = match ConstantTimeEq::ct_eq(expect_verify_data.as_ref(), finished.bytes()).into()
+        {
             true => verify::FinishedMessageVerified::assertion(),
             false => {
                 return Err(cx

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -964,7 +964,7 @@ struct ExpectCertificateVerify {
     transcript: HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
-    client_cert: CertificateChain,
+    client_cert: CertificateChain<'static>,
     send_tickets: usize,
 }
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -313,9 +313,9 @@ fn join_randoms(first: &[u8; 32], second: &[u8; 32]) -> [u8; 64] {
 
 type MessageCipherPair = (Box<dyn MessageDecrypter>, Box<dyn MessageEncrypter>);
 
-pub(crate) fn decode_ecdh_params<T: Codec>(
+pub(crate) fn decode_ecdh_params<'a, T: Codec<'a>>(
     common: &mut CommonState,
-    kx_params: &[u8],
+    kx_params: &'a [u8],
 ) -> Result<T, Error> {
     let mut rd = Reader::init(kx_params);
     let ecdh_params = T::read(&mut rd)?;

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -321,7 +321,7 @@ impl DigitallySignedStruct {
     }
 }
 
-impl Codec for DigitallySignedStruct {
+impl Codec<'_> for DigitallySignedStruct {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.scheme.encode(bytes);
         self.sig.encode(bytes);


### PR DESCRIPTION
this PR lays the groundwork for making the decoding - decryption - decoding pipeline "non-allocating" AKA removing as many allocations as possible

at a very high level that is enabled by these changes

- `MessageDeframer::pop` performs decoding - decryption in-place and yields borrowed data (slices) to the next layer
- `Codec` gains a lifetime parameter `'a` to allow its `read` method to return maximally borrowed data (`&'a`) from `Reader<'a>` -- this lets the _post_-decryption decoding to also be non-allocating
- `Payload` becomes a `std::Cow`-like enum to support carrying either borrowed or owned data -- `HandshakePayload` and other types indirectly become `Cow`-like as well
- `State::handle` is tweaked to allow its return type hold borrowed data contained in the `message` parameter

to showcase how this enables the removal of allocations from the pipeline, this PR makes decoding & decryption of application-data as well as certificates (`CertificateChain`) non-allocating

removing the rest of the allocations that exist in the pipeline will be done in a subsequent PR

breaking changes:
- this change the signature of `MessageDecrypter::decrypt`. actual implementations don't have to change much, as you can see in the diff, but a breaking change is still a breaking change.

this PR builds on top of #1595 

--- 


I think it's worthwhile to explain why `Payload` and many of the `State` implementers need to become `Cow`-like and cannot contain just references.

In very simplified terms, you can think of the process of advancing `Connection`'s internal state machine as the following function: (this applies to both the buffered `Connection` and `UnbufferedConnection` APIs)

```rust
struct Connection {
    state: Option<Box<dyn State +'static>>,
    deframer: MessageDeframer,
    // ..
}

// in impl Connection
fn process_tls_records<'a>(&mut self, buffer: &mut DeframerSliceBuffer<'a>) {
    let mut current = self.state.take().unwrap();

    while let Some(message) = deframer.pop(buffer);{
        // message has type BorrowedPlainMessage<'a>
        let next = current.handle(state, message);
        current = next;
    }

    self.state = Some(current.into_owned());
}
```

each time this function is called, _several_ records are decoded and decrypted from the buffered incoming TLS data (the `buffer` parameter in the above snippet). as mentioned above, `Deframer::pop` now yields slices with lifetime `'a`. each `message`s that's fed into the state machine through the `State::handle` method can change the concrete state type behind the `current` trait object; each of those intermediate states can hold the `'a` borrowed data in `message` thanks to the `State::handle` change done in this PR.

eventually, the `deframer` is exhausted (e.g. the user may need to read data from the socket and append it to `buffer`) and it's time to return from the function. however, just after exiting the `while` loop `current` may contain borrowed `'a` content. it's not possible to store that borrowed content in `Connection` because its `state` field has a `'static` constraint. that's where we are forced to erase the `'a` lifetime by switching the true state behind `current` into its owned variant; this heap allocates any borrowed content. it's worth noting that `into_owned` it's a no-operation in the case the state type does not contain any borrowed data.

so yes, there's still one potential allocation in this function call but all of the many decoding and decryption events that happen within this function call becoming non-allocating; it also becomes possible to move between states -- within a single function call -- without needing to allocate borrowed content.
