### PR TITLE
Re-export the types crate contents

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -61,5 +61,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
+    "rustls_pki_types",
     "rustls_pki_types::*",
 ]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -532,6 +532,11 @@ pub mod version {
     pub use crate::versions::TLS13;
 }
 
+/// Re-exports the contents of rustls-pki-types crate for easy access
+pub mod pki_types {
+    pub use pki_types::*;
+}
+
 /// Message signing interfaces.
 pub mod sign {
     pub use crate::crypto::signer::{CertifiedKey, Signer, SigningKey};


### PR DESCRIPTION
Fixes #1662. (I think this should be on the list for backporting to 0.22.1.)