### PR TITLE
Update webpki, pki-types, bump alpha version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.0-alpha.5"
+version = "0.22.0-alpha.6"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1752,7 +1752,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.22.0-alpha.5",
+ "rustls 0.22.0-alpha.6",
  "rustls-pemfile 2.0.0-alpha.2",
  "rustls-pki-types",
 ]
@@ -1764,7 +1764,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring 0.17.5",
- "rustls 0.22.0-alpha.5",
+ "rustls 0.22.0-alpha.6",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.22.0-alpha.5",
+ "rustls 0.22.0-alpha.6",
  "rustls-pemfile 2.0.0-alpha.2",
  "rustls-pki-types",
  "serde",
@@ -1827,7 +1827,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.22.0-alpha.5",
+ "rustls 0.22.0-alpha.6",
  "rustls-pki-types",
  "rustls-webpki 0.102.0-alpha.8",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ dependencies = [
  "ring 0.17.5",
  "rustls-pemfile 2.0.0-alpha.2",
  "rustls-pki-types",
- "rustls-webpki 0.102.0-alpha.7",
+ "rustls-webpki 0.102.0-alpha.8",
  "rustversion",
  "subtle",
  "webpki-roots 0.26.0-alpha.2",
@@ -1805,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf0cbc2bc68777eb846b2b7fedf03807bb763adc585bf006ac2fa2884daa9d1"
+checksum = "f0d3edd6cdcdf26eda538757038343986e666d0b8ba4b5ac1de663b78475550d"
 
 [[package]]
 name = "rustls-provider-example"
@@ -1829,7 +1829,7 @@ dependencies = [
  "rsa",
  "rustls 0.22.0-alpha.5",
  "rustls-pki-types",
- "rustls-webpki 0.102.0-alpha.7",
+ "rustls-webpki 0.102.0-alpha.8",
  "serde",
  "serde_json",
  "sha2",
@@ -1850,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0-alpha.7"
+version = "0.102.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c0e946e5f395d68bfc4a43e9b584d2169c2685e2c584a268b6d7ef8117bcfa"
+checksum = "139cdfd1d8b96f927fbe0a0c98785afe94b63e95a7ef815ebae9263d20e10a0d"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.5",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "cdf0cbc2bc68777eb846b2b7fedf03807bb763adc585bf006ac2fa2884daa9d1"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0-alpha.7"
+version = "0.102.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c0e946e5f395d68bfc4a43e9b584d2169c2685e2c584a268b6d7ef8117bcfa"
+checksum = "139cdfd1d8b96f927fbe0a0c98785afe94b63e95a7ef815ebae9263d20e10a0d"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.0-alpha.5"
+version = "0.22.0-alpha.6"
 dependencies = [
  "log",
  "ring",

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -23,7 +23,7 @@ rustls = { path = "../rustls", default-features = false, features = ["logging", 
 rsa = { version = "0.9.0", features = ["sha2"] }
 sha2 = "0.10.0"
 signature = "2"
-webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.7", features = ["alloc", "std"], default-features = false }
+webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.8", features = ["alloc", "std"], default-features = false }
 webpki-roots = "=0.26.0-alpha.2"
 x25519-dalek = "2"
 

--- a/provider-example/src/verify.rs
+++ b/provider-example/src/verify.rs
@@ -16,6 +16,7 @@ pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
 static RSA_PSS_SHA256: &dyn SignatureVerificationAlgorithm = &RsaPssSha256Verify;
 static RSA_PKCS1_SHA256: &dyn SignatureVerificationAlgorithm = &RsaPkcs1Sha256Verify;
 
+#[derive(Debug)]
 struct RsaPssSha256Verify;
 
 impl SignatureVerificationAlgorithm for RsaPssSha256Verify {
@@ -43,6 +44,7 @@ impl SignatureVerificationAlgorithm for RsaPssSha256Verify {
     }
 }
 
+#[derive(Debug)]
 struct RsaPkcs1Sha256Verify;
 
 impl SignatureVerificationAlgorithm for RsaPkcs1Sha256Verify {

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -20,7 +20,7 @@ aws-lc-rs = { version = "1.5", optional = true }
 log = { version = "0.4.4", optional = true }
 ring = { version = "0.17", optional = true }
 subtle = { version = "2.5.0", default-features = false }
-webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.7", features = ["std"], default-features = false }
+webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.8", features = ["std"], default-features = false }
 pki-types = { package = "rustls-pki-types", version = "0.2.2", features = ["std"] }
 zeroize = "1.6.0"
 

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.22.0-alpha.5"
+version = "0.22.0-alpha.6"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -220,7 +220,7 @@ mod tests {
     #[test]
     fn certificate_debug() {
         assert_eq!(
-            "CertificateDer(Der([97, 98]))",
+            "CertificateDer(0x6162)",
             format!("{:?}", CertificateDer::from(b"ab".to_vec()))
         );
     }


### PR DESCRIPTION
Updates webpki to alpha.8, pki-types to 0.2.3. This requires accommodating the new `Debug` bound requirement in the provider example, and fixing some expected output in a webpki verify test.

Bumps the crate version to  0.22.0-alpha.6.

