### PR TITLE
make the `provider-example` library no-std compatible (almost)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,9 @@ jobs:
       - name: cargo build (debug; rustls-provider-example)
         run: cargo build --locked -p rustls-provider-example
 
+      - name: cargo build (debug; rustls-provider-example lib in no-std mode)
+        run: cargo build --locked -p rustls-provider-example --no-default-features
+
   msrv:
     name: MSRV
     runs-on: ubuntu-20.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
  "typenum",
 ]
 
@@ -492,19 +491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core",
- "subtle-ng",
- "zeroize",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,7 +503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -528,15 +513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -576,7 +552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -597,12 +573,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -761,10 +736,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -913,7 +886,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -938,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d78d066f8d487fa69d5c3f92f98c11e2540796d213016d107fe86eabf9f26b"
+checksum = "e11bd4ee27b79fa1820e72ef8489cc729c87299ec3f7f52b8fc8dcb87cb2d485"
 dependencies = [
  "hpke-rs-crypto",
  "log",
@@ -949,34 +922,29 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs-crypto"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79df748353d9cee46d565f591d0039973a6554f8ef026b2647ab1ef2b64b91df"
+checksum = "1c3f1ae0a26c18d6469a70db1217136056261c4a244b09a755bc60bd4e055b67"
 dependencies = [
- "getrandom",
- "rand",
- "serde",
- "serde_json",
- "tls_codec",
+ "rand_core",
 ]
 
 [[package]]
 name = "hpke-rs-rust-crypto"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d6fcfe6949aedbacad5aedb2f8ef9f054a142510e8f4f7355a4ccb3f5bd01f"
+checksum = "a08d4500baf0aced746723d3515d08212bdb9d941df6d1aca3d46d1619b2a1cf"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "getrandom",
  "hkdf",
  "hpke-rs-crypto",
  "p256",
  "p384",
- "rand",
  "rand_chacha",
+ "rand_core",
  "sha2",
- "x25519-dalek-ng",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -1323,10 +1291,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
- "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
 ]
 
 [[package]]
@@ -1372,15 +1338,6 @@ checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
 dependencies = [
  "base64",
  "serde",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -1662,7 +1619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
  "const-oid",
- "digest 0.10.7",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -1947,7 +1904,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1962,7 +1919,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core",
 ]
 
