### PR TITLE
Randomize ClientHello extensions

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -38,12 +38,14 @@ impl<'a> ServerCertDetails<'a> {
 
 pub(super) struct ClientHelloDetails {
     pub(super) sent_extensions: Vec<ExtensionType>,
+    pub(super) extension_order_seed: u16,
 }
 
 impl ClientHelloDetails {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(extension_order_seed: u16) -> Self {
         Self {
             sent_extensions: Vec::new(),
+            extension_order_seed,
         }
     }
 

--- a/rustls/src/rand.rs
+++ b/rustls/src/rand.rs
@@ -22,6 +22,13 @@ pub(crate) fn random_u32(secure_random: &dyn SecureRandom) -> Result<u32, GetRan
     Ok(u32::from_be_bytes(buf))
 }
 
+/// Return a uniformly random [`u16`].
+pub(crate) fn random_u16(secure_random: &dyn SecureRandom) -> Result<u16, GetRandomFailed> {
+    let mut buf = [0u8; 2];
+    secure_random.fill(&mut buf)?;
+    Ok(u16::from_be_bytes(buf))
+}
+
 /// Random material generation failed.
 #[derive(Debug)]
 pub struct GetRandomFailed;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5623,10 +5623,10 @@ fn test_client_construction_fails_if_random_source_fails_in_second_request() {
 }
 
 #[test]
-fn test_client_construction_requires_64_bytes_of_random_material() {
+fn test_client_construction_requires_66_bytes_of_random_material() {
     static FAULTY_RANDOM: FaultyRandom = FaultyRandom {
         rand_queue: Mutex::new(
-            b"nice random number generator !!!\
+            b"nice random number generator !!!!!\
                                  it's really not very good is it?",
         ),
     };


### PR DESCRIPTION
Google Chrome project proposes Client Hello extensions should be
randomized in order to prevent fingerprinting [1]

This commit sorts all the extensions that have been sent in the same
order as before and randomizes all new extensions that have not been sent
in the position after the extensions already seen.
And keeps the PSK extension in the end.

[1] https://chromestatus.com/feature/5124606246518784

resolves https://github.com/rustls/rustls/issues/1313