### PR TITLE
turn CertificatePayload type alias into a newtype

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -4,6 +4,7 @@ use crate::client::{ClientConfig, ResolvesClientCert};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::error::Error;
 use crate::key_log::NoKeyLog;
+use crate::msgs::handshake::CertificateChain;
 use crate::suites::SupportedCipherSuite;
 use crate::webpki;
 use crate::{verify, versions};
@@ -112,7 +113,8 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             .state
             .provider
             .load_private_key(key_der)?;
-        let resolver = handy::AlwaysResolvesClientCert::new(private_key, cert_chain)?;
+        let resolver =
+            handy::AlwaysResolvesClientCert::new(private_key, CertificateChain(cert_chain))?;
         Ok(self.with_client_cert_resolver(Arc::new(resolver)))
     }
 

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -3,7 +3,7 @@ use super::ResolvesClientCert;
 use crate::log::{debug, trace};
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::handshake::ServerExtension;
-use crate::msgs::handshake::{CertificatePayload, DistinguishedName};
+use crate::msgs::handshake::{CertificateChain, DistinguishedName};
 use crate::{sign, SignatureScheme};
 
 use alloc::boxed::Box;
@@ -12,12 +12,12 @@ use alloc::vec::Vec;
 
 #[derive(Debug)]
 pub(super) struct ServerCertDetails {
-    pub(super) cert_chain: CertificatePayload,
+    pub(super) cert_chain: CertificateChain,
     pub(super) ocsp_response: Vec<u8>,
 }
 
 impl ServerCertDetails {
-    pub(super) fn new(cert_chain: CertificatePayload, ocsp_response: Vec<u8>) -> Self {
+    pub(super) fn new(cert_chain: CertificateChain, ocsp_response: Vec<u8>) -> Self {
         Self {
             cert_chain,
             ocsp_response,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -423,7 +423,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
             cx.common.peer_certificates = Some(
                 resuming_session
                     .server_cert_chain()
-                    .to_vec(),
+                    .clone(),
             );
 
             // We *don't* reverify the certificate chain here: resumption is a

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -6,6 +6,7 @@ use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
 use crate::msgs::enums::{AlertLevel, KeyUpdateRequest};
 use crate::msgs::fragmenter::MessageFragmenter;
+use crate::msgs::handshake::CertificateChain;
 use crate::msgs::message::MessagePayload;
 use crate::msgs::message::{BorrowedPlainMessage, Message, OpaqueMessage, PlainMessage};
 use crate::quic;
@@ -37,7 +38,7 @@ pub struct CommonState {
     pub(crate) has_received_close_notify: bool,
     pub(crate) has_seen_eof: bool,
     pub(crate) received_middlebox_ccs: u8,
-    pub(crate) peer_certificates: Option<Vec<CertificateDer<'static>>>,
+    pub(crate) peer_certificates: Option<CertificateChain>,
     message_fragmenter: MessageFragmenter,
     pub(crate) received_plaintext: ChunkVecBuffer,
     sendable_plaintext: ChunkVecBuffer,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -399,9 +399,9 @@ pub mod internal {
         }
         pub mod handshake {
             pub use crate::msgs::handshake::{
-                ClientExtension, ClientHelloPayload, DistinguishedName, EchConfig,
-                EchConfigContents, HandshakeMessagePayload, HandshakePayload, HpkeKeyConfig,
-                HpkeSymmetricCipherSuite, KeyShareEntry, Random, SessionId,
+                CertificateChain, ClientExtension, ClientHelloPayload, DistinguishedName,
+                EchConfig, EchConfigContents, HandshakeMessagePayload, HandshakePayload,
+                HpkeKeyConfig, HpkeSymmetricCipherSuite, KeyShareEntry, Random, SessionId,
             };
         }
         pub mod message {

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -7,15 +7,16 @@ use crate::msgs::enums::{
     KeyUpdateRequest, NamedGroup, PSKKeyExchangeMode, ServerNameType,
 };
 use crate::msgs::handshake::{
-    CertReqExtension, CertificateEntry, CertificateExtension, CertificatePayloadTls13,
-    CertificateRequestPayload, CertificateRequestPayloadTls13, CertificateStatus,
-    CertificateStatusRequest, ClientExtension, ClientHelloPayload, ClientSessionTicket,
-    ConvertProtocolNameList, ConvertServerNameList, DistinguishedName, EcParameters,
-    EcdheServerKeyExchange, HandshakeMessagePayload, HandshakePayload, HasServerExtensions,
-    HelloRetryExtension, HelloRetryRequest, KeyShareEntry, NewSessionTicketExtension,
-    NewSessionTicketPayload, NewSessionTicketPayloadTls13, PresharedKeyBinder,
-    PresharedKeyIdentity, PresharedKeyOffer, ProtocolName, Random, ServerEcdhParams,
-    ServerExtension, ServerHelloPayload, ServerKeyExchangePayload, SessionId, UnknownExtension,
+    CertReqExtension, CertificateChain, CertificateEntry, CertificateExtension,
+    CertificatePayloadTls13, CertificateRequestPayload, CertificateRequestPayloadTls13,
+    CertificateStatus, CertificateStatusRequest, ClientExtension, ClientHelloPayload,
+    ClientSessionTicket, ConvertProtocolNameList, ConvertServerNameList, DistinguishedName,
+    EcParameters, EcdheServerKeyExchange, HandshakeMessagePayload, HandshakePayload,
+    HasServerExtensions, HelloRetryExtension, HelloRetryRequest, KeyShareEntry,
+    NewSessionTicketExtension, NewSessionTicketPayload, NewSessionTicketPayloadTls13,
+    PresharedKeyBinder, PresharedKeyIdentity, PresharedKeyOffer, ProtocolName, Random,
+    ServerEcdhParams, ServerExtension, ServerHelloPayload, ServerKeyExchangePayload, SessionId,
+    UnknownExtension,
 };
 use crate::verify::DigitallySignedStruct;
 
@@ -901,7 +902,9 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Certificate,
-            payload: HandshakePayload::Certificate(vec![CertificateDer::from(vec![1, 2, 3])]),
+            payload: HandshakePayload::Certificate(CertificateChain(vec![CertificateDer::from(
+                vec![1, 2, 3],
+            )])),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::ServerKeyExchange,

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -1,6 +1,7 @@
 use crate::builder::{ConfigBuilder, WantsVerifier};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::error::Error;
+use crate::msgs::handshake::CertificateChain;
 use crate::server::handy;
 use crate::server::{ResolvesServerCert, ServerConfig};
 use crate::suites::SupportedCipherSuite;
@@ -75,7 +76,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             .state
             .provider
             .load_private_key(key_der)?;
-        let resolver = handy::AlwaysResolvesChain::new(private_key, cert_chain);
+        let resolver = handy::AlwaysResolvesChain::new(private_key, CertificateChain(cert_chain));
         Ok(self.with_cert_resolver(Arc::new(resolver)))
     }
 
@@ -99,7 +100,11 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             .state
             .provider
             .load_private_key(key_der)?;
-        let resolver = handy::AlwaysResolvesChain::new_with_extras(private_key, cert_chain, ocsp);
+        let resolver = handy::AlwaysResolvesChain::new_with_extras(
+            private_key,
+            CertificateChain(cert_chain),
+            ocsp,
+        );
         Ok(self.with_cert_resolver(Arc::new(resolver)))
     }
 

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -1,13 +1,12 @@
 use crate::dns_name::DnsNameRef;
 use crate::error::Error;
 use crate::limited_cache;
+use crate::msgs::handshake::CertificateChain;
 use crate::server;
 use crate::server::ClientHello;
 use crate::sign;
 use crate::webpki::{verify_server_name, ParsedCertificate};
 use crate::ServerName;
-
-use pki_types::CertificateDer;
 
 use alloc::string::{String, ToString};
 use alloc::sync::Arc;
@@ -111,11 +110,8 @@ pub(super) struct AlwaysResolvesChain(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesChain {
     /// Creates an `AlwaysResolvesChain`, using the supplied key and certificate chain.
-    pub(super) fn new(
-        private_key: Arc<dyn sign::SigningKey>,
-        chain: Vec<CertificateDer<'static>>,
-    ) -> Self {
-        Self(Arc::new(sign::CertifiedKey::new(chain, private_key)))
+    pub(super) fn new(private_key: Arc<dyn sign::SigningKey>, chain: CertificateChain) -> Self {
+        Self(Arc::new(sign::CertifiedKey::new(chain.0, private_key)))
     }
 
     /// Creates an `AlwaysResolvesChain`, using the supplied key, certificate chain and OCSP response.
@@ -123,7 +119,7 @@ impl AlwaysResolvesChain {
     /// If non-empty, the given OCSP response is attached.
     pub(super) fn new_with_extras(
         private_key: Arc<dyn sign::SigningKey>,
-        chain: Vec<CertificateDer<'static>>,
+        chain: CertificateChain,
         ocsp: Vec<u8>,
     ) -> Self {
         let mut r = Self::new(private_key, chain);

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -11,6 +11,7 @@ use crate::hash_hs::HandshakeHash;
 use crate::log::{debug, trace, warn};
 use crate::msgs::codec::Codec;
 use crate::msgs::enums::KeyUpdateRequest;
+use crate::msgs::handshake::CertificateChain;
 use crate::msgs::handshake::HandshakeMessagePayload;
 use crate::msgs::handshake::HandshakePayload;
 use crate::msgs::handshake::{NewSessionTicketExtension, NewSessionTicketPayloadTls13};
@@ -942,7 +943,7 @@ struct ExpectCertificateVerify {
     transcript: HandshakeHash,
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
-    client_cert: Vec<CertificateDer<'static>>,
+    client_cert: CertificateChain,
     send_tickets: usize,
 }
 


### PR DESCRIPTION
being careful not to use it in user-facing / non-internal API like `{Client,Server}Config`

extracted out of #1597 as it can land ahead of time. I found this useful in that PR as `CertificateChain` becomes non-owning, gains a lifetime parameter and there's a need to go from the borrowed version to the owned version which fits nicely in a method on the newtype