@@ -2024,12 +1981,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -2103,27 +2054,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tls_codec"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38a1d5fcfa859f0ec2b5e111dc903890bd7dac7f34713232bf9aa4fd7cad7b2"
-dependencies = [
- "tls_codec_derive",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e00e3e7a54e0f1c8834ce72ed49c8487fbd3f801d8cfe1a0ad0640382f8e15"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "tokio"
@@ -2553,18 +2483,6 @@ dependencies = [
  "curve25519-dalek",
  "rand_core",
  "serde",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek-ng"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7074de8999662970c3c4c8f7f30925028dd8f4ca31ad4c055efa9cdf2ec326"
-dependencies = [
- "curve25519-dalek-ng",
- "rand",
- "rand_core",
  "zeroize",
 ]
 

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 chacha20poly1305 = "0.10.0"
 der = "0.7.0"
 ecdsa = "0.16.8"
-env_logger = "0.10"
 hmac = "0.12.0"
 hpke-rs = "0.1.2"
 hpke-rs-crypto = "0.1.2"
@@ -24,11 +23,12 @@ rsa = { version = "0.9.0", features = ["sha2"] }
 sha2 = "0.10.0"
 signature = "2"
 webpki = { package = "rustls-webpki", version = "0.102", features = ["alloc", "std"], default-features = false }
-webpki-roots = "0.26"
 x25519-dalek = "2"
 
 [dev-dependencies]
+env_logger = "0.10"
 hex = "0.4.3"
 rcgen = "0.11.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+webpki-roots = "=0.26.0"

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -11,13 +11,13 @@ chacha20poly1305 = { version = "0.10.0", default-features = false, features = ["
 der = "0.7.0"
 ecdsa = "0.16.8"
 hmac = "0.12.0"
-hpke-rs = "0.1.2"
-hpke-rs-crypto = "0.1.2"
-hpke-rs-rust-crypto = "0.1.2"
+hpke-rs = "0.2.0"
+hpke-rs-crypto = "0.2.0"
+hpke-rs-rust-crypto = "0.2.0"
 p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecdsa", "pkcs8"] }
-pkcs8 = { version = "0.10.2" }
+pkcs8 = "0.10.2"
 pki-types = { package = "rustls-pki-types", version = "1" }
-rand_core = "0.6.0"
+rand_core = { version = "0.6.0", features = ["getrandom"] }
 rustls = { path = "../rustls", default-features = false, features = ["logging", "tls12"] }
 rsa = { version = "0.9.0", features = ["sha2"], default-features = false }
 sha2 = { version = "0.10.0", default-features = false }
@@ -32,3 +32,11 @@ rcgen = "0.11.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 webpki-roots = "=0.26.0"
+
+[features]
+default = ["std"]
+std = ["hpke-rs/std", "hpke-rs-crypto/std", "pkcs8/std"]
+
+[[test]]
+name = "hpke"
+required-features = ["std"]

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -7,22 +7,22 @@ description = "Example of rustls with custom crypto provider."
 publish = false
 
 [dependencies]
-chacha20poly1305 = "0.10.0"
+chacha20poly1305 = { version = "0.10.0", default-features = false, features = ["alloc"] }
 der = "0.7.0"
 ecdsa = "0.16.8"
 hmac = "0.12.0"
 hpke-rs = "0.1.2"
 hpke-rs-crypto = "0.1.2"
 hpke-rs-rust-crypto = "0.1.2"
-p256 = "0.13.2"
-pkcs8 = { version = "0.10.2", features = ["std"] }
-pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
+p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecdsa", "pkcs8"] }
+pkcs8 = { version = "0.10.2" }
+pki-types = { package = "rustls-pki-types", version = "1" }
 rand_core = "0.6.0"
 rustls = { path = "../rustls", default-features = false, features = ["logging", "tls12"] }
-rsa = { version = "0.9.0", features = ["sha2"] }
-sha2 = "0.10.0"
+rsa = { version = "0.9.0", features = ["sha2"], default-features = false }
+sha2 = { version = "0.10.0", default-features = false }
 signature = "2"
-webpki = { package = "rustls-webpki", version = "0.102", features = ["alloc", "std"], default-features = false }
+webpki = { package = "rustls-webpki", version = "0.102", features = ["alloc"], default-features = false }
 x25519-dalek = "2"
 
 [dev-dependencies]

--- a/provider-example/src/aead.rs
+++ b/provider-example/src/aead.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use chacha20poly1305::{AeadInPlace, KeyInit, KeySizeUser};
 use rustls::crypto::cipher::{self, AeadKey, Iv, UnsupportedOperationError, NONCE_LEN};
 use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};

--- a/provider-example/src/hash.rs
+++ b/provider-example/src/hash.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use rustls::crypto::hash;
 use sha2::Digest;
 

--- a/provider-example/src/hmac.rs
+++ b/provider-example/src/hmac.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use hmac::{Hmac, Mac};
 use rustls::crypto;
 use sha2::{Digest, Sha256};

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -1,6 +1,8 @@
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::fmt::{Debug, Formatter};
 use std::error::Error as StdError;
-use std::fmt::{Debug, Formatter};
-use std::sync::Arc;
 
 use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
 use hpke_rs_crypto::HpkeCrypto;

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -91,6 +91,11 @@ impl Hpke for HpkeRs {
     }
 }
 
+#[cfg(feature = "std")]
 fn other_err(err: impl StdError + Send + Sync + 'static) -> Error {
     Error::Other(OtherError(Arc::new(err)))
+}
+#[cfg(not(feature = "std"))]
+fn other_err(err: impl Send + Sync + 'static) -> Error {
+    Error::General(alloc::format!("{}", err));
 }

--- a/provider-example/src/kx.rs
+++ b/provider-example/src/kx.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crypto::SupportedKxGroup;
 use rustls::crypto;
 

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -1,4 +1,9 @@
-use std::sync::Arc;
+#![no_std]
+
+extern crate alloc;
+extern crate std;
+
+use alloc::sync::Arc;
 
 use pki_types::PrivateKeyDer;
 use rustls::crypto::CryptoProvider;

--- a/provider-example/src/sign.rs
+++ b/provider-example/src/sign.rs
@@ -1,4 +1,6 @@
-use std::sync::Arc;
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 use pkcs8::DecodePrivateKey;
 use pki_types::PrivateKeyDer;


### PR DESCRIPTION
for use in in-tree examples.

this has been extracted out of #1534 and it's the part that has run into merge conflicts more often in the last few weeks so I'd like to land it ahead of time.

`provider-example` is *almost* no-std compatible because `rustls` is not no-std compatible until #1502 lands. still this PR gets more of the no-std compatibility done and only a few Cargo.toml changes are needed after #1502 lands.

the latest crates.io release of `hpke` is not no-std compatible but I've send a [bunch of PRs to fix that](https://github.com/franziskuskiefer/hpke-rs/pulls?q=+is%3Apr+author%3Ajaparic+)