### PR TITLE
v0.22.1 preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1752,7 +1752,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.22.0",
+ "rustls 0.22.1",
  "rustls-pemfile 2.0.0",
  "rustls-pki-types",
 ]
@@ -1764,7 +1764,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring 0.17.6",
- "rustls 0.22.0",
+ "rustls 0.22.1",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.22.0",
+ "rustls 0.22.1",
  "rustls-pemfile 2.0.0",
  "rustls-pki-types",
  "serde",
@@ -1827,7 +1827,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.22.0",
+ "rustls 0.22.1",
  "rustls-pki-types",
  "rustls-webpki 0.102.0",
  "serde",

--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -1,6 +1,6 @@
 use std::{fs, io};
 
-use pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum KeyType {

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -13,9 +13,11 @@ use std::time::Duration;
 use std::{fs, thread};
 
 use docopt::Docopt;
-use pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use serde_derive::Deserialize;
 
+use rustls::pki_types::{
+    CertificateDer, CertificateRevocationListDer, PrivateKeyDer, PrivatePkcs8KeyDer,
+};
 use rustls::server::{Acceptor, ClientHello, ServerConfig, WebPkiClientVerifier};
 use rustls::RootCertStore;
 

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -2,8 +2,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use pki_types::ServerName;
-
+use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
 
 fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str) {

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -5,10 +5,10 @@ use std::{fs, process, str};
 
 use docopt::Docopt;
 use mio::net::TcpStream;
-use pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 use serde::Deserialize;
 
 use rustls::crypto::CryptoProvider;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 use rustls::RootCertStore;
 
 const CLIENT: mio::Token = mio::Token(0);

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -6,10 +6,10 @@ use std::{fs, net};
 use docopt::Docopt;
 use log::{debug, error};
 use mio::net::{TcpListener, TcpStream};
-use pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use serde::Deserialize;
 
 use rustls::crypto::{ring, CryptoProvider};
+use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use rustls::server::WebPkiClientVerifier;
 use rustls::{self, RootCertStore};
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "log",
  "ring",

--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -9,17 +9,18 @@ use rustls::internal::record_layer::RecordLayer;
 use std::io;
 
 fuzz_target!(|data: &[u8]| {
+    let mut buf = deframer::DeframerVecBuffer::default();
     let mut dfm = deframer::MessageDeframer::default();
     if dfm
-        .read(&mut io::Cursor::new(data))
+        .read(&mut io::Cursor::new(data), &mut buf)
         .is_err()
     {
         return;
     }
-    dfm.has_pending();
+    buf.has_pending();
 
     let mut rl = RecordLayer::new();
-    while let Ok(Some(decrypted)) = dfm.pop(&mut rl, None) {
+    while let Ok(Some(decrypted)) = dfm.pop(&mut rl, None, &mut buf) {
         Message::try_from(decrypted.message).ok();
     }
 });

--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -20,7 +20,10 @@ fuzz_target!(|data: &[u8]| {
     buf.has_pending();
 
     let mut rl = RecordLayer::new();
-    while let Ok(Some(decrypted)) = dfm.pop(&mut rl, None, &mut buf) {
+    let mut borrowed_buf = buf.borrow();
+    while let Ok(Some(decrypted)) = dfm.pop(&mut rl, None, &mut borrowed_buf) {
         Message::try_from(decrypted.message).ok();
     }
+    let discard = borrowed_buf.pending_discard();
+    buf.discard(discard);
 });

--- a/fuzz/fuzzers/server_name.rs
+++ b/fuzz/fuzzers/server_name.rs
@@ -3,7 +3,7 @@
 extern crate libfuzzer_sys;
 extern crate rustls;
 
-use pki_types::ServerName;
+use rustls::pki_types::ServerName;
 
 fuzz_target!(|data: &[u8]| {
     let _ = std::str::from_utf8(data)

--- a/provider-example/examples/server.rs
+++ b/provider-example/examples/server.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::sync::Arc;
 
-use pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::Acceptor;
 use rustls::ServerConfig;
 

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use pki_types::PrivateKeyDer;
 use rustls::crypto::CryptoProvider;
+use rustls::pki_types::PrivateKeyDer;
 
 mod aead;
 mod hash;

--- a/provider-example/src/sign.rs
+++ b/provider-example/src/sign.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use pkcs8::DecodePrivateKey;
-use pki_types::PrivateKeyDer;
+use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
 use signature::{RandomizedSigner, SignatureEncoding};

--- a/provider-example/src/verify.rs
+++ b/provider-example/src/verify.rs
@@ -1,8 +1,8 @@
 use der::Reader;
-use pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
 use rsa::signature::Verifier;
 use rsa::{pkcs1v15, pss, BigUint, RsaPublicKey};
 use rustls::crypto::WebPkiSupportedAlgorithms;
+use rustls::pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
 use rustls::SignatureScheme;
 use webpki::alg_id;
 

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -61,5 +61,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
+    "rustls_pki_types",
     "rustls_pki_types::*",
 ]

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1040,6 +1040,18 @@ impl State<ClientConnectionData> for ExpectFinished {
             _fin_verified,
         }))
     }
+
+    // we could not decrypt the encrypted handshake message with session resumption
+    // this might mean that the ticket was invalid for some reason, so we remove it
+    // from the store to restart a session from scratch
+    fn handle_decrypt_error(&self) {
+        if self.resuming {
+            self.config
+                .resumption
+                .store
+                .remove_tls12_session(&self.server_name);
+        }
+    }
 }
 
 // -- Traffic transit state --

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -630,6 +630,8 @@ pub(crate) trait State<Data>: Send + Sync {
     fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
         Err(Error::HandshakeNotComplete)
     }
