### PR TITLE
crypto: rework CryptoProvider as struct

### DIFF
--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -125,7 +125,7 @@ impl ResumptionKind {
 #[derive(Clone, Debug)]
 pub struct BenchmarkParams {
     /// Which `CryptoProvider` to test
-    pub provider: &'static dyn rustls::crypto::CryptoProvider,
+    pub provider: rustls::crypto::CryptoProvider,
     /// How to make a suitable [`rustls::server::ProducesTickets`].
     pub ticketer: &'static fn() -> Arc<dyn rustls::server::ProducesTickets>,
     /// The type of key used to sign the TLS certificate
@@ -141,7 +141,7 @@ pub struct BenchmarkParams {
 impl BenchmarkParams {
     /// Create a new set of benchmark params
     pub const fn new(
-        provider: &'static dyn rustls::crypto::CryptoProvider,
+        provider: rustls::crypto::CryptoProvider,
         ticketer: &'static fn() -> Arc<dyn rustls::server::ProducesTickets>,
         key_type: KeyType,
         ciphersuite: rustls::SupportedCipherSuite,

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -225,8 +225,6 @@ impl TestPki {
         // based on the ClientHello (e.g. selecting a different certificate, or customizing
         // supported algorithms/protocol versions).
         let mut server_config = ServerConfig::builder()
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_client_cert_verifier(verifier)
             .with_single_cert(
                 vec![self.server_cert_der.clone()],

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -225,7 +225,8 @@ impl TestPki {
         // based on the ClientHello (e.g. selecting a different certificate, or customizing
         // supported algorithms/protocol versions).
         let mut server_config = ServerConfig::builder()
-            .with_safe_defaults()
+            .with_safe_default_protocol_versions()
+            .unwrap()
             .with_client_cert_verifier(verifier)
             .with_single_cert(
                 vec![self.server_cert_der.clone()],

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -66,7 +66,8 @@ fn main() {
     );
 
     let mut config = rustls::ClientConfig::builder()
-        .with_safe_defaults()
+        .with_safe_default_protocol_versions()
+        .unwrap()
         .with_root_certificates(root_store)
         .with_no_client_auth();
 

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -66,8 +66,6 @@ fn main() {
     );
 
     let mut config = rustls::ClientConfig::builder()
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_root_certificates(root_store)
         .with_no_client_auth();
 

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -22,8 +22,6 @@ fn main() {
             .cloned(),
     );
     let mut config = rustls::ClientConfig::builder()
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_root_certificates(root_store)
         .with_no_client_auth();
 

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -22,7 +22,8 @@ fn main() {
             .cloned(),
     );
     let mut config = rustls::ClientConfig::builder()
-        .with_safe_defaults()
+        .with_safe_default_protocol_versions()
+        .unwrap()
         .with_root_certificates(root_store)
         .with_no_client_auth();
 

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -11,8 +11,6 @@ fuzz_target!(|data: &[u8]| {
     let root_store = RootCertStore::empty();
     let config = Arc::new(
         ClientConfig::builder()
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_root_certificates(root_store)
             .with_no_client_auth(),
     );

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -11,7 +11,8 @@ fuzz_target!(|data: &[u8]| {
     let root_store = RootCertStore::empty();
     let config = Arc::new(
         ClientConfig::builder()
-            .with_safe_defaults()
+            .with_safe_default_protocol_versions()
+            .unwrap()
             .with_root_certificates(root_store)
             .with_no_client_auth(),
     );

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -24,8 +24,6 @@ impl ResolvesServerCert for Fail {
 fuzz_target!(|data: &[u8]| {
     let config = Arc::new(
         ServerConfig::builder()
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_no_client_auth()
             .with_cert_resolver(Arc::new(Fail)),
     );

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -24,7 +24,8 @@ impl ResolvesServerCert for Fail {
 fuzz_target!(|data: &[u8]| {
     let config = Arc::new(
         ServerConfig::builder()
-            .with_safe_defaults()
+            .with_safe_default_protocol_versions()
+            .unwrap()
             .with_no_client_auth()
             .with_cert_resolver(Arc::new(Fail)),
     );

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -2,8 +2,6 @@ use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls_provider_example::PROVIDER;
-
 fn main() {
     env_logger::init();
 
@@ -14,10 +12,12 @@ fn main() {
             .cloned(),
     );
 
-    let config = rustls::ClientConfig::builder_with_provider(PROVIDER)
-        .with_safe_defaults()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
+    let config =
+        rustls::ClientConfig::builder_with_provider(rustls_provider_example::provider().into())
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();

--- a/provider-example/examples/server.rs
+++ b/provider-example/examples/server.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::Acceptor;
 use rustls::ServerConfig;
-use rustls_provider_example::PROVIDER;
 
 fn main() {
     env_logger::init();
@@ -94,11 +93,13 @@ impl TestPki {
     }
 
     fn server_config(self) -> Arc<ServerConfig> {
-        let mut server_config = ServerConfig::builder_with_provider(PROVIDER)
-            .with_safe_defaults()
-            .with_no_client_auth()
-            .with_single_cert(vec![self.server_cert_der], self.server_key_der)
-            .unwrap();
+        let mut server_config =
+            ServerConfig::builder_with_provider(rustls_provider_example::provider().into())
+                .with_safe_default_protocol_versions()
+                .unwrap()
+                .with_no_client_auth()
+                .with_single_cert(vec![self.server_cert_der], self.server_key_der)
+                .unwrap();
 
         server_config.key_log = Arc::new(rustls::KeyLogFile::new());
 

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -11,6 +11,7 @@ mod sign;
 mod verify;
 
 pub use hpke::HPKE_PROVIDER;
+use rustls::crypto::KeyProvider;
 
 pub static PROVIDER: &'static dyn rustls::crypto::CryptoProvider = &Provider;
 
@@ -31,6 +32,10 @@ impl rustls::crypto::CryptoProvider for Provider {
     }
 
     fn secure_random(&self) -> &'static dyn rustls::crypto::SecureRandom {
+        &Self
+    }
+
+    fn key_provider(&self) -> &'static dyn KeyProvider {
         &Self
     }
 }

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -18,13 +18,6 @@ pub static PROVIDER: &'static dyn rustls::crypto::CryptoProvider = &Provider;
 struct Provider;
 
 impl rustls::crypto::CryptoProvider for Provider {
-    fn fill_random(&self, bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
-        use rand_core::RngCore;
-        rand_core::OsRng
-            .try_fill_bytes(bytes)
-            .map_err(|_| rustls::crypto::GetRandomFailed)
-    }
-
     fn default_cipher_suites(&self) -> &'static [rustls::SupportedCipherSuite] {
         ALL_CIPHER_SUITES
     }
@@ -44,6 +37,15 @@ impl rustls::crypto::CryptoProvider for Provider {
 
     fn signature_verification_algorithms(&self) -> rustls::crypto::WebPkiSupportedAlgorithms {
         verify::ALGORITHMS
+    }
+}
+
+impl rustls::crypto::SecureRandom for Provider {
+    fn fill(&self, bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
+        use rand_core::RngCore;
+        rand_core::OsRng
+            .try_fill_bytes(bytes)
+            .map_err(|_| rustls::crypto::GetRandomFailed)
     }
 }
 

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -26,15 +26,6 @@ impl rustls::crypto::CryptoProvider for Provider {
         kx::ALL_KX_GROUPS
     }
 
-    fn load_private_key(
-        &self,
-        key_der: PrivateKeyDer<'static>,
-    ) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
-        let key = sign::EcdsaSigningKeyP256::try_from(key_der)
-            .map_err(|err| rustls::OtherError(Arc::new(err)))?;
-        Ok(Arc::new(key))
-    }
-
     fn signature_verification_algorithms(&self) -> rustls::crypto::WebPkiSupportedAlgorithms {
         verify::ALGORITHMS
     }
@@ -50,6 +41,17 @@ impl rustls::crypto::SecureRandom for Provider {
         rand_core::OsRng
             .try_fill_bytes(bytes)
             .map_err(|_| rustls::crypto::GetRandomFailed)
+    }
+}
+
+impl rustls::crypto::KeyProvider for Provider {
+    fn load_private_key(
+        &self,
+        key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
+        let key = sign::EcdsaSigningKeyP256::try_from(key_der)
+            .map_err(|err| rustls::OtherError(Arc::new(err)))?;
+        Ok(Arc::new(key))
     }
 }
 

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -38,6 +38,10 @@ impl rustls::crypto::CryptoProvider for Provider {
     fn signature_verification_algorithms(&self) -> rustls::crypto::WebPkiSupportedAlgorithms {
         verify::ALGORITHMS
     }
+
+    fn secure_random(&self) -> &'static dyn rustls::crypto::SecureRandom {
+        &Self
+    }
 }
 
 impl rustls::crypto::SecureRandom for Provider {

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -19,19 +19,18 @@ use std::sync::Arc;
 /// For settings besides these, see the fields of [`ServerConfig`] and [`ClientConfig`].
 ///
 /// The usual choice for protocol primitives is to call
-/// [`crate::ClientConfig::builder`]/[`ServerConfig::builder`] and [`ConfigBuilder::with_safe_default_protocol_versions`],
-/// which will use rustls' default cryptographic provider and default protocol versions.
+/// [`crate::ClientConfig::builder`]/[`ServerConfig::builder`]
+/// which will use rustls' default cryptographic provider and safe defaults for ciphersuites and
+/// supported protocol versions.
 ///
 /// ```
 /// # #[cfg(feature = "ring")] {
 /// use rustls::{ClientConfig, ServerConfig};
 /// ClientConfig::builder()
-///     .with_safe_default_protocol_versions()
 /// //  ...
 /// # ;
 ///
 /// ServerConfig::builder()
-///     .with_safe_default_protocol_versions()
 /// //  ...
 /// # ;
 /// # }
@@ -42,15 +41,13 @@ use std::sync::Arc;
 /// ```no_run
 /// # #[cfg(feature = "ring")] {
 /// # use rustls::ServerConfig;
-/// ServerConfig::builder()
-///     .with_protocol_versions(&[&rustls::version::TLS13])
-///     .unwrap()
+/// ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
 /// //  ...
 /// # ;
 /// # }
 /// ```
 ///
-/// Overriding a default introduces a `Result` that must be unwrapped,
+/// Overriding the default cryptographic provider introduces a `Result` that must be unwrapped,
 /// because the config builder checks for consistency of the choices made. For instance, it's an error to
 /// configure only TLS 1.2 cipher suites while specifying that TLS 1.3 should be the only supported protocol
 /// version.
@@ -81,8 +78,6 @@ use std::sync::Arc;
 /// # use rustls::ClientConfig;
 /// # let root_certs = rustls::RootCertStore::empty();
 /// ClientConfig::builder()
-///     .with_safe_default_protocol_versions()
-///     .unwrap()
 ///     .with_root_certificates(root_certs)
 ///     .with_no_client_auth();
 /// # }
@@ -109,8 +104,6 @@ use std::sync::Arc;
 /// #    pki_types::PrivatePkcs8KeyDer::from(vec![])
 /// # );
 /// ServerConfig::builder()
-///     .with_safe_default_protocol_versions()
-///     .unwrap()
 ///     .with_no_client_auth()
 ///     .with_single_cert(certs, private_key)
 ///     .expect("bad certificate/key");

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -137,6 +137,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
         let private_key = self
             .state
             .provider
+            .key_provider()
             .load_private_key(key_der)?;
         let resolver =
             handy::AlwaysResolvesClientCert::new(private_key, CertificateChain(cert_chain))?;

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -13,6 +13,8 @@ use crate::sign;
 use crate::suites::{ExtractedSecrets, SupportedCipherSuite};
 use crate::versions;
 use crate::KeyLog;
+#[cfg(feature = "ring")]
+use crate::WantsVerifier;
 use crate::{verify, WantsVersions};
 
 use super::handy::{ClientSessionMemoryCache, NoClientSessionStorage};
@@ -232,16 +234,42 @@ impl Clone for ClientConfig {
 }
 
 impl ClientConfig {
-    #[cfg(feature = "ring")]
     /// Create a builder for a client configuration with the default
-    /// [`CryptoProvider`]: [`crate::crypto::ring::default_provider`].
+    /// [`CryptoProvider`]: [`crate::crypto::ring::default_provider`] and safe ciphersuite and
+    /// protocol defaults.
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
-    pub fn builder() -> ConfigBuilder<Self, WantsVersions> {
+    #[cfg(feature = "ring")]
+    pub fn builder() -> ConfigBuilder<Self, WantsVerifier> {
+        // Safety: we know the *ring* provider's ciphersuites are compatible with the safe default protocol versions.
         Self::builder_with_provider(crate::crypto::ring::default_provider().into())
+            .with_safe_default_protocol_versions()
+            .unwrap()
+    }
+
+    /// Create a builder for a client configuration with the default
+    /// [`CryptoProvider`]: [`crate::crypto::ring::default_provider`], safe ciphersuite defaults and
+    /// the provided protocol versions.
+    ///
+    /// Panics if provided an empty slice of supported versions.
+    ///
+    /// For more information, see the [`ConfigBuilder`] documentation.
+    #[cfg(feature = "ring")]
+    pub fn builder_with_protocol_versions(
+        versions: &[&'static versions::SupportedProtocolVersion],
+    ) -> ConfigBuilder<Self, WantsVerifier> {
+        // Safety: we know the *ring* provider's ciphersuites are compatible with all protocol version choices.
+        Self::builder_with_provider(crate::crypto::ring::default_provider().into())
+            .with_protocol_versions(versions)
+            .unwrap()
     }
 
     /// Create a builder for a client configuration with a specific [`CryptoProvider`].
+    ///
+    /// This will use the provider's configured ciphersuites. You must additionally choose
+    /// which protocol versions to enable, using `with_protocol_versions` or
+    /// `with_safe_default_protocol_versions` and handling the `Result` in case a protocol
+    /// version is not supported by the provider's ciphersuites.
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
     pub fn builder_with_provider(

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -121,7 +121,7 @@ pub(super) fn start_handshake(
             // we're  doing an abbreviated handshake.  See section 3.4 in
             // RFC5077.
             if !inner.ticket().is_empty() {
-                inner.session_id = SessionId::random(config.provider.secure_random())?;
+                inner.session_id = SessionId::random(config.provider.secure_random)?;
             }
             session_id = Some(inner.session_id);
         }
@@ -137,10 +137,10 @@ pub(super) fn start_handshake(
         Some(session_id) => session_id,
         None if cx.common.is_quic() => SessionId::empty(),
         None if !config.supports_version(ProtocolVersion::TLSv1_3) => SessionId::empty(),
-        None => SessionId::random(config.provider.secure_random())?,
+        None => SessionId::random(config.provider.secure_random)?,
     };
 
-    let random = Random::new(config.provider.secure_random())?;
+    let random = Random::new(config.provider.secure_random)?;
 
     Ok(emit_client_hello_for_retry(
         transcript_buffer,
@@ -218,6 +218,7 @@ fn emit_client_hello_for_retry(
         ClientExtension::EcPointFormats(ECPointFormat::SUPPORTED.to_vec()),
         ClientExtension::NamedGroups(
             config
+                .provider
                 .kx_groups
                 .iter()
                 .map(|skxg| skxg.name())
@@ -277,6 +278,7 @@ fn emit_client_hello_for_retry(
         .collect();
 
     let mut cipher_suites: Vec<_> = config
+        .provider
         .cipher_suites
         .iter()
         .filter_map(|cs| match cs.usable_for_protocol(cx.common.protocol) {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -121,7 +121,7 @@ pub(super) fn start_handshake(
             // we're  doing an abbreviated handshake.  See section 3.4 in
             // RFC5077.
             if !inner.ticket().is_empty() {
-                inner.session_id = SessionId::random(config.provider)?;
+                inner.session_id = SessionId::random(config.provider.secure_random())?;
             }
             session_id = Some(inner.session_id);
         }
@@ -137,10 +137,10 @@ pub(super) fn start_handshake(
         Some(session_id) => session_id,
         None if cx.common.is_quic() => SessionId::empty(),
         None if !config.supports_version(ProtocolVersion::TLSv1_3) => SessionId::empty(),
-        None => SessionId::random(config.provider)?,
+        None => SessionId::random(config.provider.secure_random())?,
     };
 
-    let random = Random::new(config.provider)?;
+    let random = Random::new(config.provider.secure_random())?;
 
     Ok(emit_client_hello_for_retry(
         transcript_buffer,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -213,6 +213,7 @@ pub(super) fn initial_key_share(
         .and_then(|group_name| config.find_kx_group(group_name))
         .unwrap_or_else(|| {
             config
+                .provider
                 .kx_groups
                 .iter()
                 .copied()

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -1,4 +1,4 @@
-use crate::crypto::{CryptoProvider, SupportedKxGroup};
+use crate::crypto::{CryptoProvider, SecureRandom, SupportedKxGroup};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
@@ -41,14 +41,6 @@ pub static AWS_LC_RS: &dyn CryptoProvider = &AwsLcRs;
 struct AwsLcRs;
 
 impl CryptoProvider for AwsLcRs {
-    fn fill_random(&self, buf: &mut [u8]) -> Result<(), GetRandomFailed> {
-        use ring_like::rand::SecureRandom;
-
-        ring_like::rand::SystemRandom::new()
-            .fill(buf)
-            .map_err(|_| GetRandomFailed)
-    }
-
     fn default_cipher_suites(&self) -> &'static [SupportedCipherSuite] {
         DEFAULT_CIPHER_SUITES
     }
@@ -67,6 +59,16 @@ impl CryptoProvider for AwsLcRs {
 
     fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
         SUPPORTED_SIG_ALGS
+    }
+}
+
+impl SecureRandom for AwsLcRs {
+    fn fill(&self, buf: &mut [u8]) -> Result<(), GetRandomFailed> {
+        use ring_like::rand::SecureRandom;
+
+        ring_like::rand::SystemRandom::new()
+            .fill(buf)
+            .map_err(|_| GetRandomFailed)
     }
 }
 

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -60,6 +60,10 @@ impl CryptoProvider for AwsLcRs {
     fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
         SUPPORTED_SIG_ALGS
     }
+
+    fn secure_random(&self) -> &'static dyn SecureRandom {
+        &Self
+    }
 }
 
 impl SecureRandom for AwsLcRs {

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -1,4 +1,4 @@
-use crate::crypto::{CryptoProvider, SecureRandom, SupportedKxGroup};
+use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom, SupportedKxGroup};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
@@ -49,14 +49,6 @@ impl CryptoProvider for AwsLcRs {
         ALL_KX_GROUPS
     }
 
-    fn load_private_key(
-        &self,
-        key_der: PrivateKeyDer<'static>,
-    ) -> Result<Arc<dyn SigningKey>, Error> {
-        sign::any_supported_type(&key_der)
-            .map_err(|_| Error::General(String::from("invalid private key")))
-    }
-
     fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
         SUPPORTED_SIG_ALGS
     }
@@ -73,6 +65,16 @@ impl SecureRandom for AwsLcRs {
         ring_like::rand::SystemRandom::new()
             .fill(buf)
             .map_err(|_| GetRandomFailed)
+    }
+}
+
+impl KeyProvider for AwsLcRs {
+    fn load_private_key(
+        &self,
+        key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn SigningKey>, Error> {
+        sign::any_supported_type(&key_der)
+            .map_err(|_| Error::General(String::from("invalid private key")))
     }
 }
 

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -56,6 +56,10 @@ impl CryptoProvider for AwsLcRs {
     fn secure_random(&self) -> &'static dyn SecureRandom {
         &Self
     }
+
+    fn key_provider(&self) -> &'static dyn KeyProvider {
+        &Self
+    }
 }
 
 impl SecureRandom for AwsLcRs {

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -1,4 +1,4 @@
-use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom, SupportedKxGroup};
+use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
@@ -35,32 +35,18 @@ pub(crate) mod tls12;
 pub(crate) mod tls13;
 
 /// A `CryptoProvider` backed by aws-lc-rs.
-pub static AWS_LC_RS: &dyn CryptoProvider = &AwsLcRs;
+pub fn default_provider() -> CryptoProvider {
+    CryptoProvider {
+        cipher_suites: DEFAULT_CIPHER_SUITES.to_vec(),
+        kx_groups: ALL_KX_GROUPS.to_vec(),
+        signature_verification_algorithms: SUPPORTED_SIG_ALGS,
+        secure_random: &AwsLcRs,
+        key_provider: &AwsLcRs,
+    }
+}
 
 #[derive(Debug)]
 struct AwsLcRs;
-
-impl CryptoProvider for AwsLcRs {
-    fn default_cipher_suites(&self) -> &'static [SupportedCipherSuite] {
-        DEFAULT_CIPHER_SUITES
-    }
-
-    fn default_kx_groups(&self) -> &'static [&'static dyn SupportedKxGroup] {
-        ALL_KX_GROUPS
-    }
-
-    fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
-        SUPPORTED_SIG_ALGS
-    }
-
-    fn secure_random(&self) -> &'static dyn SecureRandom {
-        &Self
-    }
-
-    fn key_provider(&self) -> &'static dyn KeyProvider {
-        &Self
-    }
-}
 
 impl SecureRandom for AwsLcRs {
     fn fill(&self, buf: &mut [u8]) -> Result<(), GetRandomFailed> {

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -116,6 +116,10 @@ pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 ///     fn secure_random(&self) -> &'static dyn rustls::crypto::SecureRandom {
 ///        &HsmKeyLoader
 ///     }
+///
+///     fn key_provider(&self) -> &'static dyn rustls::crypto::KeyProvider {
+///        &HsmKeyLoader
+///     }
 /// }
 ///
 /// impl rustls::crypto::SecureRandom for HsmKeyLoader {
@@ -160,7 +164,7 @@ pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 /// [provider-example/]: https://github.com/rustls/rustls/tree/main/provider-example/
 /// [rust-crypto]: https://github.com/rustcrypto
 /// [dalek-cryptography]: https://github.com/dalek-cryptography
-pub trait CryptoProvider: KeyProvider + Send + Sync + Debug + 'static {
+pub trait CryptoProvider: Send + Sync + Debug + 'static {
     /// Provide a safe set of cipher suites that can be used as the defaults.
     ///
     /// This is used by [`crate::ConfigBuilder::with_safe_defaults()`] and
@@ -196,6 +200,9 @@ pub trait CryptoProvider: KeyProvider + Send + Sync + Debug + 'static {
 
     /// Return a source of cryptographically secure randomness.
     fn secure_random(&self) -> &'static dyn SecureRandom;
+
+    /// Return a mechanism for loading private [SigningKey]s from [PrivateKeyDer].
+    fn key_provider(&self) -> &'static dyn KeyProvider;
 }
 
 /// A source of cryptographically secure randomness.

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -1,4 +1,4 @@
-use crate::crypto::{CryptoProvider, SecureRandom, SupportedKxGroup};
+use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom, SupportedKxGroup};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
@@ -44,14 +44,6 @@ impl CryptoProvider for Ring {
         ALL_KX_GROUPS
     }
 
-    fn load_private_key(
-        &self,
-        key_der: PrivateKeyDer<'static>,
-    ) -> Result<Arc<dyn SigningKey>, Error> {
-        sign::any_supported_type(&key_der)
-            .map_err(|_| Error::General("invalid private key".to_owned()))
-    }
-
     fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
         SUPPORTED_SIG_ALGS
     }
@@ -68,6 +60,16 @@ impl SecureRandom for Ring {
         ring_like::rand::SystemRandom::new()
             .fill(buf)
             .map_err(|_| GetRandomFailed)
+    }
+}
+
+impl KeyProvider for Ring {
+    fn load_private_key(
+        &self,
+        key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn SigningKey>, Error> {
+        sign::any_supported_type(&key_der)
+            .map_err(|_| Error::General("invalid private key".to_owned()))
     }
 }
 

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -51,6 +51,10 @@ impl CryptoProvider for Ring {
     fn secure_random(&self) -> &'static dyn SecureRandom {
         &Self
     }
+
+    fn key_provider(&self) -> &'static dyn KeyProvider {
+        &Self
+    }
 }
 
 impl SecureRandom for Ring {

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -1,4 +1,4 @@
-use crate::crypto::{CryptoProvider, SupportedKxGroup};
+use crate::crypto::{CryptoProvider, SecureRandom, SupportedKxGroup};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
@@ -36,14 +36,6 @@ pub static RING: &dyn CryptoProvider = &Ring;
 struct Ring;
 
 impl CryptoProvider for Ring {
-    fn fill_random(&self, buf: &mut [u8]) -> Result<(), GetRandomFailed> {
-        use ring_like::rand::SecureRandom;
-
-        ring_like::rand::SystemRandom::new()
-            .fill(buf)
-            .map_err(|_| GetRandomFailed)
-    }
-
     fn default_cipher_suites(&self) -> &'static [SupportedCipherSuite] {
         DEFAULT_CIPHER_SUITES
     }
@@ -62,6 +54,16 @@ impl CryptoProvider for Ring {
 
     fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
         SUPPORTED_SIG_ALGS
+    }
+}
+
+impl SecureRandom for Ring {
+    fn fill(&self, buf: &mut [u8]) -> Result<(), GetRandomFailed> {
+        use ring_like::rand::SecureRandom;
+
+        ring_like::rand::SystemRandom::new()
+            .fill(buf)
+            .map_err(|_| GetRandomFailed)
     }
 }
 

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -1,4 +1,4 @@
-use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom, SupportedKxGroup};
+use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
@@ -29,33 +29,19 @@ pub(crate) mod tls13;
 /// A `CryptoProvider` backed by the [*ring*] crate.
 ///
 /// [*ring*]: https://github.com/briansmith/ring
-pub static RING: &dyn CryptoProvider = &Ring;
+pub fn default_provider() -> CryptoProvider {
+    CryptoProvider {
+        cipher_suites: DEFAULT_CIPHER_SUITES.to_vec(),
+        kx_groups: ALL_KX_GROUPS.to_vec(),
+        signature_verification_algorithms: SUPPORTED_SIG_ALGS,
+        secure_random: &Ring,
+        key_provider: &Ring,
+    }
+}
 
 /// Default crypto provider.
 #[derive(Debug)]
 struct Ring;
-
-impl CryptoProvider for Ring {
-    fn default_cipher_suites(&self) -> &'static [SupportedCipherSuite] {
-        DEFAULT_CIPHER_SUITES
-    }
-
-    fn default_kx_groups(&self) -> &'static [&'static dyn SupportedKxGroup] {
-        ALL_KX_GROUPS
-    }
-
-    fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
-        SUPPORTED_SIG_ALGS
-    }
-
-    fn secure_random(&self) -> &'static dyn SecureRandom {
-        &Self
-    }
-
-    fn key_provider(&self) -> &'static dyn KeyProvider {
-        &Self
-    }
-}
 
 impl SecureRandom for Ring {
     fn fill(&self, buf: &mut [u8]) -> Result<(), GetRandomFailed> {

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -55,6 +55,10 @@ impl CryptoProvider for Ring {
     fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
         SUPPORTED_SIG_ALGS
     }
+
+    fn secure_random(&self) -> &'static dyn SecureRandom {
+        &Self
+    }
 }
 
 impl SecureRandom for Ring {

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -19,8 +19,8 @@ use core::fmt::Debug;
 ///
 /// There are two main ways to get a signing key:
 ///
-///  - [`CryptoProvider::load_private_key()`], or
-///  - some other method outside of the `CryptoProvider` extension trait,
+///  - [`KeyProvider::load_private_key()`], or
+///  - some other method outside of the `KeyProvider` extension trait,
 ///    for instance:
 ///    - [`crypto::ring::sign::any_ecdsa_type()`]
 ///    - [`crypto::ring::sign::any_eddsa_type()`]
@@ -29,17 +29,17 @@ use core::fmt::Debug;
 ///    - [`crypto::aws_lc_rs::sign::any_eddsa_type()`]
 ///    - [`crypto::aws_lc_rs::sign::any_supported_type()`]
 ///
-/// The `CryptoProvider` method `load_private_key()` is called under the hood by
+/// The `KeyProvider` method `load_private_key()` is called under the hood by
 /// [`ConfigBuilder::with_single_cert()`],
 /// [`ConfigBuilder::with_client_auth_cert()`], and
 /// [`ConfigBuilder::with_single_cert_with_ocsp()`].
 ///
-/// A signing key created outside of the `CryptoProvider` extension trait can be used
+/// A signing key created outside of the `KeyProvider` extension trait can be used
 /// to create a [`CertifiedKey`], which in turn can be used to create a
 /// [`ResolvesServerCertUsingSni`]. Alternately, a `CertifiedKey` can be returned from a
 /// custom implementation of the [`ResolvesServerCert`] or [`ResolvesClientCert`] traits.
 ///
-/// [`CryptoProvider::load_private_key()`]: crate::crypto::CryptoProvider::load_private_key
+/// [`KeyProvider::load_private_key()`]: crate::crypto::KeyProvider::load_private_key
 /// [`ConfigBuilder::with_single_cert()`]: crate::ConfigBuilder::with_single_cert
 /// [`ConfigBuilder::with_single_cert_with_ocsp()`]: crate::ConfigBuilder::with_single_cert_with_ocsp
 /// [`ConfigBuilder::with_client_auth_cert()`]: crate::ConfigBuilder::with_client_auth_cert

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -129,8 +129,6 @@
 //! # #[cfg(feature = "ring")] {
 //! # let root_store: rustls::RootCertStore = panic!();
 //! let config = rustls::ClientConfig::builder()
-//!     .with_safe_default_protocol_versions()
-//!     .unwrap()
 //!     .with_root_certificates(root_store)
 //!     .with_no_client_auth();
 //! # }
@@ -151,8 +149,6 @@
 //! #      .cloned()
 //! # );
 //! # let config = rustls::ClientConfig::builder()
-//! #     .with_safe_default_protocol_versions()
-//! #     .unwrap()
 //! #     .with_root_certificates(root_store)
 //! #     .with_no_client_auth();
 //! let rc_config = Arc::new(config);

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -129,7 +129,8 @@
 //! # #[cfg(feature = "ring")] {
 //! # let root_store: rustls::RootCertStore = panic!();
 //! let config = rustls::ClientConfig::builder()
-//!     .with_safe_defaults()
+//!     .with_safe_default_protocol_versions()
+//!     .unwrap()
 //!     .with_root_certificates(root_store)
 //!     .with_no_client_auth();
 //! # }
@@ -150,7 +151,8 @@
 //! #      .cloned()
 //! # );
 //! # let config = rustls::ClientConfig::builder()
-//! #     .with_safe_defaults()
+//! #     .with_safe_default_protocol_versions()
+//! #     .unwrap()
 //! #     .with_root_certificates(root_store)
 //! #     .with_no_client_auth();
 //! let rc_config = Arc::new(config);
@@ -260,14 +262,8 @@
 //!
 //! - `aws_lc_rs`: this makes the rustls crate depend on the aws-lc-rs crate,
 //!   which can be used for cryptography as an alternative to *ring*.
-//!   Use `rustls::crypto::aws_lc_rs::AWS_LC_RS` as a `CryptoProvider` when making a
-//!   `ClientConfig` or `ServerConfig` to use aws-lc-rs -- eg:
-//!
-//!   ```
-//!   # #[cfg(feature = "aws_lc_rs")] {
-//!   rustls::ClientConfig::builder_with_provider(rustls::crypto::aws_lc_rs::AWS_LC_RS);
-//!   # }
-//!   ```
+//!   Use `rustls::crypto::aws_lc_rs::default_provider()` as a `CryptoProvider`
+//!   when making a `ClientConfig` or `ServerConfig` to use aws-lc-rs
 //!
 //!   Note that aws-lc-rs has additional build-time dependencies like cmake.
 //!   See [the documentation](https://aws.github.io/aws-lc-rs/requirements/index.html) for details.
@@ -424,14 +420,12 @@ pub mod internal {
 // Have a (non-public) "test provider" mod which supplies
 // tests that need part of a *ring*-compatible provider module.
 #[cfg(all(any(test, bench), not(feature = "ring"), feature = "aws_lc_rs"))]
-use crate::crypto::{aws_lc_rs as test_provider, aws_lc_rs::AWS_LC_RS as TEST_PROVIDER};
+use crate::crypto::aws_lc_rs as test_provider;
 #[cfg(all(any(test, bench), feature = "ring"))]
-use crate::crypto::{ring as test_provider, ring::RING as TEST_PROVIDER};
+use crate::crypto::ring as test_provider;
 
 // The public interface is:
-pub use crate::builder::{
-    ConfigBuilder, ConfigSide, WantsCipherSuites, WantsKxGroups, WantsVerifier, WantsVersions,
-};
+pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier, WantsVersions};
 pub use crate::common_state::{CommonState, IoState, Side};
 pub use crate::conn::{Connection, ConnectionCommon, Reader, SideData, Writer};
 pub use crate::enums::{

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "tls12")]
 use crate::crypto::ActiveKeyExchange;
-use crate::crypto::CryptoProvider;
+use crate::crypto::SecureRandom;
 use crate::enums::{CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme};
 use crate::error::InvalidMessage;
 #[cfg(feature = "logging")]
@@ -97,11 +97,9 @@ impl Codec for Random {
 }
 
 impl Random {
-    pub(crate) fn new(
-        provider: &'static dyn CryptoProvider,
-    ) -> Result<Self, rand::GetRandomFailed> {
+    pub(crate) fn new(secure_random: &dyn SecureRandom) -> Result<Self, rand::GetRandomFailed> {
         let mut data = [0u8; 32];
-        provider.fill(&mut data)?;
+        secure_random.fill(&mut data)?;
         Ok(Self(data))
     }
 }
@@ -165,9 +163,9 @@ impl Codec for SessionId {
 }
 
 impl SessionId {
-    pub fn random(provider: &'static dyn CryptoProvider) -> Result<Self, rand::GetRandomFailed> {
+    pub fn random(secure_random: &dyn SecureRandom) -> Result<Self, rand::GetRandomFailed> {
         let mut data = [0u8; 32];
-        provider.fill(&mut data)?;
+        secure_random.fill(&mut data)?;
         Ok(Self { data, len: 32 })
     }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -101,7 +101,7 @@ impl Random {
         provider: &'static dyn CryptoProvider,
     ) -> Result<Self, rand::GetRandomFailed> {
         let mut data = [0u8; 32];
-        provider.fill_random(&mut data)?;
+        provider.fill(&mut data)?;
         Ok(Self(data))
     }
 }
@@ -167,7 +167,7 @@ impl Codec for SessionId {
 impl SessionId {
     pub fn random(provider: &'static dyn CryptoProvider) -> Result<Self, rand::GetRandomFailed> {
         let mut data = [0u8; 32];
-        provider.fill_random(&mut data)?;
+        provider.fill(&mut data)?;
         Ok(Self { data, len: 32 })
     }
 

--- a/rustls/src/rand.rs
+++ b/rustls/src/rand.rs
@@ -1,24 +1,24 @@
 //! The single place where we generate random material for our own use.
 
-use crate::crypto::CryptoProvider;
+use crate::crypto::SecureRandom;
 
 use alloc::vec;
 use alloc::vec::Vec;
 
 /// Make a [`Vec<u8>`] of the given size containing random material.
 pub(crate) fn random_vec(
-    provider: &dyn CryptoProvider,
+    secure_random: &dyn SecureRandom,
     len: usize,
 ) -> Result<Vec<u8>, GetRandomFailed> {
     let mut v = vec![0; len];
-    provider.fill(&mut v)?;
+    secure_random.fill(&mut v)?;
     Ok(v)
 }
 
 /// Return a uniformly random [`u32`].
-pub(crate) fn random_u32(provider: &dyn CryptoProvider) -> Result<u32, GetRandomFailed> {
+pub(crate) fn random_u32(secure_random: &dyn SecureRandom) -> Result<u32, GetRandomFailed> {
     let mut buf = [0u8; 4];
-    provider.fill(&mut buf)?;
+    secure_random.fill(&mut buf)?;
     Ok(u32::from_be_bytes(buf))
 }
 

--- a/rustls/src/rand.rs
+++ b/rustls/src/rand.rs
@@ -11,14 +11,14 @@ pub(crate) fn random_vec(
     len: usize,
 ) -> Result<Vec<u8>, GetRandomFailed> {
     let mut v = vec![0; len];
-    provider.fill_random(&mut v)?;
+    provider.fill(&mut v)?;
     Ok(v)
 }
 
 /// Return a uniformly random [`u32`].
 pub(crate) fn random_u32(provider: &dyn CryptoProvider) -> Result<u32, GetRandomFailed> {
     let mut buf = [0u8; 4];
-    provider.fill_random(&mut buf)?;
+    provider.fill(&mut buf)?;
     Ok(u32::from_be_bytes(buf))
 }
 

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -76,6 +76,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
         let private_key = self
             .state
             .provider
+            .key_provider()
             .load_private_key(key_der)?;
         let resolver = handy::AlwaysResolvesChain::new(private_key, CertificateChain(cert_chain));
         Ok(self.with_cert_resolver(Arc::new(resolver)))
@@ -101,6 +102,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
         let private_key = self
             .state
             .provider
+            .key_provider()
             .load_private_key(key_der)?;
         let resolver = handy::AlwaysResolvesChain::new_with_extras(
             private_key,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -384,8 +384,10 @@ impl ExpectClientHello {
         };
 
         // Save their Random.
-        let randoms =
-            ConnectionRandoms::new(client_hello.random, Random::new(self.config.provider)?);
+        let randoms = ConnectionRandoms::new(
+            client_hello.random,
+            Random::new(self.config.provider.secure_random())?,
+        );
         match suite {
             SupportedCipherSuite::Tls13(suite) => tls13::CompleteClientHelloHandling {
                 config: self.config,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -297,6 +297,7 @@ impl ExpectClientHello {
         // intersection of ciphersuites.
         let client_suites = self
             .config
+            .provider
             .cipher_suites
             .iter()
             .copied()
@@ -335,8 +336,10 @@ impl ExpectClientHello {
 
         // Reduce our supported ciphersuites by the certificate.
         // (no-op for TLS1.3)
-        let suitable_suites =
-            suites::reduce_given_sigalg(&self.config.cipher_suites, certkey.get_key().algorithm());
+        let suitable_suites = suites::reduce_given_sigalg(
+            &self.config.provider.cipher_suites,
+            certkey.get_key().algorithm(),
+        );
 
         // And version
         let suitable_suites = suites::reduce_given_version_and_protocol(
@@ -386,7 +389,7 @@ impl ExpectClientHello {
         // Save their Random.
         let randoms = ConnectionRandoms::new(
             client_hello.random,
-            Random::new(self.config.provider.secure_random())?,
+            Random::new(self.config.provider.secure_random)?,
         );
         match suite {
             SupportedCipherSuite::Tls13(suite) => tls13::CompleteClientHelloHandling {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -209,7 +209,7 @@ mod client_hello {
             if !self.config.session_storage.can_cache() {
                 self.session_id = SessionId::empty();
             } else if self.session_id.is_empty() && !ticket_received {
-                self.session_id = SessionId::random(self.config.provider)?;
+                self.session_id = SessionId::random(self.config.provider.secure_random())?;
             }
 
             self.send_ticket = emit_server_hello(

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -179,6 +179,7 @@ mod client_hello {
 
             let group = self
                 .config
+                .provider
                 .kx_groups
                 .iter()
                 .find(|skxg| groups_ext.contains(&skxg.name()))
@@ -209,7 +210,7 @@ mod client_hello {
             if !self.config.session_storage.can_cache() {
                 self.session_id = SessionId::empty();
             } else if self.session_id.is_empty() && !ticket_received {
-                self.session_id = SessionId::random(self.config.provider.secure_random())?;
+                self.session_id = SessionId::random(self.config.provider.secure_random)?;
             }
 
             self.send_ticket = emit_server_hello(

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -202,6 +202,7 @@ mod client_hello {
             // choose a share that we support
             let chosen_share_and_kxg = self
                 .config
+                .provider
                 .kx_groups
                 .iter()
                 .find_map(|group| {
@@ -218,6 +219,7 @@ mod client_hello {
                     // send a HelloRetryRequest.
                     let retry_group_maybe = self
                         .config
+                        .provider
                         .kx_groups
                         .iter()
                         .find(|group| groups_ext.contains(&group.name()))
@@ -1085,7 +1087,7 @@ impl ExpectFinished {
         key_schedule: &KeyScheduleTraffic,
         config: &ServerConfig,
     ) -> Result<(), Error> {
-        let secure_random = config.provider.secure_random();
+        let secure_random = config.provider.secure_random;
         let nonce = rand::random_vec(secure_random, 32)?;
         let age_add = rand::random_u32(secure_random)?;
         let plain = get_server_session_value(

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1085,8 +1085,9 @@ impl ExpectFinished {
         key_schedule: &KeyScheduleTraffic,
         config: &ServerConfig,
     ) -> Result<(), Error> {
-        let nonce = rand::random_vec(config.provider, 32)?;
-        let age_add = rand::random_u32(config.provider)?;
+        let secure_random = config.provider.secure_random();
+        let nonce = rand::random_vec(secure_random, 32)?;
+        let age_add = rand::random_u32(secure_random)?;
         let plain = get_server_session_value(
             transcript,
             suite,
@@ -1106,7 +1107,7 @@ impl ExpectFinished {
             };
             (ticket, config.ticketer.lifetime())
         } else {
-            let id = rand::random_vec(config.provider, 32)?;
+            let id = rand::random_vec(secure_random, 32)?;
             let stored = config
                 .session_storage
                 .put(id.clone(), plain);

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -211,7 +211,7 @@ impl Context {
     fn bench(&self, count: usize) {
         let verifier = WebPkiServerVerifier::new_without_revocation(
             self.roots.clone(),
-            ring::RING.signature_verification_algorithms(),
+            ring::default_provider().signature_verification_algorithms,
         );
         const OCSP_RESPONSE: &[u8] = &[];
         let mut times = Vec::new();

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -242,13 +242,13 @@ impl WebPkiClientVerifier {
     /// will be verified using the trust anchors found in the provided `roots`. If you
     /// wish to disable client authentication use [WebPkiClientVerifier::no_client_auth()] instead.
     ///
-    /// The cryptography used comes from the default [`CryptoProvider`]: [`crate::crypto::ring::RING`].
+    /// The cryptography used comes from the default [`CryptoProvider`]: [`crate::crypto::ring::default_provider`].
     /// Use [`Self::builder_with_provider`] if you wish to customize this.
     ///
     /// For more information, see the [`ClientCertVerifierBuilder`] documentation.
     #[cfg(feature = "ring")]
     pub fn builder(roots: Arc<RootCertStore>) -> ClientCertVerifierBuilder {
-        Self::builder_with_provider(roots, crate::crypto::ring::RING)
+        Self::builder_with_provider(roots, crate::crypto::ring::default_provider().into())
     }
 
     /// Create a builder for the `webpki` client certificate verifier configuration using
@@ -263,9 +263,9 @@ impl WebPkiClientVerifier {
     /// For more information, see the [`ClientCertVerifierBuilder`] documentation.
     pub fn builder_with_provider(
         roots: Arc<RootCertStore>,
-        provider: &'static dyn CryptoProvider,
+        provider: Arc<CryptoProvider>,
     ) -> ClientCertVerifierBuilder {
-        ClientCertVerifierBuilder::new(roots, provider.signature_verification_algorithms())
+        ClientCertVerifierBuilder::new(roots, provider.signature_verification_algorithms)
     }
 
     /// Create a new `WebPkiClientVerifier` that disables client authentication. The server will

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -234,7 +234,7 @@ mod tests {
     fn webpki_supported_algorithms_is_debug() {
         assert_eq!(
             "WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }",
-            format!("{:?}", crate::crypto::ring::RING.signature_verification_algorithms())
+            format!("{:?}", crate::crypto::ring::default_provider().signature_verification_algorithms)
         );
     }
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -484,15 +484,11 @@ fn test_config_builders_debug() {
         .into(),
     );
     assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring } } }", format!("{:?}", b));
-    let b = server_config_builder();
+    let b = server_config_builder_with_versions(&[&rustls::version::TLS13]);
     assert_eq!(
-        "ConfigBuilder<ServerConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring } } }",
+        "ConfigBuilder<ServerConfig, _> { state: WantsVerifier { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3] } }",
         format!("{:?}", b)
     );
-    assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring } } }", format!("{:?}", b));
-    let b = b
-        .with_protocol_versions(&[&rustls::version::TLS13])
-        .unwrap();
     let b = b.with_no_client_auth();
     assert_eq!("ConfigBuilder<ServerConfig, _> { state: WantsServerCert { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3], verifier: NoClientAuth } }", format!("{:?}", b));
 
@@ -505,16 +501,11 @@ fn test_config_builders_debug() {
         .into(),
     );
     assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_CHACHA20_POLY1305_SHA256], kx_groups: [X25519], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring } } }", format!("{:?}", b));
-    let b = client_config_builder();
+    let b = client_config_builder_with_versions(&[&rustls::version::TLS13]);
     assert_eq!(
-        "ConfigBuilder<ClientConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring } } }",
+       "ConfigBuilder<ClientConfig, _> { state: WantsVerifier { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3] } }",
         format!("{:?}", b)
     );
-    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVersions { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring } } }", format!("{:?}", b));
-    let b = b
-        .with_protocol_versions(&[&rustls::version::TLS13])
-        .unwrap();
-    assert_eq!("ConfigBuilder<ClientConfig, _> { state: WantsVerifier { provider: CryptoProvider { cipher_suites: [TLS13_AES_256_GCM_SHA384, TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256], kx_groups: [X25519, secp256r1, secp384r1], signature_verification_algorithms: WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }, secure_random: Ring, key_provider: Ring }, versions: [TLSv1_3] } }", format!("{:?}", b));
 }
 
 /// Test that the server handles combination of `offer_client_auth()` returning true
@@ -532,8 +523,6 @@ fn server_allow_any_anonymous_or_authenticated_client() {
             .unwrap();
 
         let server_config = server_config_builder()
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_client_cert_verifier(client_auth)
             .with_single_cert(kt.get_chain(), kt.get_key())
             .unwrap();
@@ -5081,16 +5070,12 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
 
     let server_config_1 = Arc::new(common::finish_server_config(
         KeyType::Ed25519,
-        server_config_builder()
-            .with_protocol_versions(&[&rustls::version::TLS13])
-            .unwrap(),
+        server_config_builder_with_versions(&[&rustls::version::TLS13]),
     ));
 
     let mut server_config_2 = common::finish_server_config(
         KeyType::Ed25519,
-        server_config_builder()
-            .with_protocol_versions(&[&rustls::version::TLS12])
-            .unwrap(),
+        server_config_builder_with_versions(&[&rustls::version::TLS12]),
     );
     server_config_2.session_storage = Arc::new(rustls::server::NoServerSessionStorage {});
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5521,13 +5521,6 @@ impl rustls::crypto::CryptoProvider for FaultyRandomProvider {
         self.parent.default_kx_groups()
     }
 
-    fn load_private_key(
-        &self,
-        key_der: PrivateKeyDer<'static>,
-    ) -> Result<Arc<dyn rustls::sign::SigningKey>, Error> {
-        self.parent.load_private_key(key_der)
-    }
-
     fn signature_verification_algorithms(&self) -> rustls::crypto::WebPkiSupportedAlgorithms {
         self.parent
             .signature_verification_algorithms()
@@ -5562,6 +5555,15 @@ impl rustls::crypto::SecureRandom for FaultyRandom {
         output.copy_from_slice(fixed_output);
         *queue = &queue[output.len()..];
         Ok(())
+    }
+}
+
+impl rustls::crypto::KeyProvider for FaultyRandomProvider {
+    fn load_private_key(
+        &self,
+        key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn sign::SigningKey>, Error> {
+        self.parent.load_private_key(key_der)
     }
 }
 

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -42,7 +42,8 @@ fn server_config_with_verifier(
     client_cert_verifier: MockClientVerifier,
 ) -> ServerConfig {
     server_config_builder()
-        .with_safe_defaults()
+        .with_safe_default_protocol_versions()
+        .unwrap()
         .with_client_cert_verifier(Arc::new(client_cert_verifier))
         .with_single_cert(kt.get_chain(), kt.get_key())
         .unwrap()

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -42,8 +42,6 @@ fn server_config_with_verifier(
     client_cert_verifier: MockClientVerifier,
 ) -> ServerConfig {
     server_config_builder()
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_client_cert_verifier(Arc::new(client_cert_verifier))
         .with_single_cert(kt.get_chain(), kt.get_key())
         .unwrap()


### PR DESCRIPTION
This branch replaces the existing `CryptoProvider` trait with a `CryptoProvider` struct. This has several advantages:

* it consolidates all of the cryptography related settings into one API surface, the `CryptoProvider` struct members. Previously the provider had methods to suggest default ciphersuites, key exchanges etc, but the builder API methods could override them in confusing ways.
* it allows removing the `WantsCipherSuites` and `WantsKxGroups` builder states - the "safe defaults" are automatically supplied by the choice of a crypto provider. Customization is achieved by overriding the provider's struct fields. Having fewer builder states makes the API easier to understand and document.
* it makes customization easier: the end user can rely on ["struct update syntax"](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax) to only specify fields values for the required
  customization, and defer the rest to an existing `CryptoProvider`. 
  
Achieving this requires a couple of additional changes:

* The `fill_random` and `load_private_key` fns of the `CryptoProvider` trait are broken out into separate traits, `SecureRandom` and `KeyProvider`, so that we can hold separate `&dyn` references to them in the new `CryptoProvider` struct.
* The cipher suite and key exchange groups are now expressed as `Vec` elements. This avoids imposing a `&'static` lifetime that would preclude runtime customization (e.g. the tls*-mio examples that build the list of ciphersuites at runtime based on command line flags).
* As a result of the `Vec` members we can no longer offer the concrete `CryptoProvider`s as `static` members of their respective modules. Instead we add `pub fn provider() -> CryptoProvider` methods to the `ring` and `aws-lc-rs` module that construct the `CryptoProvider` with the safe defaults, ready for further customization.

Finally, to avoid an unnecessary `Result` unwrap when using the default crypto provider and default protocol versions, or customized protocol versions, the `ClientConfig` and `ServerConfig` default `builder` fns transition directly to `WantsVerifier` using default safe protocol versions. Customization of only protocol versions can be done with new `builder_with_protocol_versions` fns that transition to `WantsVerifier` without needing an unwrap. Using a custom provider requires handling the `Result` that may occur if either the default safe protocol versions or provided custom versions can't be supported by the provider's ciphersuites.

Updates #1372, #1603