### PR TITLE
client: allow providing webpki cert verifier w/o dangerous

### DIFF
--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -95,18 +95,19 @@ impl ServerCertVerifierBuilder {
     /// This function will return a `CertVerifierBuilderError` if:
     /// 1. No trust anchors have been provided.
     /// 2. DER encoded CRLs have been provided that can not be parsed successfully.
-    pub fn build(self) -> Result<Arc<dyn ServerCertVerifier>, VerifierBuilderError> {
+    pub fn build(self) -> Result<Arc<WebPkiServerVerifier>, VerifierBuilderError> {
         if self.roots.is_empty() {
             return Err(VerifierBuilderError::NoRootAnchors);
         }
 
-        Ok(Arc::new(WebPkiServerVerifier::new(
+        Ok(WebPkiServerVerifier::new(
             self.roots,
             parse_crls(self.crls)?,
             self.revocation_check_depth,
             self.unknown_revocation_policy,
             self.supported_algs,
-        )))
+        )
+        .into())
     }
 }
 


### PR DESCRIPTION
Previously to supply a custom webpki-based server certificate verifier when building a client configuration the caller had to invoke `dangerous` to get access to a fn that can accept an `Arc<dyn verify::ServerCertVerifier>`. We did this because implementing a `ServerCertVerifier` from scratch leaves a lot of room for dangerous errors.

However, when providing a `WebPkiServerVerifier` constructed with `webpki::WebPkiServerVerifier::builder`, there is much less danger. We've arranged the builder and concrete type to be safe for general usage.

This commit changes the builder to return the concrete verifier type, and then adds a new `with_webpki_verifier` fn to the client config builder that accepts a `Arc<WebPkiServerVerifier>` without needing to go through `dangerous`. This will make the standard case of customizing the built-in webpki verifier not appear dangerous, while still requiring fully customized verifiers be provided through the dangerous API.