### PR TITLE
api: move TicketSwitcher to ticketer

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -375,7 +375,6 @@ mod enums;
 mod key_log;
 mod key_log_file;
 mod suites;
-mod ticketer;
 mod versions;
 mod webpki;
 
@@ -451,7 +450,6 @@ pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     CipherSuiteCommon, ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite,
 };
-pub use crate::ticketer::TicketSwitcher;
 #[cfg(feature = "tls12")]
 pub use crate::tls12::Tls12CipherSuite;
 pub use crate::tls13::Tls13CipherSuite;
@@ -544,6 +542,9 @@ pub mod sign {
 
 /// APIs for implementing QUIC TLS
 pub mod quic;
+
+/// APIs for implementing TLS tickets
+pub mod ticketer;
 
 /// This is the rustls manual.
 pub mod manual;


### PR DESCRIPTION
The top level of the crate is meant for "paved path" exports.

In 0.21.x, there was a top-level [`struct Ticketer`](https://docs.rs/rustls/0.21.9/rustls/struct.Ticketer.html).

In current `main`, that's been [moved to the separate crypto providers](https://docs.rs/rustls/0.22.0-alpha.6/rustls/crypto/ring/struct.Ticketer.html). Additionally, there is a [new public type `TicketSwitcher`](https://docs.rs/rustls/0.22.0-alpha.6/rustls/struct.TicketSwitcher.html). This type should probably not be at the top level.

Related: #1435