### PR TITLE
examples: consistently document example program purpose

### DIFF
--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -1,3 +1,12 @@
+//! This is an example client that uses rustls for TLS, and sends early 0-RTT data.
+//!
+//! You may set the `SSLKEYLOGFILE` env var when using this example to write a
+//! log file with key material (insecure) for debugging purposes. See [`rustls::KeyLog`]
+//! for more information.
+//!
+//! Note that `unwrap()` is used to deal with networking errors; this is not something
+//! that is sensible outside of example code.
+
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::sync::Arc;

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -1,3 +1,24 @@
+//! This is an example client that uses rustls for TLS, and [mio] for I/O.
+//!
+//! It uses command line flags to demonstrate configuring a TLS client that may:
+//!  * Specify supported TLS protocol versions
+//!  * Customize ciper suite selection
+//!  * Perform client certificate authentication
+//!  * Disable session tickets
+//!  * Disable SNI
+//!  * Disable certificate validation (insecure)
+//!
+//! See [`USAGE`] for more details.
+//!
+//! You may set the `SSLKEYLOGFILE` env var when using this example to write a
+//! log file with key material (insecure) for debugging purposes. See [`rustls::KeyLog`]
+//! for more information.
+//!
+//! Note that `unwrap()` is used to deal with networking errors; this is not something
+//! that is sensible outside of example code.
+//!
+//! [mio]: https://docs.rs/mio/latest/mio/
+
 use std::io::{self, BufReader, Read, Write};
 use std::net::ToSocketAddrs;
 use std::sync::Arc;

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -1,3 +1,24 @@
+//! This is an example server that uses rustls for TLS, and [mio] for I/O.
+//!
+//! It uses command line flags to demonstrate configuring a TLS server that may:
+//!  * Specify supported TLS protocol versions
+//!  * Customize ciper suite selection
+//!  * Perform optional or mandatory client certificate authentication
+//!  * Check client certificates for revocation status with CRLs
+//!  * Support session tickets
+//!  * Staple an OCSP response
+//!
+//! See [`USAGE`] for more details.
+//!
+//! You may set the `SSLKEYLOGFILE` env var when using this example to write a
+//! log file with key material (insecure) for debugging purposes. See [`rustls::KeyLog`]
+//! for more information.
+//!
+//! Note that `unwrap()` is used to deal with networking errors; this is not something
+//! that is sensible outside of example code.
+//!
+//! [mio]: https://docs.rs/mio/latest/mio/
+
 use std::collections::HashMap;
 use std::io::{self, BufReader, Read, Write};
 use std::sync::Arc;


### PR DESCRIPTION
Adding an introductory Rustdoc comment to new examples was review feedback delivered in https://github.com/rustls/rustls/pull/1583, but we're not doing this consistently for all existing examples (💔). 

This branch addresses this oversight that by adding short intro documentation to `simple_0rtt_client.rs`, and the two MIO examples (`tlsclient-mio.rs` and `tlsserver-mio.rs`).