### PR TITLE
doc: replace "nb." with "Note:"

### DIFF
--- a/bogo/regen-certs
+++ b/bogo/regen-certs
@@ -47,7 +47,7 @@ EOF
 )
 
 # rsa_chain_cert.pem/rsa_chain_key.pem: rsa2048/sha256 with chain rsa2048/sha256
-# nb. chain is not validated
+# Note: chain is not validated
 openssl req -batch -x509 \
           -utf8 \
           -newkey rsa:2048 \

--- a/provider-example/examples/server.rs
+++ b/provider-example/examples/server.rs
@@ -35,7 +35,7 @@ fn main() {
                 )
                 .as_bytes();
 
-                // nb. do not used `unwrap()` on IO in real programs!
+                // Note: do not use `unwrap()` on IO in real programs!
                 conn.writer().write_all(msg).unwrap();
                 conn.write_tls(&mut stream).unwrap();
                 conn.complete_io(&mut stream).unwrap();

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -778,7 +778,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
         // 5b.
         let mut transcript = st.transcript;
         emit_clientkx(&mut transcript, cx.common, kx.pub_key());
-        // nb. EMS handshake hash only runs up to ClientKeyExchange.
+        // Note: EMS handshake hash only runs up to ClientKeyExchange.
         let ems_seed = st
             .using_ems
             .then(|| transcript.get_current_hash());
@@ -918,7 +918,7 @@ impl State<ClientConnectionData> for ExpectCcs {
         // message.
         cx.common.check_aligned_handshake()?;
 
-        // nb. msgs layer validates trivial contents of CCS
+        // Note: msgs layer validates trivial contents of CCS.
         cx.common
             .record_layer
             .start_decrypting();

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -310,7 +310,7 @@ impl ConnectionRandoms {
 
 fn is_valid_ccs(msg: &PlainMessage) -> bool {
     // We passthrough ChangeCipherSpec messages in the deframer without decrypting them.
-    // nb. this is prior to the record layer, so is unencrypted. see
+    // Note: this is prior to the record layer, so is unencrypted. See
     // third paragraph of section 5 in RFC8446.
     msg.typ == ContentType::ChangeCipherSpec && msg.payload.0 == [0x01]
 }

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -128,7 +128,7 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms
         webpki_algs::RSA_PKCS1_3072_8192_SHA384,
     ],
     mapping: &[
-        // nb. for TLS1.2 the curve is not fixed by SignatureScheme. for TLS1.3 it is.
+        // Note: for TLS1.2 the curve is not fixed by SignatureScheme. For TLS1.3 it is.
         (
             SignatureScheme::ECDSA_NISTP384_SHA384,
             &[

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -94,7 +94,7 @@ impl StdError for UnsupportedOperationError {}
 
 /// How a TLS1.2 `key_block` is partitioned.
 ///
-/// nb. ciphersuites with non-zero `mac_key_length` not currently supported
+/// Note: ciphersuites with non-zero `mac_key_length` are  not currently supported.
 pub struct KeyBlockShape {
     /// How long keys are.
     ///
@@ -218,7 +218,7 @@ pub const NONCE_LEN: usize = 12;
 pub fn make_tls13_aad(payload_len: usize) -> [u8; 5] {
     [
         ContentType::ApplicationData.get_u8(),
-        // nb. this is `legacy_record_version`, ie TLS1.2 even for TLS1.3.
+        // Note: this is `legacy_record_version`, i.e. TLS1.2 even for TLS1.3.
         (ProtocolVersion::TLSv1_2.get_u16() >> 8) as u8,
         (ProtocolVersion::TLSv1_2.get_u16() & 0xff) as u8,
         (payload_len >> 8) as u8,

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -123,7 +123,7 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms
         webpki_algs::RSA_PKCS1_3072_8192_SHA384,
     ],
     mapping: &[
-        // nb. for TLS1.2 the curve is not fixed by SignatureScheme. for TLS1.3 it is.
+        // Note: for TLS1.2 the curve is not fixed by SignatureScheme. For TLS1.3 it is.
         (
             SignatureScheme::ECDSA_NISTP384_SHA384,
             &[

--- a/rustls/src/dns_name.rs
+++ b/rustls/src/dns_name.rs
@@ -16,7 +16,7 @@ impl<'a> DnsName {
 
     /// Validate the given bytes are a DNS name if they are viewed as ASCII.
     pub fn try_from_ascii(bytes: &[u8]) -> Result<Self, InvalidDnsNameError> {
-        // nb. a sequence of bytes that is accepted by `validate()` is both
+        // Note: a sequence of bytes that is accepted by `validate()` is both
         // valid UTF-8, and valid ASCII.
         String::from_utf8(bytes.to_vec())
             .map_err(|_| InvalidDnsNameError)

--- a/rustls/src/limited_cache.rs
+++ b/rustls/src/limited_cache.rs
@@ -57,7 +57,7 @@ where
     pub(crate) fn insert(&mut self, k: K, v: V) {
         let inserted_new_item = match self.map.entry(k) {
             Entry::Occupied(mut old) => {
-                // nb. does not freshen entry in `oldest`
+                // Note: does not freshen entry in `oldest`
                 old.insert(v);
                 false
             }

--- a/rustls/src/manual/implvulns.rs
+++ b/rustls/src/manual/implvulns.rs
@@ -86,7 +86,7 @@ the message type before further operations.
 
 A sample sequence for a full TLSv1.2 handshake by a client looks like:
 
-- `hs::ExpectServerHello` (nb. ClientHello is logically sent before this state); transition to `tls12::ExpectCertificate`
+- `hs::ExpectServerHello` (Note: ClientHello is logically sent before this state); transition to `tls12::ExpectCertificate`
 - `tls12::ExpectCertificate`; transition to `tls12::ExpectServerKX`
 - `tls12::ExpectServerKX`; transition to `tls12::ExpectServerDoneOrCertReq`
 - `tls12::ExpectServerDoneOrCertReq`; delegates to `tls12::ExpectCertificateRequest` or `tls12::ExpectServerDone` depending on incoming message.

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1166,7 +1166,7 @@ impl State<ServerConnectionData> for ExpectFinished {
             }
         };
 
-        // nb. future derivations include Client Finished, but not the
+        // Note: future derivations include Client Finished, but not the
         // main application data keying.
         self.transcript.add_message(&m);
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -145,7 +145,7 @@ impl ConnectionSecrets {
     /// and the session's `secrets`.
     pub(crate) fn make_cipher_pair(&self, side: Side) -> MessageCipherPair {
         // Make a key block, and chop it up.
-        // nb. we don't implement any ciphersuites with nonzero mac_key_len.
+        // Note: we don't implement any ciphersuites with nonzero mac_key_len.
         let key_block = self.make_key_block();
         let shape = self.suite.aead_alg.key_block_shape();
 


### PR DESCRIPTION
"nota bene" (mark well) is jargon that we don't need.

Note: I wouldn't bother with this but I noticed it in the public documentation for KeyBlockShape. I figure it's valuable to use less jargon in the public docs when possible, and I might as well tweak the internal-facing uses as well.