### PR TITLE
msgs/handshake.rs: remove get_ fn prefixes

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -42,7 +42,7 @@ impl ClientHelloDetails {
         allowed_unsolicited: &[ExtensionType],
     ) -> bool {
         for ext in received_exts {
-            let ext_type = ext.get_type();
+            let ext_type = ext.ext_type();
             if !self.sent_extensions.contains(&ext_type) && !allowed_unsolicited.contains(&ext_type)
             {
                 trace!("Unsolicited extension {:?}", ext_type);

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -274,7 +274,7 @@ fn emit_client_hello_for_retry(
     // Note what extensions we sent.
     input.hello.sent_extensions = exts
         .iter()
-        .map(ClientExtension::get_type)
+        .map(ClientExtension::ext_type)
         .collect();
 
     let mut cipher_suites: Vec<_> = config

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -772,7 +772,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         }
 
         // Or asks us to talk a protocol we didn't offer, or doesn't support HRR at all.
-        match hrr.get_supported_versions() {
+        match hrr.supported_versions() {
             Some(ProtocolVersion::TLSv1_3) => {
                 cx.common.negotiated_version = Some(ProtocolVersion::TLSv1_3);
             }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -564,7 +564,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
 
         // Extract ALPN protocol
         if !cx.common.is_tls13() {
-            process_alpn_protocol(cx.common, config, server_hello.get_alpn_protocol())?;
+            process_alpn_protocol(cx.common, config, server_hello.alpn_protocol())?;
         }
 
         // If ECPointFormats extension is supplied by the server, it must contain

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -492,7 +492,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
 
         let server_version = if server_hello.legacy_version == TLSv1_2 {
             server_hello
-                .get_supported_versions()
+                .supported_versions()
                 .unwrap_or(server_hello.legacy_version)
         } else {
             server_hello.legacy_version
@@ -508,7 +508,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
                 }
 
                 if server_hello
-                    .get_supported_versions()
+                    .supported_versions()
                     .is_some()
                 {
                     return Err({

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -569,7 +569,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
 
         // If ECPointFormats extension is supplied by the server, it must contain
         // Uncompressed.  But it's allowed to be omitted.
-        if let Some(point_fmts) = server_hello.get_ecpoints_extension() {
+        if let Some(point_fmts) = server_hello.ecpoints_extension() {
             if !point_fmts.contains(&ECPointFormat::Uncompressed) {
                 return Err(cx.common.send_fatal_alert(
                     AlertDescription::HandshakeFailure,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -693,7 +693,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         cx.common.check_aligned_handshake()?;
 
         let cookie = hrr.get_cookie();
-        let req_group = hrr.get_requested_key_share_group();
+        let req_group = hrr.requested_key_share_group();
 
         // We always send a key share when TLS 1.3 is enabled.
         let offered_key_share = self.next.offered_key_share.unwrap();

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -244,7 +244,7 @@ fn emit_client_hello_for_retry(
         exts.push(ClientExtension::KeyShare(vec![key_share]));
     }
 
-    if let Some(cookie) = retryreq.and_then(HelloRetryRequest::get_cookie) {
+    if let Some(cookie) = retryreq.and_then(HelloRetryRequest::cookie) {
         exts.push(ClientExtension::Cookie(cookie.clone()));
     }
 
@@ -692,7 +692,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
 
         cx.common.check_aligned_handshake()?;
 
-        let cookie = hrr.get_cookie();
+        let cookie = hrr.cookie();
         let req_group = hrr.requested_key_share_group();
 
         // We always send a key share when TLS 1.3 is enabled.

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -569,7 +569,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             self.config
                 .client_auth_cert_resolver
                 .as_ref(),
-            certreq.get_authorities_extension(),
+            certreq.authorities_extension(),
             &compat_sigschemes,
             Some(certreq.context.0.clone()),
         );

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -394,7 +394,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
 
         // QUIC transport parameters
         if cx.common.is_quic() {
-            match exts.get_quic_params_extension() {
+            match exts.quic_params_extension() {
                 Some(params) => cx.common.quic.params = Some(params),
                 None => {
                     return Err(cx

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -551,7 +551,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
 
         let no_sigschemes = Vec::new();
         let compat_sigschemes = certreq
-            .get_sigalgs_extension()
+            .sigalgs_extension()
             .unwrap_or(&no_sigschemes)
             .iter()
             .cloned()

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -81,7 +81,7 @@ pub(super) fn handle_server_hello(
     validate_server_hello(cx.common, server_hello)?;
 
     let their_key_share = server_hello
-        .get_key_share()
+        .key_share()
         .ok_or_else(|| {
             cx.common.send_fatal_alert(
                 AlertDescription::MissingExtension,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -960,12 +960,12 @@ impl ExpectTraffic {
             UnixTime::now(),
             nst.lifetime,
             nst.age_add,
-            nst.get_max_early_data_size()
+            nst.max_early_data_size()
                 .unwrap_or_default(),
         );
 
         if cx.common.is_quic() {
-            if let Some(sz) = nst.get_max_early_data_size() {
+            if let Some(sz) = nst.max_early_data_size() {
                 if sz != 0 && sz != 0xffff_ffff {
                     return Err(PeerMisbehaved::InvalidMaxEarlyDataSize.into());
                 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -239,7 +239,7 @@ pub(super) fn fill_in_psk_binder(
 
     // The binder is calculated over the clienthello, but doesn't include itself or its
     // length, or the length of its container.
-    let binder_plaintext = hmp.get_encoding_for_binder_signing();
+    let binder_plaintext = hmp.encoding_for_binder_signing();
     let handshake_hash = transcript.get_hash_given(suite_hash, &binder_plaintext);
 
     // Run a fake key_schedule to simulate what the server will do if it chooses

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -390,7 +390,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
         self.transcript.add_message(&m);
 
         validate_encrypted_extensions(cx.common, &self.hello, exts)?;
-        hs::process_alpn_protocol(cx.common, &self.config, exts.get_alpn_protocol())?;
+        hs::process_alpn_protocol(cx.common, &self.config, exts.alpn_protocol())?;
 
         // QUIC transport parameters
         if cx.common.is_quic() {

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -191,7 +191,7 @@ fn validate_server_hello(
     server_hello: &ServerHelloPayload,
 ) -> Result<(), Error> {
     for ext in &server_hello.extensions {
-        if !ALLOWED_PLAINTEXT_EXTS.contains(&ext.get_type()) {
+        if !ALLOWED_PLAINTEXT_EXTS.contains(&ext.ext_type()) {
             return Err(common.send_fatal_alert(
                 AlertDescription::UnsupportedExtension,
                 PeerMisbehaved::UnexpectedCleartextExtension,
@@ -355,8 +355,8 @@ fn validate_encrypted_extensions(
     }
 
     for ext in exts {
-        if ALLOWED_PLAINTEXT_EXTS.contains(&ext.get_type())
-            || DISALLOWED_TLS13_EXTS.contains(&ext.get_type())
+        if ALLOWED_PLAINTEXT_EXTS.contains(&ext.ext_type())
+            || DISALLOWED_TLS13_EXTS.contains(&ext.ext_type())
         {
             return Err(common.send_fatal_alert(
                 AlertDescription::UnsupportedExtension,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -99,7 +99,7 @@ pub(super) fn handle_server_hello(
     }
 
     let key_schedule_pre_handshake = if let (Some(selected_psk), Some(early_key_schedule)) =
-        (server_hello.get_psk_index(), early_key_schedule)
+        (server_hello.psk_index(), early_key_schedule)
     {
         if let Some(ref resuming) = resuming_session {
             let resuming_suite = match suite.can_resume_from(resuming.suite()) {

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -621,7 +621,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
                 PeerMisbehaved::BadCertChainExtensions,
             ));
         }
-        let end_entity_ocsp = cert_chain.get_end_entity_ocsp();
+        let end_entity_ocsp = cert_chain.end_entity_ocsp();
         let server_cert = ServerCertDetails::new(cert_chain.convert(), end_entity_ocsp);
 
         Ok(Box::new(ExpectCertificateVerify {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -977,7 +977,7 @@ impl ClientHelloPayload {
             .map_or(false, |ext| ext.ext_type() == ExtensionType::PreSharedKey)
     }
 
-    pub(crate) fn get_psk_modes(&self) -> Option<&[PSKKeyExchangeMode]> {
+    pub(crate) fn psk_modes(&self) -> Option<&[PSKKeyExchangeMode]> {
         let ext = self.find_extension(ExtensionType::PSKKeyExchangeModes)?;
         match *ext {
             ClientExtension::PresharedKeyModes(ref psk_modes) => Some(psk_modes),
@@ -986,7 +986,7 @@ impl ClientHelloPayload {
     }
 
     pub(crate) fn psk_mode_offered(&self, mode: PSKKeyExchangeMode) -> bool {
-        self.get_psk_modes()
+        self.psk_modes()
             .map(|modes| modes.contains(&mode))
             .unwrap_or(false)
     }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1149,7 +1149,7 @@ impl HelloRetryRequest {
         }
     }
 
-    pub(crate) fn get_supported_versions(&self) -> Option<ProtocolVersion> {
+    pub(crate) fn supported_versions(&self) -> Option<ProtocolVersion> {
         let ext = self.find_extension(ExtensionType::SupportedVersions)?;
         match *ext {
             HelloRetryExtension::SupportedVersions(ver) => Some(ver),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1141,7 +1141,7 @@ impl HelloRetryRequest {
         }
     }
 
-    pub(crate) fn get_cookie(&self) -> Option<&PayloadU16> {
+    pub(crate) fn cookie(&self) -> Option<&PayloadU16> {
         let ext = self.find_extension(ExtensionType::Cookie)?;
         match *ext {
             HelloRetryExtension::Cookie(ref ck) => Some(ck),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1245,7 +1245,7 @@ impl ServerHelloPayload {
             .is_some()
     }
 
-    pub(crate) fn get_supported_versions(&self) -> Option<ProtocolVersion> {
+    pub(crate) fn supported_versions(&self) -> Option<ProtocolVersion> {
         let ext = self.find_extension(ExtensionType::SupportedVersions)?;
         match *ext {
             ServerExtension::SupportedVersions(vers) => Some(vers),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1223,7 +1223,7 @@ impl ServerHelloPayload {
         }
     }
 
-    pub(crate) fn get_psk_index(&self) -> Option<u16> {
+    pub(crate) fn psk_index(&self) -> Option<u16> {
         let ext = self.find_extension(ExtensionType::PreSharedKey)?;
         match *ext {
             ServerExtension::PresharedKey(ref index) => Some(*index),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -907,7 +907,7 @@ impl ClientHelloPayload {
         }
     }
 
-    pub(crate) fn get_alpn_extension(&self) -> Option<&Vec<ProtocolName>> {
+    pub(crate) fn alpn_extension(&self) -> Option<&Vec<ProtocolName>> {
         let ext = self.find_extension(ExtensionType::ALProtocolNegotiation)?;
         match *ext {
             ClientExtension::Protocols(ref req) => Some(req),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1019,7 +1019,7 @@ pub(crate) enum HelloRetryExtension {
 }
 
 impl HelloRetryExtension {
-    pub(crate) fn get_type(&self) -> ExtensionType {
+    pub(crate) fn ext_type(&self) -> ExtensionType {
         match *self {
             Self::KeyShare(_) => ExtensionType::KeyShare,
             Self::Cookie(_) => ExtensionType::Cookie,
@@ -1031,7 +1031,7 @@ impl HelloRetryExtension {
 
 impl Codec for HelloRetryExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.get_type().encode(bytes);
+        self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
         match *self {
@@ -1108,7 +1108,7 @@ impl HelloRetryRequest {
         let mut seen = BTreeSet::new();
 
         for ext in &self.extensions {
-            let typ = ext.get_type().get_u16();
+            let typ = ext.ext_type().get_u16();
 
             if seen.contains(&typ) {
                 return true;
@@ -1121,16 +1121,16 @@ impl HelloRetryRequest {
 
     pub(crate) fn has_unknown_extension(&self) -> bool {
         self.extensions.iter().any(|ext| {
-            ext.get_type() != ExtensionType::KeyShare
-                && ext.get_type() != ExtensionType::SupportedVersions
-                && ext.get_type() != ExtensionType::Cookie
+            ext.ext_type() != ExtensionType::KeyShare
+                && ext.ext_type() != ExtensionType::SupportedVersions
+                && ext.ext_type() != ExtensionType::Cookie
         })
     }
 
     fn find_extension(&self, ext: ExtensionType) -> Option<&HelloRetryExtension> {
         self.extensions
             .iter()
-            .find(|x| x.get_type() == ext)
+            .find(|x| x.ext_type() == ext)
     }
 
     pub fn get_requested_key_share_group(&self) -> Option<NamedGroup> {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -706,7 +706,7 @@ pub enum ServerExtension {
 }
 
 impl ServerExtension {
-    pub(crate) fn get_type(&self) -> ExtensionType {
+    pub(crate) fn ext_type(&self) -> ExtensionType {
         match *self {
             Self::EcPointFormats(_) => ExtensionType::ECPointFormats,
             Self::ServerNameAck => ExtensionType::ServerName,
@@ -728,7 +728,7 @@ impl ServerExtension {
 
 impl Codec for ServerExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.get_type().encode(bytes);
+        self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
         match *self {
@@ -1643,7 +1643,7 @@ pub(crate) trait HasServerExtensions {
         let mut seen = BTreeSet::new();
 
         for ext in self.get_extensions() {
-            let typ = ext.get_type().get_u16();
+            let typ = ext.ext_type().get_u16();
 
             if seen.contains(&typ) {
                 return true;
@@ -1657,7 +1657,7 @@ pub(crate) trait HasServerExtensions {
     fn find_extension(&self, ext: ExtensionType) -> Option<&ServerExtension> {
         self.get_extensions()
             .iter()
-            .find(|x| x.get_type() == ext)
+            .find(|x| x.ext_type() == ext)
     }
 
     fn get_alpn_protocol(&self) -> Option<&[u8]> {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1668,7 +1668,7 @@ pub(crate) trait HasServerExtensions {
         }
     }
 
-    fn get_quic_params_extension(&self) -> Option<Vec<u8>> {
+    fn quic_params_extension(&self) -> Option<Vec<u8>> {
         let ext = self
             .find_extension(ExtensionType::TransportParameters)
             .or_else(|| self.find_extension(ExtensionType::TransportParametersDraft))?;

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1850,7 +1850,7 @@ impl CertificateRequestPayloadTls13 {
             .find(|x| x.ext_type() == ext)
     }
 
-    pub(crate) fn get_sigalgs_extension(&self) -> Option<&[SignatureScheme]> {
+    pub(crate) fn sigalgs_extension(&self) -> Option<&[SignatureScheme]> {
         let ext = self.find_extension(ExtensionType::SignatureAlgorithms)?;
         match *ext {
             CertReqExtension::SignatureAlgorithms(ref sa) => Some(sa),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1909,7 +1909,7 @@ pub(crate) enum NewSessionTicketExtension {
 }
 
 impl NewSessionTicketExtension {
-    pub(crate) fn get_type(&self) -> ExtensionType {
+    pub(crate) fn ext_type(&self) -> ExtensionType {
         match *self {
             Self::EarlyData(_) => ExtensionType::EarlyData,
             Self::Unknown(ref r) => r.typ,
@@ -1919,7 +1919,7 @@ impl NewSessionTicketExtension {
 
 impl Codec for NewSessionTicketExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.get_type().encode(bytes);
+        self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
         match *self {
@@ -1971,7 +1971,7 @@ impl NewSessionTicketPayloadTls13 {
         let mut seen = BTreeSet::new();
 
         for ext in &self.exts {
-            let typ = ext.get_type().get_u16();
+            let typ = ext.ext_type().get_u16();
 
             if seen.contains(&typ) {
                 return true;
@@ -1985,7 +1985,7 @@ impl NewSessionTicketPayloadTls13 {
     pub(crate) fn find_extension(&self, ext: ExtensionType) -> Option<&NewSessionTicketExtension> {
         self.exts
             .iter()
-            .find(|x| x.get_type() == ext)
+            .find(|x| x.ext_type() == ext)
     }
 
     pub(crate) fn get_max_early_data_size(&self) -> Option<u32> {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1209,7 +1209,7 @@ impl Codec for ServerHelloPayload {
 }
 
 impl HasServerExtensions for ServerHelloPayload {
-    fn get_extensions(&self) -> &[ServerExtension] {
+    fn extensions(&self) -> &[ServerExtension] {
         &self.extensions
     }
 }
@@ -1635,14 +1635,14 @@ impl TlsListElement for ServerExtension {
 }
 
 pub(crate) trait HasServerExtensions {
-    fn get_extensions(&self) -> &[ServerExtension];
+    fn extensions(&self) -> &[ServerExtension];
 
     /// Returns true if there is more than one extension of a given
     /// type.
     fn has_duplicate_extension(&self) -> bool {
         let mut seen = BTreeSet::new();
 
-        for ext in self.get_extensions() {
+        for ext in self.extensions() {
             let typ = ext.ext_type().get_u16();
 
             if seen.contains(&typ) {
@@ -1655,7 +1655,7 @@ pub(crate) trait HasServerExtensions {
     }
 
     fn find_extension(&self, ext: ExtensionType) -> Option<&ServerExtension> {
-        self.get_extensions()
+        self.extensions()
             .iter()
             .find(|x| x.ext_type() == ext)
     }
@@ -1686,7 +1686,7 @@ pub(crate) trait HasServerExtensions {
 }
 
 impl HasServerExtensions for Vec<ServerExtension> {
-    fn get_extensions(&self) -> &[ServerExtension] {
+    fn extensions(&self) -> &[ServerExtension] {
         self
     }
 }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1988,7 +1988,7 @@ impl NewSessionTicketPayloadTls13 {
             .find(|x| x.ext_type() == ext)
     }
 
-    pub(crate) fn get_max_early_data_size(&self) -> Option<u32> {
+    pub(crate) fn max_early_data_size(&self) -> Option<u32> {
         let ext = self.find_extension(ExtensionType::EarlyData)?;
         match *ext {
             NewSessionTicketExtension::EarlyData(ref sz) => Some(*sz),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -899,7 +899,7 @@ impl ClientHelloPayload {
     }
 
     #[cfg(feature = "tls12")]
-    pub(crate) fn get_ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
+    pub(crate) fn ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
         let ext = self.find_extension(ExtensionType::ECPointFormats)?;
         match *ext {
             ClientExtension::EcPointFormats(ref req) => Some(req),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1858,7 +1858,7 @@ impl CertificateRequestPayloadTls13 {
         }
     }
 
-    pub(crate) fn get_authorities_extension(&self) -> Option<&[DistinguishedName]> {
+    pub(crate) fn authorities_extension(&self) -> Option<&[DistinguishedName]> {
         let ext = self.find_extension(ExtensionType::CertificateAuthorities)?;
         match *ext {
             CertReqExtension::AuthorityNames(ref an) => Some(an),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1215,7 +1215,7 @@ impl HasServerExtensions for ServerHelloPayload {
 }
 
 impl ServerHelloPayload {
-    pub(crate) fn get_key_share(&self) -> Option<&KeyShareEntry> {
+    pub(crate) fn key_share(&self) -> Option<&KeyShareEntry> {
         let ext = self.find_extension(ExtensionType::KeyShare)?;
         match *ext {
             ServerExtension::KeyShare(ref share) => Some(share),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -882,7 +882,7 @@ impl ClientHelloPayload {
         }
     }
 
-    pub fn get_sigalgs_extension(&self) -> Option<&[SignatureScheme]> {
+    pub fn sigalgs_extension(&self) -> Option<&[SignatureScheme]> {
         let ext = self.find_extension(ExtensionType::SignatureAlgorithms)?;
         match *ext {
             ClientExtension::SignatureAlgorithms(ref req) => Some(req),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1133,7 +1133,7 @@ impl HelloRetryRequest {
             .find(|x| x.ext_type() == ext)
     }
 
-    pub fn get_requested_key_share_group(&self) -> Option<NamedGroup> {
+    pub fn requested_key_share_group(&self) -> Option<NamedGroup> {
         let ext = self.find_extension(ExtensionType::KeyShare)?;
         match *ext {
             HelloRetryExtension::KeyShare(grp) => Some(grp),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1297,7 +1297,7 @@ impl CertificateExtension {
         }
     }
 
-    pub(crate) fn get_cert_status(&self) -> Option<&Vec<u8>> {
+    pub(crate) fn cert_status(&self) -> Option<&Vec<u8>> {
         match *self {
             Self::CertificateStatus(ref cs) => Some(&cs.ocsp_response.0),
             _ => None,
@@ -1391,7 +1391,7 @@ impl CertificateEntry {
         self.exts
             .iter()
             .find(|ext| ext.ext_type() == ExtensionType::StatusRequest)
-            .and_then(CertificateExtension::get_cert_status)
+            .and_then(CertificateExtension::cert_status)
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2241,7 +2241,7 @@ impl HandshakeMessagePayload {
         }
     }
 
-    pub(crate) fn get_encoding_for_binder_signing(&self) -> Vec<u8> {
+    pub(crate) fn encoding_for_binder_signing(&self) -> Vec<u8> {
         let mut ret = self.get_encoding();
 
         let binder_len = match self.payload {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -890,7 +890,7 @@ impl ClientHelloPayload {
         }
     }
 
-    pub(crate) fn get_namedgroups_extension(&self) -> Option<&[NamedGroup]> {
+    pub(crate) fn namedgroups_extension(&self) -> Option<&[NamedGroup]> {
         let ext = self.find_extension(ExtensionType::EllipticCurves)?;
         match *ext {
             ClientExtension::NamedGroups(ref req) => Some(req),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -963,7 +963,7 @@ impl ClientHelloPayload {
         false
     }
 
-    pub(crate) fn get_psk(&self) -> Option<&PresharedKeyOffer> {
+    pub(crate) fn psk(&self) -> Option<&PresharedKeyOffer> {
         let ext = self.find_extension(ExtensionType::PreSharedKey)?;
         match *ext {
             ClientExtension::PresharedKey(ref psk) => Some(psk),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -931,7 +931,7 @@ impl ClientHelloPayload {
         self.find_extension(ExtensionType::SessionTicket)
     }
 
-    pub(crate) fn get_versions_extension(&self) -> Option<&[ProtocolVersion]> {
+    pub(crate) fn versions_extension(&self) -> Option<&[ProtocolVersion]> {
         let ext = self.find_extension(ExtensionType::SupportedVersions)?;
         match *ext {
             ClientExtension::SupportedVersions(ref vers) => Some(vers),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1231,7 +1231,7 @@ impl ServerHelloPayload {
         }
     }
 
-    pub(crate) fn get_ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
+    pub(crate) fn ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
         let ext = self.find_extension(ExtensionType::ECPointFormats)?;
         match *ext {
             ServerExtension::EcPointFormats(ref fmts) => Some(fmts),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -927,7 +927,7 @@ impl ClientHelloPayload {
     }
 
     #[cfg(feature = "tls12")]
-    pub(crate) fn get_ticket_extension(&self) -> Option<&ClientExtension> {
+    pub(crate) fn ticket_extension(&self) -> Option<&ClientExtension> {
         self.find_extension(ExtensionType::SessionTicket)
     }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1290,7 +1290,7 @@ pub(crate) enum CertificateExtension {
 }
 
 impl CertificateExtension {
-    pub(crate) fn get_type(&self) -> ExtensionType {
+    pub(crate) fn ext_type(&self) -> ExtensionType {
         match *self {
             Self::CertificateStatus(_) => ExtensionType::StatusRequest,
             Self::Unknown(ref r) => r.typ,
@@ -1307,7 +1307,7 @@ impl CertificateExtension {
 
 impl Codec for CertificateExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.get_type().encode(bytes);
+        self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
         match *self {
@@ -1370,7 +1370,7 @@ impl CertificateEntry {
         let mut seen = BTreeSet::new();
 
         for ext in &self.exts {
-            let typ = ext.get_type().get_u16();
+            let typ = ext.ext_type().get_u16();
 
             if seen.contains(&typ) {
                 return true;
@@ -1384,13 +1384,13 @@ impl CertificateEntry {
     pub(crate) fn has_unknown_extension(&self) -> bool {
         self.exts
             .iter()
-            .any(|ext| ext.get_type() != ExtensionType::StatusRequest)
+            .any(|ext| ext.ext_type() != ExtensionType::StatusRequest)
     }
 
     pub(crate) fn get_ocsp_response(&self) -> Option<&Vec<u8>> {
         self.exts
             .iter()
-            .find(|ext| ext.get_type() == ExtensionType::StatusRequest)
+            .find(|ext| ext.ext_type() == ExtensionType::StatusRequest)
             .and_then(CertificateExtension::get_cert_status)
     }
 }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1387,7 +1387,7 @@ impl CertificateEntry {
             .any(|ext| ext.ext_type() != ExtensionType::StatusRequest)
     }
 
-    pub(crate) fn get_ocsp_response(&self) -> Option<&Vec<u8>> {
+    pub(crate) fn ocsp_response(&self) -> Option<&Vec<u8>> {
         self.exts
             .iter()
             .find(|ext| ext.ext_type() == ExtensionType::StatusRequest)
@@ -1460,7 +1460,7 @@ impl CertificatePayloadTls13 {
     pub(crate) fn get_end_entity_ocsp(&self) -> Vec<u8> {
         self.entries
             .first()
-            .and_then(CertificateEntry::get_ocsp_response)
+            .and_then(CertificateEntry::ocsp_response)
             .cloned()
             .unwrap_or_default()
     }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1770,7 +1770,7 @@ pub(crate) enum CertReqExtension {
 }
 
 impl CertReqExtension {
-    pub(crate) fn get_type(&self) -> ExtensionType {
+    pub(crate) fn ext_type(&self) -> ExtensionType {
         match *self {
             Self::SignatureAlgorithms(_) => ExtensionType::SignatureAlgorithms,
             Self::AuthorityNames(_) => ExtensionType::CertificateAuthorities,
@@ -1781,7 +1781,7 @@ impl CertReqExtension {
 
 impl Codec for CertReqExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.get_type().encode(bytes);
+        self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
         match *self {
@@ -1847,7 +1847,7 @@ impl CertificateRequestPayloadTls13 {
     pub(crate) fn find_extension(&self, ext: ExtensionType) -> Option<&CertReqExtension> {
         self.extensions
             .iter()
-            .find(|x| x.get_type() == ext)
+            .find(|x| x.ext_type() == ext)
     }
 
     pub(crate) fn get_sigalgs_extension(&self) -> Option<&[SignatureScheme]> {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1457,7 +1457,7 @@ impl CertificatePayloadTls13 {
         false
     }
 
-    pub(crate) fn get_end_entity_ocsp(&self) -> Vec<u8> {
+    pub(crate) fn end_entity_ocsp(&self) -> Vec<u8> {
         self.entries
             .first()
             .and_then(CertificateEntry::ocsp_response)

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1660,7 +1660,7 @@ pub(crate) trait HasServerExtensions {
             .find(|x| x.ext_type() == ext)
     }
 
-    fn get_alpn_protocol(&self) -> Option<&[u8]> {
+    fn alpn_protocol(&self) -> Option<&[u8]> {
         let ext = self.find_extension(ExtensionType::ALProtocolNegotiation)?;
         match *ext {
             ServerExtension::Protocols(ref protos) => protos.as_single_slice(),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -559,7 +559,7 @@ pub enum ClientExtension {
 }
 
 impl ClientExtension {
-    pub(crate) fn get_type(&self) -> ExtensionType {
+    pub(crate) fn ext_type(&self) -> ExtensionType {
         match *self {
             Self::EcPointFormats(_) => ExtensionType::ECPointFormats,
             Self::NamedGroups(_) => ExtensionType::EllipticCurves,
@@ -584,7 +584,7 @@ impl ClientExtension {
 
 impl Codec for ClientExtension {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.get_type().encode(bytes);
+        self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
         match *self {
@@ -857,7 +857,7 @@ impl ClientHelloPayload {
         let mut seen = BTreeSet::new();
 
         for ext in &self.extensions {
-            let typ = ext.get_type().get_u16();
+            let typ = ext.ext_type().get_u16();
 
             if seen.contains(&typ) {
                 return true;
@@ -871,7 +871,7 @@ impl ClientHelloPayload {
     pub(crate) fn find_extension(&self, ext: ExtensionType) -> Option<&ClientExtension> {
         self.extensions
             .iter()
-            .find(|x| x.get_type() == ext)
+            .find(|x| x.ext_type() == ext)
     }
 
     pub(crate) fn get_sni_extension(&self) -> Option<&[ServerName]> {
@@ -974,7 +974,7 @@ impl ClientHelloPayload {
     pub(crate) fn check_psk_ext_is_last(&self) -> bool {
         self.extensions
             .last()
-            .map_or(false, |ext| ext.get_type() == ExtensionType::PreSharedKey)
+            .map_or(false, |ext| ext.ext_type() == ExtensionType::PreSharedKey)
     }
 
     pub(crate) fn get_psk_modes(&self) -> Option<&[PSKKeyExchangeMode]> {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -278,7 +278,7 @@ impl TlsListElement for ServerName {
 
 pub(crate) trait ConvertServerNameList {
     fn has_duplicate_names_for_type(&self) -> bool;
-    fn get_single_hostname(&self) -> Option<DnsName<'_>>;
+    fn single_hostname(&self) -> Option<DnsName<'_>>;
 }
 
 impl ConvertServerNameList for [ServerName] {
@@ -295,7 +295,7 @@ impl ConvertServerNameList for [ServerName] {
         false
     }
 
-    fn get_single_hostname(&self) -> Option<DnsName<'_>> {
+    fn single_hostname(&self) -> Option<DnsName<'_>> {
         fn only_dns_hostnames(name: &ServerName) -> Option<DnsName<'_>> {
             if let ServerNamePayload::HostName(ref dns) = name.payload {
                 Some(dns.borrow())

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -939,7 +939,7 @@ impl ClientHelloPayload {
         }
     }
 
-    pub fn get_keyshare_extension(&self) -> Option<&[KeyShareEntry]> {
+    pub fn keyshare_extension(&self) -> Option<&[KeyShareEntry]> {
         let ext = self.find_extension(ExtensionType::KeyShare)?;
         match *ext {
             ClientExtension::KeyShare(ref shares) => Some(shares),
@@ -948,7 +948,7 @@ impl ClientHelloPayload {
     }
 
     pub(crate) fn has_keyshare_extension_with_duplicates(&self) -> bool {
-        if let Some(entries) = self.get_keyshare_extension() {
+        if let Some(entries) = self.keyshare_extension() {
             let mut seen = BTreeSet::new();
 
             for kse in entries {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -874,7 +874,7 @@ impl ClientHelloPayload {
             .find(|x| x.ext_type() == ext)
     }
 
-    pub(crate) fn get_sni_extension(&self) -> Option<&[ServerName]> {
+    pub(crate) fn sni_extension(&self) -> Option<&[ServerName]> {
         let ext = self.find_extension(ExtensionType::ServerName)?;
         match *ext {
             ClientExtension::ServerName(ref req) => Some(req),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -915,7 +915,7 @@ impl ClientHelloPayload {
         }
     }
 
-    pub(crate) fn get_quic_params_extension(&self) -> Option<Vec<u8>> {
+    pub(crate) fn quic_params_extension(&self) -> Option<Vec<u8>> {
         let ext = self
             .find_extension(ExtensionType::TransportParameters)
             .or_else(|| self.find_extension(ExtensionType::TransportParametersDraft))?;

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -732,7 +732,7 @@ fn test_cert_extension_getter(typ: ExtensionType, getter: fn(&CertificateEntry) 
 #[test]
 fn certentry_get_ocsp_response() {
     test_cert_extension_getter(ExtensionType::StatusRequest, |ce| {
-        ce.get_ocsp_response().is_some()
+        ce.ocsp_response().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -586,7 +586,7 @@ fn test_truncated_helloretry_extension_is_detected() {
         }
 
         // these extension types don't have any internal encoding that rustls validates:
-        if let ExtensionType::Unknown(_) = ext.get_type() {
+        if let ExtensionType::Unknown(_) = ext.ext_type() {
             continue;
         }
 
@@ -603,7 +603,7 @@ fn test_truncated_helloretry_extension_is_detected() {
 fn test_helloretry_extension_getter(typ: ExtensionType, getter: fn(&HelloRetryRequest) -> bool) {
     let mut hrr = get_sample_helloretryrequest();
     let mut exts = core::mem::take(&mut hrr.extensions);
-    exts.retain(|ext| ext.get_type() == typ);
+    exts.retain(|ext| ext.ext_type() == typ);
 
     assert!(!getter(&hrr));
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -114,7 +114,7 @@ fn can_roundtrip_unknown_client_ext() {
     let ext = ClientExtension::read(&mut rd).unwrap();
 
     println!("{:?}", ext);
-    assert_eq!(ext.get_type(), ExtensionType::Unknown(0x1234));
+    assert_eq!(ext.ext_type(), ExtensionType::Unknown(0x1234));
     assert_eq!(bytes.to_vec(), ext.get_encoding());
 }
 
@@ -167,7 +167,7 @@ fn can_roundtrip_single_sni() {
     let ext = ClientExtension::read(&mut rd).unwrap();
     println!("{:?}", ext);
 
-    assert_eq!(ext.get_type(), ExtensionType::ServerName);
+    assert_eq!(ext.ext_type(), ExtensionType::ServerName);
     assert_eq!(bytes.to_vec(), ext.get_encoding());
 }
 
@@ -178,7 +178,7 @@ fn can_round_trip_mixed_case_sni() {
     let ext = ClientExtension::read(&mut rd).unwrap();
     println!("{:?}", ext);
 
-    assert_eq!(ext.get_type(), ExtensionType::ServerName);
+    assert_eq!(ext.ext_type(), ExtensionType::ServerName);
     assert_eq!(bytes.to_vec(), ext.get_encoding());
 }
 
@@ -189,7 +189,7 @@ fn can_roundtrip_other_sni_name_types() {
     let ext = ClientExtension::read(&mut rd).unwrap();
     println!("{:?}", ext);
 
-    assert_eq!(ext.get_type(), ExtensionType::ServerName);
+    assert_eq!(ext.ext_type(), ExtensionType::ServerName);
     assert_eq!(bytes.to_vec(), ext.get_encoding());
 }
 
@@ -200,7 +200,7 @@ fn get_single_hostname_returns_none_for_other_sni_name_types() {
     let ext = ClientExtension::read(&mut rd).unwrap();
     println!("{:?}", ext);
 
-    assert_eq!(ext.get_type(), ExtensionType::ServerName);
+    assert_eq!(ext.ext_type(), ExtensionType::ServerName);
     if let ClientExtension::ServerName(snr) = ext {
         assert!(!snr.has_duplicate_names_for_type());
         assert!(snr.single_hostname().is_none());
@@ -216,7 +216,7 @@ fn can_roundtrip_multiname_sni() {
     let ext = ClientExtension::read(&mut rd).unwrap();
     println!("{:?}", ext);
 
-    assert_eq!(ext.get_type(), ExtensionType::ServerName);
+    assert_eq!(ext.ext_type(), ExtensionType::ServerName);
     assert_eq!(bytes.to_vec(), ext.get_encoding());
     match ext {
         ClientExtension::ServerName(req) => {
@@ -326,7 +326,7 @@ fn can_roundtrip_multi_proto() {
     let ext = ClientExtension::read(&mut rd).unwrap();
     println!("{:?}", ext);
 
-    assert_eq!(ext.get_type(), ExtensionType::ALProtocolNegotiation);
+    assert_eq!(ext.ext_type(), ExtensionType::ALProtocolNegotiation);
     assert_eq!(ext.get_encoding(), bytes.to_vec());
     match ext {
         ClientExtension::Protocols(prot) => {
@@ -345,7 +345,7 @@ fn can_roundtrip_single_proto() {
     let ext = ClientExtension::read(&mut rd).unwrap();
     println!("{:?}", ext);
 
-    assert_eq!(ext.get_type(), ExtensionType::ALProtocolNegotiation);
+    assert_eq!(ext.ext_type(), ExtensionType::ALProtocolNegotiation);
     assert_eq!(bytes.to_vec(), ext.get_encoding());
     match ext {
         ClientExtension::Protocols(prot) => {
@@ -468,7 +468,7 @@ fn test_truncated_client_extension_is_detected() {
         }
 
         // these extension types don't have any internal encoding that rustls validates:
-        match ext.get_type() {
+        match ext.ext_type() {
             ExtensionType::TransportParameters | ExtensionType::Unknown(_) => {
                 continue;
             }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -505,7 +505,7 @@ fn test_client_extension_getter(typ: ExtensionType, getter: fn(&ClientHelloPaylo
 #[test]
 fn client_get_sni_extension() {
     test_client_extension_getter(ExtensionType::ServerName, |chp| {
-        chp.get_sni_extension().is_some()
+        chp.sni_extension().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -561,7 +561,7 @@ fn client_get_keyshare_extension() {
 
 #[test]
 fn client_get_psk() {
-    test_client_extension_getter(ExtensionType::PreSharedKey, |chp| chp.get_psk().is_some());
+    test_client_extension_getter(ExtensionType::PreSharedKey, |chp| chp.psk().is_some());
 }
 
 #[test]

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -203,7 +203,7 @@ fn get_single_hostname_returns_none_for_other_sni_name_types() {
     assert_eq!(ext.get_type(), ExtensionType::ServerName);
     if let ClientExtension::ServerName(snr) = ext {
         assert!(!snr.has_duplicate_names_for_type());
-        assert!(snr.get_single_hostname().is_none());
+        assert!(snr.single_hostname().is_none());
     } else {
         unreachable!();
     }
@@ -224,7 +224,7 @@ fn can_roundtrip_multiname_sni() {
 
             assert!(req.has_duplicate_names_for_type());
 
-            let dns_name = req.get_single_hostname().unwrap();
+            let dns_name = req.single_hostname().unwrap();
             assert_eq!(dns_name.as_ref(), "hi");
 
             assert_eq!(req[0].typ, ServerNameType::HostName);

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -555,7 +555,7 @@ fn client_get_versions_extension() {
 #[test]
 fn client_get_keyshare_extension() {
     test_client_extension_getter(ExtensionType::KeyShare, |chp| {
-        chp.get_keyshare_extension().is_some()
+        chp.keyshare_extension().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -534,7 +534,7 @@ fn client_get_ecpoints_extension() {
 #[test]
 fn client_get_alpn_extension() {
     test_client_extension_getter(ExtensionType::ALProtocolNegotiation, |chp| {
-        chp.get_alpn_extension().is_some()
+        chp.alpn_extension().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -699,7 +699,7 @@ fn server_get_psk_index() {
 #[test]
 fn server_get_ecpoints_extension() {
     test_server_extension_getter(ExtensionType::ECPointFormats, |shp| {
-        shp.get_ecpoints_extension().is_some()
+        shp.ecpoints_extension().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -519,8 +519,7 @@ fn client_get_sigalgs_extension() {
 #[test]
 fn client_get_namedgroups_extension() {
     test_client_extension_getter(ExtensionType::EllipticCurves, |chp| {
-        chp.get_namedgroups_extension()
-            .is_some()
+        chp.namedgroups_extension().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -541,8 +541,7 @@ fn client_get_alpn_extension() {
 #[test]
 fn client_get_quic_params_extension() {
     test_client_extension_getter(ExtensionType::TransportParameters, |chp| {
-        chp.get_quic_params_extension()
-            .is_some()
+        chp.quic_params_extension().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -633,7 +633,7 @@ fn helloretry_get_cookie() {
 #[test]
 fn helloretry_get_supported_versions() {
     test_helloretry_extension_getter(ExtensionType::SupportedVersions, |hrr| {
-        hrr.get_supported_versions().is_some()
+        hrr.supported_versions().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -654,7 +654,7 @@ fn test_truncated_server_extension_is_detected() {
         }
 
         // these extension types don't have any internal encoding that rustls validates:
-        match ext.get_type() {
+        match ext.ext_type() {
             ExtensionType::TransportParameters | ExtensionType::Unknown(_) => {
                 continue;
             }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -567,7 +567,7 @@ fn client_get_psk() {
 #[test]
 fn client_get_psk_modes() {
     test_client_extension_getter(ExtensionType::PSKKeyExchangeModes, |chp| {
-        chp.get_psk_modes().is_some()
+        chp.psk_modes().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -688,7 +688,7 @@ fn test_server_extension_getter(typ: ExtensionType, getter: fn(&ServerHelloPaylo
 
 #[test]
 fn server_get_key_share() {
-    test_server_extension_getter(ExtensionType::KeyShare, |shp| shp.get_key_share().is_some());
+    test_server_extension_getter(ExtensionType::KeyShare, |shp| shp.key_share().is_some());
 }
 
 #[test]

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -512,7 +512,7 @@ fn client_get_sni_extension() {
 #[test]
 fn client_get_sigalgs_extension() {
     test_client_extension_getter(ExtensionType::SignatureAlgorithms, |chp| {
-        chp.get_sigalgs_extension().is_some()
+        chp.sigalgs_extension().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -706,7 +706,7 @@ fn server_get_ecpoints_extension() {
 #[test]
 fn server_get_supported_versions() {
     test_server_extension_getter(ExtensionType::SupportedVersions, |shp| {
-        shp.get_supported_versions().is_some()
+        shp.supported_versions().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -548,7 +548,7 @@ fn client_get_quic_params_extension() {
 #[test]
 fn client_get_versions_extension() {
     test_client_extension_getter(ExtensionType::SupportedVersions, |chp| {
-        chp.get_versions_extension().is_some()
+        chp.versions_extension().is_some()
     });
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -620,7 +620,7 @@ fn test_helloretry_extension_getter(typ: ExtensionType, getter: fn(&HelloRetryRe
 #[test]
 fn helloretry_get_requested_key_share_group() {
     test_helloretry_extension_getter(ExtensionType::KeyShare, |hrr| {
-        hrr.get_requested_key_share_group()
+        hrr.requested_key_share_group()
             .is_some()
     });
 }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -693,9 +693,7 @@ fn server_get_key_share() {
 
 #[test]
 fn server_get_psk_index() {
-    test_server_extension_getter(ExtensionType::PreSharedKey, |shp| {
-        shp.get_psk_index().is_some()
-    });
+    test_server_extension_getter(ExtensionType::PreSharedKey, |shp| shp.psk_index().is_some());
 }
 
 #[test]

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -627,7 +627,7 @@ fn helloretry_get_requested_key_share_group() {
 
 #[test]
 fn helloretry_get_cookie() {
-    test_helloretry_extension_getter(ExtensionType::Cookie, |hrr| hrr.get_cookie().is_some());
+    test_helloretry_extension_getter(ExtensionType::Cookie, |hrr| hrr.cookie().is_some());
 }
 
 #[test]

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -715,7 +715,7 @@ fn test_cert_extension_getter(typ: ExtensionType, getter: fn(&CertificateEntry) 
         .entries
         .remove(0);
     let mut exts = core::mem::take(&mut ce.exts);
-    exts.retain(|ext| ext.get_type() == typ);
+    exts.retain(|ext| ext.ext_type() == typ);
 
     assert!(!getter(&ce));
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -527,7 +527,7 @@ fn client_get_namedgroups_extension() {
 #[test]
 fn client_get_ecpoints_extension() {
     test_client_extension_getter(ExtensionType::ECPointFormats, |chp| {
-        chp.get_ecpoints_extension().is_some()
+        chp.ecpoints_extension().is_some()
     });
 }
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -133,7 +133,7 @@ impl ExtensionProcessing {
 
         let for_resume = resumedata.is_some();
         // SNI
-        if !for_resume && hello.get_sni_extension().is_some() {
+        if !for_resume && hello.sni_extension().is_some() {
             self.exts
                 .push(ServerExtension::ServerNameAck);
         }
@@ -475,7 +475,7 @@ pub(super) fn process_client_hello<'a>(
     // send an Illegal Parameter alert instead of the Internal Error alert
     // (or whatever) that we'd send if this were checked later or in a
     // different way.
-    let sni: Option<DnsName> = match client_hello.get_sni_extension() {
+    let sni: Option<DnsName> = match client_hello.sni_extension() {
         Some(sni) => {
             if sni.has_duplicate_names_for_type() {
                 return Err(cx.common.send_fatal_alert(

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -252,7 +252,7 @@ impl ExpectClientHello {
             .supports_version(ProtocolVersion::TLSv1_2);
 
         // Are we doing TLS1.3?
-        let maybe_versions_ext = client_hello.get_versions_extension();
+        let maybe_versions_ext = client_hello.versions_extension();
         let version = if let Some(versions) = maybe_versions_ext {
             if versions.contains(&ProtocolVersion::TLSv1_3) && tls13_enabled {
                 ProtocolVersion::TLSv1_3

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -121,7 +121,7 @@ impl ExtensionProcessing {
                 ));
             }
 
-            match hello.get_quic_params_extension() {
+            match hello.quic_params_extension() {
                 Some(params) => cx.common.quic.params = Some(params),
                 None => {
                     return Err(cx

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -77,7 +77,7 @@ impl ExtensionProcessing {
     ) -> Result<(), Error> {
         // ALPN
         let our_protocols = &config.alpn_protocols;
-        let maybe_their_protocols = hello.get_alpn_extension();
+        let maybe_their_protocols = hello.alpn_extension();
         if let Some(their_protocols) = maybe_their_protocols {
             let their_protocols = their_protocols.to_slices();
 
@@ -316,7 +316,7 @@ impl ExpectClientHello {
             let client_hello = ClientHello::new(
                 &cx.data.sni,
                 &sig_schemes,
-                client_hello.get_alpn_extension(),
+                client_hello.alpn_extension(),
                 &client_hello.cipher_suites,
             );
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -484,7 +484,7 @@ pub(super) fn process_client_hello<'a>(
                 ));
             }
 
-            if let Some(hostname) = sni.get_single_hostname() {
+            if let Some(hostname) = sni.single_hostname() {
                 Some(hostname.to_lowercase_owned())
             } else {
                 return Err(cx.common.send_fatal_alert(

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -507,7 +507,7 @@ pub(super) fn process_client_hello<'a>(
     }
 
     let sig_schemes = client_hello
-        .get_sigalgs_extension()
+        .sigalgs_extension()
         .ok_or_else(|| {
             cx.common.send_fatal_alert(
                 AlertDescription::HandshakeFailure,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -738,7 +738,7 @@ impl Accepted {
         ClientHello::new(
             &self.connection.core.data.sni,
             &self.sig_schemes,
-            payload.get_alpn_extension(),
+            payload.alpn_extension(),
             &payload.cipher_suites,
         )
     }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -84,7 +84,7 @@ mod client_hello {
             }
 
             let groups_ext = client_hello
-                .get_namedgroups_extension()
+                .namedgroups_extension()
                 .ok_or_else(|| {
                     cx.common.send_fatal_alert(
                         AlertDescription::HandshakeFailure,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -92,7 +92,7 @@ mod client_hello {
                     )
                 })?;
             let ecpoints_ext = client_hello
-                .get_ecpoints_extension()
+                .ecpoints_extension()
                 .ok_or_else(|| {
                     cx.common.send_fatal_alert(
                         AlertDescription::HandshakeFailure,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -129,7 +129,7 @@ mod client_hello {
             //
             let mut ticket_received = false;
             let resume_data = client_hello
-                .get_ticket_extension()
+                .ticket_extension()
                 .and_then(|ticket_ext| match ticket_ext {
                     ClientExtension::SessionTicket(ClientSessionTicket::Offer(ticket)) => {
                         Some(ticket)

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -278,7 +278,7 @@ mod client_hello {
             let mut chosen_psk_index = None;
             let mut resumedata = None;
 
-            if let Some(psk_offer) = client_hello.get_psk() {
+            if let Some(psk_offer) = client_hello.psk() {
                 if !client_hello.check_psk_ext_is_last() {
                     return Err(cx.common.send_fatal_alert(
                         AlertDescription::IllegalParameter,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -161,7 +161,7 @@ mod client_hello {
             }
 
             let groups_ext = client_hello
-                .get_namedgroups_extension()
+                .namedgroups_extension()
                 .ok_or_else(|| {
                     cx.common.send_fatal_alert(
                         AlertDescription::HandshakeFailure,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -111,9 +111,7 @@ mod client_hello {
             binder: &[u8],
         ) -> bool {
             let binder_plaintext = match &client_hello.payload {
-                MessagePayload::Handshake { parsed, .. } => {
-                    parsed.get_encoding_for_binder_signing()
-                }
+                MessagePayload::Handshake { parsed, .. } => parsed.encoding_for_binder_signing(),
                 _ => unreachable!(),
             };
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -290,7 +290,7 @@ mod client_hello {
                 //  offers a "pre_shared_key" extension. If clients offer
                 //  "pre_shared_key" without a "psk_key_exchange_modes" extension,
                 //  servers MUST abort the handshake." - RFC8446 4.2.9
-                if client_hello.get_psk_modes().is_none() {
+                if client_hello.psk_modes().is_none() {
                     return Err(cx.common.send_fatal_alert(
                         AlertDescription::MissingExtension,
                         PeerMisbehaved::MissingPskModesExtension,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -172,7 +172,7 @@ mod client_hello {
             sigschemes_ext.retain(SignatureScheme::supported_in_tls13);
 
             let shares_ext = client_hello
-                .get_keyshare_extension()
+                .keyshare_extension()
                 .ok_or_else(|| {
                     cx.common.send_fatal_alert(
                         AlertDescription::HandshakeFailure,

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4639,7 +4639,7 @@ fn test_client_rejects_hrr_with_varied_session_id() {
     let assert_server_requests_retry_and_echoes_session_id = |msg: &mut Message| -> Altered {
         if let MessagePayload::Handshake { parsed, .. } = &mut msg.payload {
             if let HandshakePayload::HelloRetryRequest(hrr) = &mut parsed.payload {
-                let group = hrr.get_requested_key_share_group();
+                let group = hrr.requested_key_share_group();
                 assert_eq!(group, Some(rustls::NamedGroup::X25519));
 
                 assert_eq!(hrr.session_id, different_session_id);

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4624,7 +4624,7 @@ fn test_client_rejects_hrr_with_varied_session_id() {
         if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
             if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
                 let keyshares = ch
-                    .get_keyshare_extension()
+                    .keyshare_extension()
                     .expect("missing key share extension");
                 assert_eq!(keyshares.len(), 1);
                 assert_eq!(keyshares[0].group(), rustls::NamedGroup::secp384r1);

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4487,7 +4487,7 @@ fn test_client_does_not_offer_sha1() {
             };
 
             let sigalgs = client_hello
-                .get_sigalgs_extension()
+                .sigalgs_extension()
                 .unwrap();
             assert!(
                 !sigalgs.contains(&SignatureScheme::RSA_PKCS1_SHA1),


### PR DESCRIPTION
This is a stylistic tidying pulled out of review feedback [from djc](https://github.com/rustls/rustls/pull/1718#discussion_r1441548330) on #1718 - we want to avoid proliferating new `get_xxx` fns in this file, but there are so many existing usages that it would be a jarring inconsistency to change style for new fns. 

Instead, this branch fixes all of the existing instances in one go so that moving forward we can avoid the `get_` prefix while maintaining consistency. We already call out avoiding `get_` prefixes in [our style guide](https://github.com/rustls/rustls/blob/main/CONTRIBUTING.md#avoid-get_-prefixes).

