### PR TITLE
remove InvalidKeyError

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -9,7 +9,6 @@ use crate::Error;
 use pki_types::PrivateKeyDer;
 use webpki::aws_lc_rs as webpki_algs;
 
-use alloc::string::String;
 use alloc::sync::Arc;
 
 // aws-lc-rs has a -- roughly -- ring-compatible API, so we just reuse all that
@@ -64,7 +63,6 @@ impl KeyProvider for AwsLcRs {
         key_der: PrivateKeyDer<'static>,
     ) -> Result<Arc<dyn SigningKey>, Error> {
         sign::any_supported_type(&key_der)
-            .map_err(|_| Error::General(String::from("invalid private key")))
     }
 }
 

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -9,7 +9,6 @@ use crate::Error;
 use pki_types::PrivateKeyDer;
 use webpki::ring as webpki_algs;
 
-use alloc::borrow::ToOwned;
 use alloc::sync::Arc;
 
 pub(crate) use ring as ring_like;
@@ -59,7 +58,6 @@ impl KeyProvider for Ring {
         key_der: PrivateKeyDer<'static>,
     ) -> Result<Arc<dyn SigningKey>, Error> {
         sign::any_supported_type(&key_der)
-            .map_err(|_| Error::General("invalid private key".to_owned()))
     }
 }
 

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -11,32 +11,40 @@ use super::ring_like::signature::{self, EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair
 use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
 
 use alloc::boxed::Box;
+use alloc::format;
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug, Formatter};
-use std::error::Error as StdError;
 
 /// Parse `der` as any supported key encoding/type, returning
 /// the first which works.