+
+    fn handle_decrypt_error(&self) {}
 }
 
 pub(crate) struct Context<'a, Data> {

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -3,7 +3,7 @@ use crate::enums::{AlertDescription, ContentType};
 use crate::error::{Error, PeerMisbehaved};
 #[cfg(feature = "logging")]
 use crate::log::trace;
-use crate::msgs::deframer::{Deframed, MessageDeframer};
+use crate::msgs::deframer::{Deframed, DeframerVecBuffer, MessageDeframer};
 use crate::msgs::handshake::Random;
 use crate::msgs::message::{Message, MessagePayload, PlainMessage};
 use crate::suites::{ExtractedSecrets, PartiallyExtractedSecrets};
@@ -328,6 +328,7 @@ fn is_valid_ccs(msg: &PlainMessage) -> bool {
 /// Interface shared by client and server connections.
 pub struct ConnectionCommon<Data> {
     pub(crate) core: ConnectionCore<Data>,
+    deframer_buffer: DeframerVecBuffer,
 }
 
 impl<Data> ConnectionCommon<Data> {
@@ -339,7 +340,7 @@ impl<Data> ConnectionCommon<Data> {
             // Are we done? i.e., have we processed all received messages, and received a
             // close_notify to indicate that no new messages will arrive?
             peer_cleanly_closed: common.has_received_close_notify
-                && !self.core.message_deframer.has_pending(),
+                && !self.deframer_buffer.has_pending(),
             has_seen_eof: common.has_seen_eof,
         }
     }
@@ -453,7 +454,7 @@ impl<Data> ConnectionCommon<Data> {
     pub(crate) fn first_handshake_message(&mut self) -> Result<Option<Message>, Error> {
         match self
             .core
-            .deframe(None)?
+            .deframe(None, &mut self.deframer_buffer)?
             .map(Message::try_from)
         {
             Some(Ok(msg)) => Ok(Some(msg)),
@@ -486,7 +487,8 @@ impl<Data> ConnectionCommon<Data> {
     /// [`process_new_packets`]: Connection::process_new_packets
     #[inline]
     pub fn process_new_packets(&mut self) -> Result<IoState, Error> {
-        self.core.process_new_packets()
+        self.core
+            .process_new_packets(&mut self.deframer_buffer)
     }
 
     /// Read TLS content from `rd` into the internal buffer.
@@ -516,7 +518,10 @@ impl<Data> ConnectionCommon<Data> {
             ));
         }
 
-        let res = self.core.message_deframer.read(rd);
+        let res = self
+            .core
+            .message_deframer
+            .read(rd, &mut self.deframer_buffer);
         if let Ok(0) = res {
             self.has_seen_eof = true;
         }
@@ -605,7 +610,10 @@ impl<T> DerefMut for ConnectionCommon<T> {
 
 impl<Data> From<ConnectionCore<Data>> for ConnectionCommon<Data> {
     fn from(core: ConnectionCore<Data>) -> Self {
-        Self { core }
+        Self {
+            core,
+            deframer_buffer: DeframerVecBuffer::default(),
+        }
     }
 }
 
@@ -626,7 +634,10 @@ impl<Data> ConnectionCore<Data> {
         }
     }
 
-    pub(crate) fn process_new_packets(&mut self) -> Result<IoState, Error> {
+    pub(crate) fn process_new_packets(
+        &mut self,
+        deframer_buffer: &mut DeframerVecBuffer,
+    ) -> Result<IoState, Error> {
         let mut state = match mem::replace(&mut self.state, Err(Error::HandshakeNotComplete)) {
             Ok(state) => state,
             Err(e) => {
@@ -635,7 +646,7 @@ impl<Data> ConnectionCore<Data> {
             }
         };
 
-        while let Some(msg) = self.deframe(Some(&*state))? {
+        while let Some(msg) = self.deframe(Some(&*state), deframer_buffer)? {
             match self.process_msg(msg, state) {
                 Ok(new) => state = new,
                 Err(e) => {
@@ -650,10 +661,15 @@ impl<Data> ConnectionCore<Data> {
     }
 
     /// Pull a message out of the deframer and send any messages that need to be sent as a result.
-    fn deframe(&mut self, state: Option<&dyn State<Data>>) -> Result<Option<PlainMessage>, Error> {
+    fn deframe(
+        &mut self,
+        state: Option<&dyn State<Data>>,
+        deframer_buffer: &mut DeframerVecBuffer,
+    ) -> Result<Option<PlainMessage>, Error> {
         match self.message_deframer.pop(
             &mut self.common_state.record_layer,
             self.common_state.negotiated_version,
+            deframer_buffer,
         ) {
             Ok(Some(Deframed {
                 want_close_before_decrypt,

--- a/rustls/src/crypto/aws_lc_rs/tls13.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls13.rs
@@ -222,6 +222,8 @@ impl MessageEncrypter for AeadMessageEncrypter {
 
         Ok(OpaqueMessage::new(
             ContentType::ApplicationData,
+            // Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
+            // protocol version, see https://www.rfc-editor.org/rfc/rfc8446#section-5.1
             ProtocolVersion::TLSv1_2,
             payload,
         ))

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -194,6 +194,8 @@ impl MessageEncrypter for Tls13MessageEncrypter {
 
         Ok(OpaqueMessage::new(
             ContentType::ApplicationData,
+            // Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
+            // protocol version, see https://www.rfc-editor.org/rfc/rfc8446#section-5.1
             ProtocolVersion::TLSv1_2,
             payload,
         ))

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -393,7 +393,7 @@ pub mod internal {
             pub use crate::msgs::codec::{Codec, Reader};
         }
         pub mod deframer {
-            pub use crate::msgs::deframer::MessageDeframer;
+            pub use crate::msgs::deframer::{DeframerVecBuffer, MessageDeframer};
         }
         pub mod enums {
             pub use crate::msgs::enums::{

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -532,6 +532,11 @@ pub mod version {
     pub use crate::versions::TLS13;
 }
 
+/// Re-exports the contents of rustls-pki-types crate for easy access
+pub mod pki_types {
+    pub use pki_types::*;
+}
+
 /// Message signing interfaces.
 pub mod sign {
     pub use crate::crypto::signer::{CertifiedKey, Signer, SigningKey};

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -532,7 +532,7 @@ pub mod version {
     pub use crate::versions::TLS13;
 }
 
-/// Re-exports the contents of rustls-pki-types crate for easy access
+/// Re-exports the contents of the [rustls-pki-types](https://docs.rs/rustls-pki-types) crate for easy access
 pub mod pki_types {
     pub use pki_types::*;
 }

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -723,11 +723,7 @@ mod tests {
     }
 
     fn assert_len(want: usize, got: io::Result<usize>) {
-        if let Ok(gotval) = got {
-            assert_eq!(gotval, want);
-        } else {
-            panic!("read failed, expected {:?} bytes", want);
-        }
+        assert_eq!(Some(want), got.ok())
     }
 
     fn pop_first(d: &mut MessageDeframer, rl: &mut RecordLayer) {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -6,6 +6,7 @@ use crate::crypto::cipher::{AeadKey, Iv};
 use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock};
 use crate::enums::{AlertDescription, ProtocolVersion};
 use crate::error::Error;
+use crate::msgs::deframer::DeframerVecBuffer;
 use crate::msgs::handshake::{ClientExtension, ServerExtension};
 use crate::server::{ServerConfig, ServerConnectionData};
 use crate::tls13::key_schedule::{
@@ -314,6 +315,7 @@ impl From<ServerConnection> for Connection {
 /// A shared interface for QUIC connections.
 pub struct ConnectionCommon<Data> {
     core: ConnectionCore<Data>,
+    deframer_buffer: DeframerVecBuffer,
 }
 
 impl<Data: SideData> ConnectionCommon<Data> {
@@ -356,10 +358,13 @@ impl<Data: SideData> ConnectionCommon<Data> {
     ///
     /// Handshake data obtained from separate encryption levels should be supplied in separate calls.
     pub fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), Error> {
+        self.core.message_deframer.push(
+            ProtocolVersion::TLSv1_3,
+            plaintext,
+            &mut self.deframer_buffer,
+        )?;
         self.core
-            .message_deframer
-            .push(ProtocolVersion::TLSv1_3, plaintext)?;
-        self.core.process_new_packets()?;
+            .process_new_packets(&mut self.deframer_buffer)?;
         Ok(())
     }
 
@@ -397,7 +402,10 @@ impl<Data> DerefMut for ConnectionCommon<Data> {
 
 impl<Data> From<ConnectionCore<Data>> for ConnectionCommon<Data> {
     fn from(core: ConnectionCore<Data>) -> Self {
-        Self { core }
+        Self {
+            core,
+            deframer_buffer: DeframerVecBuffer::default(),
+        }
     }
 }
 

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -587,7 +587,7 @@ pub trait Algorithm: Send + Sync {
 }
 
 /// A QUIC header protection key
-pub trait HeaderProtectionKey {
+pub trait HeaderProtectionKey: Send + Sync {
     /// Adds QUIC Header Protection.
     ///
     /// `sample` must contain the sample of encrypted payload; see
@@ -648,7 +648,7 @@ pub trait HeaderProtectionKey {
 }
 
 /// Keys to encrypt or decrypt the payload of a packet
-pub trait PacketKey {
+pub trait PacketKey: Send + Sync {
     /// Encrypt a QUIC packet
     ///
     /// Takes a `packet_number`, used to derive the nonce; the packet `header`, which is used as
@@ -892,5 +892,19 @@ impl Version {
 impl Default for Version {
     fn default() -> Self {
         Self::V1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::quic::HeaderProtectionKey;
+
+    use super::PacketKey;
+
+    #[test]
+    fn auto_traits() {
+        fn assert_auto<T: Send + Sync>() {}
+        assert_auto::<Box<dyn PacketKey>>();
+        assert_auto::<Box<dyn HeaderProtectionKey>>();
     }
 }

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -54,12 +54,6 @@ pub enum SupportedCipherSuite {
     Tls13(&'static Tls13CipherSuite),
 }
 
-impl fmt::Debug for SupportedCipherSuite {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.suite().fmt(f)
-    }
-}
-
 impl SupportedCipherSuite {
     /// The cipher suite's identifier
     pub fn suite(&self) -> CipherSuite {
@@ -122,6 +116,12 @@ impl SupportedCipherSuite {
                 .and_then(|cs| cs.quic)
                 .is_some(),
         }
+    }
+}
+
+impl fmt::Debug for SupportedCipherSuite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.suite().fmt(f)
     }
 }
 

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -149,7 +149,7 @@ pub trait ClientCertVerifier: Debug + Send + Sync {
 
     /// Return `true` to require a client certificate and `false` to make
     /// client authentication optional.
-    /// Defaults to `Some(self.offer_client_auth())`.
+    /// Defaults to `self.offer_client_auth()`.
     fn client_auth_mandatory(&self) -> bool {
         self.offer_client_auth()
     }


### PR DESCRIPTION
## Description

This branch targets the [`rel-0.22`](https://github.com/rustls/rustls/tree/rel-0.22) feature branch, which was created at commit [e051f5c](https://github.com/rustls/rustls/commit/e051f5c1723511a7413a621051e192405387190c) - the last semver compatible update to `main` after the `0.22` release.

It brings in the following PRs since then:
* https://github.com/rustls/rustls/pull/1669
* https://github.com/rustls/rustls/pull/1668
* https://github.com/rustls/rustls/pull/1671
* https://github.com/rustls/rustls/pull/1674
* https://github.com/rustls/rustls/pull/1595
* https://github.com/rustls/rustls/pull/1665
* https://github.com/rustls/rustls/pull/1679

It skips these PRs from main that I believe are semver incompatible:
* https://github.com/rustls/rustls/pull/1636
* https://github.com/rustls/rustls/pull/1670
* https://github.com/rustls/rustls/pull/1672
* https://github.com/rustls/rustls/pull/1673

## Proposed Release Notes

* TLS 1.2 servers now remove session tickets after observing a failure to decrypt, preventing future resumption with the same unusable ticket.
* The `rustls_pki_types` crate is now re-exported as `rustls::pki_types`.
* The crate examples examples have been updated to use the `rustls::pki_types` re-export.
* The `quic::PacketKey` and `quic::HeaderProtectionKey` traits are now `Send + Sync`.
* Performance improvements to the `MessageDeframer` internals.
* Small documentation improvements.
