### PR TITLE
Add 'fips' cargo feature to enable to the aws-lc-rs crypto provider with the AWS-LC FIPS implementations.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,16 +43,27 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
 
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v4
+
       - name: cargo build (debug; default features)
         run: cargo build --locked
 
-      - name: cargo test (debug; all features)
-        run: cargo test --locked --all-features
+      # nb. feature sets that include "fips" should be --release --
+      # this is required for fips on windows.
+      - name: cargo test (release; all features)
+        run: cargo test --release --locked --all-features
         env:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; aws-lc-rs)
         run: cargo test --no-default-features --features aws_lc_rs,tls12,read_buf,logging
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: cargo test (release; fips)
+        run: cargo test --release --no-default-features --features fips,tls12,read_buf,logging
         env:
           RUST_BACKTRACE: 1
 
@@ -109,6 +120,10 @@ jobs:
 
       - name: cargo test (debug; no default features; aws-lc-rs,tls12)
         run: cargo test --no-default-features --features aws_lc_rs,tls12
+        working-directory: rustls
+
+      - name: cargo test (debug; no default features; fips,tls12)
+        run: cargo test --no-default-features --features fips,tls12
         working-directory: rustls
 
       - name: cargo test (release; no run)
@@ -185,6 +200,9 @@ jobs:
 
       - name: Smoke-test benchmark program (aws-lc-rs)
         run: cargo run -p rustls --release --locked --example bench --no-default-features --features aws_lc_rs,tls12
+
+      - name: Smoke-test benchmark program (fips)
+        run: cargo run -p rustls --release --locked --example bench --no-default-features --features fips,tls12
 
       - name: Run micro-benchmarks
         run: cargo bench --locked --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,18 +52,27 @@ jobs:
 
       # nb. feature sets that include "fips" should be --release --
       # this is required for fips on windows.
+      # nb. "--all-targets" does not include doctests
       - name: cargo test (release; all features)
-        run: cargo test --release --locked --all-features
+        run: cargo test --release --locked --all-features --all-targets
+        env:
+          RUST_BACKTRACE: 1
+
+      # nb. this is separate so it can be skipped on macOS & windows, where
+      # doctests don't work: https://github.com/rust-lang/cargo/issues/8531
+      - name: cargo test --doc (release; all-features)
+        if: ${{ runner.os != 'macOS' && runner.os != 'Windows' }}
+        run: cargo test --release --locked --all-features --doc
         env:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; aws-lc-rs)
-        run: cargo test --no-default-features --features aws_lc_rs,tls12,read_buf,logging
+        run: cargo test --no-default-features --features aws_lc_rs,tls12,read_buf,logging --all-targets
         env:
           RUST_BACKTRACE: 1
 
       - name: cargo test (release; fips)
-        run: cargo test --release --no-default-features --features fips,tls12,read_buf,logging
+        run: cargo test --release --no-default-features --features fips,tls12,read_buf,logging --all-targets
         env:
           RUST_BACKTRACE: 1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,11 +294,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fcdffa26123df7f3cf4215be038e3836734f31154abd602195a7ca5ef9623b"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb94ba389c4c48d9dc1983f8653cb92f7d9fc50b261e0501be2b7a636cbcbc4a"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
  "mirai-annotations",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,6 @@ dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
  "paste",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1930,7 +1929,7 @@ dependencies = [
  "getrandom",
  "libc",
  "spin 0.9.8",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.48.0",
 ]
 
