### PR TITLE
no-std support phase II

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,10 @@ jobs:
         run: cargo build --locked --no-default-features --target x86_64-unknown-none
         working-directory: rustls
 
+      - name: cargo build (debug; no default features; no-std, hashbrown)
+        run: cargo build --locked --no-default-features --features hashbrown --target x86_64-unknown-none
+        working-directory: rustls
+
       - name: cargo test (debug; default features)
         run: cargo test --locked
         working-directory: rustls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1140,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -1331,7 +1352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2157,6 +2178,7 @@ dependencies = [
  "base64 0.22.0",
  "bencher",
  "env_logger",
+ "hashbrown 0.13.2",
  "log",
  "num-bigint",
  "once_cell",
@@ -3077,6 +3099,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
 ]
 
 [[package]]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -17,6 +17,7 @@ rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
 aws-lc-rs = { version = "1.6", optional = true, default-features = false, features = ["aws-lc-sys"] }
+hashbrown = { version = "0.13", optional = true } # 0.14+ requires 1.63 MSRV
 log = { version = "0.4.4", optional = true }
 # remove once our MSRV is >= 1.70
 once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -34,14 +34,14 @@ impl client::ClientSessionStore for NoClientSessionStorage {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 mod cache {
     use alloc::collections::VecDeque;
     use core::fmt;
-    use std::sync::Mutex;
 
     use pki_types::ServerName;
 
+    use crate::lock::Mutex;
     use crate::msgs::persist;
     use crate::{limited_cache, NamedGroup};
 
@@ -80,11 +80,23 @@ mod cache {
     impl ClientSessionMemoryCache {
         /// Make a new ClientSessionMemoryCache.  `size` is the
         /// maximum number of stored sessions.
+        #[cfg(feature = "std")]
         pub fn new(size: usize) -> Self {
             let max_servers = size.saturating_add(MAX_TLS13_TICKETS_PER_SERVER - 1)
                 / MAX_TLS13_TICKETS_PER_SERVER;
             Self {
                 servers: Mutex::new(limited_cache::LimitedCache::new(max_servers)),
+            }
+        }
+
+        /// Make a new ClientSessionMemoryCache.  `size` is the
+        /// maximum number of stored sessions.
+        #[cfg(not(feature = "std"))]
+        pub fn new<M: crate::lock::MakeMutex>(size: usize) -> Self {
+            let max_servers = size.saturating_add(MAX_TLS13_TICKETS_PER_SERVER - 1)
+                / MAX_TLS13_TICKETS_PER_SERVER;
+            Self {
+                servers: Mutex::new::<M>(limited_cache::LimitedCache::new(max_servers)),
             }
         }
     }
@@ -180,7 +192,7 @@ mod cache {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 pub use cache::ClientSessionMemoryCache;
 
 #[derive(Debug)]

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -26,7 +26,7 @@ pub(crate) mod hash;
 pub(crate) mod kx;
 #[path = "../ring/quic.rs"]
 pub(crate) mod quic;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 #[path = "../ring/ticketer.rs"]
 pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
@@ -222,7 +222,7 @@ pub mod kx_group {
 }
 
 pub use kx::ALL_KX_GROUPS;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 pub use ticketer::Ticketer;
 
 use super::SupportedKxGroup;
@@ -243,7 +243,7 @@ mod ring_shim {
 }
 
 /// AEAD algorithm that is used by `mod ticketer`.
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::AES_256_GCM;
 
 /// Are we in FIPS mode?

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod hash;
 pub(crate) mod hmac;
 pub(crate) mod kx;
 pub(crate) mod quic;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
 pub(crate) mod tls12;
@@ -170,7 +170,7 @@ pub mod kx_group {
 }
 
 pub use kx::ALL_KX_GROUPS;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 pub use ticketer::Ticketer;
 
 /// Compatibility shims between ring 0.16.x and 0.17.x API
@@ -190,7 +190,7 @@ mod ring_shim {
 }
 
 /// AEAD algorithm that is used by `mod ticketer`.
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::CHACHA20_POLY1305;
 
 pub(super) fn fips() -> bool {

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -22,10 +22,26 @@ impl Ticketer {
     ///
     /// The encryption mechanism used is injected via TICKETER_AEAD;
     /// it must take a 256-bit key and 96-bit nonce.
+    #[cfg(feature = "std")]
     pub fn new() -> Result<Arc<dyn ProducesTickets>, Error> {
         Ok(Arc::new(crate::ticketer::TicketSwitcher::new(
             6 * 60 * 60,
             make_ticket_generator,
+        )?))
+    }
+
+    /// Make the recommended Ticketer.  This produces tickets
+    /// with a 12 hour life and randomly generated keys.
+    ///
+    /// The encryption mechanism used is Chacha20Poly1305.
+    #[cfg(not(feature = "std"))]
+    pub fn new<M: crate::lock::MakeMutex>(
+        time_provider: &'static dyn TimeProvider,
+    ) -> Result<Arc<dyn ProducesTickets>, Error> {
+        Ok(Arc::new(crate::ticketer::TicketSwitcher::new::<M>(
+            6 * 60 * 60,
+            make_ticket_generator,
+            time_provider,
         )?))
     }
 }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -389,7 +389,7 @@ mod conn;
 pub mod crypto;
 mod error;
 mod hash_hs;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 mod limited_cache;
 mod rand;
 mod record_layer;
@@ -582,7 +582,7 @@ pub mod server {
 
     pub use builder::WantsServerCert;
     pub use handy::NoServerSessionStorage;
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ResolvesServerCertUsingSni;
     #[cfg(feature = "std")]
     pub use handy::ServerSessionMemoryCache;
@@ -638,3 +638,16 @@ pub mod ticketer;
 pub mod manual;
 
 pub mod time_provider;
+
+#[cfg(any(feature = "std", feature = "hashbrown"))]
+mod hash_map {
+    #[cfg(feature = "std")]
+    pub(crate) use std::collections::hash_map::Entry;
+    #[cfg(feature = "std")]
+    pub(crate) use std::collections::HashMap;
+
+    #[cfg(all(not(feature = "std"), feature = "hashbrown"))]
+    pub(crate) use hashbrown::hash_map::Entry;
+    #[cfg(all(not(feature = "std"), feature = "hashbrown"))]
+    pub(crate) use hashbrown::HashMap;
+}

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -521,7 +521,7 @@ pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     CipherSuiteCommon, ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite,
 };
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 pub use crate::ticketer::TicketSwitcher;
 #[cfg(feature = "tls12")]
 pub use crate::tls12::Tls12CipherSuite;
@@ -548,7 +548,7 @@ pub mod client {
     };
     #[cfg(feature = "std")]
     pub use client_conn::{ClientConnection, WriteEarlyData};
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ClientSessionMemoryCache;
 
     /// Dangerous configuration that should be audited and used with extreme care.
@@ -584,7 +584,7 @@ pub mod server {
     pub use handy::NoServerSessionStorage;
     #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ResolvesServerCertUsingSni;
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ServerSessionMemoryCache;
     pub use server_conn::{
         Accepted, ClientHello, ProducesTickets, ResolvesServerCert, ServerConfig,
@@ -630,7 +630,7 @@ pub mod sign {
 /// APIs for implementing QUIC TLS
 pub mod quic;
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 /// APIs for implementing TLS tickets
 pub mod ticketer;
 
@@ -638,6 +638,9 @@ pub mod ticketer;
 pub mod manual;
 
 pub mod time_provider;
+
+/// APIs abstracting over locking primitives.
+pub mod lock;
 
 #[cfg(any(feature = "std", feature = "hashbrown"))]
 mod hash_map {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -405,6 +405,7 @@ mod verifybench;
 mod x509;
 #[macro_use]
 mod check;
+#[cfg(feature = "logging")]
 mod bs_debug;
 mod builder;
 mod enums;

--- a/rustls/src/limited_cache.rs
+++ b/rustls/src/limited_cache.rs
@@ -1,8 +1,8 @@
 use alloc::collections::VecDeque;
 use core::borrow::Borrow;
 use core::hash::Hash;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+
+use crate::hash_map::{Entry, HashMap};
 
 /// A HashMap-alike, which never gets larger than a specified
 /// capacity, and evicts the oldest insertion to maintain this.
@@ -19,7 +19,6 @@ pub(crate) struct LimitedCache<K: Clone + Hash + Eq, V> {
     oldest: VecDeque<K>,
 }
 
-#[cfg(feature = "std")]
 impl<K, V> LimitedCache<K, V>
 where
     K: Eq + Hash + Clone + core::fmt::Debug,
@@ -211,7 +210,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn test_get_or_insert_default_and_edit_evicts_old_items_to_meet_capacity() {
         let mut t = Test::new(3);
@@ -240,7 +238,6 @@ mod tests {
         assert_eq!(t.get("jkl"), None);
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn test_get_or_insert_default_and_edit_edits_existing_item() {
         let mut t = Test::new(3);

--- a/rustls/src/lock.rs
+++ b/rustls/src/lock.rs
@@ -1,0 +1,88 @@
+#[cfg(not(feature = "std"))]
+pub use no_std_lock::*;
+#[cfg(feature = "std")]
+pub use std_lock::*;
+
+#[cfg(feature = "std")]
+mod std_lock {
+    use std::sync::Mutex as StdMutex;
+    pub use std::sync::MutexGuard;
+
+    /// A wrapper around [`std::sync::Mutex`].
+    #[derive(Debug)]
+    pub struct Mutex<T> {
+        inner: std::sync::Mutex<T>,
+    }
+
+    impl<T> Mutex<T> {
+        /// Creates a new mutex in an unlocked state ready for use.
+        pub fn new(data: T) -> Self {
+            Self {
+                inner: StdMutex::new(data),
+            }
+        }
+
+        /// Acquires the mutex, blocking the current thread until it is able to do so.
+        ///
+        /// This will return `None` in the case the mutex is poisoned.
+        #[inline]
+        pub fn lock(&self) -> Option<MutexGuard<'_, T>> {
+            self.inner.lock().ok()
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod no_std_lock {
+    use alloc::boxed::Box;
+    use alloc::sync::Arc;
+    use core::fmt::Debug;
+    use core::ops::DerefMut;
+
+    #[derive(Debug)]
+    /// A no-std compatible wrapper around [`Lock`].
+    pub struct Mutex<T> {
+        inner: Arc<dyn Lock<T>>,
+    }
+
+    impl<T: Send + 'static> Mutex<T> {
+        /// Creates a new mutex in an unlocked state ready for use.
+        pub fn new<M>(val: T) -> Self
+        where
+            M: MakeMutex,
+            T: Send + 'static,
+        {
+            Self {
+                inner: M::make_mutex(val),
+            }
+        }
+
+        /// Acquires the mutex, blocking the current thread until it is able to do so.
+        ///
+        /// This will return `None` in the case the mutex is poisoned.
+        #[inline]
+        pub fn lock(&self) -> Option<MutexGuard<T>> {
+            self.inner.lock().ok()
+        }
+    }
+
+    /// A lock protecting shared data.
+    pub trait Lock<T>: Debug + Send + Sync {
+        /// Acquire the lock.
+        fn lock(&self) -> Result<MutexGuard<T>, Poisoned>;
+    }
+
+    /// A lock builder.                                                                                     
+    pub trait MakeMutex {
+        /// Create a new mutex.                                                                             
+        fn make_mutex<T>(value: T) -> Arc<dyn Lock<T>>
+        where
+            T: Send + 'static;
+    }
+
+    /// A no-std compatible mutex guard.
+    pub type MutexGuard<'a, T> = Box<dyn DerefMut<Target = T> + 'a>;
+
+    /// A marker type used to indicate `Lock::lock` failed due to a poisoned lock.
+    pub struct Poisoned;
+}

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -195,16 +195,16 @@ impl server::ResolvesServerCert for AlwaysResolvesChain {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 mod sni_resolver {
     use alloc::string::{String, ToString};
     use alloc::sync::Arc;
     use core::fmt::Debug;
-    use std::collections::HashMap;
 
     use pki_types::{DnsName, ServerName};
 
     use crate::error::Error;
+    use crate::hash_map::HashMap;
     use crate::server::ClientHello;
     use crate::webpki::{verify_server_name, ParsedCertificate};
     use crate::{server, sign};
@@ -295,7 +295,7 @@ mod sni_resolver {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hashbrown"))]
 pub use sni_resolver::ResolvesServerCertUsingSni;
 
 #[cfg(test)]

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -212,12 +212,15 @@ impl<'a> ClientHello<'a> {
 /// * [`ServerConfig::max_fragment_size`]: the default is `None` (meaning 16kB).
 /// * [`ServerConfig::session_storage`]: if the `std` feature is enabled, the default stores 256
 ///   sessions in memory. If the `std` feature is not enabled, the default is to not store any
-///   sessions.
+///   sessions. In a no-std context, by enabling the `hashbrown` feature you may provide your
+///   own `session_storage` using [`ServerSessionMemoryCache`] and a `crate::lock::MakeMutex`
+///   implementation.
 /// * [`ServerConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ServerConfig::key_log`]: key material is not logged.
 /// * [`ServerConfig::send_tls13_tickets`]: 4 tickets are sent.
 ///
 /// [`RootCertStore`]: crate::RootCertStore
+/// [`ServerSessionMemoryCache`]: crate::server::handy::ServerSessionMemoryCache
 #[derive(Debug)]
 pub struct ServerConfig {
     /// Source of randomness and other crypto.


### PR DESCRIPTION
This PR implements the second phase of no-std support described on [the RFC](https://github.com/rustls/rustls/pull/1399).

Part of the work here relies on using `hashbrown` as a no-std alternative to `std::collections::HashMap`. Which adds a new feature to `rustls` to avoid importing this dependency when std is available.

This continues from where https://github.com/rustls/rustls/pull/1502 left off.