### PR TITLE
Use `-Z direct-minimal-versions` for minimal versions checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,7 @@ jobs:
 
 
   minver:
-    name: Check minimum versions
+    name: Check minimum versions of direct dependencies
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
@@ -248,9 +248,9 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Update to minimal-versions
+      - name: Update to direct-minimal-versions
         # This has no effect if no `Cargo.lock` exists yet.
-        run: cargo update -Z minimal-versions
+        run: cargo update -Z direct-minimal-versions
 
       - name: cargo test (debug; all features)
         run: cargo test --locked --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,14 +248,16 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Update to direct-minimal-versions
-        # This has no effect if no `Cargo.lock` exists yet.
-        run: cargo update -Z direct-minimal-versions
+      - name: Install cargo-minimal-versions
+        uses: taiki-e/install-action@cargo-minimal-versions
 
-      - name: cargo test (debug; all features)
-        run: cargo test --locked --all-features
-        env:
-          RUST_BACKTRACE: 1
+      # cargo-minimal-versions requires cargo-hack
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Check direct-minimal-versions
+        run: cargo minimal-versions --direct --ignore-private check
+        working-directory: rustls/
 
   cross:
     name: Check cross compilation targets


### PR DESCRIPTION
Following the advice on https://doc.rust-lang.org/cargo/reference/unstable.html#minimal-versions, apparently `-Z direct-minimal-versions` is closer to what we want (checking that _our_ `Cargo.toml` has correct versions in it, rather than every `Cargo.toml` in our dependencies).

Use `cargo-minimal-versions` which lets us care only about public crates.

This also side-steps the aws-lc-rs issue seen in #1586 