### PR TITLE
Add config option for requiring peer must support `extended_master_secret` extension in TLS 1.2

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -159,6 +159,8 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             key_log: Arc::new(NoKeyLog {}),
             enable_secret_extraction: false,
             enable_early_data: false,
+            #[cfg(feature = "tls12")]
+            require_ems: false,
         }
     }
 }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -193,6 +193,20 @@ pub struct ClientConfig {
     /// The default is false.
     pub enable_early_data: bool,
 
+    /// If set to `true`, requires the server to support the extended
+    /// master secret extraction method defined in [RFC 7627].
+    ///
+    /// The default is `false`.
+    ///
+    /// It must be set to `true` to meet FIPS requirement mentioned in section
+    /// **D.Q Transition of the TLS 1.2 KDF to Support the Extended Master
+    /// Secret** from [FIPS 140-3 IG.pdf].
+    ///
+    /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
+    /// [FIPS 140-3 IG.pdf]: https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf
+    #[cfg(feature = "tls12")]
+    pub require_ems: bool,
+
     /// Source of randomness and other crypto.
     pub(super) provider: Arc<CryptoProvider>,
 
@@ -308,6 +322,8 @@ impl Clone for ClientConfig {
             key_log: Arc::clone(&self.key_log),
             enable_secret_extraction: self.enable_secret_extraction,
             enable_early_data: self.enable_early_data,
+            #[cfg(feature = "tls12")]
+            require_ems: self.require_ems,
         }
     }
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -3,7 +3,7 @@ use crate::common_state::{CommonState, Side, State};
 use crate::conn::ConnectionRandoms;
 use crate::enums::ProtocolVersion;
 use crate::enums::{AlertDescription, ContentType, HandshakeType};
-use crate::error::{Error, InvalidMessage, PeerMisbehaved};
+use crate::error::{Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
@@ -81,6 +81,14 @@ mod server_hello {
 
             // Doing EMS?
             self.using_ems = server_hello.ems_support_acked();
+            if self.config.require_ems && !self.using_ems {
+                return Err({
+                    cx.common.send_fatal_alert(
+                        AlertDescription::HandshakeFailure,
+                        PeerIncompatible::ExtendedMasterSecretExtensionRequired,
+                    )
+                });
+            }
 
             // Might the server send a ticket?
             let must_issue_new_ticket = if server_hello

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -257,6 +257,7 @@ impl From<PeerMisbehaved> for Error {
 /// versions.
 pub enum PeerIncompatible {
     EcPointsExtensionRequired,
+    ExtendedMasterSecretExtensionRequired,
     KeyShareExtensionRequired,
     NamedGroupsExtensionRequired,
     NoCertificateRequestSignatureSchemesInCommon,

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -124,6 +124,8 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             max_early_data_size: 0,
             send_half_rtt_data: false,
             send_tls13_tickets: 4,
+            #[cfg(feature = "tls12")]
+            require_ems: false,
         }
     }
 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -315,6 +315,20 @@ pub struct ServerConfig {
     /// If this is 0, no tickets are sent and clients will not be able to
     /// do any resumption.
     pub send_tls13_tickets: usize,
+
+    /// If set to `true`, requires the client to support the extended
+    /// master secret extraction method defined in [RFC 7627].
+    ///
+    /// The default is `false`.
+    ///
+    /// It must be set to `true` to meet FIPS requirement mentioned in section
+    /// **D.Q Transition of the TLS 1.2 KDF to Support the Extended Master
+    /// Secret** from [FIPS 140-3 IG.pdf].
+    ///
+    /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
+    /// [FIPS 140-3 IG.pdf]: https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf
+    #[cfg(feature = "tls12")]
+    pub require_ems: bool,
 }
 
 // Avoid a `Clone` bound on `C`.
@@ -335,6 +349,8 @@ impl Clone for ServerConfig {
             max_early_data_size: self.max_early_data_size,
             send_half_rtt_data: self.send_half_rtt_data,
             send_tls13_tickets: self.send_tls13_tickets,
+            #[cfg(feature = "tls12")]
+            require_ems: self.require_ems,
         }
     }
 }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -81,6 +81,11 @@ mod client_hello {
 
             if client_hello.ems_support_offered() {
                 self.using_ems = true;
+            } else if self.config.require_ems {
+                return Err(cx.common.send_fatal_alert(
+                    AlertDescription::HandshakeFailure,
+                    PeerIncompatible::ExtendedMasterSecretExtensionRequired,
+                ));
             }
 
             let groups_ext = client_hello


### PR DESCRIPTION
## Reason / Background

- New FIPS application that use `rustls` needs a way to ensure `extended_master_secret` extension is always used in TLS 1.2 to fulfill the requirements mentioned in Section **"D.Q Transition of the TLS 1.2 KDF to Support the Extended Master Secret"** from [FIPS 140-3 IG.pdf](https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf):

  > A new validation, or any revalidation that extends the module’s sunset date, submitted more than one year 
  > after the publication date of this IG shall use the extended master secret in the TLS 1.2 KDF. The 
  > revalidations not extending the module’s sunset date are not subject to this requirement

## Changes in this PR

* Added server config for requiring `ExtendedMasterSecret` extension support from client, if not alert and terminate handshake.

* Added client config for requiring `ExtendedMasterSecret` extension support from server, if not alert and terminate handshake.

## Tests

* Added negative tests cases for server and client when requiring `ExtendedMasterSecret` extension support.

## TBD

- This PR directly add new config field in client/server config. Is it better to move them into `dangerous` config?
- Are positive cases needed?
