### PR TITLE
remove InvalidKeyError

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -9,7 +9,6 @@ use crate::Error;
 use pki_types::PrivateKeyDer;
 use webpki::aws_lc_rs as webpki_algs;
 
-use alloc::string::String;
 use alloc::sync::Arc;
 
 // aws-lc-rs has a -- roughly -- ring-compatible API, so we just reuse all that
@@ -64,7 +63,6 @@ impl KeyProvider for AwsLcRs {
         key_der: PrivateKeyDer<'static>,
     ) -> Result<Arc<dyn SigningKey>, Error> {
         sign::any_supported_type(&key_der)
-            .map_err(|_| Error::General(String::from("invalid private key")))
     }
 }
 

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -9,7 +9,6 @@ use crate::Error;
 use pki_types::PrivateKeyDer;
 use webpki::ring as webpki_algs;
 
-use alloc::borrow::ToOwned;
 use alloc::sync::Arc;
 
 pub(crate) use ring as ring_like;
@@ -59,7 +58,6 @@ impl KeyProvider for Ring {
         key_der: PrivateKeyDer<'static>,
     ) -> Result<Arc<dyn SigningKey>, Error> {
         sign::any_supported_type(&key_der)
-            .map_err(|_| Error::General("invalid private key".to_owned()))
     }
 }
 


### PR DESCRIPTION
The per-provider key loading functions returned this singleton error, but it was usually then wrapped into Error::General("invalid private key"). That means the singleton error is unnecessary API surface, but also it means potentially valuable information is lost.

Move the wrapping into `Error::General` to a lower level, add detail about which specific parsing operation failed, and pass along error details from the lower-level library.