### PR TITLE
docs: provide more guidance for customizing private keys

### DIFF
--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -202,6 +202,13 @@ pub trait SecureRandom: Send + Sync + Debug {
 }
 
 /// A mechanism for loading private [SigningKey]s from [PrivateKeyDer].
+///
+/// This trait is intended to be used with private key material that is sourced from DER,
+/// such as a private-key that may be present on-disk. It is not intended to be used with
+/// keys held in hardware security modules (HSMs) or physical tokens. For these use-cases
+/// see the Rustls manual section on [customizing private key usage].
+///
+/// [customizing private key usage]: <https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#customising-private-key-usage>
 pub trait KeyProvider: Send + Sync + Debug {
     /// Decode and validate a private signing key from `key_der`.
     ///

--- a/rustls/src/manual/howto.rs
+++ b/rustls/src/manual/howto.rs
@@ -21,6 +21,9 @@ Once you have these two pieces, configuring a server to use them involves, brief
 - making a [`ResolvesServerCertUsingSni`][cert_using_sni] and feeding in your `sign::CertifiedKey` for all SNI hostnames you want to use it for,
 - setting that as your `ServerConfig`'s [`cert_resolver`][cert_resolver]
 
+For a complete example of implementing a custom `sign::SigningKey` and `sign::Signer` see
+the [rustls-cng] crate.
+
 [signing_key]: ../../sign/trait.SigningKey.html
 [choose_scheme]: ../../sign/trait.SigningKey.html#tymethod.choose_scheme
 [sig_scheme]: ../../enum.SignatureScheme.html
@@ -29,6 +32,7 @@ Once you have these two pieces, configuring a server to use them involves, brief
 [certified_key]: ../../sign/struct.CertifiedKey.html
 [cert_using_sni]: ../../struct.ResolvesServerCertUsingSni.html
 [cert_resolver]: ../../struct.ServerConfig.html#structfield.cert_resolver
+[rustls-cng]: https://github.com/rustls/rustls-cng/blob/dev/src/signer.rs
 
 [^1]: For PKCS#8 it does not support password encryption -- there's not a meaningful threat
       model addressed by this, and the encryption supported is typically extremely poor.


### PR DESCRIPTION
This branch adds a pointer from the `KeyProvider` trait to the manual section on customizing private key usage. It also updates that section of the manual to point to the `rustls-cng` crate as a complete example.

Updates https://github.com/rustls/rustls/issues/1703