### PR TITLE
Prepare 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,12 +1732,12 @@ dependencies = [
  "env_logger",
  "log",
  "ring 0.17.5",
- "rustls-pemfile 2.0.0-alpha.2",
+ "rustls-pemfile 2.0.0",
  "rustls-pki-types",
- "rustls-webpki 0.102.0-alpha.8",
+ "rustls-webpki 0.102.0",
  "rustversion",
  "subtle",
- "webpki-roots 0.26.0-alpha.2",
+ "webpki-roots 0.26.0",
  "zeroize",
 ]
 
@@ -1753,7 +1753,7 @@ dependencies = [
  "itertools",
  "rayon",
  "rustls 0.22.0-alpha.6",
- "rustls-pemfile 2.0.0-alpha.2",
+ "rustls-pemfile 2.0.0",
  "rustls-pki-types",
 ]
 
@@ -1777,11 +1777,11 @@ dependencies = [
  "mio",
  "rcgen",
  "rustls 0.22.0-alpha.6",
- "rustls-pemfile 2.0.0-alpha.2",
+ "rustls-pemfile 2.0.0",
  "rustls-pki-types",
  "serde",
  "serde_derive",
- "webpki-roots 0.26.0-alpha.2",
+ "webpki-roots 0.26.0",
 ]
 
 [[package]]
@@ -1795,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.0.0-alpha.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9975e1f0807681e097d288d545dc40c98a4d3a6ef95a40b18d00e5e4daa9a4"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
  "base64",
  "rustls-pki-types",
@@ -1805,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "0.2.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d3edd6cdcdf26eda538757038343986e666d0b8ba4b5ac1de663b78475550d"
+checksum = "eb0a1f9b9efec70d32e6d6aa3e58ebd88c3754ec98dfe9145c63cf54cc829b83"
 
 [[package]]
 name = "rustls-provider-example"
@@ -1829,12 +1829,12 @@ dependencies = [
  "rsa",
  "rustls 0.22.0-alpha.6",
  "rustls-pki-types",
- "rustls-webpki 0.102.0-alpha.8",
+ "rustls-webpki 0.102.0",
  "serde",
  "serde_json",
  "sha2",
  "signature",
- "webpki-roots 0.26.0-alpha.2",
+ "webpki-roots 0.26.0",
  "x25519-dalek",
 ]
 
@@ -1850,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0-alpha.8"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139cdfd1d8b96f927fbe0a0c98785afe94b63e95a7ef815ebae9263d20e10a0d"
+checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.5",
@@ -2346,9 +2346,9 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.0-alpha.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e3d99d80231fabcc72d887ed09f843b7f3942c75907285e51112a46c8f6f81"
+checksum = "0de2cfda980f21be5a7ed2eadb3e6fe074d56022bea2cdeb1a62eb220fc04188"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.0-alpha.6"
+version = "0.22.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1752,7 +1752,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.22.0-alpha.6",
+ "rustls 0.22.0",
  "rustls-pemfile 2.0.0",
  "rustls-pki-types",
 ]
@@ -1764,7 +1764,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring 0.17.5",
- "rustls 0.22.0-alpha.6",
+ "rustls 0.22.0",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.22.0-alpha.6",
+ "rustls 0.22.0",
  "rustls-pemfile 2.0.0",
  "rustls-pki-types",
  "serde",
@@ -1827,7 +1827,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.22.0-alpha.6",
+ "rustls 0.22.0",
  "rustls-pki-types",
  "rustls-webpki 0.102.0",
  "serde",

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.4.3"
 clap = { version = "4.3.21", features = ["derive"] }
 fxhash = "0.2.1"
 itertools = "0.12"
-pki-types = { package = "rustls-pki-types", version = "0.2" }
+pki-types = { package = "rustls-pki-types", version = "1" }
 rayon = "1.7.0"
 rustls = { path = "../rustls", features = ["ring", "aws_lc_rs"] }
