### PR TITLE
Don't add empty `certificate_authorities` extension

### DIFF
--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -714,13 +714,11 @@ mod client_hello {
         cr.extensions
             .push(CertReqExtension::SignatureAlgorithms(schemes.to_vec()));
 
-        cr.extensions
-            .push(CertReqExtension::AuthorityNames(
-                config
-                    .verifier
-                    .root_hint_subjects()
-                    .to_vec(),
-            ));
+        let authorities = config.verifier.root_hint_subjects();
+        if !authorities.is_empty() {
+            cr.extensions
+                .push(CertReqExtension::AuthorityNames(authorities.to_vec()));
+        }
 
         let m = Message {
             version: ProtocolVersion::TLSv1_3,


### PR DESCRIPTION
There's already a test case for this and the API-level behaviour is unchanged.

fixes #1727 