### PR TITLE
crypto: make signer mod pub(crate)

### DIFF
--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -28,9 +28,6 @@ pub mod hash;
 /// HMAC interfaces.
 pub mod hmac;
 
-/// Message signing interfaces.
-pub mod signer;
-
 /// Cryptography specific to TLS1.2.
 pub mod tls12;
 
@@ -40,6 +37,10 @@ pub mod tls13;
 /// Hybrid public key encryption (RFC 9180).
 #[doc(hidden)]
 pub mod hpke;
+
+// Message signing interfaces. Re-exported under rustls::sign. Kept crate-internal here to
+// avoid having two import paths to the same types.
+pub(crate) mod signer;
 
 pub use crate::rand::GetRandomFailed;
 


### PR DESCRIPTION
Historically the types that now live in `rustls::crypto::signer` were present in `rustls::sign`. When the crypto provider work refactored them into their new home, we also added a `lib.rs` re-export under `rustls::sign`. This left two import paths for accessing the same types.

To avoid duplicated import paths without causing more downstream churn from moving the types this branch makes the
`rustls::crypto::signer` module `pub(crate)`, leaving `rustls::sign` as the sole way to access the contained types externally.

Replaces https://github.com/rustls/rustls/pull/1619
Resolves https://github.com/rustls/rustls/issues/1614