-rustls-pemfile = "=2.0.0-alpha.2"
+rustls-pemfile = "2"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,10 +11,10 @@ docopt = "~1.1"
 env_logger = "0.10"
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
-pki-types = { package = "rustls-pki-types", version = "0.2.2", features = ["std"] }
+pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
 rcgen = { version = "0.11.3", features = ["pem"], default-features = false }
 rustls = { path = "../rustls", features = [ "logging" ]}
-rustls-pemfile = "=2.0.0-alpha.2"
+rustls-pemfile = "2"
 serde = "1.0"
 serde_derive = "1.0"
-webpki-roots = "=0.26.0-alpha.2"
+webpki-roots = "0.26"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -92,15 +92,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "0.2.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf0cbc2bc68777eb846b2b7fedf03807bb763adc585bf006ac2fa2884daa9d1"
+checksum = "eb0a1f9b9efec70d32e6d6aa3e58ebd88c3754ec98dfe9145c63cf54cc829b83"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.0-alpha.8"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139cdfd1d8b96f927fbe0a0c98785afe94b63e95a7ef815ebae9263d20e10a0d"
+checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.0-alpha.6"
+version = "0.22.0"
 dependencies = [
  "log",
  "ring",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-pki-types = { package = "rustls-pki-types", version = "0.2.2" }
+pki-types = { package = "rustls-pki-types", version = "1" }
 rustls = { path = "../rustls" }
 
 # Prevent this from interfering with workspaces

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -17,14 +17,14 @@ hpke-rs-crypto = "0.1.2"
 hpke-rs-rust-crypto = "0.1.2"
 p256 = "0.13.2"
 pkcs8 = { version = "0.10.2", features = ["std"] }
-pki-types = { package = "rustls-pki-types", version = "0.2.2", features = ["std"] }
+pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
 rand_core = "0.6.0"
 rustls = { path = "../rustls", default-features = false, features = ["logging", "tls12"] }
 rsa = { version = "0.9.0", features = ["sha2"] }
 sha2 = "0.10.0"
 signature = "2"
-webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.8", features = ["alloc", "std"], default-features = false }
-webpki-roots = "=0.26.0-alpha.2"
+webpki = { package = "rustls-webpki", version = "0.102", features = ["alloc", "std"], default-features = false }
+webpki-roots = "0.26"
 x25519-dalek = "2"
 
 [dev-dependencies]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.22.0-alpha.6"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -20,8 +20,8 @@ aws-lc-rs = { version = "1.5", optional = true }
 log = { version = "0.4.4", optional = true }
 ring = { version = "0.17", optional = true }
 subtle = { version = "2.5.0", default-features = false }
-webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.8", features = ["std"], default-features = false }
-pki-types = { package = "rustls-pki-types", version = "0.2.2", features = ["std"] }
+webpki = { package = "rustls-webpki", version = "0.102", features = ["std"], default-features = false }
+pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
 zeroize = "1.6.0"
 
 [features]
@@ -37,8 +37,8 @@ base64 = "0.21"
 bencher = "0.1.5"
 env_logger = "0.10"
 log = "0.4.4"
-rustls-pemfile = "=2.0.0-alpha.2"
-webpki-roots = "=0.26.0-alpha.2"
+rustls-pemfile = "2"
+webpki-roots = "0.26"
 
 [[example]]
 name = "bogo_shim"


### PR DESCRIPTION
# Release notes

## New features
 - **Configurable cryptography providers**. The cryptography used by rustls is represented by the `CryptoProvider` trait. *ring* is now optional, but remains the default provider.
 - **Optional support for cryptography from [aws-lc-rs](https://github.com/aws/aws-lc-rs)**. Once the certification process completes , we will support FIPS mode using aws-lc-rs.
 - **Certificate revocation list (CRL) support**. The default certificate verifier used in rustls can now be configured with CRLs to control revocation of client and server certificates.
 - **Separate configuration of root hints in client certificate verifier**. To deal with cross-signed client certificate topologies, the list of hints sent to a client can now be configured. The default behaviour remains to send the names of the configured root certificates.

## Breaking changes
  - `RootCertStore::add_parsable_certificates` now takes a `impl IntoIterator<Item = impl AsRef<[u8]>>`.
  - *Breaking change*: remove support for SCT stapling.  Ecosystem support for this is rare compared to
    inclusion of SCTs in certificates.
  - *Breaking change*: rename `WebPkiVerifier` to `WebPkiServerVerifier`
  - *Breaking change*: remove default trait implementations in `ServerCertVerifier`/`ClientCertVerifier` so the trait doesn't depend on webpki. Instead the previous implementations are exposed as `rustls::crypto::verify_tls12_signature`, `rustls::crypto::verify_tls13_signature` and `$PROVIDER.signature_verification_algorithms.supported_schemes()`,  using the crypto provider of your choice.
  - *Breaking change*: rework certificate auth verifiers construction into a builder. This covers both server and client certificate verifiers: call `WebPkiServerVerifier::builder()` and `WebPkiClientVerifier::builder()`.
  - *Breaking change*: we have removed the `dangerous_configuration`, `secret_extraction` and `quic` crate features. The API features those previously gated are now available without a crate feature. Types previously gated on the `dangerous_configuration` feature now appear in `danger` modules in the same place.
  - *Breaking change*: new types for keys and certificates. `rustls::Certificate` has been replaced with `CertificateDer` from the new [rustls-pki-types](https://docs.rs/rustls-pki-types/latest/rustls_pki_types/) crate. Likewise, `rustls::PrivateKey` has been replaced with `rustls_pki_types::PrivateKeyDer`.
  - *Breaking change*: `RootCertStore` is now passed around wrapped in an `Arc`, to improve efficiency when creating a different verifier for different servers/clients but with the same roots.
  - *Breaking change*: traits exposed by rustls now come with a `Debug` bound. Please exercise caution in using `#[derive(Debug)]` on types that contain secret data.
  - *Breaking change*: `RootCertStore::add_server_trust_anchors` became `RootCertStore::add_trust_anchors` (https://github.com/rustls/rustls/commit/697846460dd1652529ec33a098e43b88ac3a85c8)
 - *Breaking change*: The deprecated `ConfigBuilder<ClientConfig, WantsClientCert>::with_single_cert` fn was removed in favour of `with_client_auth_cert` (https://github.com/rustls/rustls/commit/42cda4658f3f5c865a9248803a8a083633525998)
  - *Breaking change*: some types and values have moved to accommodate cryptography provider work:

| *Old* | *New* |
|-|-|
| `rustls::CipherSuiteCommon` | `rustls::crypto::CipherSuiteCommon` |
| `rustls::SupportedKxGroup` | `rustls::crypto::SupportedKxGroup` |
| `rustls::cipher_suite::*` | `rustls::crypto::ring::cipher_suite::*` |
| `rustls::Ticketer` | `rustls::crypto::ring::Ticketer` |
| `rustls::ALL_KX_GROUPS` | `rustls::crypto::ring::ALL_KX_GROUPS` |
| `rustls::ALL_CIPHER_SUITES` | `rustls::crypto::ring::ALL_CIPHER_SUITES` |
| `rustls::DEFAULT_CIPHER_SUITES` | `rustls::crypto::ring::DEFAULT_CIPHER_SUITES` |
| `rustls::kx_group::*` | `rustls::crypto::ring::kx_group::*` |
| `rustls::sign::any_ecdsa_type` | `rustls::crypto::ring::sign::any_ecdsa_type` |
| `rustls::sign::any_eddsa_type` | `rustls::crypto::ring::sign::any_eddsa_type` |
| `rustls::sign::any_supported_type` | `rustls::crypto::ring::sign::any_supported_type` |


## Moved/renamed/new items
### Moved
* `ALL_CIPHER_SUITES` (crypto providers)
* `ALL_KX_GROUPS` (crypto providers)
* `DEFAULT_CIPHER_SUITES` (crypto providers)
* `SECP256R1` (crypto providers)
* `SECP384R1` (crypto providers)
* `any_ecdsa_type` (crypto providers)
* `any_eddsa_type` (crypto providers)
* `any_supported_type` (crypto providers)
* `CipherSuiteCommon` (`crypto`)
* `ClientCertVerified` (`server::danger`)
* `ClientCertVerifier` (`server::danger`)
* `DangerousClientConfig` (`client::danger`)
* `HandshakeSignatureValid` (`client::danger`)
* `ServerCertVerified` (`client::danger`)
* `ServerCertVerifier` (`client::danger`)
* `SupportedKxGroup` (`crypto`)
* `Ticketer` (crypto providers)
* `TLS13_AES_128_GCM_SHA256` (crypto providers)
* `TLS13_AES_256_GCM_SHA384` (crypto providers)
* `TLS13_CHACHA20_POLY1305_SHA256` (crypto providers)
* `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` (crypto providers)
* `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384` (crypto providers)
* `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` (crypto providers)
* `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` (crypto providers)
* `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384` (crypto providers)
* `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256` (crypto providers)
* `X25519` (crypto providers)

### Renamed
* `WebPkiVerifier` (`client::WebPkiServerVerifier`)
* `Certificate` (`rustls_pki_types::CertificateDer`)
* `PrivateKey` (`rustls_pki_types::PrivateKeyDer`)
* `SignError` (`crypto::ring::sign::InvalidKeyError`)

### Added/newly public
* `ActiveKeyExchange` (`crypto`)
* `AeadKey` (`crypto::cipher`)
* `Algorithm` (`quic`)
* `ClientCertVerifierBuilder` (`server`)
* `DangerousClientConfigBuilder` (`client::danger`)
* `expand` (`crypto::tls13`)
* `OkmBlock` (`crypto::tls13`)
* `OutputLengthError` (`crypto::tls13`)
* `ServerCertVerifierBuilder` (`client`)
* `TicketSwitcher` (`ticketer`)
* `WebPkiClientVerifier` (`server`)

### Added/newly public (crypto provider extensibility)
* `default_provider()` (`crypto::ring`)
* `default_provider()` (`crypto::aws_lc_rs`)
* `HashAlgorithm` (`crypto::hash`)
* `Hash` (`crypto::hash`)
* `Hkdf` (`crypto::tls13`)
* `HkdfExpander` (`crypto::tls13`)
* `HkdfExpanderUsingHmac` (`crypto::tls13`)
* `HkdfUsingHmac` (`crypto::tls13`)
* `Hmac` (`crypto::hmac`)
* `Iv` (`crypto::cipher`)
* `KeyBlockShape` (`crypto::cipher`)
* `Key` (`crypto::hmac`)
* `KeyExchangeAlgorithm` (`crypto`)
* `make_tls12_aad` (`crypto::cipher`)
* `make_tls13_aad` (`crypto::cipher`)
* `MessageDecrypter` (`crypto::cipher`)
* `MessageEncrypter` (`crypto::cipher`)
* `Nonce` (`crypto::cipher`)
* `Nonce` (`crypto::cipher`)
* `OpaqueMessage` (`crypto::cipher`)
* `Output` (`crypto::hash`)
* `PlainMessage` (`crypto::cipher`)
* `Prf` (`crypto::tls12`)
* `PrfUsingHmac` (`crypto::tls12`)
* `SharedSecret` (`crypto`)
* `Tag` (`crypto::hmac`)
* `Tls12AeadAlgorithm` (`crypto::cipher`)
* `UnsupportedOperationError` (`crypto::cipher`)
* `WebPkiSupportedAlgorithms` (`crypto`)

### Added/newly public (error types)
* `GetRandomFailed` (`crypto`)
* `OtherError` (top level)
* `UnsupportedOperationError` (`crypto::cipher`)
* `VerifierBuilderError` (`client`)
* `VerifierBuilderError` (`server`)

### Removed
* `AllowAnyAnonymousOrAuthenticatedClient`
* `AllowAnyAuthenticatedClient`
* `BulkAlgorithm`
* `CertificateTransparencyPolicy`
* `supported_sign_tls13`
* `WantsTransparencyPolicyOrClientCert`
* `OwnedTrustAnchor`

--- 

closes #1435 