### PR TITLE
quic: require that PacketKey and HeaderProtectionKey are Send + Sync

### DIFF
--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -579,7 +579,7 @@ pub trait Algorithm: Send + Sync {
 }
 
 /// A QUIC header protection key
-pub trait HeaderProtectionKey {
+pub trait HeaderProtectionKey: Send + Sync {
     /// Adds QUIC Header Protection.
     ///
     /// `sample` must contain the sample of encrypted payload; see
@@ -640,7 +640,7 @@ pub trait HeaderProtectionKey {
 }
 
 /// Keys to encrypt or decrypt the payload of a packet
-pub trait PacketKey {
+pub trait PacketKey: Send + Sync {
     /// Encrypt a QUIC packet
     ///
     /// Takes a `packet_number`, used to derive the nonce; the packet `header`, which is used as
@@ -884,5 +884,19 @@ impl Version {
 impl Default for Version {
     fn default() -> Self {
         Self::V1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::quic::HeaderProtectionKey;
+
+    use super::PacketKey;
+
+    #[test]
+    fn auto_traits() {
+        fn assert_auto<T: Send + Sync>() {}
+        assert_auto::<Box<dyn PacketKey>>();
+        assert_auto::<Box<dyn HeaderProtectionKey>>();
     }
 }

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -54,12 +54,6 @@ pub enum SupportedCipherSuite {
     Tls13(&'static Tls13CipherSuite),
 }
 
-impl fmt::Debug for SupportedCipherSuite {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.suite().fmt(f)
-    }
-}
-
 impl SupportedCipherSuite {
     /// The cipher suite's identifier
     pub fn suite(&self) -> CipherSuite {
@@ -122,6 +116,12 @@ impl SupportedCipherSuite {
                 .and_then(|cs| cs.quic)
                 .is_some(),
         }
+    }
+}
+
+impl fmt::Debug for SupportedCipherSuite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.suite().fmt(f)
     }
 }
 


### PR DESCRIPTION
Note that this is technically semver-incompatible, but I think we should land it in 0.22.x anyway since expected breakage should be negligible.