### PR TITLE
Small HPKE trait tweaks

### DIFF
--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -20,7 +20,7 @@ pub static HPKE_PROVIDER: &'static dyn HpkeProvider = &HpkeRsProvider {};
 struct HpkeRsProvider {}
 
 impl HpkeProvider for HpkeRsProvider {
-    fn start(&self, suite: &HpkeSuite) -> Result<Box<dyn Hpke + '_>, Error> {
+    fn start(&self, suite: &HpkeSuite) -> Result<Box<dyn Hpke + 'static>, Error> {
         Ok(Box::new(HpkeRs(hpke_rs::Hpke::new(
             hpke_rs::Mode::Base,
             KemAlgorithm::try_from(suite.kem.get_u16()).map_err(other_err)?,
@@ -72,7 +72,7 @@ impl Hpke for HpkeRs {
         &mut self,
         info: &[u8],
         pub_key: &HpkePublicKey,
-    ) -> Result<(EncapsulatedSecret, Box<dyn HpkeSealer + '_>), Error> {
+    ) -> Result<(EncapsulatedSecret, Box<dyn HpkeSealer + 'static>), Error> {
         let pk_r = hpke_rs::HpkePublicKey::new(pub_key.0.clone());
         let (enc, context) = self
             .0
@@ -112,7 +112,7 @@ impl Hpke for HpkeRs {
         enc: &EncapsulatedSecret,
         info: &[u8],
         secret_key: &HpkePrivateKey,
-    ) -> Result<Box<dyn HpkeOpener + '_>, Error> {
+    ) -> Result<Box<dyn HpkeOpener + 'static>, Error> {
         let sk_r = hpke_rs::HpkePrivateKey::new(secret_key.secret_bytes().to_vec());
         Ok(Box::new(HpkeRsReceiver {
             context: self

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -54,12 +54,12 @@ impl Debug for HpkeRs {
 impl Hpke for HpkeRs {
     fn seal(
         &mut self,
-        pk_r: &HpkePublicKey,
         info: &[u8],
         aad: &[u8],
         plaintext: &[u8],
+        pub_key: &HpkePublicKey,
     ) -> Result<(EncapsulatedSecret, Vec<u8>), Error> {
-        let pk_r = hpke_rs::HpkePublicKey::new(pk_r.0.clone());
+        let pk_r = hpke_rs::HpkePublicKey::new(pub_key.0.clone());
         let (enc, ciphertext) = self
             .0
             .seal(&pk_r, info, aad, plaintext, None, None, None)
@@ -70,12 +70,12 @@ impl Hpke for HpkeRs {
     fn open(
         &mut self,
         enc: &EncapsulatedSecret,
-        sk_r: &HpkePrivateKey,
         info: &[u8],
         aad: &[u8],
         ciphertext: &[u8],
+        secret_key: &HpkePrivateKey,
     ) -> Result<Vec<u8>, Error> {
-        let sk_r = hpke_rs::HpkePrivateKey::new(sk_r.secret_bytes().to_vec());
+        let sk_r = hpke_rs::HpkePrivateKey::new(secret_key.secret_bytes().to_vec());
         self.0
             .open(
                 enc.0.as_slice(),

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -15,7 +15,7 @@ use rustls::{Error, OtherError};
 
 pub static HPKE_PROVIDER: &'static dyn HpkeProvider = &HpkeRsProvider {};
 
-/// A Rustls HPKE provider backed by hpke-rs.
+/// A Rustls HPKE provider backed by hpke-rs and the RustCrypto backend.
 #[derive(Debug)]
 struct HpkeRsProvider {}
 

--- a/provider-example/tests/hpke.rs
+++ b/provider-example/tests/hpke.rs
@@ -30,11 +30,11 @@ fn check_test_vectors() {
             let pt = hex::decode(enc.pt).unwrap();
 
             let (enc, ciphertext) = hpke
-                .seal(&pk_r, &info, &aad, &pt)
+                .seal(&info, &aad, &pt, &pk_r)
                 .unwrap();
 
             let plaintext = hpke
-                .open(&enc, &sk_r, &info, &aad, &ciphertext)
+                .open(&enc, &info, &aad, &ciphertext, &sk_r)
                 .unwrap();
             assert_eq!(plaintext, pt);
         }

--- a/rustls/src/crypto/hpke.rs
+++ b/rustls/src/crypto/hpke.rs
@@ -19,7 +19,7 @@ pub trait HpkeProvider: Debug + Send + Sync + 'static {
     /// Start setting up to use HPKE in base mode with the chosen suite.
     ///
     /// May return an error if the suite is unsupported by the provider.
-    fn start(&self, suite: &HpkeSuite) -> Result<Box<dyn Hpke + '_>, Error>;
+    fn start(&self, suite: &HpkeSuite) -> Result<Box<dyn Hpke + 'static>, Error>;
 
     /// Does the provider support the given [HpkeSuite]?
     fn supports_suite(&self, suite: &HpkeSuite) -> bool;
@@ -61,7 +61,7 @@ pub trait Hpke: Debug + Send + Sync {
         &mut self,
         info: &[u8],
         pub_key: &HpkePublicKey,
-    ) -> Result<(EncapsulatedSecret, Box<dyn HpkeSealer + '_>), Error>;
+    ) -> Result<(EncapsulatedSecret, Box<dyn HpkeSealer + 'static>), Error>;
 
     /// Open the provided `ciphertext` using the encapsulated secret `enc`, with application
     /// supplied `info`, and additional data `aad`.
@@ -86,14 +86,14 @@ pub trait Hpke: Debug + Send + Sync {
         enc: &EncapsulatedSecret,
         info: &[u8],
         secret_key: &HpkePrivateKey,
-    ) -> Result<Box<dyn HpkeOpener + '_>, Error>;
+    ) -> Result<Box<dyn HpkeOpener + 'static>, Error>;
 }
 
 /// An HPKE sealer context.
 ///
 /// This is a stateful object that can be used to seal messages for receipt by
 /// a receiver.
-pub trait HpkeSealer: Debug + Send + Sync {
+pub trait HpkeSealer: Debug + Send + Sync + 'static {
     /// Seal the provided `plaintext` with additional data `aad`, returning
     /// ciphertext.
     fn seal(&mut self, aad: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, Error>;
@@ -103,7 +103,7 @@ pub trait HpkeSealer: Debug + Send + Sync {
 ///
 /// This is a stateful object that can be used to open sealed messages sealed
 /// by a sender.
-pub trait HpkeOpener: Debug + Send + Sync {
+pub trait HpkeOpener: Debug + Send + Sync + 'static {
     /// Open the provided `ciphertext` with additional data `aad`, returning plaintext.
     fn open(&mut self, aad: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, Error>;
 }

--- a/rustls/src/crypto/hpke.rs
+++ b/rustls/src/crypto/hpke.rs
@@ -39,31 +39,32 @@ pub struct HpkeSuite {
 
 /// An HPKE instance that can be used for base-mode single-shot encryption and decryption.
 pub trait Hpke: Debug + Send + Sync {
-    /// Seal the provided `plaintext` to the recipient public key `pk_r` with application supplied
+    /// Seal the provided `plaintext` to the recipient public key `pub_key` with application supplied
     /// `info`, and additional data `aad`.
     ///
     /// Returns ciphertext that can be used with [Self::open] by the recipient to recover plaintext
-    /// using the same `info` and `aad` and the private key corresponding to `pk_r`.
+    /// using the same `info` and `aad` and the private key corresponding to `pub_key`. RFC 9180
+    /// refers to `pub_key` as `pkR`.
     fn seal(
         &mut self,
-        pk_r: &HpkePublicKey,
         info: &[u8],
         aad: &[u8],
         plaintext: &[u8],
+        pub_key: &HpkePublicKey,
     ) -> Result<(EncapsulatedSecret, Vec<u8>), Error>;
 
     /// Open the provided `ciphertext` using the encapsulated secret `enc`, with application
     /// supplied `info`, and additional data `aad`.
     ///
     /// Returns plaintext if  the `info` and `aad` match those used with [Self::seal], and
-    /// decryption with `sk_r` succeeds.
+    /// decryption with `secret_key` succeeds. RFC 9180 refers to `secret_key` as `skR`.
     fn open(
         &mut self,
         enc: &EncapsulatedSecret,
-        sk_r: &HpkePrivateKey,
         info: &[u8],
         aad: &[u8],
         ciphertext: &[u8],
+        secret_key: &HpkePrivateKey,
     ) -> Result<Vec<u8>, Error>;
 }
 

--- a/rustls/src/crypto/hpke.rs
+++ b/rustls/src/crypto/hpke.rs
@@ -136,4 +136,5 @@ pub struct HpkeKeyPair {
 }
 
 /// An encapsulated secret returned from setting up a sender or receiver context.
+#[derive(Debug)]
 pub struct EncapsulatedSecret(pub Vec<u8>);

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2271,7 +2271,7 @@ impl HandshakeMessagePayload {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HpkeSymmetricCipherSuite {
     pub kdf_id: HpkeKdf,
     pub aead_id: HpkeAead,


### PR DESCRIPTION
Pulling out more work from #1718 that can land ahead of the ECH-specific work.

* reorder seal/open args and use less terse arg names - addresses stylistic [feedback from djc](https://github.com/rustls/rustls/pull/1718#discussion_r1441532194).
* add stateful HPKE interface - this was part of the original work introducing this trait, but we pulled it thinking we could get away with just the simpler "one-shot" interface. In practice ECH requires the stateful interface so we can reuse the HPKE sealer state between initial client hello and hello retry request processing.
* derive Copy for HpkeSymmetricCipherSuite  - small quality of life improvement
* tighten up HPKE lifetime bounds - this better aligns with the existing crypto provider traits and makes maintaining the sealer/opener state much easier.
* make EncapsulatedSecret derive Debug - small quality of life improvement, required for holding an encapsulated secret in another type that is Debug.
* clarify the hpke-rs backend - small comment adjustment to emphasize the hpke-rs example in the larger provider-example uses the Rust Crypt backend in particular.