### PR TITLE
[experiment / RFC] runtime-agnostic async API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,12 +689,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -727,8 +742,12 @@ version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1724,6 +1743,19 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.0-alpha.4"
+source = "git+https://github.com/japaric/rustls?branch=rfc1420-impl-take2#bbc0830ba1f67f0f13f19471448d18914261ab7b"
+dependencies = [
+ "log",
+ "ring 0.17.5",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.0-alpha.7",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.22.0-alpha.5"
 dependencies = [
  "aws-lc-rs",
@@ -1739,6 +1771,16 @@ dependencies = [
  "subtle",
  "webpki-roots 0.26.0-alpha.2",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-async"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "log",
+ "rustls 0.22.0-alpha.4",
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -116,6 +116,161 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 4.0.0",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.1.2",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.1",
+ "futures-lite 2.0.1",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4353121d5644cdf2beb5726ab752e79a8db1ebb52031770ec47db31d245526"
+dependencies = [
+ "async-channel 2.1.1",
+ "async-executor",
+ "async-io 2.2.1",
+ "async-lock 3.1.2",
+ "blocking",
+ "futures-lite 2.0.1",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6d3b15875ba253d1110c740755e246537483f152fa334f91abd7fe84c88b3ff"
+dependencies = [
+ "async-lock 3.1.2",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.0.1",
+ "parking",
+ "polling 3.3.1",
+ "rustix 0.38.25",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea8b3453dd7cc96711834b75400d671b73e3656975fa68d9f277163b7f7e316"
+dependencies = [
+ "event-listener 4.0.0",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 1.13.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,8 +278,14 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -216,7 +377,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.39",
  "which",
 ]
 
@@ -239,6 +400,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel 2.1.1",
+ "async-lock 3.1.2",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite 2.0.1",
+ "piper",
+ "tracing",
 ]
 
 [[package]]
@@ -360,7 +537,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -383,6 +560,15 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -488,7 +674,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -619,7 +805,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -648,8 +834,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"
@@ -723,6 +951,35 @@ name = "futures-io"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3831c2651acb5177cbd83943f3d9c8912c5ad03c76afcc0e9511ba568ec5ebb"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-sink"
@@ -807,6 +1064,18 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -941,7 +1210,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1055,14 +1324,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.5",
  "widestring",
- "windows-sys",
+ "windows-sys 0.48.0",
  "winreg",
 ]
 
@@ -1079,8 +1368,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix",
- "windows-sys",
+ "rustix 0.38.25",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1105,6 +1394,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1152,6 +1450,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
@@ -1171,6 +1475,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-cache"
@@ -1226,7 +1533,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1349,6 +1656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,7 +1681,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1421,6 +1734,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1770,36 @@ name = "platforms"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.25",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "poly1305"
@@ -1489,7 +1843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1671,7 +2025,7 @@ dependencies = [
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1718,6 +2072,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
@@ -1725,8 +2093,8 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.4.11",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1777,10 +2145,14 @@ dependencies = [
 name = "rustls-async"
 version = "0.1.0"
 dependencies = [
+ "async-std",
+ "env_logger",
  "futures",
  "log",
  "rustls 0.22.0-alpha.4",
+ "rustls-pemfile 2.0.0-alpha.2",
  "rustls-pki-types",
+ "webpki-roots 0.26.0-alpha.2",
 ]
 
 [[package]]
@@ -1967,7 +2339,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2025,12 +2397,22 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2075,6 +2457,17 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
@@ -2110,7 +2503,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2164,7 +2557,7 @@ checksum = "d8e00e3e7a54e0f1c8834ce72ed49c8487fbd3f801d8cfe1a0ad0640382f8e15"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2179,8 +2572,8 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2",
- "windows-sys",
+ "socket2 0.5.5",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2226,7 +2619,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2305,10 +2698,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "value-bag"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "wasi"
@@ -2337,8 +2742,20 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2359,7 +2776,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2404,7 +2821,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.25",
 ]
 
 [[package]]
@@ -2450,7 +2867,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2459,13 +2885,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -2475,10 +2916,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2487,10 +2940,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2499,10 +2964,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2511,13 +2988,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2570,5 +3053,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "async",
   # CI benchmarks
   "ci-bench",
   # Network-based tests

--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rustls-async"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+futures = { version = "0.3.29", default-features = false, features = ["std"] }
+log = "0.4.20"
+pki-types = { package = "rustls-pki-types", version = "0.2.2" }
+# FIXME use a path dependency
+rustls = { git = "https://github.com/japaric/rustls", branch = "rfc1420-impl-take2" }
+
+[dev-dependencies]
+async-std = { version = "1.12.0", features = ["attributes"] }
+env_logger = "0.10.1"
+rustls-pemfile = "=2.0.0-alpha.2"
+webpki-roots = "=0.26.0-alpha.2"

--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -11,7 +11,12 @@ pki-types = { package = "rustls-pki-types", version = "0.2.2" }
 rustls = { git = "https://github.com/japaric/rustls", branch = "rfc1420-impl-take2" }
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["attributes"] }
 env_logger = "0.10.1"
 rustls-pemfile = "=2.0.0-alpha.2"
 webpki-roots = "=0.26.0-alpha.2"
+
+# async runtime selection
+async-std = { version = "1.12.0", features = ["attributes"] }
+
+# tokio = { version = "1.34.0", features = ["macros", "net", "rt"] }
+# tokio-util = { version = "0.7.10", features = ["compat"] }

--- a/async/examples/client.rs
+++ b/async/examples/client.rs
@@ -2,12 +2,21 @@ use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
 
-use async_std::net::TcpStream;
 use futures::io::{AsyncReadExt, AsyncWriteExt};
 #[allow(unused_imports)]
 use rustls::version::{TLS12, TLS13};
 use rustls::{ClientConfig, RootCertStore};
 use rustls_async::{Error, TcpConnector};
+
+// runtime selection:
+// - adjust the dependencies in `Cargo.toml`
+// - adjust the imports in this file
+// - uppdate the attribute on the `main` function
+// - comment / uncomment the `compat_write` call in `main` if using `async_std` / `tokio`
+use async_std::net::TcpStream;
+
+// use tokio::net::TcpStream;
+// use tokio_util::compat::TokioAsyncWriteCompatExt;
 
 // remote server
 const CERTFILE: Option<&str> = None;
@@ -15,6 +24,7 @@ const SERVER_NAME: &str = "example.com";
 const PORT: u16 = 443;
 
 #[async_std::main]
+// #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Error> {
     env_logger::init();
 
@@ -31,6 +41,9 @@ async fn main() -> Result<(), Error> {
     let config = Arc::new(config);
 
     let sock = TcpStream::connect(format!("{SERVER_NAME}:{PORT}")).await?;
+
+    // tokio only
+    // let sock = sock.compat_write();
 
     let connector = TcpConnector::from(config);
     let domain = SERVER_NAME.try_into().unwrap();

--- a/async/examples/client.rs
+++ b/async/examples/client.rs
@@ -1,0 +1,70 @@
+use std::fs::File;
+use std::io::BufReader;
+use std::sync::Arc;
+
+use async_std::net::TcpStream;
+use futures::io::{AsyncReadExt, AsyncWriteExt};
+#[allow(unused_imports)]
+use rustls::version::{TLS12, TLS13};
+use rustls::{ClientConfig, RootCertStore};
+use rustls_async::{Error, TcpConnector};
+
+// remote server
+const CERTFILE: Option<&str> = None;
+const SERVER_NAME: &str = "example.com";
+const PORT: u16 = 443;
+
+#[async_std::main]
+async fn main() -> Result<(), Error> {
+    env_logger::init();
+
+    let config = ClientConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        // switch protocol version
+        .with_protocol_versions(&[&TLS12])
+        // .with_protocol_versions(&[&TLS13])
+        .unwrap()
+        .with_root_certificates(build_root_store()?)
+        .with_no_client_auth();
+
+    let config = Arc::new(config);
+
+    let sock = TcpStream::connect(format!("{SERVER_NAME}:{PORT}")).await?;
+
+    let connector = TcpConnector::from(config);
+    let domain = SERVER_NAME.try_into().unwrap();
+    let mut stream = connector.connect(domain, sock)?.await?;
+
+    let request = build_http_request();
+    stream.write_all(&request).await?;
+    stream.flush().await?;
+
+    let mut response = [0; 8 * 1024];
+    let read = stream.read(&mut response).await?;
+    println!("{}", String::from_utf8_lossy(&response[..read]));
+
+    Ok(())
+}
+
+fn build_root_store() -> Result<RootCertStore, Error> {
+    let mut root_store = RootCertStore::empty();
+    if let Some(path) = CERTFILE {
+        let certfile = File::open(path)?;
+        let mut reader = BufReader::new(certfile);
+        root_store.add_parsable_certificates(
+            rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>()?,
+        );
+    } else {
+        root_store.extend(
+            webpki_roots::TLS_SERVER_ROOTS
+                .iter()
+                .cloned(),
+        );
+    }
+    Ok(root_store)
+}
+
+fn build_http_request() -> Vec<u8> {
+    format!("GET / HTTP/1.1\r\nHost: {SERVER_NAME}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n").into_bytes()
+}

--- a/async/src/lib.rs
+++ b/async/src/lib.rs
@@ -1,0 +1,523 @@
+use core::pin::Pin;
+use core::result::Result as CoreResult;
+use core::task::Poll;
+use core::{mem, task};
+use std::error::Error as StdError;
+use std::io;
+use std::io::ErrorKind;
+use std::sync::Arc;
+
+use futures::io::{AsyncRead, AsyncWrite};
+use futures::Future;
+use pki_types::ServerName;
+use rustls::client::UnbufferedClientConnection;
+use rustls::unbuffered::{
+    AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,
+    UnbufferedStatus,
+};
+use rustls::ClientConfig;
+
+// FIXME use an enum
+pub type Error = Box<dyn StdError + Send + Sync>;
+type Result<T> = CoreResult<T, Error>;
+
+pub struct TcpConnector {
+    config: Arc<ClientConfig>,
+}
+
+impl TcpConnector {
+    pub fn connect<IO>(
+        &self,
+        domain: ServerName<'static>,
+        stream: IO,
+        // FIXME should not return an error but instead hoist it into a `Connect` variant
+    ) -> Result<Connect<IO>>
+    where
+        IO: AsyncRead + AsyncWrite,
+    {
+        let conn = UnbufferedClientConnection::new(self.config.clone(), domain)?;
+
+        Ok(Connect::new(conn, stream))
+    }
+}
+
+impl From<Arc<ClientConfig>> for TcpConnector {
+    fn from(config: Arc<ClientConfig>) -> Self {
+        Self { config }
+    }
+}
+
+pub struct Connect<IO> {
+    inner: Option<ConnectInner<IO>>,
+}
+
+impl<IO> Connect<IO> {
+    fn new(conn: UnbufferedClientConnection, io: IO) -> Self {
+        Self {
+            inner: Some(ConnectInner::new(conn, io)),
+        }
+    }
+}
+
+struct ConnectInner<IO> {
+    conn: UnbufferedClientConnection,
+    incoming: Buffer,
+    io: IO,
+    outgoing: Buffer,
+}
+
+impl<IO> ConnectInner<IO> {
+    fn new(conn: UnbufferedClientConnection, io: IO) -> Self {
+        Self {
+            conn,
+            incoming: Buffer::default(),
+            io,
+            outgoing: Buffer::default(),
+        }
+    }
+}
+
+impl<IO> Future for Connect<IO>
+where
+    IO: Unpin + AsyncRead + AsyncWrite,
+{
+    type Output = Result<TlsStream<IO>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        let mut inner = self
+            .inner
+            .take()
+            .expect("polled after completion");
+
+        let mut updates = Updates::default();
+        let poll = loop {
+            let action = inner.advance(&mut updates)?;
+
+            match action {
+                Action::Continue => continue,
+
+                Action::Write => {
+                    let mut outgoing = mem::take(&mut inner.outgoing);
+                    let would_block = poll_write(&mut inner.io, &mut outgoing, cx)?;
+
+                    updates.transmit_complete = outgoing.is_empty();
+                    inner.outgoing = outgoing;
+
+                    if would_block {
+                        break Poll::Pending;
+                    }
+                }
+
+                Action::Read => {
+                    let mut incoming = mem::take(&mut inner.incoming);
+
+                    let would_block = poll_read(&mut inner.io, &mut incoming, cx)?;
+
+                    inner.incoming = incoming;
+
+                    if would_block {
+                        break Poll::Pending;
+                    }
+                }
+
+                Action::Break => {
+                    // XXX should we yield earlier when it's already possible to encrypt
+                    // application data? that would reduce the number of round-trips
+                    let ConnectInner {
+                        conn,
+                        incoming,
+                        io,
+                        outgoing,
+                    } = inner;
+
+                    return Poll::Ready(Ok(TlsStream {
+                        conn,
+                        incoming,
+                        io,
+                        outgoing,
+                    }));
+                }
+            }
+        };
+
+        self.inner = Some(inner);
+
+        poll
+    }
+}
+
+/// returns `true` if the operation would block
+fn poll_read<IO>(io: &mut IO, incoming: &mut Buffer, cx: &mut task::Context) -> io::Result<bool>
+where
+    IO: AsyncRead + Unpin,
+{
+    if incoming.unfilled().is_empty() {
+        // XXX should this be user configurable?
+        incoming.reserve(1024);
+    }
+
+    let would_block = match Pin::new(io).poll_read(cx, incoming.unfilled()) {
+        Poll::Ready(res) => {
+            let read = res?;
+            log::trace!("read {read}B from socket");
+            incoming.advance(read);
+            false
+        }
+
+        Poll::Pending => true,
+    };
+
+    Ok(would_block)
+}
+
+/// returns `true` if the operation would block
+fn poll_write<IO>(io: &mut IO, outgoing: &mut Buffer, cx: &mut task::Context) -> io::Result<bool>
+where
+    IO: AsyncWrite + Unpin,
+{
+    let pending = match Pin::new(io).poll_write(cx, outgoing.filled()) {
+        Poll::Ready(res) => {
+            let written = res?;
+            log::trace!("wrote {written}B into socket");
+            outgoing.discard(written);
+            log::trace!("{}B remain in the outgoing buffer", outgoing.len());
+            false
+        }
+
+        Poll::Pending => true,
+    };
+    Ok(pending)
+}
+
+#[derive(Default)]
+struct Updates {
+    transmit_complete: bool,
+}
+
+impl<IO> ConnectInner<IO> {
+    fn advance(&mut self, updates: &mut Updates) -> Result<Action> {
+        log::trace!("incoming buffer has {}B of data", self.incoming.len());
+
+        let UnbufferedStatus { discard, state } = self
+            .conn
+            .process_tls_records(self.incoming.filled_mut())?;
+
+        log::trace!("state: {state:?}");
+        let next = match state {
+            ConnectionState::MustEncodeTlsData(mut state) => {
+                try_or_resize_and_retry(
+                    |out_buffer| state.encode(out_buffer),
+                    |e| {
+                        if let EncodeError::InsufficientSize(is) = &e {
+                            Ok(*is)
+                        } else {
+                            Err(e.into())
+                        }
+                    },
+                    &mut self.outgoing,
+                )?;
+
+                Action::Continue
+            }
+
+            ConnectionState::MustTransmitTlsData(state) => {
+                if updates.transmit_complete {
+                    updates.transmit_complete = false;
+                    state.done();
+                    Action::Continue
+                } else {
+                    Action::Write
+                }
+            }
+
+            ConnectionState::NeedsMoreTlsData { .. } => Action::Read,
+
+            ConnectionState::TrafficTransit(_) => Action::Break,
+
+            state => unreachable!("{state:?}"), // due to type state
+        };
+
+        self.incoming.discard(discard);
+
+        Ok(next)
+    }
+}
+
+enum Action {
+    Break,
+    Continue,
+    Read,
+    Write,
+}
+
+pub struct TlsStream<IO> {
+    conn: UnbufferedClientConnection,
+    incoming: Buffer,
+    io: IO,
+    outgoing: Buffer,
+}
+
+impl<IO> AsyncWrite for TlsStream<IO>
+where
+    IO: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut outgoing = mem::take(&mut self.outgoing);
+
+        // no IO here; just in-memory writes
+        match self
+            .conn
+            .process_tls_records(&mut [])
+            .map_err(map_err)?
+            .state
+        {
+            ConnectionState::TrafficTransit(mut state) => {
+                try_or_resize_and_retry(
+                    |out_buffer| state.encrypt(buf, out_buffer),
+                    |e| {
+                        if let EncryptError::InsufficientSize(is) = &e {
+                            Ok(*is)
+                        } else {
+                            Err(e.into())
+                        }
+                    },
+                    &mut outgoing,
+                )
+                .map_err(map_err)?;
+            }
+
+            ConnectionState::ConnectionClosed => {
+                return Poll::Ready(Err(io::Error::new(
+                    ErrorKind::ConnectionAborted,
+                    "connection closed by the peer",
+                )));
+            }
+
+            state => unreachable!("{state:?}"),
+        }
+
+        // opportunistically try to write data into the socket
+        // XXX should this be a loop?
+        while !outgoing.is_empty() {
+            let would_block = poll_write(&mut self.io, &mut outgoing, cx)?;
+            if would_block {
+                break;
+            }
+        }
+
+        self.outgoing = outgoing;
+
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+        let mut outgoing = mem::take(&mut self.outgoing);
+
+        // write buffered TLS data into socket
+        while !outgoing.is_empty() {
+            let would_block = poll_write(&mut self.io, &mut outgoing, cx)?;
+
+            if would_block {
+                self.outgoing = outgoing;
+                return Poll::Pending;
+            }
+        }
+
+        self.outgoing = outgoing;
+
+        Pin::new(&mut self.io).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+        // XXX send out close_notify here?
+        Pin::new(&mut self.io).poll_close(cx)
+    }
+}
+
+impl<IO> AsyncRead for TlsStream<IO>
+where
+    IO: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut incoming = mem::take(&mut self.incoming);
+        let mut cursor = WriteCursor::new(buf);
+
+        while !cursor.is_full() {
+            log::trace!("incoming buffer has {}B of data", incoming.len());
+
+            let UnbufferedStatus { mut discard, state } = self
+                .conn
+                .process_tls_records(incoming.filled_mut())
+                .map_err(map_err)?;
+
+            match state {
+                ConnectionState::AppDataAvailable(mut state) => {
+                    while let Some(res) = state.next_record() {
+                        let AppDataRecord {
+                            discard: new_discard,
+                            payload,
+                        } = res.map_err(map_err)?;
+                        discard += new_discard;
+
+                        let remainder = cursor.append(payload);
+
+                        if !remainder.is_empty() {
+                            // stash
+                            todo!()
+                        }
+                    }
+                }
+
+                ConnectionState::TrafficTransit(_) => {
+                    let would_block = poll_read(&mut self.io, &mut incoming, cx)?;
+
+                    if would_block {
+                        self.incoming = incoming;
+                        return Poll::Pending;
+                    }
+                }
+
+                ConnectionState::ConnectionClosed => break,
+
+                state => unreachable!("{state:?}"),
+            }
+
+            incoming.discard(discard);
+        }
+
+        Poll::Ready(Ok(cursor.into_used()))
+    }
+}
+
+struct WriteCursor<'a> {
+    buf: &'a mut [u8],
+    used: usize,
+}
+
+impl<'a> WriteCursor<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, used: 0 }
+    }
+
+    fn into_used(self) -> usize {
+        self.used
+    }
+
+    fn append<'b>(&mut self, data: &'b [u8]) -> &'b [u8] {
+        let len = self
+            .remaining_capacity()
+            .min(data.len());
+
+        self.unfilled()[..len].copy_from_slice(&data[..len]);
+        self.used += len;
+
+        data.split_at(len).1
+    }
+
+    fn unfilled(&mut self) -> &mut [u8] {
+        &mut self.buf[self.used..]
+    }
+
+    fn is_full(&self) -> bool {
+        self.remaining_capacity() == 0
+    }
+
+    fn remaining_capacity(&self) -> usize {
+        self.buf.len() - self.used
+    }
+}
+
+fn map_err<E>(err: E) -> io::Error
+where
+    E: Into<Box<dyn StdError + Send + Sync>>,
+{
+    io::Error::new(ErrorKind::Other, err)
+}
+
+#[derive(Default)]
+struct Buffer {
+    inner: Vec<u8>,
+    used: usize,
+}
+
+impl Buffer {
+    fn advance(&mut self, num_bytes: usize) {
+        self.used += num_bytes;
+    }
+
+    fn discard(&mut self, num_bytes: usize) {
+        if num_bytes == 0 {
+            return;
+        }
+
+        debug_assert!(num_bytes <= self.used);
+
+        self.inner
+            .copy_within(num_bytes..self.used, 0);
+        self.used -= num_bytes;
+
+        log::trace!("discarded {num_bytes}B");
+    }
+
+    fn reserve(&mut self, additional_bytes: usize) {
+        let new_len = self.used + additional_bytes;
+        self.inner.resize(new_len, 0);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn len(&self) -> usize {
+        self.filled().len()
+    }
+
+    fn filled(&self) -> &[u8] {
+        &self.inner[..self.used]
+    }
+
+    fn filled_mut(&mut self) -> &mut [u8] {
+        &mut self.inner[..self.used]
+    }
+
+    fn unfilled(&mut self) -> &mut [u8] {
+        &mut self.inner[self.used..]
+    }
+
+    fn capacity(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+fn try_or_resize_and_retry<E>(
+    mut f: impl FnMut(&mut [u8]) -> CoreResult<usize, E>,
+    map_err: impl FnOnce(E) -> Result<InsufficientSizeError>,
+    outgoing: &mut Buffer,
+) -> Result<usize>
+where
+    E: StdError + Send + Sync + 'static,
+{
+    let written = match f(outgoing.unfilled()) {
+        Ok(written) => written,
+
+        Err(e) => {
+            let InsufficientSizeError { required_size } = map_err(e)?;
+            outgoing.reserve(required_size);
+            log::trace!("resized `outgoing_tls` buffer to {}B", outgoing.capacity());
+
+            f(outgoing.unfilled())?
+        }
+    };
+
+    outgoing.advance(written);
+
+    Ok(written)
+}


### PR DESCRIPTION
This PR contains an async adapter that works with both async-std and tokio but depends on neither crate. Instead it uses the `futures::Async{Read,Write}` interfaces to make the API, runtime generic.

- this is just a sketch (= I have not done extensive testing)
- the sketch only includes the client API
- a client example that can use either async-std or tokio is included
- there are no API docs but the API surface mimics the high level async API found in `rustls-tokio`
- the API is **not** no-std compatible because the `Async{Read,Write}` traits include the `std::io::Error` type in its interface
- the async API is implemented on top of the `UnbufferedConnection` API