### PR TITLE
macros: allow trailing enum_builder comma

### DIFF
--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -41,7 +41,7 @@ enum_builder! {
         BadCertificateHashValue => 0x72,
         UnknownPSKIdentity => 0x73,
         CertificateRequired => 0x74,
-        NoApplicationProtocol => 0x78
+        NoApplicationProtocol => 0x78,
     }
 }
 
@@ -69,7 +69,7 @@ enum_builder! {
         CertificateURL => 0x15,
         CertificateStatus => 0x16,
         KeyUpdate => 0x18,
-        MessageHash => 0xfe
+        MessageHash => 0xfe,
     }
 }
 
@@ -83,7 +83,7 @@ enum_builder! {
         Alert => 0x15,
         Handshake => 0x16,
         ApplicationData => 0x17,
-        Heartbeat => 0x18
+        Heartbeat => 0x18,
     }
 }
 
@@ -101,7 +101,7 @@ enum_builder! {
         TLSv1_3 => 0x0304,
         DTLSv1_0 => 0xFEFF,
         DTLSv1_2 => 0xFEFD,
-        DTLSv1_3 => 0xFEFC
+        DTLSv1_3 => 0xFEFC,
     }
 }
 
@@ -486,7 +486,7 @@ enum_builder! {
         TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => 0xccad,
         TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256 => 0xccae,
         SSL_RSA_FIPS_WITH_DES_CBC_SHA => 0xfefe,
-        SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA => 0xfeff
+        SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA => 0xfeff,
     }
 }
 
@@ -508,7 +508,7 @@ enum_builder! {
         RSA_PSS_SHA384 => 0x0805,
         RSA_PSS_SHA512 => 0x0806,
         ED25519 => 0x0807,
-        ED448 => 0x0808
+        ED448 => 0x0808,
     }
 }
 
@@ -563,7 +563,7 @@ enum_builder! {
         DSA => 0x02,
         ECDSA => 0x03,
         ED25519 => 0x07,
-        ED448 => 0x08
+        ED448 => 0x08,
     }
 }
 

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -15,7 +15,7 @@ enum_builder! {
         SHA224 => 0x03,
         SHA256 => 0x04,
         SHA384 => 0x05,
-        SHA512 => 0x06
+        SHA512 => 0x06,
     }
 }
 
@@ -34,7 +34,7 @@ enum_builder! {
         FortezzaDMS => 0x14,
         ECDSASign => 0x40,
         RSAFixedECDH => 0x41,
-        ECDSAFixedECDH => 0x42
+        ECDSAFixedECDH => 0x42,
     }
 }
 
@@ -46,7 +46,7 @@ enum_builder! {
     pub enum Compression {
         Null => 0x00,
         Deflate => 0x01,
-        LSZ => 0x40
+        LSZ => 0x40,
     }
 }
 
@@ -57,7 +57,7 @@ enum_builder! {
     @U8
     pub enum AlertLevel {
         Warning => 0x01,
-        Fatal => 0x02
+        Fatal => 0x02,
     }
 }
 
@@ -68,7 +68,7 @@ enum_builder! {
     @U8
     pub(crate) enum HeartbeatMessageType {
         Request => 0x01,
-        Response => 0x02
+        Response => 0x02,
     }
 }
 
@@ -114,7 +114,7 @@ enum_builder! {
         NextProtocolNegotiation => 0x3374,
         ChannelId => 0x754f,
         RenegotiationInfo => 0xff01,
-        TransportParametersDraft => 0xffa5
+        TransportParametersDraft => 0xffa5,
     }
 }
 
@@ -124,7 +124,7 @@ enum_builder! {
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
     pub(crate) enum ServerNameType {
-        HostName => 0x00
+        HostName => 0x00,
     }
 }
 
@@ -170,7 +170,7 @@ enum_builder! {
         X25519 => 0x001d,
         X448 => 0x001e,
         arbitrary_explicit_prime_curves => 0xff01,
-        arbitrary_explicit_char2_curves => 0xff02
+        arbitrary_explicit_char2_curves => 0xff02,
     }
 }
 
@@ -189,7 +189,7 @@ enum_builder! {
         FFDHE3072 => 0x0101,
         FFDHE4096 => 0x0102,
         FFDHE6144 => 0x0103,
-        FFDHE8192 => 0x0104
+        FFDHE8192 => 0x0104,
     }
 }
 
