### PR TITLE
crypto: doc-hide the HPKE module

### DIFF
--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -38,6 +38,7 @@ pub mod tls12;
 pub mod tls13;
 
 /// Hybrid public key encryption (RFC 9180).
+#[doc(hidden)]
 pub mod hpke;
 
 pub use crate::rand::GetRandomFailed;


### PR DESCRIPTION
The bits and pieces we're landing for HPKE support aren't ready for broad use yet. To avoid confusion before the 0.22 release this commit adds a `#[doc(hidden)]` attribute to the `crypto/hpke.rs` mod.