### PR TITLE
bench: remove cachegrind diff post-processing

### DIFF
--- a/ci-bench/src/cachegrind.rs
+++ b/ci-bench/src/cachegrind.rs
@@ -284,19 +284,8 @@ pub fn diff(baseline: &Path, candidate: &Path, scenario: &str) -> anyhow::Result
         )
     }
 
-    let annotated =
+    let diff =
         String::from_utf8(cg_annotate.stdout).context("cg_annotate produced invalid UTF8")?;
-
-    // Discard lines before the first `Ir` header
-    let mut diff = String::new();
-    for line in annotated
-        .trim()
-        .lines()
-        .skip_while(|l| l.trim() != "Ir")
-    {
-        diff.push_str(line);
-        diff.push('\n');
-    }
 
     fs::remove_file(tmp_path).ok();
 


### PR DESCRIPTION
This code was meant to strip unnecessary information from the start of a cachegrind diff. However, for some versions of cachegrind it results in a completely blank string. Instead of making it work for all cachegrind versions, it is probably better to get rid of it altogether (it does not make enough of a difference that the complexity of a proper solution would be worth it).