@@ -201,7 +201,7 @@ enum_builder! {
     pub enum ECPointFormat {
         Uncompressed => 0x00,
         ANSIX962CompressedPrime => 0x01,
-        ANSIX962CompressedChar2 => 0x02
+        ANSIX962CompressedChar2 => 0x02,
     }
 }
 
@@ -216,7 +216,7 @@ enum_builder! {
     @U8
     pub(crate) enum HeartbeatMode {
         PeerAllowedToSend => 0x01,
-        PeerNotAllowedToSend => 0x02
+        PeerNotAllowedToSend => 0x02,
     }
 }
 
@@ -228,7 +228,7 @@ enum_builder! {
     pub(crate) enum ECCurveType {
         ExplicitPrime => 0x01,
         ExplicitChar2 => 0x02,
-        NamedCurve => 0x03
+        NamedCurve => 0x03,
     }
 }
 
@@ -239,7 +239,7 @@ enum_builder! {
     @U8
     pub enum PSKKeyExchangeMode {
         PSK_KE => 0x00,
-        PSK_DHE_KE => 0x01
+        PSK_DHE_KE => 0x01,
     }
 }
 
@@ -250,7 +250,7 @@ enum_builder! {
     @U8
     pub enum KeyUpdateRequest {
         UpdateNotRequested => 0x00,
-        UpdateRequested => 0x01
+        UpdateRequested => 0x01,
     }
 }
 
@@ -260,7 +260,7 @@ enum_builder! {
     /// The `Unknown` item is used when processing unrecognised ordinals.
     @U8
     pub enum CertificateStatusType {
-        OCSP => 0x01
+        OCSP => 0x01,
     }
 }
 
@@ -275,7 +275,7 @@ enum_builder! {
         DHKEM_P384_HKDF_SHA384 => 0x0011,
         DHKEM_P521_HKDF_SHA512 => 0x0012,
         DHKEM_X25519_HKDF_SHA256 => 0x0020,
-        DHKEM_X448_HKDF_SHA512 => 0x0021
+        DHKEM_X448_HKDF_SHA512 => 0x0021,
     }
 }
 
@@ -288,7 +288,7 @@ enum_builder! {
     pub enum HpkeKdf {
         HKDF_SHA256 => 0x0001,
         HKDF_SHA384 => 0x0002,
-        HKDF_SHA512 => 0x0003
+        HKDF_SHA512 => 0x0003,
     }
 }
 
@@ -309,7 +309,7 @@ enum_builder! {
         AES_128_GCM => 0x0001,
         AES_256_GCM => 0x0002,
         CHACHA20_POLY_1305 => 0x0003,
-        EXPORT_ONLY => 0xFFFF
+        EXPORT_ONLY => 0xFFFF,
     }
 }
 
@@ -329,7 +329,7 @@ enum_builder! {
     /// [draft-ietf-tls-esni Section 4]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-17.html#section-4>
     @U16
     pub enum EchVersion {
-        V14 => 0xfe0d
+        V14 => 0xfe0d,
     }
 }
 

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -4,7 +4,7 @@ macro_rules! enum_builder {
     $(#[$comment:meta])*
     @U8
         $enum_vis:vis enum $enum_name:ident
-        { $( $enum_var: ident => $enum_val: expr ),* }
+        { $( $enum_var: ident => $enum_val: expr ),* $(,)? }
     ) => {
         $(#[$comment])*
         #[non_exhaustive]
@@ -49,7 +49,7 @@ macro_rules! enum_builder {
     $(#[$comment:meta])*
     @U16
         $enum_vis:vis enum $enum_name:ident
-        { $( $enum_var: ident => $enum_val: expr ),* }
+        { $( $enum_var: ident => $enum_val: expr ),* $(,)?}
     ) => {
         $(#[$comment])*
         #[non_exhaustive]


### PR DESCRIPTION
Small quality of life improvement pulled out of a suggestion [from djc](https://github.com/rustls/rustls/pull/1718#discussion_r1441536825) on #1718.

Without allowing a trailing comma for invocations of the `enum_builder!` macro we end up creating messy two line diffs for every addition to an existing built enum.

This branch updates the macro definition to allow an optional trailing comma, and then once the macro allows a trailing comma each usage is updated to include one. This will make any future diffs that add elements to these enums easier to review.
