### PR TITLE
Condense the `fragment_slice` return type

### DIFF
--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -37,7 +37,7 @@ impl MessageFragmenter {
         typ: ContentType,
         version: ProtocolVersion,
         payload: &'a [u8],
-    ) -> impl Iterator<Item = BorrowedPlainMessage<'a>> + ExactSizeIterator + 'a {
+    ) -> impl ExactSizeIterator<Item = BorrowedPlainMessage<'a>> {
         payload
             .chunks(self.max_frag)
             .map(move |c| BorrowedPlainMessage {


### PR DESCRIPTION
This fixes a clippy warning that's being emitted on the most recent nightly:

```
error: this bound is already specified as the supertrait of `ExactSizeIterator`
  --> rustls/src/msgs/fragmenter.rs:40:15
   |
40 |     ) -> impl Iterator<Item = BorrowedPlainMessage<'a>> + ExactSizeIterator + 'a {
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#implied_bounds_in
_impls
   = note: `-D clippy::implied-bounds-in-impls` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::implied_bounds_in_impls)]`
help: try removing this bound
   |
40 -     ) -> impl Iterator<Item = BorrowedPlainMessage<'a>> + ExactSizeIterator + 'a {
40 +     ) -> impl ExactSizeIterator<Item = BorrowedPlainMessage<'a>> + 'a {
   |
```