@@ -2027,7 +2026,7 @@ dependencies = [
  "ring",
  "rustls-pemfile 2.0.0",
  "rustls-pki-types",
- "rustls-webpki 0.102.1",
+ "rustls-webpki 0.102.2",
  "rustversion",
  "subtle",
  "webpki-roots 0.26.0",
@@ -2100,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
+checksum = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf"
 
 [[package]]
 name = "rustls-provider-example"
@@ -2124,7 +2123,7 @@ dependencies = [
  "rsa",
  "rustls 0.23.0-alpha.0",
  "rustls-pki-types",
- "rustls-webpki 0.102.1",
+ "rustls-webpki 0.102.2",
  "serde",
  "serde_json",
  "sha2",
@@ -2140,19 +2139,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.1"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -2180,7 +2179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -2533,12 +2532,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/admin/coverage
+++ b/admin/coverage
@@ -7,6 +7,8 @@ cargo llvm-cov clean --workspace
 
 cargo build --locked --all-targets --all-features
 cargo test --locked --all-features
+cargo test --locked --no-default-features --features tls12,logging,aws_lc_rs,fips
+cargo test --locked --no-default-features --features tls12,logging,ring
 
 ## bogo
 cargo test --locked --all-features run_bogo_tests_ring -- --ignored

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -92,15 +92,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7673e0aa20ee4937c6aacfc12bb8341cfbf054cdd21df6bec5fd0629fe9339b"
+checksum = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.1"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4ca26037c909dedb327b48c3327d0ba91d3dd3c4e05dad328f210ffb68e95b"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -31,6 +31,7 @@ aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 ring = ["dep:ring", "webpki/ring"]
 tls12 = []
 read_buf = ["rustversion"]
+fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
 
 [dev-dependencies]
 base64 = "0.21"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -20,8 +20,8 @@ aws-lc-rs = { version = "1.6", optional = true, default-features = false, featur
 log = { version = "0.4.4", optional = true }
 ring = { version = "0.17", optional = true }
 subtle = { version = "2.5.0", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.102.1", features = ["std"], default-features = false }
-pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
+webpki = { package = "rustls-webpki", version = "0.102.2", features = ["std"], default-features = false }
+pki-types = { package = "rustls-pki-types", version = "1.2", features = ["std"] }
 zeroize = "1.7"
 
 [features]

--- a/rustls/examples/internal/bench_impl.rs
+++ b/rustls/examples/internal/bench_impl.rs
@@ -173,13 +173,13 @@ impl BenchmarkParam {
 }
 
 static ALL_BENCHMARKS: &[BenchmarkParam] = &[
-    #[cfg(feature = "tls12")]
+    #[cfg(all(feature = "tls12", not(feature = "fips")))]
     BenchmarkParam::new(
         KeyType::Rsa,
         cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS12,
     ),
-    #[cfg(feature = "tls12")]
+    #[cfg(all(feature = "tls12", not(feature = "fips")))]
     BenchmarkParam::new(
         KeyType::EcdsaP256,
         cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
@@ -209,6 +209,7 @@ static ALL_BENCHMARKS: &[BenchmarkParam] = &[
         cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
         &rustls::version::TLS12,
     ),
+    #[cfg(not(feature = "fips"))]
     BenchmarkParam::new(
         KeyType::Rsa,
         cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -266,6 +266,12 @@ impl ClientConfig {
         }
     }
 
+    /// Return true if connections made with this `ClientConfig` will
+    /// operate in FIPS mode.
+    pub fn fips(&self) -> bool {
+        self.provider.fips()
+    }
+
     /// We support a given TLS version if it's quoted in the configured
     /// versions *and* at least one ciphersuite for this version is
     /// also configured.

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -197,3 +197,6 @@ mod ring_shim {
         })
     }
 }
+
+/// AEAD algorithm that is used by `mod ticketer`.
+pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::AES_256_GCM;

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -188,6 +188,10 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
             iv: gcm_iv(write_iv, explicit),
         })
     }
+
+    fn fips(&self) -> bool {
+        super::fips()
+    }
 }
 
 pub(crate) struct ChaCha20Poly1305;
@@ -233,6 +237,10 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
             key,
             iv: Iv::new(iv[..].try_into().unwrap()),
         })
+    }
+
+    fn fips(&self) -> bool {
+        false // not FIPS approved
     }
 }
 
