### PR TITLE
Issue-1632: Ensure SharedSecret::secret_bytes is publicly accessible

### DIFF
--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -263,7 +263,7 @@ pub struct SharedSecret(Vec<u8>);
 
 impl SharedSecret {
     /// Returns the shared secret as a slice of bytes.
-    pub(crate) fn secret_bytes(&self) -> &[u8] {
+    pub fn secret_bytes(&self) -> &[u8] {
         &self.0
     }
 }


### PR DESCRIPTION
When implementing a `CryptoProvider` external to this crate, one needs to be able to access the underlying `secret_bytes` after a key exchange when performing the TLS 1.2 PRF.

This change ensures that the bytes can be safely accessed.

Fixes #1632.