### PR TITLE
Limit fragmentation in `write_vectored`

### DIFF
--- a/provider-example/src/aead.rs
+++ b/provider-example/src/aead.rs
@@ -93,7 +93,7 @@ impl cipher::MessageEncrypter for Tls13Cipher {
 
         // construct a TLSInnerPlaintext
         let mut payload = Vec::with_capacity(total_len);
-        payload.extend_from_slice(m.payload);
+        m.payload.copy_to_vec(&mut payload);
         payload.push(m.typ.get_u8());
 
         let nonce = chacha20poly1305::Nonce::from(cipher::Nonce::new(&self.1, seq).0);
@@ -145,7 +145,7 @@ impl cipher::MessageEncrypter for Tls12Cipher {
         let total_len = self.encrypted_payload_len(m.payload.len());
 
         let mut payload = Vec::with_capacity(total_len);
-        payload.extend_from_slice(m.payload);
+        m.payload.copy_to_vec(&mut payload);
 
         let nonce = chacha20poly1305::Nonce::from(cipher::Nonce::new(&self.1, seq).0);
         let aad = cipher::make_tls12_aad(seq, m.typ, m.version, payload.len());

--- a/provider-example/src/aead.rs
+++ b/provider-example/src/aead.rs
@@ -86,7 +86,7 @@ struct Tls13Cipher(chacha20poly1305::ChaCha20Poly1305, cipher::Iv);
 impl cipher::MessageEncrypter for Tls13Cipher {
     fn encrypt(
         &mut self,
-        m: cipher::BorrowedPlainMessage,
+        m: cipher::OutboundMessage,
         seq: u64,
     ) -> Result<cipher::OpaqueMessage, rustls::Error> {
         let total_len = self.encrypted_payload_len(m.payload.len());
@@ -121,7 +121,7 @@ impl cipher::MessageDecrypter for Tls13Cipher {
         &mut self,
         mut m: cipher::BorrowedOpaqueMessage<'a>,
         seq: u64,
-    ) -> Result<cipher::BorrowedPlainMessage<'a>, rustls::Error> {
+    ) -> Result<cipher::InboundMessage<'a>, rustls::Error> {
         let payload = &mut m.payload;
         let nonce = chacha20poly1305::Nonce::from(cipher::Nonce::new(&self.1, seq).0);
         let aad = cipher::make_tls13_aad(payload.len());
@@ -139,7 +139,7 @@ struct Tls12Cipher(chacha20poly1305::ChaCha20Poly1305, cipher::Iv);
 impl cipher::MessageEncrypter for Tls12Cipher {
     fn encrypt(
         &mut self,
-        m: cipher::BorrowedPlainMessage,
+        m: cipher::OutboundMessage,
         seq: u64,
     ) -> Result<cipher::OpaqueMessage, rustls::Error> {
         let total_len = self.encrypted_payload_len(m.payload.len());
@@ -166,7 +166,7 @@ impl cipher::MessageDecrypter for Tls12Cipher {
         &mut self,
         mut m: cipher::BorrowedOpaqueMessage<'a>,
         seq: u64,
-    ) -> Result<cipher::BorrowedPlainMessage<'a>, rustls::Error> {
+    ) -> Result<cipher::InboundMessage<'a>, rustls::Error> {
         let payload = &m.payload;
         let nonce = chacha20poly1305::Nonce::from(cipher::Nonce::new(&self.1, seq).0);
         let aad = cipher::make_tls12_aad(
@@ -181,7 +181,7 @@ impl cipher::MessageDecrypter for Tls12Cipher {
             .decrypt_in_place(&nonce, &aad, &mut BufferAdapter(payload))
             .map_err(|_| rustls::Error::DecryptError)?;
 
-        Ok(m.into_plain_message())
+        Ok(m.into_inbound_message())
     }
 }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -787,7 +787,7 @@ impl MayEncryptEarlyData<'_> {
         self.conn
             .core
             .common_state
-            .write_plaintext(&early_data[..allowed], outgoing_tls)
+            .write_plaintext(early_data[..allowed].into(), outgoing_tls)
             .map_err(|e| e.into())
     }
 }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -7,8 +7,9 @@ use crate::msgs::base::Payload;
 use crate::msgs::enums::{AlertLevel, KeyUpdateRequest};
 use crate::msgs::fragmenter::MessageFragmenter;
 use crate::msgs::handshake::CertificateChain;
-use crate::msgs::message::MessagePayload;
-use crate::msgs::message::{BorrowedPlainMessage, Message, OpaqueMessage, PlainMessage};
+use crate::msgs::message::{
+    BorrowedPlainMessage, Message, MessagePayload, OpaqueMessage, OutboundMessage, PlainMessage,
+};
 use crate::quic;
 use crate::record_layer;
 use crate::suites::PartiallyExtractedSecrets;
@@ -300,7 +301,7 @@ impl CommonState {
         len
     }
 
-    fn send_single_fragment(&mut self, m: BorrowedPlainMessage) {
+    fn send_single_fragment(&mut self, m: OutboundMessage) {
         // Close connection once we start to run out of
         // sequence space.
         if self
@@ -548,7 +549,7 @@ impl CommonState {
         &self,
         outgoing_tls: &mut [u8],
         opt_msg: Option<&[u8]>,
-        fragments: impl Iterator<Item = BorrowedPlainMessage<'a>>,
+        fragments: impl Iterator<Item = OutboundMessage<'a>>,
     ) -> Result<(), EncryptError> {
         let mut required_size = 0;
         if let Some(message) = opt_msg {
@@ -572,7 +573,7 @@ impl CommonState {
         &mut self,
         outgoing_tls: &mut [u8],
         opt_msg: Option<Vec<u8>>,
-        fragments: impl Iterator<Item = BorrowedPlainMessage<'a>>,
+        fragments: impl Iterator<Item = OutboundMessage<'a>>,
     ) -> usize {
         let mut written = 0;
 
@@ -658,7 +659,7 @@ impl CommonState {
         let message = PlainMessage::from(Message::build_key_update_notify());
         self.queued_key_update_message = Some(
             self.record_layer
-                .encrypt_outgoing(message.borrow())
+                .encrypt_outgoing(message.borrow_outbound())
                 .encode(),
         );
     }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -344,15 +344,6 @@ impl ConnectionRandoms {
     }
 }
 
-// --- Common (to client and server) connection functions ---
-
-fn is_valid_ccs(msg: &InboundMessage) -> bool {
-    // We passthrough ChangeCipherSpec messages in the deframer without decrypting them.
-    // Note: this is prior to the record layer, so is unencrypted. See
-    // third paragraph of section 5 in RFC8446.
-    msg.typ == ContentType::ChangeCipherSpec && msg.payload == [0x01]
-}
-
 /// Interface shared by client and server connections.
 pub struct ConnectionCommon<Data> {
     pub(crate) core: ConnectionCore<Data>,
@@ -853,7 +844,7 @@ impl<Data> ConnectionCore<Data> {
                 .may_receive_application_data
             && self.common_state.is_tls13()
         {
-            if !is_valid_ccs(&msg)
+            if !msg.is_valid_ccs()
                 || self.common_state.received_middlebox_ccs > TLS13_MAX_DROPPED_CCS
             {
                 // "An implementation which receives any other change_cipher_spec value or

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -400,7 +400,7 @@ impl<Data> WriteTraffic<'_, Data> {
         self.conn
             .core
             .common_state
-            .write_plaintext(application_data, outgoing_tls)
+            .write_plaintext(application_data.into(), outgoing_tls)
     }
 
     /// Encrypts a close_notify warning alert in `outgoing_tls`

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -309,7 +309,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = Vec::with_capacity(total_len);
         payload.extend_from_slice(&nonce.as_ref()[4..]);
-        payload.extend_from_slice(msg.payload);
+        msg.payload.copy_to_vec(&mut payload);
 
         self.enc_key
             .seal_in_place_separate_tag(nonce, aad, &mut payload[GCM_EXPLICIT_NONCE_LEN..])
@@ -385,7 +385,7 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
 
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut buf = Vec::with_capacity(total_len);
-        buf.extend_from_slice(msg.payload);
+        msg.payload.copy_to_vec(&mut buf);
 
         self.enc_key
             .seal_in_place_append_tag(nonce, aad, &mut buf)

--- a/rustls/src/crypto/aws_lc_rs/tls13.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls13.rs
@@ -223,7 +223,7 @@ impl MessageEncrypter for AeadMessageEncrypter {
     fn encrypt(&mut self, msg: OutboundMessage, seq: u64) -> Result<OpaqueMessage, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = Vec::with_capacity(total_len);
-        payload.extend_from_slice(msg.payload);
+        msg.payload.copy_to_vec(&mut payload);
         msg.typ.encode(&mut payload);
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
@@ -279,7 +279,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
     fn encrypt(&mut self, msg: OutboundMessage, seq: u64) -> Result<OpaqueMessage, Error> {
         let total_len = msg.payload.len() + 1 + self.enc_key.algorithm().tag_len();
         let mut payload = Vec::with_capacity(total_len);
-        payload.extend_from_slice(msg.payload);
+        msg.payload.copy_to_vec(&mut payload);
         msg.typ.encode(&mut payload);
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -8,7 +8,7 @@ use crate::error::Error;
 pub use crate::msgs::base::BorrowedPayload;
 use crate::msgs::codec;
 pub use crate::msgs::message::{
-    BorrowedOpaqueMessage, BorrowedPlainMessage, OpaqueMessage, PlainMessage,
+    BorrowedOpaqueMessage, InboundMessage, OpaqueMessage, OutboundMessage, PlainMessage,
 };
 use crate::suites::ConnectionTrafficSecrets;
 
@@ -141,14 +141,14 @@ pub trait MessageDecrypter: Send + Sync {
         &mut self,
         msg: BorrowedOpaqueMessage<'a>,
         seq: u64,
-    ) -> Result<BorrowedPlainMessage<'a>, Error>;
+    ) -> Result<InboundMessage<'a>, Error>;
 }
 
 /// Objects with this trait can encrypt TLS messages.
 pub trait MessageEncrypter: Send + Sync {
     /// Encrypt the given TLS message `msg`, using the sequence number
     /// `seq which can be used to derive a unique [`Nonce`].
-    fn encrypt(&mut self, msg: BorrowedPlainMessage, seq: u64) -> Result<OpaqueMessage, Error>;
+    fn encrypt(&mut self, msg: OutboundMessage, seq: u64) -> Result<OpaqueMessage, Error>;
 
     /// Return the length of the ciphertext that results from encrypting plaintext of
     /// length `payload_len`
@@ -318,7 +318,7 @@ impl From<[u8; Self::MAX_LEN]> for AeadKey {
 struct InvalidMessageEncrypter {}
 
 impl MessageEncrypter for InvalidMessageEncrypter {
-    fn encrypt(&mut self, _m: BorrowedPlainMessage, _seq: u64) -> Result<OpaqueMessage, Error> {
+    fn encrypt(&mut self, _m: OutboundMessage, _seq: u64) -> Result<OpaqueMessage, Error> {
         Err(Error::EncryptError)
     }
 
@@ -335,7 +335,7 @@ impl MessageDecrypter for InvalidMessageDecrypter {
         &mut self,
         _m: BorrowedOpaqueMessage<'a>,
         _seq: u64,
-    ) -> Result<BorrowedPlainMessage<'a>, Error> {
+    ) -> Result<InboundMessage<'a>, Error> {
         Err(Error::DecryptError)
     }
 }

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -293,7 +293,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = Vec::with_capacity(total_len);
         payload.extend_from_slice(&nonce.as_ref()[4..]);
-        payload.extend_from_slice(msg.payload);
+        msg.payload.copy_to_vec(&mut payload);
 
         self.enc_key
             .seal_in_place_separate_tag(nonce, aad, &mut payload[GCM_EXPLICIT_NONCE_LEN..])
@@ -369,7 +369,7 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
 
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut buf = Vec::with_capacity(total_len);
-        buf.extend_from_slice(msg.payload);
+        msg.payload.copy_to_vec(&mut buf);
 
         self.enc_key
             .seal_in_place_append_tag(nonce, aad, &mut buf)

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -7,7 +7,7 @@ use crate::crypto::KeyExchangeAlgorithm;
 use crate::enums::{CipherSuite, SignatureScheme};
 use crate::error::Error;
 use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
-use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage};
+use crate::msgs::message::{InboundMessage, OpaqueMessage, OutboundMessage};
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls12::Tls12CipherSuite;
 
@@ -249,7 +249,7 @@ impl MessageDecrypter for GcmMessageDecrypter {
         &mut self,
         mut msg: BorrowedOpaqueMessage<'a>,
         seq: u64,
-    ) -> Result<BorrowedPlainMessage<'a>, Error> {
+    ) -> Result<InboundMessage<'a>, Error> {
         let payload = &msg.payload;
         if payload.len() < GCM_OVERHEAD {
             return Err(Error::DecryptError);
@@ -281,12 +281,12 @@ impl MessageDecrypter for GcmMessageDecrypter {
         }
 
         payload.truncate(plain_len);
-        Ok(msg.into_plain_message())
+        Ok(msg.into_inbound_message())
     }
 }
 
 impl MessageEncrypter for GcmMessageEncrypter {
-    fn encrypt(&mut self, msg: BorrowedPlainMessage, seq: u64) -> Result<OpaqueMessage, Error> {
+    fn encrypt(&mut self, msg: OutboundMessage, seq: u64) -> Result<OpaqueMessage, Error> {
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
 
@@ -331,7 +331,7 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
         &mut self,
         mut msg: BorrowedOpaqueMessage<'a>,
         seq: u64,
-    ) -> Result<BorrowedPlainMessage<'a>, Error> {
+    ) -> Result<InboundMessage<'a>, Error> {
         let payload = &msg.payload;
 
         if payload.len() < CHACHAPOLY1305_OVERHEAD {
@@ -358,12 +358,12 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
         }
 
         payload.truncate(plain_len);
-        Ok(msg.into_plain_message())
+        Ok(msg.into_inbound_message())
     }
 }
 
 impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
-    fn encrypt(&mut self, msg: BorrowedPlainMessage, seq: u64) -> Result<OpaqueMessage, Error> {
+    fn encrypt(&mut self, msg: OutboundMessage, seq: u64) -> Result<OpaqueMessage, Error> {
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).0);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
 

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -10,7 +10,7 @@ use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use crate::enums::{CipherSuite, ContentType, ProtocolVersion};
 use crate::error::Error;
 use crate::msgs::codec::Codec;
-use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage};
+use crate::msgs::message::{InboundMessage, OpaqueMessage, OutboundMessage};
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls13::Tls13CipherSuite;
 
@@ -192,7 +192,7 @@ struct Tls13MessageDecrypter {
 }
 
 impl MessageEncrypter for Tls13MessageEncrypter {
-    fn encrypt(&mut self, msg: BorrowedPlainMessage, seq: u64) -> Result<OpaqueMessage, Error> {
+    fn encrypt(&mut self, msg: OutboundMessage, seq: u64) -> Result<OpaqueMessage, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = Vec::with_capacity(total_len);
         payload.extend_from_slice(msg.payload);
@@ -223,7 +223,7 @@ impl MessageDecrypter for Tls13MessageDecrypter {
         &mut self,
         mut msg: BorrowedOpaqueMessage<'a>,
         seq: u64,
-    ) -> Result<BorrowedPlainMessage<'a>, Error> {
+    ) -> Result<InboundMessage<'a>, Error> {
         let payload = &mut msg.payload;
         if payload.len() < self.dec_key.algorithm().tag_len() {
             return Err(Error::DecryptError);

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -195,7 +195,7 @@ impl MessageEncrypter for Tls13MessageEncrypter {
     fn encrypt(&mut self, msg: OutboundMessage, seq: u64) -> Result<OpaqueMessage, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = Vec::with_capacity(total_len);
-        payload.extend_from_slice(msg.payload);
+        msg.payload.copy_to_vec(&mut payload);
         msg.typ.encode(&mut payload);
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -482,7 +482,9 @@ pub mod internal {
             };
         }
         pub mod message {
-            pub use crate::msgs::message::{Message, MessagePayload, OpaqueMessage, PlainMessage};
+            pub use crate::msgs::message::{
+                BorrowedPlainMessage, Message, MessagePayload, OpaqueMessage, PlainMessage,
+            };
         }
         pub mod persist {
             pub use crate::msgs::persist::ServerSessionValue;

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -437,6 +437,17 @@ pub struct InboundMessage<'a> {
     pub payload: &'a [u8],
 }
 
+impl InboundMessage<'_> {
+    /// Returns true if the payload is a CCS message.
+    ///
+    /// We passthrough ChangeCipherSpec messages in the deframer without decrypting them.
+    /// Note: this is prior to the record layer, so is unencrypted. See
+    /// third paragraph of section 5 in RFC8446.
+    pub(crate) fn is_valid_ccs(&self) -> bool {
+        self.typ == ContentType::ChangeCipherSpec && self.payload == [0x01]
+    }
+}
+
 impl BorrowedPlainMessage for InboundMessage<'_> {
     fn payload_to_vec(&self) -> Vec<u8> {
         self.payload.to_vec()

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -347,7 +347,7 @@ impl PlainMessage {
         OutboundMessage {
             version: self.version,
             typ: self.typ,
-            payload: self.payload.bytes(),
+            payload: self.payload.bytes().into(),
         }
     }
 }
@@ -468,7 +468,7 @@ impl BorrowedPlainMessage for InboundMessage<'_> {
 pub struct OutboundMessage<'a> {
     pub typ: ContentType,
     pub version: ProtocolVersion,
-    pub payload: &'a [u8],
+    pub payload: OutboundChunks<'a>,
 }
 
 impl BorrowedPlainMessage for OutboundMessage<'_> {
@@ -520,6 +520,126 @@ pub trait BorrowedPlainMessage: Sized {
     fn version(&self) -> ProtocolVersion;
 }
 
+#[derive(Debug, Clone)]
+/// A collection of borrowed plaintext slices.
+/// Warning: OutboundChunks does not guarantee that the simplest variant is used.
+/// Multiple can hold non fragmented or empty payloads.
+pub enum OutboundChunks<'a> {
+    /// A single byte slice. Contrary to `Multiple`, this uses a single pointer indirection
+    Single(&'a [u8]),
+    /// A collection of chunks (byte slices)
+    /// and cursors to single out a fragmented range of bytes.
+    /// OutboundChunks assumes that start <= end
+    Multiple {
+        chunks: &'a [&'a [u8]],
+        start: usize,
+        end: usize,
+    },
+}
+
+impl<'a> OutboundChunks<'a> {
+    /// Create a payload from a slice of byte slices.
+    /// If fragmented the cursors are added by default: start = 0, end = length
+    pub fn new(chunks: &'a [&'a [u8]]) -> Self {
+        if chunks.len() == 1 {
+            Self::Single(chunks[0])
+        } else {
+            Self::Multiple {
+                chunks,
+                start: 0,
+                end: chunks
+                    .iter()
+                    .map(|chunk| chunk.len())
+                    .sum(),
+            }
+        }
+    }
+
+    /// Create a payload with a single empty slice
+    pub fn new_empty() -> Self {
+        Self::Single(&[])
+    }
+
+    /// Flatten the slice of byte slices to an owned vector of bytes
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut vec = Vec::with_capacity(self.len());
+        self.copy_to_vec(&mut vec);
+        vec
+    }
+
+    /// Append all bytes to a vector
+    pub fn copy_to_vec(&self, vec: &mut Vec<u8>) {
+        match *self {
+            Self::Single(chunk) => vec.extend_from_slice(chunk),
+            Self::Multiple { chunks, start, end } => {
+                let mut size = 0;
+                for chunk in chunks.iter() {
+                    let psize = size;
+                    let len = chunk.len();
+                    size += len;
+                    if size <= start || psize >= end {
+                        continue;
+                    }
+                    let start = if psize < start { start - psize } else { 0 };
+                    let end = if end - psize < len { end - psize } else { len };
+                    vec.extend_from_slice(&chunk[start..end]);
+                }
+            }
+        }
+    }
+
+    /// Split self in two, around an index
+    /// Works similarly to `split_at` in the core library, except it doesn't panic if out of bound
+    pub fn split_at(&self, mid: usize) -> (Self, Self) {
+        match *self {
+            Self::Single(chunk) => {
+                let mid = Ord::min(mid, chunk.len());
+                (Self::Single(&chunk[..mid]), Self::Single(&chunk[mid..]))
+            }
+            Self::Multiple { chunks, start, end } => {
+                let mid = Ord::min(start + mid, end);
+                (
+                    Self::Multiple {
+                        chunks,
+                        start,
+                        end: mid,
+                    },
+                    Self::Multiple {
+                        chunks,
+                        start: mid,
+                        end,
+                    },
+                )
+            }
+        }
+    }
+
+    /// Returns true if the payload is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the cumulative length of all chunks
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Single(chunk) => chunk.len(),
+            Self::Multiple { start, end, .. } => end - start,
+        }
+    }
+}
+
+impl<'a> From<&'a [u8]> for OutboundChunks<'a> {
+    fn from(payload: &'a [u8]) -> Self {
+        Self::Single(payload)
+    }
+}
+
+impl<'a, const N: usize> From<&'a [u8; N]> for OutboundChunks<'a> {
+    fn from(payload: &'a [u8; N]) -> Self {
+        Self::Single(payload)
+    }
+}
+
 #[derive(Debug)]
 pub enum MessageError {
     TooShortForHeader,
@@ -528,4 +648,119 @@ pub enum MessageError {
     MessageTooLarge,
     InvalidContentType,
     UnknownProtocolVersion,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{println, vec};
+
+    use super::*;
+
+    #[test]
+    fn split_at_with_single_slice() {
+        let owner: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7];
+        let borrowed_payload = OutboundChunks::Single(owner);
+
+        let (before, after) = borrowed_payload.split_at(6);
+        println!("before:{:?}\nafter:{:?}", before, after);
+        assert_eq!(before.to_vec(), &[0, 1, 2, 3, 4, 5]);
+        assert_eq!(after.to_vec(), &[6, 7]);
+    }
+
+    #[test]
+    fn split_at_with_multiple_slices() {
+        let owner: Vec<&[u8]> = vec![&[0, 1, 2, 3], &[4, 5], &[6, 7, 8], &[9, 10, 11, 12]];
+        let borrowed_payload = OutboundChunks::new(&owner);
+
+        let (before, after) = borrowed_payload.split_at(3);
+        println!("before:{:?}\nafter:{:?}", before, after);
+        assert_eq!(before.to_vec(), &[0, 1, 2]);
+        assert_eq!(after.to_vec(), &[3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+        let (before, after) = borrowed_payload.split_at(8);
+        println!("before:{:?}\nafter:{:?}", before, after);
+        assert_eq!(before.to_vec(), &[0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(after.to_vec(), &[8, 9, 10, 11, 12]);
+
+        let (before, after) = borrowed_payload.split_at(11);
+        println!("before:{:?}\nafter:{:?}", before, after);
+        assert_eq!(before.to_vec(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(after.to_vec(), &[11, 12]);
+    }
+
+    #[test]
+    fn split_out_of_bounds() {
+        let owner: Vec<&[u8]> = vec![&[0, 1, 2, 3], &[4, 5], &[6, 7, 8], &[9, 10, 11, 12]];
+
+        let single_payload = OutboundChunks::Single(owner[0]);
+        let (before, after) = single_payload.split_at(17);
+        println!("before:{:?}\nafter:{:?}", before, after);
+        assert_eq!(before.to_vec(), &[0, 1, 2, 3]);
+        assert!(after.is_empty());
+
+        let multiple_payload = OutboundChunks::new(&owner);
+        let (before, after) = multiple_payload.split_at(17);
+        println!("before:{:?}\nafter:{:?}", before, after);
+        assert_eq!(before.to_vec(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+        assert!(after.is_empty());
+
+        let empty_payload = OutboundChunks::new_empty();
+        let (before, after) = empty_payload.split_at(17);
+        println!("before:{:?}\nafter:{:?}", before, after);
+        assert!(before.is_empty());
+        assert!(after.is_empty());
+    }
+
+    #[test]
+    fn empty_slices_mixed() {
+        let owner: Vec<&[u8]> = vec![&[], &[], &[0], &[], &[1, 2], &[], &[3], &[4], &[], &[]];
+        let mut borrowed_payload = OutboundChunks::new(&owner);
+        let mut fragment_count = 0;
+        let mut fragment;
+        let expected_fragments: &[&[u8]] = &[&[0, 1], &[2, 3], &[4]];
+
+        while !borrowed_payload.is_empty() {
+            (fragment, borrowed_payload) = borrowed_payload.split_at(2);
+            println!("{fragment:?}");
+            assert_eq!(&expected_fragments[fragment_count], &fragment.to_vec());
+            fragment_count += 1;
+        }
+        assert_eq!(fragment_count, expected_fragments.len());
+    }
+
+    #[test]
+    fn exhaustive_splitting() {
+        let owner: Vec<u8> = (0..127).collect();
+        let slices = (0..7)
+            .map(|i| &owner[((1 << i) - 1)..((1 << (i + 1)) - 1)])
+            .collect::<Vec<_>>();
+        let payload = OutboundChunks::new(&slices);
+
+        assert_eq!(payload.to_vec(), owner);
+        println!("{:#?}", payload);
+
+        for start in 0..128 {
+            for end in start..128 {
+                for mid in 0..(end - start) {
+                    let witness = owner[start..end].split_at(mid);
+                    let split_payload = payload
+                        .split_at(end)
+                        .0
+                        .split_at(start)
+                        .1
+                        .split_at(mid);
+                    assert_eq!(
+                        witness.0,
+                        split_payload.0.to_vec(),
+                        "start: {start}, mid:{mid}, end:{end}"
+                    );
+                    assert_eq!(
+                        witness.1,
+                        split_payload.1.to_vec(),
+                        "start: {start}, mid:{mid}, end:{end}"
+                    );
+                }
+            }
+        }
+    }
 }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -4,6 +4,8 @@ use core::cmp;
 use std::io;
 use std::io::Read;
 
+use crate::msgs::message::OutboundChunks;
+
 /// This is a byte buffer that is built from a vector
 /// of byte vectors.  This avoids extra copies when
 /// appending a new byte vector, at the expense of
@@ -66,9 +68,9 @@ impl ChunkVecBuffer {
 
     /// Append a copy of `bytes`, perhaps a prefix if
     /// we're near the limit.
-    pub(crate) fn append_limited_copy(&mut self, bytes: &[u8]) -> usize {
-        let take = self.apply_limit(bytes.len());
-        self.append(bytes[..take].to_vec());
+    pub(crate) fn append_limited_copy(&mut self, payload: OutboundChunks<'_>) -> usize {
+        let take = self.apply_limit(payload.len());
+        self.append(payload.split_at(take).0.to_vec());
         take
     }
 
@@ -155,10 +157,10 @@ mod tests {
     #[test]
     fn short_append_copy_with_limit() {
         let mut cvb = ChunkVecBuffer::new(Some(12));
-        assert_eq!(cvb.append_limited_copy(b"hello"), 5);
-        assert_eq!(cvb.append_limited_copy(b"world"), 5);
-        assert_eq!(cvb.append_limited_copy(b"hello"), 2);
-        assert_eq!(cvb.append_limited_copy(b"world"), 0);
+        assert_eq!(cvb.append_limited_copy(b"hello".into()), 5);
+        assert_eq!(cvb.append_limited_copy(b"world".into()), 5);
+        assert_eq!(cvb.append_limited_copy(b"hello".into()), 2);
+        assert_eq!(cvb.append_limited_copy(b"world".into()), 0);
 
         let mut buf = [0u8; 12];
         assert_eq!(cvb.read(&mut buf).unwrap(), 12);

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -27,7 +27,9 @@ use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::enums::AlertLevel;
 use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
-use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
+use rustls::internal::msgs::message::{
+    BorrowedPlainMessage, Message, MessagePayload, PlainMessage,
+};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
 use rustls::SupportedCipherSuite;
 use rustls::{
@@ -745,11 +747,11 @@ fn test_tls13_valid_early_plaintext_alert() {
     //  * The negotiated protocol version is TLS 1.3.
     server
         .read_tls(&mut io::Cursor::new(
-            <Message as Into<PlainMessage>>::into(Message::build_alert(
+            PlainMessage::from(Message::build_alert(
                 AlertLevel::Fatal,
                 AlertDescription::UnknownCA,
             ))
-            .borrow()
+            .borrow_inbound()
             .to_unencrypted_opaque()
             .encode(),
         ))
@@ -797,11 +799,11 @@ fn test_tls13_late_plaintext_alert() {
     // Inject a plaintext alert from the client. The server should attempt to decrypt this message.
     server
         .read_tls(&mut io::Cursor::new(
-            <Message as Into<PlainMessage>>::into(Message::build_alert(
+            PlainMessage::from(Message::build_alert(
                 AlertLevel::Fatal,
                 AlertDescription::UnknownCA,
             ))
-            .borrow()
+            .borrow_inbound()
             .to_unencrypted_opaque()
             .encode(),
         ))


### PR DESCRIPTION
We, [Wonshtrum](https://github.com/Wonshtrum) and myself, work at Clever Cloud on a custom-made reverse proxy called [Sōzu](https://github.com/sozu-proxy/sozu/). We switched from using both OpenSSL and Rustls to being Rustls-only, one year ago, and we are very happy about it. We appreciate the security orientation of Rustls, as well as its native Rust nature.

## Our issue

In Sōzu, our reverse proxy, we strive to optimize system calls and throughput. Here is the syscall we found with strace  when transmitting a simple HTTPS response to a client:

```
writev(
    11,
    [
        {iov_base="\27\3\3\0\31\210H\371\252\25w\304\275\346u\27\371\334g\345\244\371\331\203c\302\356\324i\367", iov_len=30},
        {iov_base="\27\3\3\0\22\366IR\236\357\374\37\30\310E\330Xr\3249\24r0", iov_len=23},
        {iov_base="\27\3\3\0\24\326\337\223\356R\360\37\215\343a\2L\236\30\24D\31\10\363\16", iov_len=25},
        {iov_base="\27\3\3\0\22\347\305\255\371?\224\6\212\325\345\250*a\250\321i\366\266", iov_len=23},
        {iov_base="\27\3\3\0\23\37\24Ex\334\vHp\2758\207\27G\306\16\226\253\320\240", iov_len=24},
        {iov_base="\27\3\3\0\23\23\362q\352\307\303\364\312]\361(\227<\17\334Y\333g\310", iov_len=24},
        {iov_base="\27\3\3\0\37\216\332\374\376\303H\206\35f\334\310\252\375\341\366\224\261*\367\30mg\\\230dbh"..., iov_len=36},
        {iov_base="\27\3\3\0\23-\312\31\v\353\212\303\265\231H\371\356%\317JX\32Tg", iov_len=24},
        {iov_base="\27\3\3\0\23d\356\0276\3236\252\206^5\346=\234F\2\200\33\314>", iov_len=24},
        {iov_base="\27\3\3\0\23U\30\37x7\5d\304/ZY\274\25\17;\276t]\216", iov_len=24},
        {iov_base="\27\3\3\0\25\240\371q\2416Z\202\6\35\311|\203Bai-\20\217=\3516", iov_len=26},
        {iov_base="\27\3\3\0\23\220\350\323\321bx\321\21:\35\203?\257\313)\200\364E\377", iov_len=24},
        {iov_base="\27\3\3\0.\226\254\30\240\315\307o\250\243b`Q\n\17\226\333\347\256[\331\324#~/\240\206,"..., iov_len=51},
        {iov_base="\27\3\3\0\23\251\207:\350?/\252Z\317\322\0017\24E\256\5*\342\224", iov_len=24},
        {iov_base="\27\3\3\0\30$w0!\205\310\276\372k\204?\375k\334\334\363\314\\!\355\266\0\362\33", iov_len=29},
        {iov_base="\27\3\3\0\23\257\277rj;\3\376\251\10\310\37\265\365\303\216\260\345\361\366", iov_len=24},
        {iov_base="\27\3\3\0+\341\0313\277'\223\3\272W&\316\306\360BYI9\225Vh\347t\3}\303\321\343"..., iov_len=48},
        {iov_base="\27\3\3\0\23\247\33\26M\255%\351\214F\254\177\250+z\253]\17F\325", iov_len=24},
        {iov_base="\27\3\3\0\23fm\262t\334\271>\226\225ITia\250,\31^\37\f", iov_len=24},
        {iov_base="\27\3\3\0\33S\25/zM'\343\302L/l\\\1\22\250M\0AL\357\304\36\227\317\322Q\365", iov_len=32}
    ],
    20
) = 563
```

What we see here is a number of small pieces of data, headers mostly, being encoded into TLS frames, one at a time. The `\27\3\3\0` pattern is the beginning of a TLS frame.
This repetition is a waste of bandwitdth.

## Our investigation

The system call above is due to how the Writer's [`write_vectored` method](https://docs.rs/rustls/latest/rustls/struct.Writer.html#method.write_vectored) encodes the chunks one by one.

In our case, our reverse proxy creates a number of smaller chunks. Half of the throughput is monopolized by TLS headers.

## Our proposal


We could have solved our issue on the proxy side, by accumulating chunks and calling `write()` instead of calling `write_vectored`, but we seek to avoid dynamic memory allocation and copying.

In this pull request on Rustls, instead of treating the chunks individually in `write_vectored`, we suggest to pass them down together in a BorrowedPayload form, until they are encrypted in one single TLS frame (or several if the payload exceeds `MAX_FRAGMENT_SIZE`). This new type `BorrowedPayload` does not copy the data but manipulates slices of bytes.

## Syscall improvement

This is the same response as above: a simple "hi" and some headers.

```
writev(
    14,
    [
        {iov_base="\27\3\3\0\214\376h\202\316\333w\252\25\24\375\354\254\24p\343\320\320\311\21\340\315B\367\327\342\225\340"..., iov_len=145}
    ],
    1
) = 145
```

We can see that there is only one `iov_base` (corresponding to 1 TLS frame), instead of many prior.
The syscall has dimished in size, from 563 to 145. 

## Benchmarks

Our modification reduces bandwidth usage significantly when benchmarking our reverse proxy.

These benchmarks run on a simple desktop machine, with 4 backends to route HTTPS traffic to. The backends reply with a simple "hi" and some headers.

### Sōzu + Rustls 0.21.9

```
bombardier -c 450 -n 100000 https://localhost:8443/api -l

Statistics        Avg      Stdev        Max
  Reqs/sec      7973.06    4220.70   18732.68
  Latency       56.68ms    69.91ms      1.15s
  Latency Distribution
     50%    51.98ms
     75%    54.38ms
     90%    56.90ms
     95%    58.64ms
     99%    61.33ms
  HTTP codes:
    1xx - 0, 2xx - 100000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     5.01MB/s
```

### Sōzu + Rustls (this branch)

```
bombardier -c 450 -n 100000 https://localhost:8443/api -l                                             
Bombarding https://localhost:8443/api with 100000 request(s) using 450 connection(s)

Statistics        Avg      Stdev        Max
  Reqs/sec      8616.52    5132.64   22453.38
  Latency       52.58ms    64.24ms      1.04s
  Latency Distribution
     50%    47.85ms
     75%    50.40ms
     90%    53.53ms
     95%    55.80ms
     99%    76.39ms
  HTTP codes:
    1xx - 0, 2xx - 100000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     2.00MB/s
```

### Discussion

The strace and the benchmark suggest that our addition to the rustls codebase diminishes bandwidth use and improves overall performance in a meaningful way. Requests per second, and latency, are the key metrics for us.

Diving in Rustls, we found a number of memory allocation that could be avoided. If you would like, we would be more than happy to work with you in this direction.


(edited for clarity)