@@ -440,5 +448,9 @@ impl Prf for Tls12Prf {
             seed,
         );
         Ok(())
+    }
+
+    fn fips(&self) -> bool {
+        super::fips()
     }
 }

--- a/rustls/src/crypto/aws_lc_rs/tls13.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls13.rs
@@ -106,6 +106,10 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
         Ok(ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv })
     }
+
+    fn fips(&self) -> bool {
+        false // not FIPS approved
+    }
 }
 
 struct Aes256GcmAead(AeadAlgorithm);
@@ -130,6 +134,10 @@ impl Tls13AeadAlgorithm for Aes256GcmAead {
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
         Ok(ConnectionTrafficSecrets::Aes256Gcm { key, iv })
     }
+
+    fn fips(&self) -> bool {
+        super::fips()
+    }
 }
 
 struct Aes128GcmAead(AeadAlgorithm);
@@ -153,6 +161,10 @@ impl Tls13AeadAlgorithm for Aes128GcmAead {
         iv: Iv,
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
         Ok(ConnectionTrafficSecrets::Aes128Gcm { key, iv })
+    }
+
+    fn fips(&self) -> bool {
+        super::fips()
     }
 }
 
@@ -353,6 +365,10 @@ impl Hkdf for RingHkdf {
 
     fn hmac_sign(&self, key: &OkmBlock, message: &[u8]) -> crypto::hmac::Tag {
         crypto::hmac::Tag::new(hmac::sign(&hmac::Key::new(self.1, key.as_ref()), message).as_ref())
+    }
+
+    fn fips(&self) -> bool {
+        super::fips()
     }
 }
 

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -34,6 +34,11 @@ pub trait Tls13AeadAlgorithm: Send + Sync {
         key: AeadKey,
         iv: Iv,
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError>;
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    fn fips(&self) -> bool {
+        false
+    }
 }
 
 /// Factory trait for building `MessageEncrypter` and `MessageDecrypter` for a TLS1.2 cipher suite.
@@ -75,6 +80,11 @@ pub trait Tls12AeadAlgorithm: Send + Sync + 'static {
         iv: &[u8],
         explicit: &[u8],
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError>;
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    fn fips(&self) -> bool {
+        false
+    }
 }
 
 /// An error indicating that the AEAD algorithm does not support the requested operation.

--- a/rustls/src/crypto/hash.rs
+++ b/rustls/src/crypto/hash.rs
@@ -18,6 +18,11 @@ pub trait Hash: Send + Sync {
 
     /// Which hash function this is, eg, `HashAlgorithm::SHA256`.
     fn algorithm(&self) -> HashAlgorithm;
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    fn fips(&self) -> bool {
+        false
+    }
 }
 
 /// A hash output, stored as a value.

--- a/rustls/src/crypto/hmac.rs
+++ b/rustls/src/crypto/hmac.rs
@@ -12,6 +12,11 @@ pub trait Hmac: Send + Sync {
 
     /// Give the length of the underlying hash function.  In RFC2104 terminology this is `L`.
     fn hash_output_len(&self) -> usize;
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    fn fips(&self) -> bool {
+        false
+    }
 }
 
 /// A HMAC tag, stored as a value.

--- a/rustls/src/crypto/ring/hash.rs
+++ b/rustls/src/crypto/ring/hash.rs
@@ -29,6 +29,10 @@ impl crypto::hash::Hash for Hash {
     fn algorithm(&self) -> HashAlgorithm {
         self.1
     }
+
+    fn fips(&self) -> bool {
+        super::fips()
+    }
 }
 
 struct Context(digest::Context);

--- a/rustls/src/crypto/ring/hmac.rs
+++ b/rustls/src/crypto/ring/hmac.rs
@@ -23,6 +23,10 @@ impl crypto::hmac::Hmac for Hmac {
     fn hash_output_len(&self) -> usize {
         self.0.digest_algorithm().output_len()
     }
+
+    fn fips(&self) -> bool {
+        super::fips()
+    }
 }
 
 struct Key(ring_like::hmac::Key);

