### PR TITLE
examples: add very simple server, README 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+# Rustls Examples
+
+This directory contains a number of examples that use Rustls.
+
+We recommend new users start by looking at `simpleclient.rs` and `simpleserver.rs`. Once those are understood, `tlsclient-mio.rs` and `tlsserver-mio.rs` provide more advanced examples.
+
+## Client examples
+
+* `simpleclient.rs` - shows a simple client configuration that uses sensible defaults. It demonstrates using the `Stream` helper to treat a Rustls connection as you would a bi-directional TCP stream.
+* `tlsclient-mio.rs` - shows a more complete client example that handles command line flags for customizing TLS options, and uses MIO to handle asynchronous I/O.
+* `limitedclient.rs` - shows how to configure Rustls so that unused cryptography is discarded by the linker. This client only supports TLS 1.3 and a single cipher suite.
+* `simple_0rtt_client.rs` - shows how to make a TLS 1.3 client connection that sends early 0RTT data.
+* `unbuffered-client.rs` - shows an advanced example of using Rustls lower-level APIs to implement a client that does not buffer any data inside Rustls.
+* `unbuffered-async-client.rs` - shows an advanced example of using Rustls lower-level APIs to implement a client that does not buffer any data inside Rustls, and that processes TLS events asynchronously.
+
+## Server examples
+
+* `simpleserver.rs` - shows a very minimal server example that accepts a single TLS connection. See `tlsserver-mio.rs` or `server_acceptor.rs` for a more realistic example.
+* `tlsserver-mio.rs` - shows a more complete server example that handles command line flags for customizing TLS options, and uses MIO to handle asynchronous I/O.
+* `server_acceptor.rs` - shows how to use the `Acceptor` API to create a server that generates a unique `ServerConfig` for each client. This example also shows how to use client authentication, CRL revocation checking, and uses `rcgen` to generate its own certificates.
+* `unbuffered-server.rs` - shows an advanced example of using Rustls lower-level APIs to implement a server that does not buffer any data inside Rustls.

--- a/examples/src/bin/simpleserver.rs
+++ b/examples/src/bin/simpleserver.rs
@@ -1,0 +1,51 @@
+//! This is the simplest possible server using rustls that does something useful:
+//! it accepts the default configuration, loads a server certificate and private key,
+//! and then accepts a single client connection.
+//!
+//! You must either set the CERTFILE and PRIV_KEY_FILE env vars to point to a server
+//! certificate and private key, or place 'localhost.pem' and 'localhost-key.pem' in
+//! the directory you run this example from.
+//!
+//! Note that `unwrap()` is used to deal with networking errors; this is not something
+//! that is sensible outside of example code.
+
+use std::error::Error as StdError;
+use std::fs::File;
+use std::io::{BufReader, Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+
+const CERTFILE: &str = match option_env!("CERTFILE") {
+    Some(certfile) => certfile,
+    None => "localhost.pem",
+};
+
+const PRIV_KEY_FILE: &str = match option_env!("PRIV_KEY_FILE") {
+    Some(priv_key_file) => priv_key_file,
+    None => "localhost-key.pem",
+};
+
+fn main() -> Result<(), Box<dyn StdError>> {
+    let certs = rustls_pemfile::certs(&mut BufReader::new(&mut File::open(CERTFILE)?))
+        .collect::<Result<Vec<_>, _>>()?;
+    let private_key =
+        rustls_pemfile::private_key(&mut BufReader::new(&mut File::open(PRIV_KEY_FILE)?))?.unwrap();
+    let config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, private_key)?;
+
+    let listener = TcpListener::bind(format!("[::]:{}", 4443)).unwrap();
+    let (mut stream, _) = listener.accept()?;
+
+    let mut conn = rustls::ServerConnection::new(Arc::new(config))?;
+    conn.complete_io(&mut stream)?;
+
+    conn.writer()
+        .write_all(b"Hello from the server")?;
+    conn.complete_io(&mut stream)?;
+    let mut buf = [0; 64];
+    let len = conn.reader().read(&mut buf)?;
+    println!("Received message from client: {:?}", &buf[..len]);
+
+    Ok(())
+}


### PR DESCRIPTION
In the process of reading through https://github.com/rustls/rustls/issues/1711 it occurred to me that while we have a very simple client example, we don't have a very simple server example.

This branch adapts the example written by @djc in that thread, and additionally adds a README describing the existing examples and providing guidance on which might be interesting to look at first.