### PR TITLE
lib: remove `rustls::sign` re-export

### DIFF
--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -16,7 +16,7 @@ impl ResolvesServerCert for Fail {
     fn resolve(
         &self,
         _client_hello: rustls::server::ClientHello,
-    ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+    ) -> Option<Arc<rustls::crypto::signer::CertifiedKey>> {
         None
     }
 }

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -36,7 +36,7 @@ impl rustls::crypto::CryptoProvider for Provider {
     fn load_private_key(
         &self,
         key_der: PrivateKeyDer<'static>,
-    ) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
+    ) -> Result<Arc<dyn rustls::crypto::signer::SigningKey>, rustls::Error> {
         let key = sign::EcdsaSigningKeyP256::try_from(key_der)
             .map_err(|err| rustls::OtherError(Arc::new(err)))?;
         Ok(Arc::new(key))

--- a/provider-example/src/sign.rs
+++ b/provider-example/src/sign.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use pkcs8::DecodePrivateKey;
 use pki_types::PrivateKeyDer;
-use rustls::sign::{Signer, SigningKey};
+use rustls::crypto::signer::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
 use signature::{RandomizedSigner, SignatureEncoding};
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,6 +1,7 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCommon, ConnectionCore};
+use crate::crypto::signer;
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::dns_name::{DnsName, DnsNameRef, InvalidDnsNameError};
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
@@ -10,7 +11,6 @@ use crate::log::trace;
 use crate::msgs::enums::NamedGroup;
 use crate::msgs::handshake::ClientExtension;
 use crate::msgs::persist;
-use crate::sign;
 use crate::suites::{ExtractedSecrets, SupportedCipherSuite};
 use crate::verify;
 use crate::versions;
@@ -109,7 +109,7 @@ pub trait ResolvesClientCert: fmt::Debug + Send + Sync {
         &self,
         root_hint_subjects: &[&[u8]],
         sigschemes: &[SignatureScheme],
-    ) -> Option<Arc<sign::CertifiedKey>>;
+    ) -> Option<Arc<signer::CertifiedKey>>;
 
     /// Return true if any certificates at all are available.
     fn has_certs(&self) -> bool;

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -1,10 +1,11 @@
 use super::ResolvesClientCert;
+use crate::crypto::signer;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::handshake::ServerExtension;
 use crate::msgs::handshake::{CertificateChain, DistinguishedName};
-use crate::{sign, SignatureScheme};
+use crate::SignatureScheme;
 
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -59,8 +60,8 @@ pub(super) enum ClientAuthDetails {
     Empty { auth_context_tls13: Option<Vec<u8>> },
     /// Send a non-empty `Certificate` and a `CertificateVerify`.
     Verify {
-        certkey: Arc<sign::CertifiedKey>,
-        signer: Box<dyn sign::Signer>,
+        certkey: Arc<signer::CertifiedKey>,
+        signer: Box<dyn signer::Signer>,
         auth_context_tls13: Option<Vec<u8>>,
     },
 }

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -1,10 +1,10 @@
 use crate::client;
+use crate::crypto::signer;
 use crate::enums::SignatureScheme;
 use crate::error::Error;
 use crate::limited_cache;
 use crate::msgs::handshake::CertificateChain;
 use crate::msgs::persist;
-use crate::sign;
 use crate::NamedGroup;
 use crate::ServerName;
 
@@ -176,7 +176,7 @@ impl client::ResolvesClientCert for FailResolveClientCert {
         &self,
         _root_hint_subjects: &[&[u8]],
         _sigschemes: &[SignatureScheme],
-    ) -> Option<Arc<sign::CertifiedKey>> {
+    ) -> Option<Arc<signer::CertifiedKey>> {
         None
     }
 
@@ -186,14 +186,14 @@ impl client::ResolvesClientCert for FailResolveClientCert {
 }
 
 #[derive(Debug)]
