### PR TITLE
ci-bench: increase threshold

### DIFF
--- a/.github/workflows/icount-bench.yml
+++ b/.github/workflows/icount-bench.yml
@@ -15,14 +15,6 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Checkout PR
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Run icount benchmarks for PR
-        run: cd ci-bench && cargo run --locked --release -- run-all --output-dir ${{ runner.temp }}/pr
-
       - name: Checkout ${{ github.base_ref }}
         uses: actions/checkout@v4
         with:
@@ -32,6 +24,14 @@ jobs:
 
       - name: Run icount benchmarks for ${{ github.base_ref }}
         run: cd ci-bench && cargo run --locked --release -- run-all --output-dir ${{ runner.temp }}/base
+
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run icount benchmarks for PR
+        run: cd ci-bench && cargo run --locked --release -- run-all --output-dir ${{ runner.temp }}/pr
 
       - name: Compare results
         run: cd ci-bench && cargo run --locked --release -- compare ${{ runner.temp }}/base ${{ runner.temp }}/pr > $GITHUB_STEP_SUMMARY

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -57,7 +57,7 @@ const TRANSFER_PLAINTEXT_SIZE: usize = 1024 * 1024 * 10; // 10 MB
 const RESUMED_HANDSHAKE_RUNS: usize = 30;
 
 /// The threshold at which instruction count changes are considered relevant
-const CHANGE_THRESHOLD: f64 = 0.002; // 0.2%
+const CHANGE_THRESHOLD: f64 = 0.02; // 2%
 
 /// The name of the file where the instruction counts are stored after a `run-all` run
 const ICOUNTS_FILENAME: &str = "icounts.csv";
@@ -769,12 +769,12 @@ fn print_report(result: &CompareResult) {
         }
     }
 
-    println!("## Noteworthy instruction count differences");
+    println!(
+        "## Noteworthy instruction count differences (above {}%)",
+        CHANGE_THRESHOLD * 100.0
+    );
     if result.noteworthy.is_empty() {
-        println!(
-            "_There are no noteworthy instruction count differences (i.e. above {}%)_",
-            CHANGE_THRESHOLD * 100.0
-        );
+        println!("_There are no noteworthy instruction count differences_");
     } else {
         table(
             result


### PR DESCRIPTION
The old threshold was 0.2%, but it was triggering on doc-only changes, with diffs as high as 1.74%. I'm not sure why this measure is being noisier than it is supposed to be, but since it's causing most CI builds to get a red "x", it's worth bumping the threshold for now.

Example jobs:

https://github.com/rustls/rustls/actions/runs/7039851436?pr=1637
https://github.com/rustls/rustls/actions/runs/7040127211?pr=1643

Also, change the order of the CI job so the comparison is done using the code in the current PR. That means that changes to the ci-bench tooling can be reflected immediately in the CI runs for the current PR.