--- a/rustls/src/crypto/ring/kx.rs
+++ b/rustls/src/crypto/ring/kx.rs
@@ -44,6 +44,10 @@ impl SupportedKxGroup for KxGroup {
     fn name(&self) -> NamedGroup {
         self.name
     }
+
+    fn fips(&self) -> bool {
+        super::fips()
+    }
 }
 
 impl fmt::Debug for KxGroup {

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -192,3 +192,7 @@ mod ring_shim {
 
 /// AEAD algorithm that is used by `mod ticketer`.
 pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::CHACHA20_POLY1305;
+
+pub(super) fn fips() -> bool {
+    false
+}

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -78,13 +78,11 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -189,3 +189,6 @@ mod ring_shim {
         .map_err(|_| ())
     }
 }
+
+/// AEAD algorithm that is used by `mod ticketer`.
+pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::CHACHA20_POLY1305;

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -177,6 +177,10 @@ impl crate::quic::Algorithm for KeyBuilder {
     fn aead_key_len(&self) -> usize {
         self.0.key_len()
     }
+
+    fn fips(&self) -> bool {
+        super::fips()
+    }
 }
 
 #[cfg(test)]

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -6,6 +6,7 @@ use crate::server::ProducesTickets;
 
 use super::ring_like::aead;
 use super::ring_like::rand::{SecureRandom, SystemRandom};
+use super::TICKETER_AEAD;
 
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -20,7 +21,8 @@ impl Ticketer {
     /// Make the recommended Ticketer.  This produces tickets
     /// with a 12 hour life and randomly generated keys.
     ///
-    /// The encryption mechanism used is Chacha20Poly1305.
+    /// The encryption mechanism used is injected via TICKETER_AEAD;
+    /// it must take a 256-bit key and 96-bit nonce.
     pub fn new() -> Result<Arc<dyn ProducesTickets>, Error> {
         Ok(Arc::new(crate::ticketer::TicketSwitcher::new(
             6 * 60 * 60,
@@ -35,11 +37,10 @@ fn make_ticket_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> 
         .fill(&mut key)
         .map_err(|_| GetRandomFailed)?;
 
-    let alg = &aead::CHACHA20_POLY1305;
-    let key = aead::UnboundKey::new(alg, &key).unwrap();
+    let key = aead::UnboundKey::new(TICKETER_AEAD, &key).unwrap();
 
     Ok(Box::new(AeadTicketer {
-        alg,
+        alg: TICKETER_AEAD,
         key: aead::LessSafeKey::new(key),
         lifetime: 60 * 60 * 12,
     }))
@@ -202,10 +203,8 @@ mod tests {
 
         let t = make_ticket_generator().unwrap();
 
-        assert_eq!(
-            format!("{:?}", t),
-            "AeadTicketer { alg: CHACHA20_POLY1305, lifetime: 43200 }"
-        );
+        let expect = format!("AeadTicketer {{ alg: {TICKETER_AEAD:?}, lifetime: 43200 }}");
+        assert_eq!(format!("{:?}", t), expect);
         assert!(t.enabled());
         assert_eq!(t.lifetime(), 43200);
     }

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -173,6 +173,10 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
             iv: gcm_iv(write_iv, explicit),
         })
     }
+
+    fn fips(&self) -> bool {
+        super::fips()
+    }
 }
 
 pub(crate) struct ChaCha20Poly1305;
@@ -218,6 +222,10 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
             key,
             iv: Iv::new(iv[..].try_into().unwrap()),
         })
+    }
+
+    fn fips(&self) -> bool {
+        false // not fips approved
     }
 }
 

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -94,6 +94,10 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
         Ok(ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv })
     }
