### PR TITLE
WASM support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,8 +992,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -31,6 +31,7 @@ aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 ring = ["dep:ring", "webpki/ring"]
 tls12 = []
 read_buf = ["rustversion"]
+wasm = ["ring/wasm32_unknown_unknown_js"]
 
 [dev-dependencies]
 base64 = "0.21"


### PR DESCRIPTION
Ring already has support for WASM, so this PR just adds a feature that enables the wasm32_unknown_unknown_js flag for that crate.