### PR TITLE
Encrypted Client Hello support (client only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,6 +2273,7 @@ dependencies = [
  "async-std",
  "docopt",
  "env_logger",
+ "hickory-resolver",
  "log",
  "mio",
  "rcgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,17 +284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,14 +854,14 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1150,15 +1139,15 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
- "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -1199,60 +1188,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hickory-proto"
-version = "0.24.1"
-source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
-dependencies = [
- "async-recursion",
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "h2",
- "http",
- "idna",
- "ipnet",
- "once_cell",
- "rand",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "thiserror",
- "tinyvec",
- "tokio",
- "tokio-rustls",
- "tracing",
- "url",
- "webpki-roots 0.25.4",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.1"
-source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "resolv-conf",
- "rustls 0.21.12",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "tracing",
- "webpki-roots 0.25.4",
-]
 
 [[package]]
 name = "hkdf"
@@ -1332,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1346,6 +1281,17 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -1570,6 +1516,12 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -2048,7 +2000,7 @@ checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
 dependencies = [
  "aws-lc-rs",
  "pem",
- "ring",
+ "ring 0.17.8",
  "rustls-pki-types",
  "time",
  "yasna",
@@ -2110,6 +2062,21 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2198,14 +2165,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki 0.101.7",
+ "ring 0.16.20",
  "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -2224,10 +2191,10 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "rcgen",
- "ring",
+ "ring 0.17.8",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki",
  "rustversion",
  "serde",
  "serde_json",
@@ -2260,10 +2227,10 @@ dependencies = [
 name = "rustls-connect-tests"
 version = "0.0.1"
 dependencies = [
- "hickory-resolver",
  "regex",
- "ring",
+ "ring 0.17.8",
  "rustls 0.23.9",
+ "trust-dns-resolver",
 ]
 
 [[package]]
@@ -2273,7 +2240,6 @@ dependencies = [
  "async-std",
  "docopt",
  "env_logger",
- "hickory-resolver",
  "log",
  "mio",
  "rcgen",
@@ -2283,6 +2249,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "tokio",
+ "trust-dns-resolver",
  "webpki-roots 0.26.2",
 ]
 
@@ -2354,7 +2321,7 @@ dependencies = [
  "rsa",
  "rustls 0.23.9",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki",
  "sha2",
  "signature",
  "webpki-roots 0.26.2",
@@ -2374,22 +2341,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "aws-lc-rs",
- "ring",
+ "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -2418,7 +2375,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
+ "ring 0.17.8",
  "untrusted 0.9.0",
 ]
 
@@ -2710,12 +2667,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.21.12",
+ "rustls 0.20.9",
  "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -2760,6 +2718,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.22.0"
+source = "git+https://github.com/cpu/trust-dns?rev=9888378726ada266c1a6ac6b2630c2249f3f62cf#9888378726ada266c1a6ac6b2630c2249f3f62cf"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "http",
+ "idna 0.2.3",
+ "ipnet",
+ "lazy_static",
+ "rand",
+ "rustls 0.20.9",
+ "rustls-pemfile 1.0.4",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+ "webpki",
+ "webpki-roots 0.22.6",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.22.0"
+source = "git+https://github.com/cpu/trust-dns?rev=9888378726ada266c1a6ac6b2630c2249f3f62cf#9888378726ada266c1a6ac6b2630c2249f3f62cf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "lru-cache",
+ "parking_lot",
+ "resolv-conf",
+ "rustls 0.20.9",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "trust-dns-proto",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -2818,7 +2830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
 ]
 
@@ -2935,10 +2947,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "webpki"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,15 +1150,15 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -1192,9 +1203,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hickory-proto"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
 dependencies = [
+ "async-recursion",
  "async-trait",
  "bytes",
  "cfg-if",
@@ -1205,7 +1216,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http",
- "idna 0.4.0",
+ "idna",
  "ipnet",
  "once_cell",
  "rand",
@@ -1223,8 +1234,7 @@ dependencies = [
 [[package]]
 name = "hickory-resolver"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1322,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -1336,16 +1346,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -2817,7 +2817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ lto = true
 [patch.crates-io]
 # TODO(XXX): Remove this once 0.25 is released - we want the ECH fixes from
 #            https://github.com/hickory-dns/hickory-dns/pull/2183
-hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "6334a01430088ead8642cafaee592ec7bf49831f" }
+trust-dns-resolver = { git = "https://github.com/cpu/trust-dns", rev = "9888378726ada266c1a6ac6b2630c2249f3f62cf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,8 @@ resolver = "2"
 [profile.bench]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+# TODO(XXX): Remove this once 0.25 is released - we want the ECH fixes from
+#            https://github.com/hickory-dns/hickory-dns/pull/2183
+hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "6334a01430088ead8642cafaee592ec7bf49831f" }

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -28,7 +28,27 @@
     "ClientOCSPCallback*": "ocsp not supported yet",
     "ServerOCSPCallback*": "",
     "DuplicateCertCompressionExt*-TLS12": "RFC8879: if TLS 1.2 or earlier is negotiated, the peers MUST ignore this extension",
-    "TLS-ECH-*": "",
+#if defined(RING)
+    "TLS-ECH-*": "*ring* has no HPKE provider for ECH",
+#elif defined(AWS_LC_RS) && defined(FIPS)
+    "TLS-ECH-*": "ECH test suites use non-FIPS approved algos",
+#else
+    "TLS-ECH-Server*": "ECH server support NYI",
+    "TLS-ECH-Client-ExpectECHOuterExtensions": "ECH extension compression NYI",
+    "TLS-ECH-Client-CompressSupportedVersions": "ECH extension compression NYI",
+    "TLS-ECH-Client-SelectECHConfig": "TODO(XXX): re-enable after upstream bogo fix",
+    "TLS-ECH-Client-NoSupportedConfigs": "TODO(XXX): re-enable after upstream bogo fix",
+    "TLS-ECH-Client-SkipInvalidPublicName*": "we allow underscore names, don't fallback on no ECH configs",
+    "TLS-ECH-Client-NoSupportedConfigs-GREASE": "we don't fallback to GREASE for no ECH configs",
+    "TLS-ECH-Client-TLS12-RejectRetryConfigs": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-NoClientCertificate-TLS12": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-TLS12": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-ResumeInnerSession-TLS12": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-GREASE-Client-TLS12-RejectRetryConfigs": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-EarlyDataRejected-TLS12": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-NoClientCertificate-TLS12-Async": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-ResumeInnerSession-TLS13": "assumes no outter GREASE PSK, we send GREASE PSK",
+#endif
     "ALPS-*": "",
     "*Kyber*": "",
     "ExtraClientEncryptedExtension-*": "we don't implement ALPS",

--- a/bogo/runme
+++ b/bogo/runme
@@ -5,7 +5,7 @@
 
 set -xe
 
-case ${BOGO_SHIM_PROVIDER:-ring} in
+case ${BOGO_SHIM_PROVIDER:-aws-lc-rs} in
   ring)
       cargo build -p rustls --example bogo_shim $(../admin/all-features-except aws-lc-rs,aws_lc_rs,fips rustls)
       cpp -P -DRING config.json.in > config.json

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 rustls = { path = "../rustls", features = [ "logging" ]}
 
 [dev-dependencies]
-hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
+trust-dns-resolver = { version = "0.22", features = ["dns-over-https-rustls", "webpki-roots"] }
 regex = "1.0"
 ring = "0.17"

--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -5,7 +5,7 @@ mod ech_config {
     use hickory_resolver::Resolver;
     use rustls::internal::msgs::codec::{Codec, Reader};
     use rustls::internal::msgs::enums::EchVersion;
-    use rustls::internal::msgs::handshake::EchConfig;
+    use rustls::internal::msgs::handshake::EchConfigPayload;
 
     #[test]
     fn cloudflare() {
@@ -27,7 +27,7 @@ mod ech_config {
         let resolver =
             Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
         let raw_value = lookup_ech(&resolver, domain);
-        let parsed_config = EchConfig::read(&mut Reader::init(&raw_value))
+        let parsed_config = EchConfigPayload::read(&mut Reader::init(&raw_value))
             .expect("failed to deserialize ECH config");
         assert_eq!(parsed_config.version, EchVersion::V14);
     }

--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -4,7 +4,6 @@ mod ech_config {
     use hickory_resolver::proto::rr::{RData, RecordType};
     use hickory_resolver::Resolver;
     use rustls::internal::msgs::codec::{Codec, Reader};
-    use rustls::internal::msgs::enums::EchVersion;
     use rustls::internal::msgs::handshake::EchConfigPayload;
     use rustls::pki_types::EchConfigListBytes;
 
@@ -33,7 +32,7 @@ mod ech_config {
         assert!(!parsed_configs.is_empty());
         assert!(parsed_configs
             .iter()
-            .all(|config| config.version == EchVersion::V14));
+            .all(|config| matches!(config, EchConfigPayload::V18(_))));
     }
 
     /// Use `resolver` to make an HTTPS record type query for `domain`, returning the

--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -1,11 +1,11 @@
 mod ech_config {
-    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-    use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
-    use hickory_resolver::proto::rr::{RData, RecordType};
-    use hickory_resolver::Resolver;
     use rustls::internal::msgs::codec::{Codec, Reader};
     use rustls::internal::msgs::handshake::EchConfigPayload;
     use rustls::pki_types::EchConfigListBytes;
+    use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+    use trust_dns_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
+    use trust_dns_resolver::proto::rr::{RData, RecordType};
+    use trust_dns_resolver::Resolver;
 
     #[test]
     fn cloudflare() {
@@ -24,8 +24,7 @@ mod ech_config {
 
     /// Lookup the ECH config list for a domain and deserialize it.
     fn test_deserialize_ech_config_list(domain: &str) {
-        let resolver =
-            Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
+        let resolver = Resolver::new(ResolverConfig::google(), ResolverOpts::default()).unwrap();
         let tls_encoded_list = lookup_ech(&resolver, domain);
         let parsed_configs = Vec::<EchConfigPayload>::read(&mut Reader::init(&tls_encoded_list))
             .expect("failed to deserialize ECH config list");

--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -6,35 +6,39 @@ mod ech_config {
     use rustls::internal::msgs::codec::{Codec, Reader};
     use rustls::internal::msgs::enums::EchVersion;
     use rustls::internal::msgs::handshake::EchConfigPayload;
+    use rustls::pki_types::EchConfigListBytes;
 
     #[test]
     fn cloudflare() {
-        test_deserialize_ech_config("crypto.cloudflare.com");
+        test_deserialize_ech_config_list("crypto.cloudflare.com");
     }
 
     #[test]
     fn defo_ie() {
-        test_deserialize_ech_config("defo.ie");
+        test_deserialize_ech_config_list("defo.ie");
     }
 
     #[test]
     fn tls_ech_dev() {
-        test_deserialize_ech_config("tls-ech.dev");
+        test_deserialize_ech_config_list("tls-ech.dev");
     }
 
-    /// Lookup the ECH config for a domain and deserialize it.
-    fn test_deserialize_ech_config(domain: &str) {
+    /// Lookup the ECH config list for a domain and deserialize it.
+    fn test_deserialize_ech_config_list(domain: &str) {
         let resolver =
             Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
-        let raw_value = lookup_ech(&resolver, domain);
-        let parsed_config = EchConfigPayload::read(&mut Reader::init(&raw_value))
-            .expect("failed to deserialize ECH config");
-        assert_eq!(parsed_config.version, EchVersion::V14);
+        let tls_encoded_list = lookup_ech(&resolver, domain);
+        let parsed_configs = Vec::<EchConfigPayload>::read(&mut Reader::init(&tls_encoded_list))
+            .expect("failed to deserialize ECH config list");
+        assert!(!parsed_configs.is_empty());
+        assert!(parsed_configs
+            .iter()
+            .all(|config| config.version == EchVersion::V14));
     }
 
     /// Use `resolver` to make an HTTPS record type query for `domain`, returning the
     /// first SvcParam EchConfig value found, panicing if none are returned.
-    fn lookup_ech(resolver: &Resolver, domain: &str) -> Vec<u8> {
+    fn lookup_ech(resolver: &Resolver, domain: &str) -> EchConfigListBytes<'static> {
         resolver
             .lookup(domain, RecordType::HTTPS)
             .expect("failed to lookup HTTPS record type")
@@ -44,11 +48,14 @@ mod ech_config {
                     .svc_params()
                     .iter()
                     .find_map(|sp| match sp {
-                        (SvcParamKey::EchConfig, SvcParamValue::EchConfig(e)) => Some(e.clone().0),
+                        (SvcParamKey::EchConfigList, SvcParamValue::EchConfigList(e)) => {
+                            Some(e.clone().0)
+                        }
                         _ => None,
                     }),
                 _ => None,
             })
             .expect("missing expected HTTPS SvcParam EchConfig record")
+            .into()
     }
 }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 docopt = "~1.1"
 env_logger = "0.10" # 0.11 requires 1.71 MSRV even as a dev-dep (due to manifest features)
-hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
+trust-dns-resolver = { version = "0.22", features = ["dns-over-https-rustls", "webpki-roots"] }
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 docopt = "~1.1"
 env_logger = "0.10" # 0.11 requires 1.71 MSRV even as a dev-dep (due to manifest features)
+hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -1,0 +1,102 @@
+//! This is a simple example demonstrating how to use Encrypted Client Hello (ECH) with
+//! rustls and hickory-dns.
+//!
+//! Note that `unwrap()` is used to deal with networking errors; this is not something
+//! that is sensible outside of example code.
+
+use std::io::{stdout, Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
+use hickory_resolver::proto::rr::{RData, RecordType};
+use hickory_resolver::Resolver;
+use rustls::client::EchConfig;
+use rustls::crypto::aws_lc_rs;
+use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
+use rustls::RootCertStore;
+
+fn main() {
+    // Find raw ECH configs using DNS-over-HTTPS with Hickory DNS:
+    let resolver = Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
+    let ech_config_list = lookup_ech_configs(&resolver, "defo.ie");
+
+    // NOTE: we defer setting up env_logger and setting the trace default filter level until
+    //       after doing the DNS-over-HTTPS lookup above - we don't want to muddy the output
+    //       with the rustls debug logs from the lookup.
+    env_logger::Builder::new()
+        .parse_filters("trace")
+        .init();
+
+    // Select a compatible ECH config.
+    let ech_config = EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES).unwrap();
+
+    let root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    };
+
+    // Construct a rustls client config with a custom provider, and ECH enabled.
+    let mut config =
+        rustls::ClientConfig::builder_with_provider(aws_lc_rs::default_provider().into())
+            .with_ech(ech_config)
+            .unwrap()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+
+    // Allow using SSLKEYLOGFILE.
+    config.key_log = Arc::new(rustls::KeyLogFile::new());
+
+    // The "inner" SNI that we're really trying to reach.
+    let server_name = "www.defo.ie".try_into().unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    // The "outer" server that we're connecting to.
+    let mut sock = TcpStream::connect("defo.ie:443").unwrap();
+    let mut tls = rustls::Stream::new(&mut conn, &mut sock);
+    tls.write_all(
+        concat!(
+            "GET /ech-check.php HTTP/1.1\r\n",
+            "Host: defo.ie\r\n",
+            "Connection: close\r\n",
+            "Accept-Encoding: identity\r\n",
+            "\r\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    let ciphersuite = tls
+        .conn
+        .negotiated_cipher_suite()
+        .unwrap();
+    writeln!(
+        &mut std::io::stderr(),
+        "Current ciphersuite: {:?}",
+        ciphersuite.suite()
+    )
+    .unwrap();
+    let mut plaintext = Vec::new();
+    tls.read_to_end(&mut plaintext).unwrap();
+    stdout().write_all(&plaintext).unwrap();
+}
+
+// TODO(@cpu): consider upstreaming to hickory-dns
+fn lookup_ech_configs(resolver: &Resolver, domain: &str) -> pki_types::EchConfigListBytes<'static> {
+    resolver
+        .lookup(domain, RecordType::HTTPS)
+        .expect("failed to lookup HTTPS record type")
+        .record_iter()
+        .find_map(|r| match r.data() {
+            Some(RData::HTTPS(svcb)) => svcb
+                .svc_params()
+                .iter()
+                .find_map(|sp| match sp {
+                    (SvcParamKey::EchConfigList, SvcParamValue::EchConfigList(e)) => {
+                        Some(e.clone().0)
+                    }
+                    _ => None,
+                }),
+            _ => None,
+        })
+        .expect("missing expected HTTPS SvcParam EchConfig record")
+        .into()
+}

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -3,24 +3,63 @@
 //!
 //! Note that `unwrap()` is used to deal with networking errors; this is not something
 //! that is sensible outside of example code.
+//!
+//! Example usage:
+//! ```
+//! cargo run --package rustls-provider-example --example ech-client -- --host defo.ie defo.ie www.defo.ie
+//! ```
+//!
+//! This will perform a DNS-over-HTTPS lookup for the defo.ie ECH config, using it to determine
+//! the plaintext SNI to send to the server. The protected encrypted SNI will be "www.defo.ie".
+//! An HTTP request for Host: defo.ie will be made once the handshake completes. You should
+//! observe output that contains:
+//! ```
+//!   <p>SSL_ECH_OUTER_SNI: cover.defo.ie <br />
+//!   SSL_ECH_INNER_SNI: www.defo.ie <br />
+//!   SSL_ECH_STATUS: success <img src="greentick-small.png" alt="good" /> <br/>
+//!   </p>
+//! ```
 
-use std::io::{stdout, Read, Write};
-use std::net::TcpStream;
+use std::fs;
+use std::io::{stdout, BufReader, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 
+use docopt::Docopt;
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::Resolver;
-use rustls::client::EchConfig;
+use rustls::client::{EchConfig, EchGreaseConfig, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
+use rustls::crypto::hpke::Hpke;
+use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
+use serde_derive::Deserialize;
 
 fn main() {
-    // Find raw ECH configs using DNS-over-HTTPS with Hickory DNS:
-    let resolver = Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
-    let ech_config_list = lookup_ech_configs(&resolver, "defo.ie");
+    let version = env!("CARGO_PKG_NAME").to_string() + ", version: " + env!("CARGO_PKG_VERSION");
+    let args: Args = Docopt::new(USAGE)
+        .map(|d| d.help(true))
+        .map(|d| d.version(Some(version)))
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
+
+    // Find raw ECH configs using DNS-over-HTTPS with Hickory DNS.
+    let resolver_config = if args.flag_cloudflare_dns {
+        ResolverConfig::cloudflare_https()
+    } else {
+        ResolverConfig::google_https()
+    };
+    let resolver = Resolver::new(resolver_config, ResolverOpts::default()).unwrap();
+    let server_ech_config = match args.flag_grease {
+        true => None, // Force the use of the GREASE ext by skipping ECH config lookup
+        false => match args.flag_ech_config {
+            Some(path) => Some(read_ech(&path)),
+            None => lookup_ech_configs(&resolver, &args.arg_outer_hostname),
+        },
+    };
 
     // NOTE: we defer setting up env_logger and setting the trace default filter level until
     //       after doing the DNS-over-HTTPS lookup above - we don't want to muddy the output
@@ -29,13 +68,31 @@ fn main() {
         .parse_filters("trace")
         .init();
 
-    // Select a compatible ECH config.
-    let ech_mode = EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES)
-        .unwrap()
-        .into();
+    let ech_mode = match server_ech_config {
+        Some(ech_config_list) => EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES)
+            .unwrap()
+            .into(),
+        None => {
+            let (public_key, _) = GREASE_HPKE_SUITE
+                .generate_key_pair()
+                .unwrap();
+            EchGreaseConfig::new(GREASE_HPKE_SUITE, public_key).into()
+        }
+    };
 
-    let root_store = RootCertStore {
-        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    let root_store = match args.flag_cafile {
+        Some(file) => {
+            let mut root_store = RootCertStore::empty();
+            let certfile = fs::File::open(file).expect("Cannot open CA file");
+            let mut reader = BufReader::new(certfile);
+            root_store.add_parsable_certificates(
+                rustls_pemfile::certs(&mut reader).map(|result| result.unwrap()),
+            );
+            root_store
+        }
+        None => RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+        },
     };
 
     // Construct a rustls client config with a custom provider, and ECH enabled.
@@ -48,44 +105,106 @@ fn main() {
 
     // Allow using SSLKEYLOGFILE.
     config.key_log = Arc::new(rustls::KeyLogFile::new());
+    let config = Arc::new(config);
 
     // The "inner" SNI that we're really trying to reach.
-    let server_name = "www.defo.ie".try_into().unwrap();
-    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
-    // The "outer" server that we're connecting to.
-    let mut sock = TcpStream::connect("defo.ie:443").unwrap();
-    let mut tls = rustls::Stream::new(&mut conn, &mut sock);
-    tls.write_all(
-        concat!(
-            "GET /ech-check.php HTTP/1.1\r\n",
-            "Host: defo.ie\r\n",
-            "Connection: close\r\n",
-            "Accept-Encoding: identity\r\n",
-            "\r\n"
-        )
-        .as_bytes(),
-    )
-    .unwrap();
-    let ciphersuite = tls
-        .conn
-        .negotiated_cipher_suite()
+    let server_name: ServerName<'static> = args
+        .arg_inner_hostname
+        .clone()
+        .try_into()
         .unwrap();
-    writeln!(
-        &mut std::io::stderr(),
-        "Current ciphersuite: {:?}",
-        ciphersuite.suite()
-    )
-    .unwrap();
-    let mut plaintext = Vec::new();
-    tls.read_to_end(&mut plaintext).unwrap();
-    stdout().write_all(&plaintext).unwrap();
+
+    for i in 0..args.flag_num_reqs {
+        println!("\nRequest {}", i);
+        let mut conn = rustls::ClientConnection::new(config.clone(), server_name.clone()).unwrap();
+        // The "outer" server that we're connecting to.
+        let sock_addr = (
+            args.arg_outer_hostname.as_str(),
+            args.flag_port.unwrap_or(443),
+        )
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
+        let mut sock = TcpStream::connect(sock_addr).unwrap();
+        let mut tls = rustls::Stream::new(&mut conn, &mut sock);
+
+        let request =
+            format!(
+                "GET /{} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n",
+                args.flag_path.clone()
+                    .unwrap_or("ech-check.php".to_owned()),
+                args.flag_host.as_ref().unwrap_or(&args.arg_inner_hostname),
+            );
+        dbg!(&request);
+        tls.write_all(request.as_bytes())
+            .unwrap();
+        assert!(!tls.conn.is_handshaking());
+        assert_eq!(
+            tls.conn.ech_status(),
+            match args.flag_grease {
+                true => EchStatus::Grease,
+                false => EchStatus::Accepted,
+            }
+        );
+        let mut plaintext = Vec::new();
+        tls.read_to_end(&mut plaintext).unwrap();
+        stdout().write_all(&plaintext).unwrap();
+    }
+}
+
+const USAGE: &str = "
+Connects to the TLS server at hostname:PORT.  The default PORT
+is 443. If an ECH config can be fetched for hostname using 
+DNS-over-HTTPS, ECH is enabled. Otherwise, a placeholder ECH
+extension is sent for anti-ossification testing.
+
+If --cafile is not supplied, a built-in set of CA certificates
+are used from the webpki-roots crate.
+
+Usage:
+  ech-client [options] <outer-hostname> <inner-hostname>
+  ech-client (--version | -v)
+  ech-client (--help | -h)
+
+Options:
+    -p, --port PORT       Connect to PORT [default: 443].
+    --cafile CAFILE       Read root certificates from CAFILE.
+    --path PATH           HTTP GET this PATH [default: ech-check.php].
+    --host HOST           HTTP HOST to use for GET request [default: inner-hostname].
+    --google-dns          Use Google DNS for the DNS-over-HTTPS lookup [default].
+    --cloudflare-dns      Use Cloudflare DNS for the DNS-over-HTTPS lookup.
+    --grease              Skip looking up an ECH config and send a GREASE placeholder.
+    --ech-config ECHFILE  Skip looking up an ECH config and read it from the provided file (in binary TLS encoding).
+    --num-reqs NUM        Number of requests to make [default: 1].
+    --version, -v         Show tool version.
+    --help, -h            Show this screen.
+";
+
+#[derive(Debug, Deserialize)]
+struct Args {
+    flag_port: Option<u16>,
+    flag_cafile: Option<String>,
+    flag_path: Option<String>,
+    flag_host: Option<String>,
+    #[allow(dead_code)] // implied default
+    flag_google_dns: bool,
+    flag_cloudflare_dns: bool,
+    flag_grease: bool,
+    flag_ech_config: Option<String>,
+    flag_num_reqs: usize,
+    arg_outer_hostname: String,
+    arg_inner_hostname: String,
 }
 
 // TODO(@cpu): consider upstreaming to hickory-dns
-fn lookup_ech_configs(resolver: &Resolver, domain: &str) -> pki_types::EchConfigListBytes<'static> {
+fn lookup_ech_configs(
+    resolver: &Resolver,
+    domain: &str,
+) -> Option<pki_types::EchConfigListBytes<'static>> {
     resolver
         .lookup(domain, RecordType::HTTPS)
-        .expect("failed to lookup HTTPS record type")
+        .ok()?
         .record_iter()
         .find_map(|r| match r.data() {
             Some(RData::HTTPS(svcb)) => svcb
@@ -99,6 +218,20 @@ fn lookup_ech_configs(resolver: &Resolver, domain: &str) -> pki_types::EchConfig
                 }),
             _ => None,
         })
-        .expect("missing expected HTTPS SvcParam EchConfig record")
-        .into()
+        .map(Into::into)
 }
+
+fn read_ech(path: &str) -> pki_types::EchConfigListBytes<'static> {
+    let file = fs::File::open(path).unwrap_or_else(|_| panic!("Cannot open ECH file: {path}"));
+    let mut reader = BufReader::new(file);
+    let mut bytes = Vec::new();
+    reader
+        .read_to_end(&mut bytes)
+        .unwrap_or_else(|_| panic!("Cannot read ECH file: {path}"));
+    bytes.into()
+}
+
+/// A HPKE suite to use for GREASE ECH.
+///
+/// A real implementation should vary this suite across all of the suites that are supported.
+static GREASE_HPKE_SUITE: &dyn Hpke = aws_lc_rs::hpke::DH_KEM_X25519_HKDF_SHA256_AES_128;

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -26,10 +26,6 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 
 use docopt::Docopt;
-use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
-use hickory_resolver::proto::rr::{RData, RecordType};
-use hickory_resolver::Resolver;
 use rustls::client::{EchConfig, EchGreaseConfig, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
@@ -37,6 +33,10 @@ use rustls::crypto::hpke::Hpke;
 use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
 use serde_derive::Deserialize;
+use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+use trust_dns_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
+use trust_dns_resolver::proto::rr::{RData, RecordType};
+use trust_dns_resolver::Resolver;
 
 fn main() {
     let version = env!("CARGO_PKG_NAME").to_string() + ", version: " + env!("CARGO_PKG_VERSION");
@@ -50,7 +50,7 @@ fn main() {
     let resolver_config = if args.flag_cloudflare_dns {
         ResolverConfig::cloudflare_https()
     } else {
-        ResolverConfig::google_https()
+        ResolverConfig::google()
     };
     let resolver = Resolver::new(resolver_config, ResolverOpts::default()).unwrap();
     let server_ech_config = match args.flag_grease {

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -30,7 +30,9 @@ fn main() {
         .init();
 
     // Select a compatible ECH config.
-    let ech_config = EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES).unwrap();
+    let ech_mode = EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES)
+        .unwrap()
+        .into();
 
     let root_store = RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.into(),
@@ -39,7 +41,7 @@ fn main() {
     // Construct a rustls client config with a custom provider, and ECH enabled.
     let mut config =
         rustls::ClientConfig::builder_with_provider(aws_lc_rs::default_provider().into())
-            .with_ech(ech_config)
+            .with_ech(ech_mode)
             .unwrap()
             .with_root_certificates(root_store)
             .with_no_client_auth();

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 
+use crate::client::EchConfig;
 use crate::crypto::CryptoProvider;
 use crate::error::Error;
 use crate::msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS;
@@ -251,6 +252,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
                 provider: self.state.provider,
                 versions: versions::EnabledVersions::new(versions),
                 time_provider: self.state.time_provider,
+                client_ech_config: None,
             },
             side: self.side,
         })
@@ -265,6 +267,7 @@ pub struct WantsVerifier {
     pub(crate) provider: Arc<CryptoProvider>,
     pub(crate) versions: versions::EnabledVersions,
     pub(crate) time_provider: Arc<dyn TimeProvider>,
+    pub(crate) client_ech_config: Option<EchConfig>,
 }
 
 /// Helper trait to abstract [`ConfigBuilder`] over building a [`ClientConfig`] or [`ServerConfig`].

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 
-use crate::client::EchConfig;
+use crate::client::EchMode;
 use crate::crypto::CryptoProvider;
 use crate::error::Error;
 use crate::msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS;
@@ -252,7 +252,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
                 provider: self.state.provider,
                 versions: versions::EnabledVersions::new(versions),
                 time_provider: self.state.time_provider,
-                client_ech_config: None,
+                client_ech_mode: None,
             },
             side: self.side,
         })
@@ -267,7 +267,7 @@ pub struct WantsVerifier {
     pub(crate) provider: Arc<CryptoProvider>,
     pub(crate) versions: versions::EnabledVersions,
     pub(crate) time_provider: Arc<dyn TimeProvider>,
-    pub(crate) client_ech_config: Option<EchConfig>,
+    pub(crate) client_ech_mode: Option<EchMode>,
 }
 
 /// Helper trait to abstract [`ConfigBuilder`] over building a [`ClientConfig`] or [`ServerConfig`].

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -9,7 +9,7 @@ use pki_types::{ServerName, UnixTime};
 use super::handy::NoClientSessionStorage;
 use super::hs;
 use crate::builder::ConfigBuilder;
-use crate::client::{EchConfig, EchStatus};
+use crate::client::{EchMode, EchStatus};
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
@@ -256,7 +256,7 @@ pub struct ClientConfig {
     pub cert_compression_cache: Arc<compress::CompressionCache>,
 
     /// How to offer Encrypted Client Hello (ECH). The default is to not offer ECH.
-    pub(super) ech_config: Option<EchConfig>,
+    pub(super) ech_mode: Option<EchMode>,
 }
 
 impl ClientConfig {

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -47,6 +47,16 @@ pub enum EchMode {
     Grease(EchGreaseConfig),
 }
 
+impl EchMode {
+    /// Returns true if the ECH mode will use a FIPS approved HPKE suite.
+    pub fn fips(&self) -> bool {
+        match self {
+            Self::Enable(ech_config) => ech_config.suite.fips(),
+            Self::Grease(grease_config) => grease_config.suite.fips(),
+        }
+    }
+}
+
 impl From<EchConfig> for EchMode {
     fn from(config: EchConfig) -> Self {
         Self::Enable(config)

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -1,0 +1,668 @@
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use pki_types::{DnsName, EchConfigListBytes, ServerName};
+use subtle::ConstantTimeEq;
+
+use crate::client::tls13;
+use crate::crypto::hash::Hash;
+use crate::crypto::hpke::{EncapsulatedSecret, Hpke, HpkePublicKey, HpkeSealer, HpkeSuite};
+use crate::crypto::SecureRandom;
+use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
+#[cfg(feature = "logging")]
+use crate::log::{debug, trace, warn};
+use crate::msgs::base::{Payload, PayloadU16};
+use crate::msgs::codec::{Codec, Reader};
+use crate::msgs::enums::ExtensionType;
+use crate::msgs::handshake::{
+    ClientExtension, ClientHelloPayload, EchConfigPayload, Encoding, EncryptedClientHello,
+    EncryptedClientHelloOuter, HandshakeMessagePayload, HandshakePayload, HelloRetryRequest,
+    HpkeSymmetricCipherSuite, PresharedKeyBinder, PresharedKeyOffer, Random, ServerHelloPayload,
+    SessionId,
+};
+use crate::msgs::message::{Message, MessagePayload};
+use crate::msgs::persist;
+use crate::msgs::persist::Retrieved;
+use crate::tls13::key_schedule::{
+    server_ech_hrr_confirmation_secret, KeyScheduleEarly, KeyScheduleHandshakeStart,
+};
+use crate::CipherSuite::TLS_EMPTY_RENEGOTIATION_INFO_SCSV;
+use crate::{
+    AlertDescription, CommonState, EncryptedClientHelloError, Error, HandshakeType,
+    PeerIncompatible, PeerMisbehaved, ProtocolVersion, Tls13CipherSuite,
+};
+
+/// Configuration for performing encrypted client hello.
+///
+/// Note: differs from the protocol-encoded EchConfig (`EchConfigMsg`).
+#[derive(Clone, Debug)]
+pub struct EchConfig {
+    /// The selected EchConfig.
+    pub(crate) config: EchConfigPayload,
+
+    /// An HPKE instance corresponding to a suite from the `config` we have selected as
+    /// a compatible choice.
+    pub(crate) suite: &'static dyn Hpke,
+}
+
+impl EchConfig {
+    /// Construct an EchConfig by selecting a ECH config from the provided bytes that is compatible
+    /// with one of the given HPKE suites.
+    ///
+    /// The config list bytes should be sourced from a DNS-over-HTTPS lookup resolving the `HTTPS`
+    /// resource record for the host name of the server you wish to connect via ECH,
+    /// and extracting the ECH configuration from the `ech` parameter. The extracted bytes should
+    /// be base64 decoded to yield the `EchConfigListBytes` you provide to rustls.
+    ///
+    /// One of the provided ECH configurations must be compatible with the HPKE provider's supported
+    /// suites or an error will be returned.
+    ///
+    /// See the [ech-client.rs] example for a complete example of fetching ECH configs from DNS.
+    ///
+    /// [ech-client.rs]: https://github.com/rustls/rustls/blob/main/provider-example/examples/ech-client.rs
+    pub fn new(
+        ech_config_list: EchConfigListBytes<'_>,
+        hpke_suites: &[&'static dyn Hpke],
+    ) -> Result<Self, Error> {
+        let ech_configs = Vec::<EchConfigPayload>::read(&mut Reader::init(&ech_config_list))
+            .map_err(|_| {
+                Error::InvalidEncryptedClientHello(EncryptedClientHelloError::InvalidConfigList)
+            })?;
+
+        // Note: we name the index var _i because if the log feature is disabled
+        //       it is unused.
+        #[cfg_attr(not(feature = "std"), allow(clippy::unused_enumerate_index))]
+        for (_i, config) in ech_configs.iter().enumerate() {
+            let contents = match config {
+                EchConfigPayload::V18(contents) => contents,
+                EchConfigPayload::Unknown {
+                    version: _version, ..
+                } => {
+                    warn!(
+                        "ECH config {} has unsupported version {:?}",
+                        _i + 1,
+                        _version
+                    );
+                    continue; // Unsupported version.
+                }
+            };
+
+            if contents.has_unknown_mandatory_extension() || contents.has_duplicate_extension() {
+                warn!("ECH config has duplicate, or unknown mandatory extensions: {contents:?}",);
+                continue; // Unsupported, or malformed extensions.
+            }
+
+            let key_config = &contents.key_config;
+            for cipher_suite in &key_config.symmetric_cipher_suites {
+                if cipher_suite.aead_id.tag_len().is_none() {
+                    continue; // Unsupported EXPORT_ONLY AEAD cipher suite.
+                }
+
+                let suite = HpkeSuite {
+                    kem: key_config.kem_id,
+                    sym: *cipher_suite,
+                };
+                if let Some(hpke) = hpke_suites
+                    .iter()
+                    .find(|hpke| hpke.suite() == suite)
+                {
+                    debug!(
+                        "selected ECH config ID {:?} suite {:?}",
+                        key_config.config_id, suite
+                    );
+                    return Ok(Self {
+                        config: config.clone(),
+                        suite: *hpke,
+                    });
+                }
+            }
+        }
+
+        Err(EncryptedClientHelloError::NoCompatibleConfig.into())
+    }
+
+    /// Compute the HPKE `SetupBaseS` `info` parameter for this ECH configuration.
+    ///
+    /// See <https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-17#section-6.1>.
+    pub(crate) fn hpke_info(&self) -> Vec<u8> {
+        let mut info = Vec::with_capacity(128);
+        // "tls ech" || 0x00 || ECHConfig
+        info.extend_from_slice(b"tls ech\0");
+        self.config.encode(&mut info);
+        info
+    }
+}
+
+/// An enum representing ECH offer status.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum EchStatus {
+    /// ECH was not offered - it is a normal TLS handshake.
+    NotOffered,
+    /// ECH was offered but we do not yet know whether the offer was accepted or rejected.
+    Offered,
+    /// ECH was offered and the server accepted.
+    Accepted,
+    /// ECH was offered and the server rejected.
+    Rejected,
+}
+
+/// Contextual data for a TLS client handshake that has offered encrypted client hello (ECH).
+pub(crate) struct EchState {
+    // The public DNS name from the ECH configuration we've chosen - this is included as the SNI
+    // value for the "outer" client hello. It can only be a DnsName, not an IP address.
+    pub(crate) outer_name: DnsName<'static>,
+    // If we're resuming in the inner hello, this is the early key schedule to use for encrypting
+    // early data if the ECH offer is accepted.
+    pub(crate) early_data_key_schedule: Option<KeyScheduleEarly>,
+    // A random value we use for the inner hello.
+    pub(crate) inner_hello_random: Random,
+    // A transcript buffer maintained for the inner hello. Once ECH is confirmed we switch to
+    // using this transcript for the handshake.
+    pub(crate) inner_hello_transcript: HandshakeHashBuffer,
+    // A source of secure random data.
+    secure_random: &'static dyn SecureRandom,
+    // An HPKE sealer context that can be used for encrypting ECH data.
+    sender: Box<dyn HpkeSealer>,
+    // The ID of the ECH configuration we've chosen - this is included in the outer ECH extension.
+    config_id: u8,
+    // The private server name we'll use for the inner protected hello.
+    inner_name: ServerName<'static>,
+    // The advertised maximum name length from the ECH configuration we've chosen - this is used
+    // for padding calculations.
+    maximum_name_length: u8,
+    // A supported symmetric cipher suite from the ECH configuration we've chosen - this is
+    // included in the outer ECH extension.
+    cipher_suite: HpkeSymmetricCipherSuite,
+    // A secret encapsulated to the public key of the remote server. This is included in the
+    // outer ECH extension for non-retry outer hello messages.
+    enc: EncapsulatedSecret,
+    // Whether the inner client hello should contain a server name indication (SNI) extension.
+    enable_sni: bool,
+    // The extensions sent in the inner hello.
+    sent_extensions: Vec<ExtensionType>,
+}
+
+impl EchState {
+    pub(crate) fn new(
+        config: &EchConfig,
+        inner_name: ServerName<'static>,
+        client_auth_enabled: bool,
+        secure_random: &'static dyn SecureRandom,
+        enable_sni: bool,
+    ) -> Result<Self, Error> {
+        // TODO(XXX): this would be cleaner as a `let..else` statement once MSRV is 1.64+
+        let config_contents = match &config.config {
+            EchConfigPayload::V18(config_contents) => config_contents,
+            // the public EchConfig::new() constructor ensures we only have supported
+            // configurations.
+            _ => unreachable!("ECH config version mismatch"),
+        };
+        let key_config = &config_contents.key_config;
+
+        // Encapsulate a secret for the server's public key, and set up a sender context
+        // we can use to seal messages.
+        let (enc, sender) = config.suite.setup_sealer(
+            &config.hpke_info(),
+            &HpkePublicKey(key_config.public_key.0.clone()),
+        )?;
+
+        // Start a new transcript buffer for the inner hello.
+        let mut inner_hello_transcript = HandshakeHashBuffer::new();
+        if client_auth_enabled {
+            inner_hello_transcript.set_client_auth_enabled();
+        }
+
+        Ok(Self {
+            secure_random,
+            sender,
+            config_id: key_config.config_id,
+            inner_name,
+            outer_name: config_contents.public_name.clone(),
+            maximum_name_length: config_contents.maximum_name_length,
+            cipher_suite: config.suite.suite().sym,
+            enc,
+            inner_hello_random: Random::new(secure_random)?,
+            inner_hello_transcript,
+            early_data_key_schedule: None,
+            enable_sni,
+            sent_extensions: Vec::new(),
+        })
+    }
+
+    /// Construct a ClientHelloPayload offering ECH.
+    ///
+    /// An outer hello, with a protected inner hello for the `inner_name` will be returned, and the
+    /// ECH context will be updated to reflect the inner hello that was offered.
+    ///
+    /// If `retry_req` is `Some`, then the outer hello will be constructed for a hello retry request.
+    ///
+    /// If `resuming` is `Some`, then the inner hello will be constructed for a resumption handshake.
+    pub(crate) fn ech_hello(
+        &mut self,
+        mut outer_hello: ClientHelloPayload,
+        retry_req: Option<&HelloRetryRequest>,
+        resuming: &Option<Retrieved<&persist::Tls13ClientSessionValue>>,
+    ) -> Result<ClientHelloPayload, Error> {
+        trace!(
+            "Preparing ECH offer {}",
+            if retry_req.is_some() { "for retry" } else { "" }
+        );
+
+        // Construct the encoded inner hello and update the transcript.
+        let encoded_inner_hello = self.encode_inner_hello(&outer_hello, retry_req, resuming);
+
+        // Complete the ClientHelloOuterAAD with an ech extension, the payload should be a placeholder
+        // of size L, all zeroes. L == length of encrypting encoded client hello inner w/ the selected
+        // HPKE AEAD. (sum of plaintext + tag length, typically).
+        let payload_len = encoded_inner_hello.len()
+            + self
+                .cipher_suite
+                .aead_id
+                .tag_len()
+                // Safety: we've already verified this AEAD is supported when loading the config
+                // that was used to create the ECH context. All supported AEADs have a tag length.
+                .unwrap();
+
+        // Outer hello's created in response to a hello retry request omit the enc value.
+        let enc = match retry_req.is_some() {
+            true => Vec::default(),
+            false => self.enc.0.clone(),
+        };
+
+        fn outer_hello_ext(ctx: &EchState, enc: Vec<u8>, payload: Vec<u8>) -> ClientExtension {
+            ClientExtension::EncryptedClientHello(EncryptedClientHello::Outer(
+                EncryptedClientHelloOuter {
+                    cipher_suite: ctx.cipher_suite,
+                    config_id: ctx.config_id,
+                    enc: PayloadU16::new(enc),
+                    payload: PayloadU16::new(payload),
+                },
+            ))
+        }
+
+        // The outer handshake is not permitted to resume a session. If we're resuming in the
+        // inner handshake we remove the PSK extension from the outer hello, replacing it
+        // with a GREASE PSK to implement the "ClientHello Malleability Mitigation" mentioned
+        // in 10.12.3.
+        if let Some(ClientExtension::PresharedKey(psk_offer)) = outer_hello.extensions.last_mut() {
+            self.grease_psk(psk_offer)?;
+        }
+
+        // To compute the encoded AAD we add a placeholder extension with an empty payload.
+        outer_hello
+            .extensions
+            .push(outer_hello_ext(self, enc.clone(), vec![0; payload_len]));
+
+        // Next we compute the proper extension payload.
+        let payload = self
+            .sender
+            .seal(&outer_hello.get_encoding(), &encoded_inner_hello)?;
+
+        // And then we replace the placeholder extension with the real one.
+        outer_hello.extensions.pop();
+        outer_hello
+            .extensions
+            .push(outer_hello_ext(self, enc, payload));
+
+        Ok(outer_hello)
+    }
+
+    /// Confirm whether an ECH offer was accepted based on examining the server hello.
+    pub(crate) fn confirm_acceptance(
+        self,
+        ks: &mut KeyScheduleHandshakeStart,
+        server_hello: &ServerHelloPayload,
+        hash: &'static dyn Hash,
+    ) -> Result<Option<EchAccepted>, Error> {
+        // Start the inner transcript hash now that we know the hash algorithm to use.
+        let inner_transcript = self
+            .inner_hello_transcript
+            .start_hash(hash);
+
+        // Fork the transcript that we've started with the inner hello to use for a confirmation step.
+        // We need to preserve the original inner_transcript to use if this confirmation succeeds.
+        let mut confirmation_transcript = inner_transcript.clone();
+
+        // Add the server hello confirmation - this differs from the standard server hello encoding.
+        confirmation_transcript.add_message(&Self::server_hello_conf(server_hello));
+
+        // Derive a confirmation secret from the inner hello random and the confirmation transcript.
+        let derived = ks.server_ech_confirmation_secret(
+            self.inner_hello_random.0.as_ref(),
+            confirmation_transcript.current_hash(),
+        );
+
+        // Check that first 8 digits of the derived secret match the last 8 digits of the original
+        // server random. This match signals that the server accepted the ECH offer.
+        // Indexing safety: Random is [0; 32] by construction.
+
+        match ConstantTimeEq::ct_eq(derived.as_ref(), server_hello.random.0[24..].as_ref()).into() {
+            true => {
+                trace!("ECH accepted by server");
+                Ok(Some(EchAccepted {
+                    transcript: inner_transcript,
+                    random: self.inner_hello_random,
+                    sent_extensions: self.sent_extensions,
+                }))
+            }
+            false => {
+                trace!("ECH rejected by server");
+                Ok(None)
+            }
+        }
+    }
+
+    pub(crate) fn confirm_hrr_acceptance(
+        &self,
+        hrr: &HelloRetryRequest,
+        cs: &Tls13CipherSuite,
+        common: &mut CommonState,
+    ) -> Result<bool, Error> {
+        // The client checks for the "encrypted_client_hello" extension.
+        let ech_conf = match hrr.ech() {
+            // If none is found, the server has implicitly rejected ECH.
+            None => return Ok(false),
+            // Otherwise, if it has a length other than 8, the client aborts the
+            // handshake with a "decode_error" alert.
+            Some(ech_conf) if ech_conf.len() != 8 => {
+                return Err({
+                    common.send_fatal_alert(
+                        AlertDescription::DecodeError,
+                        PeerMisbehaved::IllegalHelloRetryRequestWithInvalidEch,
+                    )
+                })
+            }
+            Some(ech_conf) => ech_conf,
+        };
+
+        // Otherwise the client computes hrr_accept_confirmation as described in Section
+        // 7.2.1
+        let confirmation_transcript = self.inner_hello_transcript.clone();
+        let mut confirmation_transcript =
+            confirmation_transcript.start_hash(cs.common.hash_provider);
+        confirmation_transcript.rollup_for_hrr();
+        confirmation_transcript.add_message(&Self::hello_retry_request_conf(hrr));
+
+        let derived = server_ech_hrr_confirmation_secret(
+            cs.hkdf_provider,
+            &self.inner_hello_random.0,
+            confirmation_transcript.current_hash(),
+        );
+
+        match ConstantTimeEq::ct_eq(derived.as_ref(), ech_conf).into() {
+            true => {
+                trace!("ECH accepted by server in hello retry request");
+                Ok(true)
+            }
+            false => {
+                trace!("ECH rejected by server in hello retry request");
+                Ok(false)
+            }
+        }
+    }
+
+    /// Update the ECH context inner hello transcript based on a received hello retry request message.
+    ///
+    /// This will start the in-progress transcript using the given `hash`, convert it into an HRR
+    /// buffer, and then add the hello retry message `m`.
+    pub(crate) fn transcript_hrr_update(&mut self, hash: &'static dyn Hash, m: &Message) {
+        trace!("Updating ECH inner transcript for HRR");
+
+        let inner_transcript = self
+            .inner_hello_transcript
+            .clone()
+            .start_hash(hash);
+
+        let mut inner_transcript_buffer = inner_transcript.into_hrr_buffer();
+        inner_transcript_buffer.add_message(m);
+        self.inner_hello_transcript = inner_transcript_buffer;
+    }
+
+    fn encode_inner_hello(
+        &mut self,
+        outer_hello: &ClientHelloPayload,
+        retryreq: Option<&HelloRetryRequest>,
+        resuming: &Option<Retrieved<&persist::Tls13ClientSessionValue>>,
+    ) -> Vec<u8> {
+        // Start building an inner hello by cloning the initial outer hello.
+        let mut inner_hello = outer_hello.clone();
+
+        inner_hello.extensions.retain(|ext| {
+            match ext.ext_type() {
+                // SNI is unconditionally removed - it was copied from the outer hello and
+                // we will conditionally re-add our own SNI for the inner hello later.
+                ExtensionType::ServerName |
+                // We may have copied extensions that are only useful in the context where a TLS 1.3
+                // connection allows TLS 1.2. This isn't the case for ECH and so we must remove these
+                // to satisfy a bogo test.
+                ExtensionType::ExtendedMasterSecret |
+                ExtensionType::SessionTicket |
+                ExtensionType::ECPointFormats => false,
+                // Retain all other extensions.
+                _ => true,
+            }
+        });
+
+        // Remove the empty renegotiation info SCSV from the inner hello. Similar to the TLS 1.2
+        // specific extensions we remove above, this is seen as a TLS 1.2 only feature by bogo.
+        inner_hello
+            .cipher_suites
+            .retain(|cs| *cs != TLS_EMPTY_RENEGOTIATION_INFO_SCSV);
+
+        // Add the correct inner SNI - we only do this when the inner name is a DnsName and SNI
+        // is enabled. IP addresses should not be used in an SNI extensions.
+        if self.enable_sni {
+            if let ServerName::DnsName(inner_name) = &self.inner_name {
+                inner_hello
+                    .extensions
+                    .insert(0, ClientExtension::make_sni(&inner_name.borrow()));
+            }
+        }
+
+        // Add the inner variant extension to the inner hello.
+        // Section 6.1 rule 4.
+        let inner_ech_ext = ClientExtension::EncryptedClientHello(EncryptedClientHello::Inner);
+        if let Some(ClientExtension::PresharedKey(_)) = inner_hello.extensions.last() {
+            // Insert it before the PSK - this ext always needs to be last.
+            inner_hello
+                .extensions
+                .insert(inner_hello.extensions.len() - 1, inner_ech_ext);
+        } else {
+            // Insert it at the end. No PSK to worry about.
+            inner_hello
+                .extensions
+                .push(inner_ech_ext);
+        }
+
+        // Note which extensions we're sending in the inner hello. This may differ from
+        // the outer hello (e.g. the inner hello may omit SNI while the outer hello will
+        // always have the ECH cover name in SNI).
+        self.sent_extensions = inner_hello
+            .extensions
+            .iter()
+            .map(|ext| ext.ext_type())
+            .collect();
+
+        // Set the inner hello random to the one we generated when creating the ECH state.
+        // We hold on to the inner_hello_random in the ECH state to use later for confirming
+        // whether ECH was accepted or not.
+        inner_hello.random = self.inner_hello_random;
+
+        // If we're resuming, we need to update the PSK binder in the inner hello.
+        if let Some(resuming) = resuming.as_ref() {
+            let mut chp = HandshakeMessagePayload {
+                typ: HandshakeType::ClientHello,
+                payload: HandshakePayload::ClientHello(inner_hello),
+            };
+
+            // Retain the early key schedule we get from processing the binder.
+            self.early_data_key_schedule = Some(tls13::fill_in_psk_binder(
+                resuming,
+                &self.inner_hello_transcript,
+                &mut chp,
+            ));
+
+            // fill_in_psk_binder works on an owned HandshakeMessagePayload, so we need to
+            // extract our inner hello back out of it to retain ownership.
+            inner_hello = match chp.payload {
+                HandshakePayload::ClientHello(chp) => chp,
+                // Safety: we construct the HMP above and know its type unconditionally.
+                _ => unreachable!(),
+            };
+        }
+
+        // Repeating large extensions between ClientHelloInner and ClientHelloOuter can lead to excessive
+        // size. To reduce the size impact, the client MAY substitute extensions which it knows will be
+        // duplicated in ClientHelloOuter.
+
+        // TODO(@cpu): Extension compression would be handled here-ish.
+
+        // 5.1 "Encoding the ClientHelloInner"
+
+        // Setting the legacy_session_id field to the empty string.
+        // Preserve these for reuse
+        let original_session_id = inner_hello.session_id;
+
+        // SessionID is required to be empty in the EncodedClientHelloInner.
+        inner_hello.session_id = SessionId::empty();
+
+        // Encode the inner hello with the empty session ID.
+        let mut encoded_hello = inner_hello.get_encoding();
+
+        // Restore session ID.
+        inner_hello.session_id = original_session_id;
+
+        trace!("ECH Inner Hello: {:#?}", inner_hello);
+
+        // Calculate padding
+        // max_name_len = L
+        let max_name_len = self.maximum_name_length;
+        let max_name_len = if max_name_len > 0 { max_name_len } else { 255 };
+
+        let padding_len = match &self.inner_name {
+            ServerName::DnsName(name) => {
+                // name.len() = D
+                // max(0, L - D)
+                core::cmp::max(
+                    0,
+                    max_name_len.saturating_sub(name.as_ref().len() as u8) as usize,
+                )
+            }
+            _ => {
+                // L + 9
+                // "This is the length of a "server_name" extension with an L-byte name."
+                // We widen to usize here to avoid overflowing u8 + u8.
+                max_name_len as usize + 9
+            }
+        };
+
+        // Let L be the length of the EncodedClientHelloInner with all the padding computed so far
+        // Let N = 31 - ((L - 1) % 32) and add N bytes of padding.
+        let padding_len = 31 - ((encoded_hello.len() + (padding_len) - 1) % 32);
+        encoded_hello.extend(vec![0; padding_len]);
+
+        // Construct the inner hello message that will be used for the transcript.
+        let inner_hello_msg = Message {
+            version: match retryreq {
+                // <https://datatracker.ietf.org/doc/html/rfc8446#section-5.1>:
+                // "This value MUST be set to 0x0303 for all records generated
+                //  by a TLS 1.3 implementation ..."
+                Some(_) => ProtocolVersion::TLSv1_2,
+                // "... other than an initial ClientHello (i.e., one not
+                // generated after a HelloRetryRequest), where it MAY also be
+                // 0x0301 for compatibility purposes"
+                //
+                // (retryreq == None means we're in the "initial ClientHello" case)
+                None => ProtocolVersion::TLSv1_0,
+            },
+            payload: MessagePayload::handshake(HandshakeMessagePayload {
+                typ: HandshakeType::ClientHello,
+                payload: HandshakePayload::ClientHello(inner_hello),
+            }),
+        };
+
+        // Update the inner transcript buffer with the inner hello message.
+        self.inner_hello_transcript
+            .add_message(&inner_hello_msg);
+
+        encoded_hello
+    }
+
+    // See https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#name-grease-psk
+    fn grease_psk(&self, psk_offer: &mut PresharedKeyOffer) -> Result<(), Error> {
+        for ident in psk_offer.identities.iter_mut() {
+            // "For each PSK identity advertised in the ClientHelloInner, the
+            // client generates a random PSK identity with the same length."
+            self.secure_random
+                .fill(&mut ident.identity.0)?;
+            // "It also generates a random, 32-bit, unsigned integer to use as
+            // the obfuscated_ticket_age."
+            let mut ticket_age = [0_u8; 4];
+            self.secure_random
+                .fill(&mut ticket_age)?;
+            ident.obfuscated_ticket_age = u32::from_be_bytes(ticket_age);
+        }
+
+        // "Likewise, for each inner PSK binder, the client generates a random string
+        // of the same length."
+        psk_offer.binders = psk_offer
+            .binders
+            .iter()
+            .map(|old_binder| {
+                // We can't access the wrapped binder PresharedKeyBinder's PayloadU8 mutably,
+                // so we construct new PresharedKeyBinder's from scratch with the same length.
+                let mut new_binder = vec![0; old_binder.as_ref().len()];
+                self.secure_random
+                    .fill(&mut new_binder)?;
+                Ok::<PresharedKeyBinder, Error>(PresharedKeyBinder::from(new_binder))
+            })
+            .collect::<Result<_, _>>()?;
+        Ok(())
+    }
+
+    fn server_hello_conf(server_hello: &ServerHelloPayload) -> Message {
+        Self::ech_conf_message(HandshakeMessagePayload {
+            typ: HandshakeType::ServerHello,
+            payload: HandshakePayload::ServerHello(server_hello.clone()),
+        })
+    }
+
+    fn hello_retry_request_conf(retry_req: &HelloRetryRequest) -> Message {
+        Self::ech_conf_message(HandshakeMessagePayload {
+            typ: HandshakeType::HelloRetryRequest,
+            payload: HandshakePayload::HelloRetryRequest(retry_req.clone()),
+        })
+    }
+
+    fn ech_conf_message(hmp: HandshakeMessagePayload) -> Message {
+        let mut hmp_encoded = Vec::new();
+        hmp.payload_encode(&mut hmp_encoded, Encoding::EchConfirmation);
+        Message {
+            version: ProtocolVersion::TLSv1_3,
+            payload: MessagePayload::Handshake {
+                encoded: Payload::new(hmp_encoded),
+                parsed: hmp,
+            },
+        }
+    }
+}
+
+/// Returned from EchState::check_acceptance when the server has accepted the ECH offer.
+///
+/// Holds the state required to continue the handshake with the inner hello from the ECH offer.
+pub(crate) struct EchAccepted {
+    pub(crate) transcript: HandshakeHash,
+    pub(crate) random: Random,
+    pub(crate) sent_extensions: Vec<ExtensionType>,
+}
+
+pub(crate) fn fatal_alert_required(
+    retry_configs: Option<Vec<EchConfigPayload>>,
+    common: &mut CommonState,
+) -> Error {
+    common.send_fatal_alert(
+        AlertDescription::EncryptedClientHelloRequired,
+        PeerIncompatible::ServerRejectedEncryptedClientHello(retry_configs),
+    )
+}

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -146,7 +146,7 @@ pub(super) fn start_handshake(
     let random = Random::new(config.provider.secure_random)?;
     let extension_order_seed = crate::rand::random_u16(config.provider.secure_random)?;
 
-    Ok(emit_client_hello_for_retry(
+    emit_client_hello_for_retry(
         transcript_buffer,
         None,
         key_share,
@@ -164,7 +164,7 @@ pub(super) fn start_handshake(
             server_name,
         },
         cx,
-    ))
+    )
 }
 
 struct ExpectServerHello {
@@ -200,7 +200,7 @@ fn emit_client_hello_for_retry(
     suite: Option<SupportedCipherSuite>,
     mut input: ClientHelloInput,
     cx: &mut ClientContext<'_>,
-) -> NextState<'static> {
+) -> NextStateOrError<'static> {
     let config = &input.config;
     let support_tls12 = config.supports_version(ProtocolVersion::TLSv1_2) && !cx.common.is_quic();
     let support_tls13 = config.supports_version(ProtocolVersion::TLSv1_3);
@@ -406,11 +406,11 @@ fn emit_client_hello_for_retry(
         suite,
     };
 
-    if support_tls13 && retryreq.is_none() {
+    Ok(if support_tls13 && retryreq.is_none() {
         Box::new(ExpectServerHelloOrHelloRetryRequest { next, extra_exts })
     } else {
         Box::new(next)
-    }
+    })
 }
 
 /// Prepare resumption with the session state retrieved from storage.
@@ -890,7 +890,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
             _ => offered_key_share,
         };
 
-        Ok(emit_client_hello_for_retry(
+        emit_client_hello_for_retry(
             transcript_buffer,
             Some(hrr),
             Some(key_share),
@@ -898,7 +898,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
             Some(cs),
             self.next.input,
             cx,
-        ))
+        )
     }
 }
 

--- a/rustls/src/crypto/hpke.rs
+++ b/rustls/src/crypto/hpke.rs
@@ -72,6 +72,12 @@ pub trait Hpke: Debug + Send + Sync {
         secret_key: &HpkePrivateKey,
     ) -> Result<Box<dyn HpkeOpener + 'static>, Error>;
 
+    /// Generate a new public key and private key pair compatible with this HPKE instance.
+    ///
+    /// Key pairs should be encoded as raw big endian fixed length integers sized based
+    /// on the suite's DH KEM algorithm.
+    fn generate_key_pair(&self) -> Result<(HpkePublicKey, HpkePrivateKey), Error>;
+
     /// Return whether the HPKE instance is FIPS compatible.
     fn fips(&self) -> bool {
         false

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -42,6 +42,7 @@ enum_builder! {
         UnknownPSKIdentity => 0x73,
         CertificateRequired => 0x74,
         NoApplicationProtocol => 0x78,
+        EncryptedClientHelloRequired => 0x79, // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-11.2
     }
 }
 
@@ -579,6 +580,19 @@ enum_builder! {
         Zlib => 1,
         Brotli => 2,
         Zstd => 3,
+    }
+}
+
+enum_builder! {
+    /// The type of Encrypted Client Hello (`EchClientHelloType`).
+    ///
+    /// Specified in [draft-ietf-tls-esni Section 5].
+    ///
+    /// [draft-ietf-tls-esni Section 5]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-18.html#section-5>
+    @U8
+    pub enum EchClientHelloType {
+        ClientHelloOuter => 0,
+        ClientHelloInner => 1
     }
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -556,7 +556,7 @@ pub mod client {
     };
     #[cfg(feature = "std")]
     pub use client_conn::{ClientConnection, WriteEarlyData};
-    pub use ech::{EchConfig, EchStatus};
+    pub use ech::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
     #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ClientSessionMemoryCache;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -429,7 +429,7 @@ pub mod internal {
     /// Low-level TLS message parsing and encoding functions.
     pub mod msgs {
         pub mod base {
-            pub use crate::msgs::base::Payload;
+            pub use crate::msgs::base::{Payload, PayloadU16};
         }
         pub mod codec {
             pub use crate::msgs::codec::{Codec, Reader};

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -514,8 +514,8 @@ pub use crate::enums::{
     ProtocolVersion, SignatureAlgorithm, SignatureScheme,
 };
 pub use crate::error::{
-    CertRevocationListError, CertificateError, Error, InvalidMessage, OtherError, PeerIncompatible,
-    PeerMisbehaved,
+    CertRevocationListError, CertificateError, EncryptedClientHelloError, Error, InvalidMessage,
+    OtherError, PeerIncompatible, PeerMisbehaved,
 };
 pub use crate::key_log::{KeyLog, NoKeyLog};
 #[cfg(feature = "std")]
@@ -542,6 +542,7 @@ pub mod client {
     pub(super) mod builder;
     mod client_conn;
     mod common;
+    mod ech;
     pub(super) mod handy;
     mod hs;
     #[cfg(feature = "tls12")]
@@ -555,6 +556,7 @@ pub mod client {
     };
     #[cfg(feature = "std")]
     pub use client_conn::{ClientConnection, WriteEarlyData};
+    pub use ech::{EchConfig, EchStatus};
     #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ClientSessionMemoryCache;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -448,7 +448,7 @@ pub mod internal {
         pub mod handshake {
             pub use crate::msgs::handshake::{
                 CertificateChain, ClientExtension, ClientHelloPayload, DistinguishedName,
-                EchConfig, EchConfigContents, HandshakeMessagePayload, HandshakePayload,
+                EchConfigContents, EchConfigPayload, HandshakeMessagePayload, HandshakePayload,
                 HpkeKeyConfig, HpkeSymmetricCipherSuite, KeyShareEntry, Random, ServerName,
                 SessionId,
             };

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -116,6 +116,7 @@ enum_builder! {
         ChannelId => 0x754f,
         RenegotiationInfo => 0xff01,
         TransportParametersDraft => 0xffa5,
+        EncryptedClientHello => 0xfe0d, // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-11.1
     }
 }
 
@@ -324,6 +325,19 @@ enum_builder! {
     }
 }
 
+impl HpkeAead {
+    /// Returns the length of the tag for the AEAD algorithm, or none if the AEAD is EXPORT_ONLY.
+    pub(crate) fn tag_len(&self) -> Option<usize> {
+        match self {
+            // See RFC 9180 Section 7.3, column `Nt`, the length in bytes of the authentication tag
+            // for the algorithm.
+            // https://www.rfc-editor.org/rfc/rfc9180.html#section-7.3
+            Self::AES_128_GCM | Self::AES_256_GCM | Self::CHACHA20_POLY_1305 => Some(16),
+            _ => None,
+        }
+    }
+}
+
 impl Default for HpkeAead {
     // TODO(XXX): revisit the default configuration. This is just what Cloudflare ships right now.
     fn default() -> Self {
@@ -340,7 +354,7 @@ enum_builder! {
     /// [draft-ietf-tls-esni Section 4]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-17.html#section-4>
     @U16
     pub enum EchVersion {
-        V14 => 0xfe0d,
+        V18 => 0xfe0d,
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2690,12 +2690,12 @@ impl Codec<'_> for EchConfigContents {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct EchConfig {
+pub struct EchConfigPayload {
     pub version: EchVersion,
     pub contents: EchConfigContents,
 }
 
-impl Codec<'_> for EchConfig {
+impl Codec<'_> for EchConfigPayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.version.encode(bytes);
         let mut contents = Vec::with_capacity(128);
@@ -2716,7 +2716,7 @@ impl Codec<'_> for EchConfig {
     }
 }
 
-impl TlsListElement for EchConfig {
+impl TlsListElement for EchConfigPayload {
     const SIZE_LEN: ListLength = ListLength::U16;
 }
 

--- a/rustls/tests/ech.rs
+++ b/rustls/tests/ech.rs
@@ -2,11 +2,11 @@ use base64::prelude::{Engine, BASE64_STANDARD};
 use pki_types::DnsName;
 use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::enums::{EchVersion, HpkeAead, HpkeKdf, HpkeKem};
-use rustls::internal::msgs::handshake::{EchConfig, HpkeKeyConfig, HpkeSymmetricCipherSuite};
+use rustls::internal::msgs::handshake::{EchConfigPayload, HpkeKeyConfig, HpkeSymmetricCipherSuite};
 
 #[test]
 fn test_decode_config_list() {
-    fn assert_config(config: &EchConfig, public_name: impl AsRef<[u8]>, max_len: u8) {
+    fn assert_config(config: &EchConfigPayload, public_name: impl AsRef<[u8]>, max_len: u8) {
         assert_eq!(config.version, EchVersion::V14);
         assert_eq!(config.contents.maximum_name_length, max_len);
         assert_eq!(
@@ -83,7 +83,7 @@ fn test_echconfig_serialization() {
     assert_round_trip_eq(BASE64_ECHCONFIG_LIST_CF);
 }
 
-fn get_ech_config(s: &str) -> Vec<EchConfig> {
+fn get_ech_config(s: &str) -> Vec<EchConfigPayload> {
     let bytes = BASE64_STANDARD.decode(s).unwrap();
     Vec::<_>::read(&mut Reader::init(&bytes)).unwrap()
 }

--- a/rustls/tests/ech.rs
+++ b/rustls/tests/ech.rs
@@ -2,18 +2,19 @@ use base64::prelude::{Engine, BASE64_STANDARD};
 use pki_types::DnsName;
 use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::enums::{EchVersion, HpkeAead, HpkeKdf, HpkeKem};
-use rustls::internal::msgs::handshake::{EchConfigPayload, HpkeKeyConfig, HpkeSymmetricCipherSuite};
+use rustls::internal::msgs::handshake::{
+    EchConfigContents, EchConfigPayload, HpkeKeyConfig, HpkeSymmetricCipherSuite,
+};
 
 #[test]
 fn test_decode_config_list() {
-    fn assert_config(config: &EchConfigPayload, public_name: impl AsRef<[u8]>, max_len: u8) {
-        assert_eq!(config.version, EchVersion::V14);
-        assert_eq!(config.contents.maximum_name_length, max_len);
+    fn assert_config(contents: &EchConfigContents, public_name: impl AsRef<[u8]>, max_len: u8) {
+        assert_eq!(contents.maximum_name_length, max_len);
         assert_eq!(
-            config.contents.public_name,
+            contents.public_name,
             DnsName::try_from(public_name.as_ref()).unwrap()
         );
-        assert!(config.contents.extensions.0.is_empty());
+        assert!(contents.extensions.is_empty());
     }
 
     fn assert_key_config(
@@ -29,9 +30,12 @@ fn test_decode_config_list() {
 
     let config_list = get_ech_config(BASE64_ECHCONFIG_LIST_LOCALHOST);
     assert_eq!(config_list.len(), 1);
-    assert_config(&config_list[0], "localhost", 128);
+    let EchConfigPayload::V18(contents) = &config_list[0] else {
+        panic!("unexpected ECH config version: {:?}", config_list[0]);
+    };
+    assert_config(contents, "localhost", 128);
     assert_key_config(
-        &config_list[0].contents.key_config,
+        &contents.key_config,
         0,
         HpkeKem::DHKEM_X25519_HKDF_SHA256,
         vec![
@@ -48,9 +52,12 @@ fn test_decode_config_list() {
 
     let config_list = get_ech_config(BASE64_ECHCONFIG_LIST_CF);
     assert_eq!(config_list.len(), 2);
-    assert_config(&config_list[0], "cloudflare-esni.com", 37);
+    let EchConfigPayload::V18(contents_a) = &config_list[0] else {
+        panic!("unexpected ECH config version: {:?}", config_list[0]);
+    };
+    assert_config(contents_a, "cloudflare-esni.com", 37);
     assert_key_config(
-        &config_list[0].contents.key_config,
+        &contents_a.key_config,
         195,
         HpkeKem::DHKEM_X25519_HKDF_SHA256,
         vec![HpkeSymmetricCipherSuite {
@@ -58,9 +65,12 @@ fn test_decode_config_list() {
             aead_id: HpkeAead::AES_128_GCM,
         }],
     );
-    assert_config(&config_list[1], "cloudflare-esni.com", 42);
+    let EchConfigPayload::V18(contents_b) = &config_list[1] else {
+        panic!("unexpected ECH config version: {:?}", config_list[1]);
+    };
+    assert_config(contents_b, "cloudflare-esni.com", 42);
     assert_key_config(
-        &config_list[1].contents.key_config,
+        &contents_b.key_config,
         3,
         HpkeKem::DHKEM_P256_HKDF_SHA256,
         vec![HpkeSymmetricCipherSuite {
@@ -68,6 +78,21 @@ fn test_decode_config_list() {
             aead_id: HpkeAead::AES_128_GCM,
         }],
     );
+
+    let config_list = get_ech_config(BASE64_ECHCONFIG_LIST_WITH_UNSUPPORTED);
+    assert_eq!(config_list.len(), 4);
+    // The first config should be unsupported.
+    assert!(matches!(
+        config_list[0],
+        EchConfigPayload::Unknown {
+            version: EchVersion::Unknown(0xBADD),
+            ..
+        }
+    ));
+    // The other configs should be recognized.
+    for config in config_list.iter().skip(1) {
+        assert!(matches!(config, EchConfigPayload::V18(_)));
+    }
 }
 
 #[test]
@@ -81,6 +106,7 @@ fn test_echconfig_serialization() {
 
     assert_round_trip_eq(BASE64_ECHCONFIG_LIST_LOCALHOST);
     assert_round_trip_eq(BASE64_ECHCONFIG_LIST_CF);
+    assert_round_trip_eq(BASE64_ECHCONFIG_LIST_WITH_UNSUPPORTED);
 }
 
 fn get_ech_config(s: &str) -> Vec<EchConfigPayload> {
@@ -95,3 +121,6 @@ const BASE64_ECHCONFIG_LIST_LOCALHOST: &str =
 // Two EchConfigs, both with server-name "cloudflare-esni.com".
 const BASE64_ECHCONFIG_LIST_CF: &str =
     "AK3+DQBCwwAgACAJ9T5U4FeM6631r2bvAuGtmEd8zQaoTkFAtArTcMl/XQAEAAEAASUTY2xvdWRmbGFyZS1lc25pLmNvbQAA/g0AYwMAEABBBGGbUlGLuGRorUeFwmrgHImkrh9uxoPrnFKpS5bQvnc5grfMS3PvymQ2FYL02WQi1ZzZJg5OsYYdzlaGYnEoJNsABAABAAEqE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==";
+
+// Three EchConfigs, the first one with an unsupported version.
+const BASE64_ECHCONFIG_LIST_WITH_UNSUPPORTED: &str = "AQW63QAFBQQDAgH+DQBmAAAQAEEE5itp4r9ln5e+Lx4NlIpM1Zdrt6keDUb73ampHp3culoB59aXqAoY+cPEox5W4nyDSNsWGhz1HX7xlC1Lz3IiwQAMAAEAAQABAAIAAQADQA5wdWJsaWMuZXhhbXBsZQAA/g0APQAAIAAgfWYWFXMCFK7ucFMzZvNqYJ6tZcDCCOYjIjRqtbzY3hwABBERIiJADnB1YmxpYy5leGFtcGxlAAD+DQBNAAAgACCFvWoDJ3wlQntS4mngx3qOtSS6HrPS8TJmLUsKxstzVwAMAAEAAQABAAIAAQADQA5wdWJsaWMuZXhhbXBsZQAIqqoABHRlc3Q=";


### PR DESCRIPTION
## Description

This branch brings encrypted client hello (ECH) compatibility to Rustls **clients** based on [draft-ietf-tls-esni-18](https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18). 

Closes https://github.com/rustls/rustls/issues/199

## Limitations

* It does _not_ add any support for writing Rustls' servers that accept ECH (in either shared or split mode). I think client support is the most important at this stage, and this branch is already very large/complex. We will track server-side support in https://github.com/rustls/rustls/issues/1980

* Extension compression is implemented separately in https://github.com/cpu/rustls/pull/6

<details>
<summary>Comparison to previous PRs:</summary>

## Server Name Enum

Initially we expected to update the `ServerName` enum to have a variant for ECH - I tried this initially and found that it didn't fit the design of ECH very well. Mainly the issue is that we need to carry a lot of additional state beyond the inner SNI name. Putting that state into the `ServerName` is challenging, and an impedance mismatch with the existing usage. Having separate state _and_ the ECH variant in `ServerName` meant having two pieces of information and having to contend with what to do if one is present but not the other. This is also made increasingly complex since we lifted the `ServerName` type into the pki-types crate. As a point of reference, you can compare this branch with the approach in https://github.com/rustls/rustls/pull/663 where a `ServerIdentity` enum stands in for `ServerName` and contains a `EncryptedClientHello(Box<EncryptedClientHello>)` variant that holds a `Box` of heap allocated state.

## Credit where credit is due

I started this branch by first adopting work from what @sayrer started in https://github.com/rustls/rustls/pull/663. Many thanks for kicking this effort off and giving me a solid foundation to start with!

Some major changes compared to that branch:

* This branch updates from draft-10 to draft-18, rolling in associated changes (mostly related to confirmation, extension types, etc).
* As discussed above, I opted to not use a `ServerName` variant for holding the inner SNI name and associated state.
* I've caught up the diff to the current Rustls `main`, adjusting for various `Codec` changes and associated code drift.
* HPKE usage is handled through the trait, abstracting away the choice of implementation as opposed to using hpke-rs directly.
* An HPKE provider backed by aws-lc-rs was implemented so we can have a crypto provider out-of-box that supports ECH.
* I've implemented support for ECH confirmation across Hello Retry Requests - this in turn required reworking how the "inner" transcript is maintained, calculating the HRR confirmation, and threading through more bits of state across the handshake.
* I've implemented support for session resumption in the inner hello when using ECH, including support for the GREASE PSK in the outer hello.
* I've tried to avoid duplicating encoding code, instead introducing an encoding `Purpose` that lets us share the message encoding logic as much as possible with the exception of the parts that are unique for ECH confirmation.
* I've tried to roll requirements into the existing code where possible to avoid duplication (e.g. updating the hash transcripts to allow forking, updating the key derivation code to allow confirmation calculation).
* I've wired in the "ECH required" alert, and pulling out ECH retry configs from the server's encrypted extensions. The retry configs and alert are held until the end of the handshake per spec.
* The ECH config HPKE suite is considered w.r.t FIPS status of the client config, or client connection, when using ECH.
* I've implemented test coverage with boringssl's bogo test suite, fixing divergences as appropriate.
* Probably some additional items I'm forgetting!

</details>