+
+    fn fips(&self) -> bool {
+        false // chacha20poly1305 not FIPS approved
+    }
 }
 
 struct Aes256GcmAead(AeadAlgorithm);
@@ -118,6 +122,10 @@ impl Tls13AeadAlgorithm for Aes256GcmAead {
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
         Ok(ConnectionTrafficSecrets::Aes256Gcm { key, iv })
     }
+
+    fn fips(&self) -> bool {
+        super::fips()
+    }
 }
 
 struct Aes128GcmAead(AeadAlgorithm);
@@ -141,6 +149,10 @@ impl Tls13AeadAlgorithm for Aes128GcmAead {
         iv: Iv,
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
         Ok(ConnectionTrafficSecrets::Aes128Gcm { key, iv })
+    }
+
+    fn fips(&self) -> bool {
+        super::fips()
     }
 }
 
@@ -266,6 +278,10 @@ impl Hkdf for RingHkdf {
 
     fn hmac_sign(&self, key: &OkmBlock, message: &[u8]) -> crypto::hmac::Tag {
         crypto::hmac::Tag::new(hmac::sign(&hmac::Key::new(self.1, key.as_ref()), message).as_ref())
+    }
+
+    fn fips(&self) -> bool {
+        super::fips()
     }
 }
 

--- a/rustls/src/crypto/tls12.rs
+++ b/rustls/src/crypto/tls12.rs
@@ -63,6 +63,11 @@ pub trait Prf: Send + Sync {
     ///
     /// The caller guarantees that `secret`, `label`, and `seed` are non-empty.
     fn for_secret(&self, output: &mut [u8], secret: &[u8], label: &[u8], seed: &[u8]);
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    fn fips(&self) -> bool {
+        false
+    }
 }
 
 pub(crate) fn prf(out: &mut [u8], hmac_key: &dyn hmac::Key, label: &[u8], seed: &[u8]) {

--- a/rustls/src/crypto/tls13.rs
+++ b/rustls/src/crypto/tls13.rs
@@ -176,6 +176,11 @@ pub trait Hkdf: Send + Sync {
     /// See [RFC2104](https://datatracker.ietf.org/doc/html/rfc2104) for the
     /// definition of HMAC.
     fn hmac_sign(&self, key: &OkmBlock, message: &[u8]) -> hmac::Tag;
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    fn fips(&self) -> bool {
+        false
+    }
 }
 
 /// `HKDF-Expand(PRK, info, L)` to construct any type from a byte array.

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -311,6 +311,10 @@
 //!   Note that aws-lc-rs has additional build-time dependencies like cmake.
 //!   See [the documentation](https://aws.github.io/aws-lc-rs/requirements/index.html) for details.
 //!
+//! - `fips`: enable support for FIPS140-3-approved cryptography, via the aws-lc-rs crate.
+//!   This feature enables the `aws_lc_rs` feature, which makes the rustls crate depend
+//!   on [aws-lc-rs](https://github.com/aws/aws-lc-rs).
+//!
 //! - `tls12` (enabled by default): enable support for TLS version 1.2. Note that, due to the
 //!   additive nature of Cargo features and because it is enabled by default, other crates
 //!   in your dependency graph could re-enable it for your application. If you want to disable

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -587,6 +587,11 @@ pub trait Algorithm: Send + Sync {
     ///
     /// This controls the size of `AeadKey`s presented to `packet_key()` and `header_protection_key()`.
     fn aead_key_len(&self) -> usize;
+
+    /// Whether this algorithm is FIPS-approved.
+    fn fips(&self) -> bool {
+        false
+    }
 }
 
 /// A QUIC header protection key

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -403,6 +403,12 @@ impl ServerConfig {
         }
     }
 
