### PR TITLE
remove the TLS 1.2 session ticket on DecryptError

### DIFF
--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1040,6 +1040,18 @@ impl State<ClientConnectionData> for ExpectFinished {
             _fin_verified,
         }))
     }
+
+    // we could not decrypt the encrypted handshake message with session resumption
+    // this might mean that the ticket was invalid for some reason, so we remove it
+    // from the store to restart a session from scratch
+    fn handle_decrypt_error(&self) {
+        if self.resuming {
+            self.config
+                .resumption
+                .store
+                .remove_tls12_session(&self.server_name);
+        }
+    }
 }
 
 // -- Traffic transit state --

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -630,6 +630,8 @@ pub(crate) trait State<Data>: Send + Sync {
     fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
         Err(Error::HandshakeNotComplete)
     }
+
+    fn handle_decrypt_error(&self) {}
 }
 
 pub(crate) struct Context<'a, Data> {


### PR DESCRIPTION
Fix #1617

if for some reason the recorded session ticket is invalid or decoded incorrectly by the server, we can get into a case where the resumption handshake happens, and right after the ChangeCipherSpec message, the server sends an encrypted handhsake message using the invalid ticket, and the client rejects it with the BadRecordMAC alert. Unfortunately, if the calling code retries the connection, if it will try again with the same ticket and obtain the same result. This commit makes sure that if we fail to decrypt the first message, we will remove the session ticket for this server, to start from cratch on the next connection.