### PR TITLE
fix warnings in -default +ring build

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -110,3 +110,5 @@ jobs:
 
       - name: Check feature powerset
         run: cargo hack check --feature-powerset --no-dev-deps
+        env:
+          RUSTFLAGS: --deny warnings

--- a/rustls/src/crypto/ring/hmac.rs
+++ b/rustls/src/crypto/ring/hmac.rs
@@ -5,7 +5,9 @@ use crate::crypto;
 
 use alloc::boxed::Box;
 
+#[cfg(feature = "tls12")]
 pub(crate) static HMAC_SHA256: Hmac = Hmac(&ring_like::hmac::HMAC_SHA256);
+#[cfg(feature = "tls12")]
 pub(crate) static HMAC_SHA384: Hmac = Hmac(&ring_like::hmac::HMAC_SHA384);
 #[cfg(test)]
 #[allow(dead_code)] // only for TLS1.2 prf test


### PR DESCRIPTION
I found these while running `cargo c -p rustls --no-default-features --features ring` to test some WIP work