### PR TITLE
hash_hs: support cloning (forking) HandshakeHash[Buffer]

### DIFF
--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -487,7 +487,7 @@ fn emit_finished(
     transcript: &mut HandshakeHash,
     common: &mut CommonState,
 ) {
-    let vh = transcript.get_current_hash();
+    let vh = transcript.current_hash();
     let verify_data = secrets.client_verify_data(&vh);
     let verify_data_payload = Payload::new(verify_data);
 
@@ -781,7 +781,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
         // Note: EMS handshake hash only runs up to ClientKeyExchange.
         let ems_seed = st
             .using_ems
-            .then(|| transcript.get_current_hash());
+            .then(|| transcript.current_hash());
 
         // 5c.
         if let Some(ClientAuthDetails::Verify { signer, .. }) = &st.client_auth {
@@ -1004,7 +1004,7 @@ impl State<ClientConnectionData> for ExpectFinished {
         cx.common.check_aligned_handshake()?;
 
         // Work out what verify_data we expect.
-        let vh = st.transcript.get_current_hash();
+        let vh = st.transcript.current_hash();
         let expect_verify_data = st.secrets.server_verify_data(&vh);
 
         // Constant-time verification of this is relatively unimportant: they only

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -162,7 +162,7 @@ pub(super) fn handle_server_hello(
     // the two halves will have different record layer protections.  Disallow this.
     cx.common.check_aligned_handshake()?;
 
-    let hash_at_client_recvd_server_hello = transcript.get_current_hash();
+    let hash_at_client_recvd_server_hello = transcript.current_hash();
     let key_schedule = key_schedule.derive_client_handshake_secrets(
         cx.data.early_data.is_enabled(),
         hash_at_client_recvd_server_hello,
@@ -240,7 +240,7 @@ pub(super) fn fill_in_psk_binder(
     // The binder is calculated over the clienthello, but doesn't include itself or its
     // length, or the length of its container.
     let binder_plaintext = hmp.encoding_for_binder_signing();
-    let handshake_hash = transcript.get_hash_given(suite_hash, &binder_plaintext);
+    let handshake_hash = transcript.hash_given(suite_hash, &binder_plaintext);
 
     // Run a fake key_schedule to simulate what the server will do if it chooses
     // to resume.
@@ -305,8 +305,7 @@ pub(super) fn derive_early_traffic_secret(
     // For middlebox compatibility
     emit_fake_ccs(sent_tls13_fake_ccs, cx.common);
 
-    let client_hello_hash =
-        transcript_buffer.get_hash_given(resuming_suite.common.hash_provider, &[]);
+    let client_hello_hash = transcript_buffer.hash_given(resuming_suite.common.hash_provider, &[]);
     early_key_schedule.client_early_traffic_secret(
         &client_hello_hash,
         key_log,
@@ -681,7 +680,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify {
             })?;
 
         // 2. Verify their signature on the handshake.
-        let handshake_hash = self.transcript.get_current_hash();
+        let handshake_hash = self.transcript.current_hash();
         let sig_verified = self
             .config
             .verifier
@@ -749,7 +748,7 @@ fn emit_certverify_tls13(
     signer: &dyn Signer,
     common: &mut CommonState,
 ) -> Result<(), Error> {
-    let message = construct_client_verify_message(&transcript.get_current_hash());
+    let message = construct_client_verify_message(&transcript.current_hash());
 
     let scheme = signer.scheme();
     let sig = signer.sign(&message)?;
@@ -822,7 +821,7 @@ impl State<ClientConnectionData> for ExpectFinished {
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
 
-        let handshake_hash = st.transcript.get_current_hash();
+        let handshake_hash = st.transcript.current_hash();
         let expect_verify_data = st
             .key_schedule
             .sign_server_finish(&handshake_hash);
@@ -838,7 +837,7 @@ impl State<ClientConnectionData> for ExpectFinished {
 
         st.transcript.add_message(&m);
 
-        let hash_after_handshake = st.transcript.get_current_hash();
+        let hash_after_handshake = st.transcript.current_hash();
         /* The EndOfEarlyData message to server is still encrypted with early data keys,
          * but appears in the transcript after the server Finished. */
         if cx.common.early_traffic {
@@ -878,7 +877,7 @@ impl State<ClientConnectionData> for ExpectFinished {
             .key_schedule
             .into_pre_finished_client_traffic(
                 hash_after_handshake,
-                st.transcript.get_current_hash(),
+                st.transcript.current_hash(),
                 &*st.config.key_log,
                 &st.randoms.client,
             );
@@ -943,7 +942,7 @@ impl ExpectTraffic {
             ));
         }
 
-        let handshake_hash = self.transcript.get_current_hash();
+        let handshake_hash = self.transcript.current_hash();
         let secret = self
             .key_schedule
             .resumption_master_secret_and_derive_ticket_psk(&handshake_hash, &nst.nonce.0);

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -47,7 +47,7 @@ impl HandshakeHashBuffer {
     }
 
     /// Get the hash value if we were to hash `extra` too.
-    pub(crate) fn get_hash_given(
+    pub(crate) fn hash_given(
         &self,
         provider: &'static dyn hash::Hash,
         extra: &[u8],
@@ -116,7 +116,7 @@ impl HandshakeHash {
 
     /// Get the hash value if we were to hash `extra` too,
     /// using hash function `hash`.
-    pub(crate) fn get_hash_given(&self, extra: &[u8]) -> hash::Output {
+    pub(crate) fn hash_given(&self, extra: &[u8]) -> hash::Output {
         let mut ctx = self.ctx.fork();
         ctx.update(extra);
         ctx.finish()
@@ -148,7 +148,7 @@ impl HandshakeHash {
     }
 
     /// Get the current hash value.
-    pub(crate) fn get_current_hash(&self) -> hash::Output {
+    pub(crate) fn current_hash(&self) -> hash::Output {
         self.ctx.fork_finish()
     }
 
@@ -179,7 +179,7 @@ mod tests {
         let mut hh = hhb.start_hash(&SHA256);
         assert!(hh.client_auth.is_none());
         hh.update_raw(b"world");
-        let h = hh.get_current_hash();
+        let h = hh.current_hash();
         let h = h.as_ref();
         assert_eq!(h[0], 0x93);
         assert_eq!(h[1], 0x6a);
@@ -208,7 +208,7 @@ mod tests {
                 .map(|buf| buf.len()),
             Some(10)
         );
-        let h = hh.get_current_hash();
+        let h = hh.current_hash();
         let h = h.as_ref();
         assert_eq!(h[0], 0x93);
         assert_eq!(h[1], 0x6a);
@@ -235,7 +235,7 @@ mod tests {
         assert_eq!(hh.client_auth, None);
         hh.update_raw(b"world");
         assert_eq!(hh.client_auth, None);
-        let h = hh.get_current_hash();
+        let h = hh.current_hash();
         let h = h.as_ref();
         assert_eq!(h[0], 0x93);
         assert_eq!(h[1], 0x6a);

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -597,7 +597,7 @@ impl State<ServerConnectionData> for ExpectClientKx {
         self.transcript.add_message(&m);
         let ems_seed = self
             .using_ems
-            .then(|| self.transcript.get_current_hash());
+            .then(|| self.transcript.current_hash());
 
         // Complete key agreement, and set up encryption with the
         // resulting premaster secret.
@@ -823,7 +823,7 @@ fn emit_finished(
     transcript: &mut HandshakeHash,
     common: &mut CommonState,
 ) {
-    let vh = transcript.get_current_hash();
+    let vh = transcript.current_hash();
     let verify_data = secrets.server_verify_data(&vh);
     let verify_data_payload = Payload::new(verify_data);
 
@@ -856,7 +856,7 @@ impl State<ServerConnectionData> for ExpectFinished {
 
         cx.common.check_aligned_handshake()?;
 
-        let vh = self.transcript.get_current_hash();
+        let vh = self.transcript.current_hash();
         let expect_verify_data = self.secrets.client_verify_data(&vh);
 
         let _fin_verified = match ConstantTimeEq::ct_eq(&expect_verify_data[..], &finished.0).into()

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -117,7 +117,7 @@ mod client_hello {
 
             let handshake_hash = self
                 .transcript
-                .get_hash_given(&binder_plaintext);
+                .hash_given(&binder_plaintext);
 
             let key_schedule = KeyScheduleEarly::new(suite, psk);
             let real_binder =
@@ -520,7 +520,7 @@ mod client_hello {
 
         cx.common.check_aligned_handshake()?;
 
-        let client_hello_hash = transcript.get_hash_given(&[]);
+        let client_hello_hash = transcript.hash_given(&[]);
 
         trace!("sending server hello {:?}", sh);
         transcript.add_message(&sh);
@@ -544,7 +544,7 @@ mod client_hello {
         // Do key exchange
         let key_schedule = key_schedule_pre_handshake.into_handshake(kx, &share.payload.0)?;
 
-        let handshake_hash = transcript.get_current_hash();
+        let handshake_hash = transcript.current_hash();
         let key_schedule = key_schedule.derive_server_handshake_secrets(
             handshake_hash,
             &*config.key_log,
@@ -779,7 +779,7 @@ mod client_hello {
         signing_key: &dyn sign::SigningKey,
         schemes: &[SignatureScheme],
     ) -> Result<(), Error> {
-        let message = construct_server_verify_message(&transcript.get_current_hash());
+        let message = construct_server_verify_message(&transcript.current_hash());
 
         let signer = signing_key
             .choose_scheme(schemes)
@@ -816,7 +816,7 @@ mod client_hello {
         key_schedule: KeyScheduleHandshake,
         config: &ServerConfig,
     ) -> KeyScheduleTrafficWithClientFinishedPending {
-        let handshake_hash = transcript.get_current_hash();
+        let handshake_hash = transcript.current_hash();
         let verify_data = key_schedule.sign_server_finish(&handshake_hash);
         let verify_data_payload = Payload::new(verify_data.as_ref());
 
@@ -830,7 +830,7 @@ mod client_hello {
 
         trace!("sending finished {:?}", m);
         transcript.add_message(&m);
-        let hash_at_server_fin = transcript.get_current_hash();
+        let hash_at_server_fin = transcript.current_hash();
         cx.common.send_msg(m, true);
 
         // Now move to application data keys.  Read key change is deferred until
@@ -954,7 +954,7 @@ impl State<ServerConnectionData> for ExpectCertificateVerify {
                 HandshakeType::CertificateVerify,
                 HandshakePayload::CertificateVerify
             )?;
-            let handshake_hash = self.transcript.get_current_hash();
+            let handshake_hash = self.transcript.current_hash();
             self.transcript.abandon_client_auth();
             let certs = &self.client_cert;
             let msg = construct_client_verify_message(&handshake_hash);
@@ -1051,7 +1051,7 @@ fn get_server_session_value(
 ) -> persist::ServerSessionValue {
     let version = ProtocolVersion::TLSv1_3;
 
-    let handshake_hash = transcript.get_current_hash();
+    let handshake_hash = transcript.current_hash();
     let secret =
         key_schedule.resumption_master_secret_and_derive_ticket_psk(&handshake_hash, nonce);
 
@@ -1153,7 +1153,7 @@ impl State<ServerConnectionData> for ExpectFinished {
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
 
-        let handshake_hash = self.transcript.get_current_hash();
+        let handshake_hash = self.transcript.current_hash();
         let (key_schedule_traffic, expect_verify_data) = self
             .key_schedule
             .sign_client_finish(&handshake_hash, cx.common);


### PR DESCRIPTION
Pulling out more work from https://github.com/rustls/rustls/pull/1718 that can land ahead of the ECH-specific work.

For client ECH support we'll need to be able to fork (e.g. clone) the `HandshakeHashBuffer` and `HandshakeHash` types used to maintain the client transcript.

For ECH confirmation we'll fork the existing hash(buffer), add some specially encoded messages, and then use the hash state to derive a shared secret. If the secret matches an expected value we'll use the original `HandshakeHash`/`HandshakeHashBuffer`'s state from before our twiddling to continue the handshake.

Along the way, fixup more unidiomatic `get_` fns in `hash_hs.rs`, like https://github.com/rustls/rustls/pull/1726 did for the `handshake` module.