+    /// Return `true` if connections made with this `ServerConfig` will
+    /// operate in FIPS mode.
+    pub fn fips(&self) -> bool {
+        self.provider.fips()
+    }
+
     /// We support a given TLS version if it's quoted in the configured
     /// versions *and* at least one ciphersuite for this version is
     /// also configured.

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,6 +1,8 @@
 use crate::builder::ConfigBuilder;
 use crate::common_state::{CommonState, Context, Protocol, Side, State};
 use crate::conn::{ConnectionCommon, ConnectionCore, UnbufferedConnectionCommon};
+#[cfg(any(feature = "ring", feature = "fips"))]
+use crate::crypto::default_provider;
 use crate::crypto::CryptoProvider;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
@@ -12,10 +14,10 @@ use crate::msgs::message::Message;
 use crate::suites::ExtractedSecrets;
 use crate::vecbuf::ChunkVecBuffer;
 use crate::verify;
-#[cfg(feature = "ring")]
+#[cfg(any(feature = "ring", feature = "fips"))]
 use crate::versions;
 use crate::KeyLog;
-#[cfg(feature = "ring")]
+#[cfg(any(feature = "ring", feature = "fips"))]
 use crate::WantsVerifier;
 use crate::{sign, WantsVersions};
 
@@ -357,31 +359,40 @@ impl Clone for ServerConfig {
 
 impl ServerConfig {
     /// Create a builder for a server configuration with the default
-    /// [`CryptoProvider`]: [`crypto::ring::default_provider`] and safe ciphersuite and protocol
-    /// defaults.
+    /// [`CryptoProvider`].
+    ///
+    /// This is:
+    ///
+    /// - [`crypto::aws_lc_rs::default_provider`] if the `fips` crate feature is
+    ///   enabled.
+    /// - [`crypto::ring::default_provider`] if the `ring` crate feature is
+    ///   enabled and the `fips` crate feature is not enabled.
+    ///
+    /// If neither of these are true, this function is not available and you
+    /// must use [`ServerConfig::builder_with_provider()`] instead.
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
-    #[cfg(feature = "ring")]
+    #[cfg(any(feature = "ring", feature = "fips"))]
     pub fn builder() -> ConfigBuilder<Self, WantsVerifier> {
-        // Safety: we know the *ring* provider's ciphersuites are compatible with the safe default protocol versions.
-        Self::builder_with_provider(crate::crypto::ring::default_provider().into())
+        // Safety: we know the *ring* and aws-lc-rs providers' ciphersuites are compatible with the safe default protocol versions.
+        Self::builder_with_provider(default_provider().into())
             .with_safe_default_protocol_versions()
             .unwrap()
     }
 
     /// Create a builder for a server configuration with the default
-    /// [`CryptoProvider`]: [`crypto::ring::default_provider`], safe ciphersuite defaults and
-    /// the provided protocol versions.
+    /// [`CryptoProvider`] (see [`ServerConfig::builder()`] for details), safe
+    /// ciphersuite defaults and the provided protocol versions.
     ///
     /// Panics if provided an empty slice of supported versions.
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
-    #[cfg(feature = "ring")]
+    #[cfg(any(feature = "ring", feature = "fips"))]
     pub fn builder_with_protocol_versions(
         versions: &[&'static versions::SupportedProtocolVersion],
     ) -> ConfigBuilder<Self, WantsVerifier> {
-        // Safety: we know the *ring* provider's ciphersuites are compatible with all protocol version choices.
-        Self::builder_with_provider(crate::crypto::ring::default_provider().into())
+        // Safety: we know the *ring* and aws-lc-rs providers' ciphersuites are compatible with all protocol version choices.
+        Self::builder_with_provider(default_provider().into())
             .with_protocol_versions(versions)
             .unwrap()
     }

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -41,6 +41,15 @@ pub struct CipherSuiteCommon {
     pub integrity_limit: u64,
 }
 
+impl CipherSuiteCommon {
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    ///
+    /// This means all the constituent parts that do cryptography return `true` for `fips()`.
+    pub fn fips(&self) -> bool {
+        self.hash_provider.fips()
+    }
+}
+
 /// A cipher suite supported by rustls.
 ///
 /// This type carries both configuration and implementation. Compare with
@@ -115,6 +124,15 @@ impl SupportedCipherSuite {
                 .tls13()
                 .and_then(|cs| cs.quic)
                 .is_some(),
+        }
+    }
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    pub fn fips(&self) -> bool {
+        match self {
+            #[cfg(feature = "tls12")]
+            Self::Tls12(cs) => cs.fips(),
+            Self::Tls13(cs) => cs.fips(),
         }
     }
 }

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -62,6 +62,13 @@ impl Tls12CipherSuite {
             .cloned()
             .collect()
     }
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    ///
+    /// This means all the constituent parts that do cryptography return `true` for `fips()`.
+    pub fn fips(&self) -> bool {
+        self.common.fips() && self.prf_provider.fips() && self.aead_alg.fips()
+    }
 }
 
 impl From<&'static Tls12CipherSuite> for SupportedCipherSuite {

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -42,6 +42,22 @@ impl Tls13CipherSuite {
         (prev.common.hash_provider.algorithm() == self.common.hash_provider.algorithm())
             .then(|| prev)
     }
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    ///
+    /// This means all the constituent parts that do cryptography return `true` for `fips()`.
+    pub fn fips(&self) -> bool {
+        let Self {
+            common,
+            hkdf_provider,
+            aead_alg,
+            quic,
+        } = self;
+        common.fips()
+            && hkdf_provider.fips()
+            && aead_alg.fips()
+            && quic.map(|q| q.fips()).unwrap_or(true)
+    }
 }
 
 impl From<&'static Tls13CipherSuite> for SupportedCipherSuite {

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -100,6 +100,15 @@ impl WebPkiSupportedAlgorithms {
             .next()
             .ok_or_else(|| PeerMisbehaved::SignedHandshakeWithUnadvertisedSigScheme.into())
     }