-pub(super) struct AlwaysResolvesClientCert(Arc<sign::CertifiedKey>);
+pub(super) struct AlwaysResolvesClientCert(Arc<signer::CertifiedKey>);
 
 impl AlwaysResolvesClientCert {
     pub(super) fn new(
-        private_key: Arc<dyn sign::SigningKey>,
+        private_key: Arc<dyn signer::SigningKey>,
         chain: CertificateChain,
     ) -> Result<Self, Error> {
-        Ok(Self(Arc::new(sign::CertifiedKey::new(
+        Ok(Self(Arc::new(signer::CertifiedKey::new(
             chain.0,
             private_key,
         ))))
@@ -205,7 +205,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
         &self,
         _root_hint_subjects: &[&[u8]],
         _sigschemes: &[SignatureScheme],
-    ) -> Option<Arc<sign::CertifiedKey>> {
+    ) -> Option<Arc<signer::CertifiedKey>> {
         Some(Arc::clone(&self.0))
     }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,6 +1,7 @@
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::common_state::{CommonState, Side, State};
 use crate::conn::ConnectionRandoms;
+use crate::crypto::signer::Signer;
 use crate::enums::ProtocolVersion;
 use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
@@ -16,7 +17,6 @@ use crate::msgs::handshake::{
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
-use crate::sign::Signer;
 use crate::suites::{PartiallyExtractedSecrets, SupportedCipherSuite};
 use crate::tls12::{self, ConnectionSecrets, Tls12CipherSuite};
 use crate::verify::{self, DigitallySignedStruct};

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -3,6 +3,7 @@ use crate::common_state::Protocol;
 use crate::common_state::{CommonState, Side, State};
 use crate::conn::ConnectionRandoms;
 use crate::crypto;
+use crate::crypto::signer::{CertifiedKey, Signer};
 use crate::crypto::ActiveKeyExchange;
 use crate::enums::{
     AlertDescription, ContentType, HandshakeType, ProtocolVersion, SignatureScheme,
@@ -23,7 +24,6 @@ use crate::msgs::handshake::{HasServerExtensions, ServerHelloPayload};
 use crate::msgs::handshake::{PresharedKeyIdentity, PresharedKeyOffer};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
-use crate::sign::{CertifiedKey, Signer};
 use crate::suites::PartiallyExtractedSecrets;
 use crate::tls13::construct_client_verify_message;
 use crate::tls13::construct_server_verify_message;

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -1,7 +1,7 @@
+use crate::crypto::signer::SigningKey;
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
-use crate::sign::SigningKey;
 use crate::suites::SupportedCipherSuite;
 use crate::webpki::WebPkiSupportedAlgorithms;
 use crate::Error;

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -1,4 +1,4 @@
-use crate::sign::SigningKey;
+use crate::crypto::signer::SigningKey;
 use crate::suites;
 use crate::webpki::WebPkiSupportedAlgorithms;
 use crate::{Error, NamedGroup};
@@ -110,7 +110,7 @@ pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 ///         RING.signature_verification_algorithms()
 ///     }
 ///
-///     fn load_private_key(&self, key_der: pki_types::PrivateKeyDer<'static>) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
+///     fn load_private_key(&self, key_der: pki_types::PrivateKeyDer<'static>) -> Result<Arc<dyn rustls::crypto::signer::SigningKey>, rustls::Error> {
 ///         fictious_hsm_api::load_private_key(key_der)
 ///     }
 /// }
@@ -127,7 +127,7 @@ pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 /// - **Key exchange groups** - see [`crate::crypto::SupportedKxGroup`].
 /// - **Signature verification algorithms** - see [`crate::WebPkiSupportedAlgorithms`].
 /// - **Authentication key loading** - see [`crate::crypto::CryptoProvider::load_private_key()`] and
-///   [`crate::sign::SigningKey`].
+///   [`SigningKey`].
 ///
 /// # Example code
 ///

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -1,7 +1,7 @@
+use crate::crypto::signer::SigningKey;
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
-use crate::sign::SigningKey;
 use crate::suites::SupportedCipherSuite;
 use crate::webpki::WebPkiSupportedAlgorithms;
 use crate::Error;

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::duplicate_mod)]
 
+use crate::crypto::signer::{Signer, SigningKey};
 use crate::enums::{SignatureAlgorithm, SignatureScheme};
 use crate::error::Error;
-use crate::sign::{Signer, SigningKey};
 use crate::x509::{asn1_wrap, wrap_in_sequence};
 
 use super::ring_like::io::der;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -540,11 +540,6 @@ pub mod version {
     pub use crate::versions::TLS13;
 }
 
-/// Message signing interfaces.
-pub mod sign {
-    pub use crate::crypto::signer::{CertifiedKey, Signer, SigningKey};
-}
-
 /// APIs for implementing QUIC TLS
 pub mod quic;
 

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -1,15 +1,15 @@
-use crate::sign;
+use crate::crypto::signer;
 
 use pki_types::CertificateDer;
 
-/// ActiveCertifiedKey wraps [`sign::CertifiedKey`] and tracks OSCP state in a single handshake.
+/// ActiveCertifiedKey wraps [`signer::CertifiedKey`] and tracks OSCP state in a single handshake.
 pub(super) struct ActiveCertifiedKey<'a> {
-    key: &'a sign::CertifiedKey,
+    key: &'a signer::CertifiedKey,
     ocsp: Option<&'a [u8]>,
 }
 
 impl<'a> ActiveCertifiedKey<'a> {
-    pub(super) fn from_certified_key(key: &sign::CertifiedKey) -> ActiveCertifiedKey {
+    pub(super) fn from_certified_key(key: &signer::CertifiedKey) -> ActiveCertifiedKey {
         ActiveCertifiedKey {
             key,
             ocsp: key.ocsp.as_deref(),
@@ -24,7 +24,7 @@ impl<'a> ActiveCertifiedKey<'a> {
 
     /// Get the signing key
     #[inline]
-    pub(super) fn get_key(&self) -> &dyn sign::SigningKey {
+    pub(super) fn get_key(&self) -> &dyn signer::SigningKey {
         &*self.key.key
     }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,6 +1,7 @@
 use crate::builder::{ConfigBuilder, WantsCipherSuites};
 use crate::common_state::{CommonState, Context, Protocol, Side, State};
 use crate::conn::{ConnectionCommon, ConnectionCore};
+use crate::crypto::signer;
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::dns_name::DnsName;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
@@ -10,7 +11,6 @@ use crate::log::trace;
 use crate::msgs::base::Payload;
 use crate::msgs::handshake::{ClientHelloPayload, ProtocolName, ServerExtension};
 use crate::msgs::message::Message;
-use crate::sign;
 use crate::suites::{ExtractedSecrets, SupportedCipherSuite};
 use crate::vecbuf::ChunkVecBuffer;
 use crate::verify;
@@ -112,7 +112,7 @@ pub trait ResolvesServerCert: Debug + Send + Sync {
     /// ClientHello information.
     ///
     /// Return `None` to abort the handshake.
-    fn resolve(&self, client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>>;
+    fn resolve(&self, client_hello: ClientHello) -> Option<Arc<signer::CertifiedKey>>;
 }
 
 /// A struct representing the received Client Hello
@@ -679,7 +679,7 @@ impl Accepted {
     /// Convert the [`Accepted`] into a [`ServerConnection`].
     ///
     /// Takes the state returned from [`Acceptor::accept()`] as well as the [`ServerConfig`] and
-    /// [`sign::CertifiedKey`] that should be used for the session. Returns an error if
+    /// [`signer::CertifiedKey`] that should be used for the session. Returns an error if
     /// configuration-dependent validation of the received `ClientHello` message fails.
     pub fn into_connection(mut self, config: Arc<ServerConfig>) -> Result<ServerConnection, Error> {
         self.connection

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -40,6 +40,7 @@ pub(super) use client_hello::CompleteClientHelloHandling;
 mod client_hello {
     use pki_types::CertificateDer;
 
+    use crate::crypto::signer;
     use crate::crypto::SupportedKxGroup;
     use crate::enums::SignatureScheme;
     use crate::msgs::enums::ECPointFormat;
@@ -50,7 +51,6 @@ mod client_hello {
     use crate::msgs::handshake::{ClientExtension, SessionId};
     use crate::msgs::handshake::{ClientHelloPayload, ServerHelloPayload};
     use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
-    use crate::sign;
     use crate::verify::DigitallySignedStruct;
 
     use super::*;
@@ -413,7 +413,7 @@ mod client_hello {
         common: &mut CommonState,
         sigschemes: Vec<SignatureScheme>,
         selected_group: &'static dyn SupportedKxGroup,
-        signing_key: &dyn sign::SigningKey,
+        signing_key: &dyn signer::SigningKey,
         randoms: &ConnectionRandoms,
     ) -> Result<Box<dyn ActiveKeyExchange>, Error> {
         let kx = selected_group

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -41,6 +41,7 @@ use subtle::ConstantTimeEq;
 pub(super) use client_hello::CompleteClientHelloHandling;
 
 mod client_hello {
+    use crate::crypto::signer;
     use crate::crypto::SupportedKxGroup;
     use crate::enums::SignatureScheme;
     use crate::msgs::base::{Payload, PayloadU8};
@@ -62,7 +63,6 @@ mod client_hello {
     use crate::msgs::handshake::ServerHelloPayload;
     use crate::msgs::handshake::SessionId;
     use crate::server::common::ActiveCertifiedKey;
-    use crate::sign;
     use crate::tls13::key_schedule::{
         KeyScheduleEarly, KeyScheduleHandshake, KeySchedulePreHandshake,
     };
@@ -777,7 +777,7 @@ mod client_hello {
     fn emit_certificate_verify_tls13(
         transcript: &mut HandshakeHash,
         common: &mut CommonState,
-        signing_key: &dyn sign::SigningKey,
+        signing_key: &dyn signer::SigningKey,
         schemes: &[SignatureScheme],
     ) -> Result<(), Error> {
         let message = construct_server_verify_message(&transcript.get_current_hash());


### PR DESCRIPTION
In general it's confusing if there are two import paths for types and we prefer to only offer re-exports for "paved path" types that are expected to be used by all consumers.

The `rustls::sign` types re-exported from `rustls::crypto::signer` don't meet this bar, so this commit removes the re-export, preferring to use the `rustls::crypto::signer` import path throughout.

Resolves https://github.com/rustls/rustls/issues/1614