### PR TITLE
api: move WebPkiSupportedAlgorithms to crypto

### DIFF
--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -42,7 +42,7 @@ impl rustls::crypto::CryptoProvider for Provider {
         Ok(Arc::new(key))
     }
 
-    fn signature_verification_algorithms(&self) -> rustls::WebPkiSupportedAlgorithms {
+    fn signature_verification_algorithms(&self) -> rustls::crypto::WebPkiSupportedAlgorithms {
         verify::ALGORITHMS
     }
 }

--- a/provider-example/src/verify.rs
+++ b/provider-example/src/verify.rs
@@ -2,7 +2,8 @@ use der::Reader;
 use pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
 use rsa::signature::Verifier;
 use rsa::{pkcs1v15, pss, BigUint, RsaPublicKey};
-use rustls::{SignatureScheme, WebPkiSupportedAlgorithms};
+use rustls::crypto::WebPkiSupportedAlgorithms;
+use rustls::SignatureScheme;
 use webpki::alg_id;
 
 pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -1,6 +1,5 @@
 use crate::sign::SigningKey;
 use crate::suites;
-use crate::webpki::WebPkiSupportedAlgorithms;
 use crate::{Error, NamedGroup};
 
 use alloc::boxed::Box;
@@ -10,6 +9,8 @@ use core::fmt::Debug;
 
 use pki_types::PrivateKeyDer;
 use zeroize::Zeroize;
+
+pub use crate::webpki::WebPkiSupportedAlgorithms;
 
 /// *ring* based CryptoProvider.
 #[cfg(feature = "ring")]
@@ -110,7 +111,7 @@ pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 ///         RING.default_kx_groups()
 ///     }
 ///
-///     fn signature_verification_algorithms(&self) -> rustls::WebPkiSupportedAlgorithms {
+///     fn signature_verification_algorithms(&self) -> rustls::crypto::WebPkiSupportedAlgorithms {
 ///         RING.signature_verification_algorithms()
 ///     }
 ///
@@ -129,7 +130,7 @@ pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 /// - **Cipher suites** - see [`crate::SupportedCipherSuite`], [`crate::Tls12CipherSuite`], and
 ///   [`crate::Tls13CipherSuite`].
 /// - **Key exchange groups** - see [`crate::crypto::SupportedKxGroup`].
-/// - **Signature verification algorithms** - see [`crate::WebPkiSupportedAlgorithms`].
+/// - **Signature verification algorithms** - see [`crate::crypto::WebPkiSupportedAlgorithms`].
 /// - **Authentication key loading** - see [`crate::crypto::CryptoProvider::load_private_key()`] and
 ///   [`crate::sign::SigningKey`].
 ///

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -457,7 +457,7 @@ pub use crate::tls12::Tls12CipherSuite;
 pub use crate::tls13::Tls13CipherSuite;
 pub use crate::verify::DigitallySignedStruct;
 pub use crate::versions::{SupportedProtocolVersion, ALL_VERSIONS, DEFAULT_VERSIONS};
-pub use crate::webpki::{RootCertStore, WebPkiSupportedAlgorithms};
+pub use crate::webpki::RootCertStore;
 
 /// Items for use in a client.
 pub mod client {

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -5,14 +5,14 @@ use pki_types::{CertificateDer, CertificateRevocationListDer, UnixTime};
 use webpki::{CertRevocationList, RevocationCheckDepth, UnknownStatusPolicy};
 
 use super::{pki_error, VerifierBuilderError};
-use crate::crypto::CryptoProvider;
+use crate::crypto::{CryptoProvider, WebPkiSupportedAlgorithms};
 use crate::verify::{
     ClientCertVerified, ClientCertVerifier, DigitallySignedStruct, HandshakeSignatureValid,
     NoClientAuth,
 };
 use crate::webpki::parse_crls;
 use crate::webpki::verify::{verify_signed_struct, verify_tls13, ParsedCertificate};
-use crate::{DistinguishedName, Error, RootCertStore, SignatureScheme, WebPkiSupportedAlgorithms};
+use crate::{DistinguishedName, Error, RootCertStore, SignatureScheme};
 
 /// A builder for configuring a `webpki` client certificate verifier.
 ///

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use pki_types::{CertificateDer, CertificateRevocationListDer, ServerName, UnixTime};
 use webpki::{CertRevocationList, RevocationCheckDepth, UnknownStatusPolicy};
 
-use crate::crypto::CryptoProvider;
+use crate::crypto::{CryptoProvider, WebPkiSupportedAlgorithms};
 use crate::verify::{
     DigitallySignedStruct, HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
 };
@@ -15,7 +15,7 @@ use crate::webpki::verify::{
     ParsedCertificate,
 };
 use crate::webpki::{parse_crls, verify_server_name, VerifierBuilderError};
-use crate::{Error, RootCertStore, SignatureScheme, WebPkiSupportedAlgorithms};
+use crate::{Error, RootCertStore, SignatureScheme};
 
 /// A builder for configuring a `webpki` server certificate verifier.
 ///

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5546,7 +5546,7 @@ impl rustls::crypto::CryptoProvider for FaultyRandomProvider {
         self.parent.load_private_key(key_der)
     }
 
-    fn signature_verification_algorithms(&self) -> rustls::WebPkiSupportedAlgorithms {
+    fn signature_verification_algorithms(&self) -> rustls::crypto::WebPkiSupportedAlgorithms {
         self.parent
             .signature_verification_algorithms()
     }


### PR DESCRIPTION
The top level of the crate is meant for "paved path" exports.

This newly exported type is used for cryptographic provider customization, so it properly belongs in the `crypto` module.

Related: #1435