-pub fn any_supported_type(der: &PrivateKeyDer<'_>) -> Result<Arc<dyn SigningKey>, InvalidKeyError> {
+pub fn any_supported_type(der: &PrivateKeyDer<'_>) -> Result<Arc<dyn SigningKey>, Error> {
     if let Ok(rsa) = RsaSigningKey::new(der) {
-        Ok(Arc::new(rsa))
-    } else if let Ok(ecdsa) = any_ecdsa_type(der) {
-        Ok(ecdsa)
-    } else if let PrivateKeyDer::Pkcs8(pkcs8) = der {
-        any_eddsa_type(pkcs8)
-    } else {
-        Err(InvalidKeyError(()))
+        return Ok(Arc::new(rsa));
     }
+
+    if let Ok(ecdsa) = any_ecdsa_type(der) {
+        return Ok(ecdsa);
+    }
+
+    if let PrivateKeyDer::Pkcs8(pkcs8) = der {
+        if let Ok(eddsa) = any_eddsa_type(pkcs8) {
+            return Ok(eddsa);
+        }
+    }
+
+    Err(Error::General(
+        "failed to parse private key as RSA, ECDSA, or EdDSA".into(),
+    ))
 }
 
 /// Parse `der` as any ECDSA key type, returning the first which works.
 ///
 /// Both SEC1 (PEM section starting with 'BEGIN EC PRIVATE KEY') and PKCS8
 /// (PEM section starting with 'BEGIN PRIVATE KEY') encodings are supported.
-pub fn any_ecdsa_type(der: &PrivateKeyDer<'_>) -> Result<Arc<dyn SigningKey>, InvalidKeyError> {
+pub fn any_ecdsa_type(der: &PrivateKeyDer<'_>) -> Result<Arc<dyn SigningKey>, Error> {
     if let Ok(ecdsa_p256) = EcdsaSigningKey::new(
         der,
         SignatureScheme::ECDSA_NISTP256_SHA256,
@@ -53,20 +61,18 @@ pub fn any_ecdsa_type(der: &PrivateKeyDer<'_>) -> Result<Arc<dyn SigningKey>, In
         return Ok(Arc::new(ecdsa_p384));
     }
 
-    Err(InvalidKeyError(()))
+    Err(Error::General(
+        "failed to parse ECDSA private key as PKCS#8 or SEC1".into(),
+    ))
 }
 
 /// Parse `der` as any EdDSA key type, returning the first which works.
-pub fn any_eddsa_type(
-    der: &PrivatePkcs8KeyDer<'_>,
-) -> Result<Arc<dyn SigningKey>, InvalidKeyError> {
-    if let Ok(ed25519) = Ed25519SigningKey::new(der, SignatureScheme::ED25519) {
-        return Ok(Arc::new(ed25519));
-    }
-
+pub fn any_eddsa_type(der: &PrivatePkcs8KeyDer<'_>) -> Result<Arc<dyn SigningKey>, Error> {
     // TODO: Add support for Ed448
-
-    Err(InvalidKeyError(()))
+    Ok(Arc::new(Ed25519SigningKey::new(
+        der,
+        SignatureScheme::ED25519,
+    )?))
 }
 
 /// A `SigningKey` for RSA-PKCS1 or RSA-PSS.
@@ -90,13 +96,19 @@ static ALL_RSA_SCHEMES: &[SignatureScheme] = &[
 impl RsaSigningKey {
     /// Make a new `RsaSigningKey` from a DER encoding, in either
     /// PKCS#1 or PKCS#8 format.
-    pub fn new(der: &PrivateKeyDer<'_>) -> Result<Self, InvalidKeyError> {
+    pub fn new(der: &PrivateKeyDer<'_>) -> Result<Self, Error> {
         let key_pair = match der {
             PrivateKeyDer::Pkcs1(pkcs1) => RsaKeyPair::from_der(pkcs1.secret_pkcs1_der()),
             PrivateKeyDer::Pkcs8(pkcs8) => RsaKeyPair::from_pkcs8(pkcs8.secret_pkcs8_der()),
-            _ => return Err(InvalidKeyError(())),
+            _ => {
+                return Err(Error::General(
+                    "failed to parse RSA private key as either PKCS#1 or PKCS#8".into(),
+                ));
+            }
         }
-        .map_err(|_| InvalidKeyError(()))?;
+        .map_err(|key_rejected| {
+            Error::General(format!("failed to parse RSA private key: {}", key_rejected))
+        })?;
 
         Ok(Self {
             key: Arc::new(key_pair),
@@ -333,13 +345,15 @@ struct Ed25519SigningKey {
 impl Ed25519SigningKey {
     /// Make a new `Ed25519SigningKey` from a DER encoding in PKCS#8 format,
     /// expecting a key usable with precisely the given signature scheme.
-    fn new(der: &PrivatePkcs8KeyDer<'_>, scheme: SignatureScheme) -> Result<Self, InvalidKeyError> {
+    fn new(der: &PrivatePkcs8KeyDer<'_>, scheme: SignatureScheme) -> Result<Self, Error> {
         match Ed25519KeyPair::from_pkcs8_maybe_unchecked(der.secret_pkcs8_der()) {
             Ok(key_pair) => Ok(Self {
                 key: Arc::new(key_pair),
                 scheme,
             }),
-            Err(_) => Err(InvalidKeyError(())),
+            Err(e) => Err(Error::General(format!(
+                "failed to parse Ed25519 private key: {e}"
+            ))),
         }
     }
 }
@@ -391,18 +405,6 @@ impl Debug for Ed25519Signer {
             .finish()
     }
 }
-
-/// Error produced when constructing a [`SigningKey`].
-#[derive(Debug)]
-pub struct InvalidKeyError(());
-
-impl fmt::Display for InvalidKeyError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.write_str("error constructing key")
-    }
-}
-
-impl StdError for InvalidKeyError {}
 
 #[cfg(test)]
 mod tests {
@@ -473,6 +475,29 @@ mod tests {
         ));
         assert!(any_supported_type(&key).is_ok());
         assert!(any_ecdsa_type(&key).is_err());
+    }
+
+    #[test]
+    fn cannot_load_invalid_pkcs8_encoding() {
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(&b"invalid"[..]));
+        assert_eq!(
+            any_supported_type(&key).err(),
+            Some(Error::General(
+                "failed to parse private key as RSA, ECDSA, or EdDSA".into()
+            ))
+        );
+        assert_eq!(
+            any_ecdsa_type(&key).err(),
+            Some(Error::General(
+                "failed to parse ECDSA private key as PKCS#8 or SEC1".into()
+            ))
+        );
+        assert_eq!(
+            RsaSigningKey::new(&key).err(),
+            Some(Error::General(
+                "failed to parse RSA private key: InvalidEncoding".into()
+            ))
+        );
     }
 }
 


### PR DESCRIPTION
The per-provider key loading functions returned this singleton error, but it was usually then wrapped into Error::General("invalid private key"). That means the singleton error is unnecessary API surface, but also it means potentially valuable information is lost.

Move the wrapping into `Error::General` to a lower level, add detail about which specific parsing operation failed, and pass along error details from the lower-level library.

---

follow-up to #1652 -- this is that PR, but:

- elide an extra ed25519 binding: https://github.com/rustls/rustls/pull/1652#discussion_r1411795341
- early return, to avoid reporting ed25519 errors: https://github.com/rustls/rustls/pull/1652#issuecomment-1835866486
- add a test