### PR TITLE
handshake: derive a few more traits 

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -793,7 +793,7 @@ impl ServerExtension {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ClientHelloPayload {
     pub client_version: ProtocolVersion,
     pub random: Random,
@@ -1010,7 +1010,7 @@ impl ClientHelloPayload {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum HelloRetryExtension {
     KeyShare(NamedGroup),
     Cookie(PayloadU16),
@@ -1158,7 +1158,7 @@ impl HelloRetryRequest {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ServerHelloPayload {
     pub(crate) legacy_version: ProtocolVersion,
     pub(crate) random: Random,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -182,7 +182,7 @@ impl SessionId {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct UnknownExtension {
     pub(crate) typ: ExtensionType,
     pub(crate) payload: Payload,
@@ -2295,7 +2295,7 @@ impl TlsListElement for HpkeSymmetricCipherSuite {
     const SIZE_LEN: ListLength = ListLength::U16;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct HpkeKeyConfig {
     pub config_id: u8,
     pub kem_id: HpkeKem,
@@ -2322,7 +2322,7 @@ impl Codec for HpkeKeyConfig {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct EchConfigContents {
     pub key_config: HpkeKeyConfig,
     pub maximum_name_length: u8,
@@ -2353,7 +2353,7 @@ impl Codec for EchConfigContents {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct EchConfig {
     pub version: EchVersion,
     pub contents: EchConfigContents,


### PR DESCRIPTION
Pulling out more work from https://github.com/rustls/rustls/pull/1718 that can land ahead of the ECH-specific work.

* derive PartialEq on more types - this will support embedding ECH configs into a `PeerIncompatible` error we'll return when the peer rejects ECH. The ECH configs included in the error can be used for retrying a client ECH offer.
* derive Clone on a few more messages - this will support cloning messages we need to mutate (e.g. to make an "inner" client hello) as part of constructing or verifying an ECH offer.