### PR TITLE
client_conn: style tweaks for member/impl ordering

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -204,24 +204,6 @@ pub struct ClientConfig {
     pub enable_early_data: bool,
 }
 
-impl Clone for ClientConfig {
-    fn clone(&self) -> Self {
-        Self {
-            provider: Arc::<CryptoProvider>::clone(&self.provider),
-            resumption: self.resumption.clone(),
-            alpn_protocols: self.alpn_protocols.clone(),
-            max_fragment_size: self.max_fragment_size,
-            client_auth_cert_resolver: Arc::clone(&self.client_auth_cert_resolver),
-            versions: self.versions,
-            enable_sni: self.enable_sni,
-            verifier: Arc::clone(&self.verifier),
-            key_log: Arc::clone(&self.key_log),
-            enable_secret_extraction: self.enable_secret_extraction,
-            enable_early_data: self.enable_early_data,
-        }
-    }
-}
-
 impl ClientConfig {
     /// Create a builder for a client configuration with the default
     /// [`CryptoProvider`]: [`crypto::ring::default_provider`] and safe ciphersuite and
@@ -309,6 +291,24 @@ impl ClientConfig {
             .iter()
             .copied()
             .find(|skxg| skxg.name() == group)
+    }
+}
+
+impl Clone for ClientConfig {
+    fn clone(&self) -> Self {
+        Self {
+            provider: Arc::<CryptoProvider>::clone(&self.provider),
+            resumption: self.resumption.clone(),
+            alpn_protocols: self.alpn_protocols.clone(),
+            max_fragment_size: self.max_fragment_size,
+            client_auth_cert_resolver: Arc::clone(&self.client_auth_cert_resolver),
+            versions: self.versions,
+            enable_sni: self.enable_sni,
+            verifier: Arc::clone(&self.verifier),
+            key_log: Arc::clone(&self.key_log),
+            enable_secret_extraction: self.enable_secret_extraction,
+            enable_early_data: self.enable_early_data,
+        }
     }
 }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -150,9 +150,6 @@ pub trait ResolvesClientCert: fmt::Debug + Send + Sync {
 /// [`RootCertStore`]: crate::RootCertStore
 #[derive(Debug)]
 pub struct ClientConfig {
-    /// Source of randomness and other crypto.
-    pub(super) provider: Arc<CryptoProvider>,
-
     /// Which ALPN protocols we include in our client hello.
     /// If empty, no ALPN extension is sent.
     pub alpn_protocols: Vec<Vec<u8>>,
@@ -176,18 +173,11 @@ pub struct ClientConfig {
     /// How to decide what client auth certificate/keys to use.
     pub client_auth_cert_resolver: Arc<dyn ResolvesClientCert>,
 
-    /// Supported versions, in no particular order.  The default
-    /// is all supported versions.
-    pub(super) versions: versions::EnabledVersions,
-
     /// Whether to send the Server Name Indication (SNI) extension
     /// during the client handshake.
     ///
     /// The default is true.
     pub enable_sni: bool,
-
-    /// How to verify the server certificate chain.
-    pub(super) verifier: Arc<dyn verify::ServerCertVerifier>,
 
     /// How to output key material for debugging.  The default
     /// does nothing.
@@ -202,6 +192,16 @@ pub struct ClientConfig {
     ///
     /// The default is false.
     pub enable_early_data: bool,
+
+    /// Source of randomness and other crypto.
+    pub(super) provider: Arc<CryptoProvider>,
+
+    /// Supported versions, in no particular order.  The default
+    /// is all supported versions.
+    pub(super) versions: versions::EnabledVersions,
+
+    /// How to verify the server certificate chain.
+    pub(super) verifier: Arc<dyn verify::ServerCertVerifier>,
 }
 
 impl ClientConfig {

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -204,22 +204,6 @@ pub struct ClientConfig {
     pub enable_early_data: bool,
 }
 
-/// What mechanisms to support for resuming a TLS 1.2 session.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Tls12Resumption {
-    /// Disable 1.2 resumption.
-    Disabled,
-    /// Support 1.2 resumption using session ids only.
-    SessionIdOnly,
-    /// Support 1.2 resumption using session ids or RFC 5077 tickets.
-    ///
-    /// See[^1] for why you might like to disable RFC 5077 by instead choosing the `SessionIdOnly`
-    /// option. Note that TLS 1.3 tickets do not have those issues.
-    ///
-    /// [^1]: <https://words.filippo.io/we-need-to-talk-about-session-tickets/>
-    SessionIdOrTickets,
-}
-
 impl Clone for ClientConfig {
     fn clone(&self) -> Self {
         Self {
@@ -384,6 +368,22 @@ impl Default for Resumption {
     fn default() -> Self {
         Self::in_memory_sessions(256)
     }
+}
+
+/// What mechanisms to support for resuming a TLS 1.2 session.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Tls12Resumption {
+    /// Disable 1.2 resumption.
+    Disabled,
+    /// Support 1.2 resumption using session ids only.
+    SessionIdOnly,
+    /// Support 1.2 resumption using session ids or RFC 5077 tickets.
+    ///
+    /// See[^1] for why you might like to disable RFC 5077 by instead choosing the `SessionIdOnly`
+    /// option. Note that TLS 1.3 tickets do not have those issues.
+    ///
+    /// [^1]: <https://words.filippo.io/we-need-to-talk-about-session-tickets/>
+    SessionIdOrTickets,
 }
 
 /// Container for unsafe APIs


### PR DESCRIPTION
In #1718 we'll be adding new fields to `ClientConfig`, and new methods to the `impl ClientConfig` block. Before doing that let's tidy up the existing code to match the [style guide advice on ordering](https://github.com/rustls/rustls/blob/main/CONTRIBUTING.md#ordering).