### PR TITLE
api: move CipherSuiteCommon into crypto

### DIFF
--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -53,7 +53,7 @@ static ALL_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[
 
 pub static TLS13_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
     rustls::SupportedCipherSuite::Tls13(&rustls::Tls13CipherSuite {
-        common: rustls::CipherSuiteCommon {
+        common: rustls::crypto::CipherSuiteCommon {
             suite: rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
             hash_provider: &hash::Sha256,
             confidentiality_limit: u64::MAX,
@@ -66,7 +66,7 @@ pub static TLS13_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
 
 pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
     rustls::SupportedCipherSuite::Tls12(&rustls::Tls12CipherSuite {
-        common: rustls::CipherSuiteCommon {
+        common: rustls::crypto::CipherSuiteCommon {
             suite: rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
             hash_provider: &hash::Sha256,
             confidentiality_limit: u64::MAX,

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -47,6 +47,8 @@ pub(crate) mod signer;
 
 pub use crate::rand::GetRandomFailed;
 
+pub use crate::suites::CipherSuiteCommon;
+
 pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 
 /// Controls core cryptography used by rustls.

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -437,9 +437,7 @@ pub use crate::key_log_file::KeyLogFile;
 pub use crate::msgs::enums::NamedGroup;
 pub use crate::msgs::handshake::DistinguishedName;
 pub use crate::stream::{Stream, StreamOwned};
-pub use crate::suites::{
-    CipherSuiteCommon, ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite,
-};
+pub use crate::suites::{ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite};
 #[cfg(feature = "tls12")]
 pub use crate::tls12::Tls12CipherSuite;
 pub use crate::tls13::Tls13CipherSuite;


### PR DESCRIPTION
The top level of the crate is meant for "paved path" exports.

In 0.21.x, this type was in `cipher_suites`, along with a few other types that got moved to specific crypto providers. Moving this to `crypto` instead of re-exporting under its old name in `cipher_suites` seems acceptable, because it will mainly be used in implementing crypto providers. Also, its internals have changed significantly so there is already churn for this type.

Related: #1435