### PR TITLE
doc: make it easier to find changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+The detailed list of changes in each release can be found at
+https://github.com/rustls/rustls/releases.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 [![Documentation](https://docs.rs/rustls/badge.svg)](https://docs.rs/rustls/)
 [![Chat](https://img.shields.io/discord/976380008299917365?logo=discord)](https://discord.gg/MCSB76RU96)
 
-## Release history
+## Changelog
 
-Release history can be found [on GitHub](https://github.com/rustls/rustls/releases).
+The detailed list of changes in each release can be found at
+https://github.com/rustls/rustls/releases.
 
 # Documentation
 


### PR DESCRIPTION
Many projects use CHANGELOG.md to convey their list of changes. Add a link there. In README.md, instead of describing "release history", use the "Changelog" terminology.