### PR TITLE
Mark `SupportedProtocolVersion` as non-exhaustive

### DIFF
--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -7,11 +7,11 @@ use crate::enums::ProtocolVersion;
 /// All possible instances of this class are provided by the library in
 /// the [`ALL_VERSIONS`] array, as well as individually as [`TLS12`]
 /// and [`TLS13`].
+#[non_exhaustive]
 #[derive(Eq, PartialEq)]
 pub struct SupportedProtocolVersion {
     /// The TLS enumeration naming this version.
     pub version: ProtocolVersion,
-    is_private: (),
 }
 
 impl fmt::Debug for SupportedProtocolVersion {
@@ -24,13 +24,11 @@ impl fmt::Debug for SupportedProtocolVersion {
 #[cfg(feature = "tls12")]
 pub static TLS12: SupportedProtocolVersion = SupportedProtocolVersion {
     version: ProtocolVersion::TLSv1_2,
-    is_private: (),
 };
 
 /// TLS1.3
 pub static TLS13: SupportedProtocolVersion = SupportedProtocolVersion {
     version: ProtocolVersion::TLSv1_3,
-    is_private: (),
 };
 
 /// A list of all the protocol versions supported by rustls.


### PR DESCRIPTION
This fixes a clippy warning that is showing up in other PRs:
```
 warning: this seems like a manual implementation of the non-exhaustive pattern
  --> rustls/src/versions.rs:11:1
   |
11 |   pub struct SupportedProtocolVersion {
   |   ^----------------------------------
   |   |
   |  _help: add the attribute: `#[non_exhaustive] pub struct SupportedProtocolVersion`
   | |
12 | |     /// The TLS enumeration naming this version.
13 | |     pub version: ProtocolVersion,
14 | |     is_private: (),
15 | | }
   | |_^
   |
help: remove this field
  --> rustls/src/versions.rs:14:5
   |
14 |     is_private: (),
   |     ^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_non_exhaustive
   = note: `#[warn(clippy::manual_non_exhaustive)]` on by default
```