+
+    /// Return `true` if all cryptography is FIPS-approved.
+    pub fn fips(&self) -> bool {
+        self.all.iter().all(|alg| alg.fips())
+            && self
+                .mapping
+                .iter()
+                .all(|item| item.1.iter().all(|alg| alg.fips()))
+    }
 }
 
 impl fmt::Debug for WebPkiSupportedAlgorithms {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5763,3 +5763,27 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
         ClientStorageOp::RemoveTls12Session(_)
     ));
 }
+
+#[cfg(feature = "ring")]
+#[test]
+fn test_client_fips_service_indicator() {
+    assert!(!make_client_config(KeyType::Rsa).fips());
+}
+
+#[cfg(feature = "ring")]
+#[test]
+fn test_server_fips_service_indicator() {
+    assert!(!make_server_config(KeyType::Rsa).fips());
+}
+
+#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[test]
+fn test_client_fips_service_indicator() {
+    assert!(make_client_config(KeyType::Rsa).fips());
+}
+
+#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+#[test]
+fn test_server_fips_service_indicator() {
+    assert!(make_server_config(KeyType::Rsa).fips());
+}


### PR DESCRIPTION
Adopts the following commits:
* [aws-lc-rs: avoid chaha20poly1305 for ticketer algorithm](https://github.com/rustls/rustls/commit/327444fdb8d8bfd74fe88533ed2b0d7fa8cfcfcb)
* [Expose FIPS "service indicator" ](https://github.com/rustls/rustls/commit/afe43b0213879924670e2ddeaf5bd290a2409050)

I've updated the aws-lc-rs CryptoProvider's `DEFAULT_CIPHER_SUITES` to only include ciphers that are `fips_mode() == true` with the 'fips' cargo feature enabled. So this no longer is 1-1 the same list as the provider's `ALL_CIPHER_SUITES`. Applications would still have access to the complete set of cipher suites available in `ALL_CIPHER_SUITES`, just that the default provider would not contain the complete list when operating with the 'fips' feature enabled.