### PR TITLE
doc: CryptoProvider defaults can be overridden

### DIFF
--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -220,6 +220,10 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsCipherSuites> {
     }
 
     /// Choose a specific set of cipher suites.
+    ///
+    /// These can be different from the cipher suites implemented by the `CryptoProvider`.
+    /// Because the cipher suites provided by `ring` and `aws_lc_rs` have the same names,
+    /// make sure any `use` statements are importing from the provider that you want to use.
     pub fn with_cipher_suites(
         self,
         cipher_suites: &[SupportedCipherSuite],
@@ -256,6 +260,10 @@ pub struct WantsKxGroups {
 
 impl<S: ConfigSide> ConfigBuilder<S, WantsKxGroups> {
     /// Choose a specific set of key exchange groups.
+    ///
+    /// These can be different from the key exchange groups implemented by the `CryptoProvider`.
+    /// Because the cipher suites provided by `ring` and `aws_lc_rs` have the same names,
+    /// make sure any `use` statements are importing from the provider that you want to use.
     pub fn with_kx_groups(
         self,
         kx_groups: &[&'static dyn SupportedKxGroup],

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -57,6 +57,9 @@ pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 ///   which is optional).  This provider uses the [aws-lc-rs](https://github.com/aws/aws-lc-rs)
 ///   crate.
 ///
+/// This trait provides defaults. Everything in it, other than randomness, can be overridden at
+/// runtime by methods on [`ConfigBuilder`](crate::ConfigBuilder).
+///
 /// # Using a specific `CryptoProvider`
 ///
 /// Supply the provider when constructing your [`crate::ClientConfig`] or [`crate::ServerConfig`]:
@@ -164,7 +167,10 @@ pub trait CryptoProvider: Send + Sync + Debug + 'static {
     /// [`crate::ConfigBuilder::with_safe_default_cipher_suites()`].
     ///
     /// Other (non-default) cipher suites can be provided separately and configured
-    /// by passing them to [`crate::ConfigBuilder::with_cipher_suites()`]
+    /// by passing them to [`crate::ConfigBuilder::with_cipher_suites()`]. That
+    /// includes cipher suites implemented by a different `CryptoProvider`.
+    ///
+    /// The `SupportedCipherSuite` type carries both configuration and implementation.
     fn default_cipher_suites(&self) -> &'static [suites::SupportedCipherSuite];
 
     /// Return a safe set of supported key exchange groups to be used as the defaults.
@@ -173,7 +179,10 @@ pub trait CryptoProvider: Send + Sync + Debug + 'static {
     /// [`crate::ConfigBuilder::with_safe_default_kx_groups()`].
     ///
     /// Other (non-default) key exchange groups can be provided separately and configured
-    /// by passing them to [`crate::ConfigBuilder::with_kx_groups()`].
+    /// by passing them to [`crate::ConfigBuilder::with_kx_groups()`]. That includes
+    /// key exchange groups implemented by a different `CryptoProvider`.
+    ///
+    /// The `SupportedKxGroup` type carries both configuration and implementation.
     fn default_kx_groups(&self) -> &'static [&'static dyn SupportedKxGroup];
 
     /// Decode and validate a private signing key from `key_der`.
@@ -200,8 +209,11 @@ pub trait CryptoProvider: Send + Sync + Debug + 'static {
 
 /// A supported key exchange group.
 ///
-/// This has a TLS-level name expressed using the [`NamedGroup`] enum, and
+/// This type carries both configuration and implementation. Specifically,
+/// it has a TLS-level name expressed using the [`NamedGroup`] enum, and
 /// a function which produces a [`ActiveKeyExchange`].
+///
+/// Compare with [`NamedGroup`], which carries solely a protocol identifier.
 pub trait SupportedKxGroup: Send + Sync + Debug {
     /// Start a key exchange.
     ///

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -42,6 +42,9 @@ pub struct CipherSuiteCommon {
 }
 
 /// A cipher suite supported by rustls.
+///
+/// This type carries both configuration and implementation. Compare with
+/// [`CipherSuite`], which carries solely a cipher suite identifier.
 #[derive(Clone, Copy, PartialEq)]
 pub enum SupportedCipherSuite {
     /// A TLS 1.2 cipher suite


### PR DESCRIPTION
It was surprising to me that builder_with_provider could set a CryptoProvider, and then with_cipher_suites could choose implementations from a different CryptoProvider. I've tried to document things to make that a little less surprising.

Related to #1603