### PR TITLE
api: use OtherError consistently

### DIFF
--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -340,7 +340,7 @@ pub enum CertificateError {
     /// not covered by the above common cases.
     ///
     /// Enums holding this variant will never compare equal to each other.
-    Other(Arc<dyn StdError + Send + Sync>),
+    Other(OtherError),
 }
 
 impl PartialEq<Self> for CertificateError {
@@ -417,7 +417,7 @@ pub enum CertRevocationListError {
     /// The CRL is invalid for some other reason.
     ///
     /// Enums holding this variant will never compare equal to each other.
-    Other(Arc<dyn StdError + Send + Sync>),
+    Other(OtherError),
 
     /// The CRL is not correctly encoded.
     ParseError,
@@ -523,7 +523,7 @@ impl fmt::Display for Error {
                 write!(f, "the supplied max_fragment_size was too small or large")
             }
             Self::General(ref err) => write!(f, "unexpected error: {}", err),
-            Self::Other(ref err) => write!(f, "other error: {:?}", err),
+            Self::Other(ref err) => write!(f, "other error: {}", err),
         }
     }
 }
@@ -564,6 +564,18 @@ impl From<OtherError> for Error {
     }
 }
 
+impl fmt::Display for OtherError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl StdError for OtherError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(self.0.as_ref())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Error, InvalidMessage};
@@ -585,7 +597,7 @@ mod tests {
             ApplicationVerificationFailure,
             ApplicationVerificationFailure
         );
-        let other = Other(alloc::sync::Arc::from(Box::from("")));
+        let other = Other(OtherError(alloc::sync::Arc::from(Box::from(""))));
         assert_ne!(other, other);
         assert_ne!(BadEncoding, Expired);
     }
@@ -606,7 +618,7 @@ mod tests {
         assert_eq!(UnsupportedDeltaCrl, UnsupportedDeltaCrl);
         assert_eq!(UnsupportedIndirectCrl, UnsupportedIndirectCrl);
         assert_eq!(UnsupportedRevocationReason, UnsupportedRevocationReason);
-        let other = Other(alloc::sync::Arc::from(Box::from("")));
+        let other = Other(OtherError(alloc::sync::Arc::from(Box::from(""))));
         assert_ne!(other, other);
         assert_ne!(BadSignature, InvalidCrlNumber);
     }

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -6,7 +6,7 @@ use pki_types::CertificateRevocationListDer;
 use std::error::Error as StdError;
 use webpki::{CertRevocationList, OwnedCertRevocationList};
 
-use crate::error::{CertRevocationListError, CertificateError, Error};
+use crate::error::{CertRevocationListError, CertificateError, Error, OtherError};
 
 mod anchors;
 mod client_verifier;
@@ -75,7 +75,7 @@ fn pki_error(error: webpki::Error) -> Error {
             CertRevocationListError::BadSignature.into()
         }
 
-        _ => CertificateError::Other(Arc::new(error)).into(),
+        _ => CertificateError::Other(OtherError(Arc::new(error))).into(),
     }
 }
 
@@ -95,7 +95,7 @@ fn crl_error(e: webpki::Error) -> CertRevocationListError {
         UnsupportedIndirectCrl => CertRevocationListError::UnsupportedIndirectCrl,
         UnsupportedRevocationReason => CertRevocationListError::UnsupportedRevocationReason,
 
-        _ => CertRevocationListError::Other(Arc::new(e)),
+        _ => CertRevocationListError::Other(OtherError(Arc::new(e))),
     }
 }
 


### PR DESCRIPTION
`CertificateError` and `CertRevocationListError` both had an `Other` variant containing `Arc<dyn StdError + Send + Sync>`, while `rustls::Error` used the newtype `OtherError`. Use `OtherError` in all three cases.

Also, implement `StdError` and `Display` for `OtherError`, and specifically implement `source()` to return the underlying error.