### PR TITLE
Introduce concept of "process default" provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "env_logger",
  "log",
  "num-bigint",
+ "once_cell",
  "ring",
  "rustls-pemfile 2.0.0",
  "rustls-pki-types",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -56,6 +56,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "ring"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +80,7 @@ name = "rustls"
 version = "0.23.0-alpha.0"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -18,6 +18,8 @@ rustversion = { version = "1.0.6", optional = true }
 [dependencies]
 aws-lc-rs = { version = "1.6", optional = true, default-features = false, features = ["aws-lc-sys"] }
 log = { version = "0.4.4", optional = true }
+# remove once our MSRV is >= 1.70
+once_cell = "1"
 ring = { version = "0.17", optional = true }
 subtle = { version = "2.5.0", default-features = false }
 webpki = { package = "rustls-webpki", version = "0.102.2", features = ["std"], default-features = false }

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -29,6 +29,7 @@ use crate::{ClientConfig, ServerConfig};
 ///
 /// ```
 /// # #[cfg(feature = "ring")] {
+/// # rustls::crypto::ring::default_provider().install_default();
 /// use rustls::{ClientConfig, ServerConfig};
 /// ClientConfig::builder()
 /// //  ...
@@ -44,6 +45,7 @@ use crate::{ClientConfig, ServerConfig};
 ///
 /// ```no_run
 /// # #[cfg(feature = "ring")] {
+/// # rustls::crypto::ring::default_provider().install_default();
 /// # use rustls::ServerConfig;
 /// ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
 /// //  ...
@@ -79,6 +81,7 @@ use crate::{ClientConfig, ServerConfig};
 ///
 /// ```
 /// # #[cfg(feature = "ring")] {
+/// # rustls::crypto::ring::default_provider().install_default();
 /// # use rustls::ClientConfig;
 /// # let root_certs = rustls::RootCertStore::empty();
 /// ClientConfig::builder()
@@ -102,6 +105,7 @@ use crate::{ClientConfig, ServerConfig};
 ///
 /// ```no_run
 /// # #[cfg(feature = "ring")] {
+/// # rustls::crypto::ring::default_provider().install_default();
 /// # use rustls::ServerConfig;
 /// # let certs = vec![];
 /// # let private_key = pki_types::PrivateKeyDer::from(

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -203,6 +203,7 @@
 //! # use rustls;
 //! # use webpki;
 //! # use std::sync::Arc;
+//! # rustls::crypto::ring::default_provider().install_default();
 //! # let root_store = rustls::RootCertStore::from_iter(
 //! #  webpki_roots::TLS_SERVER_ROOTS
 //! #      .iter()

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -132,13 +132,15 @@ impl WebPkiServerVerifier {
     ///
     /// Server certificates will be verified using the trust anchors found in the provided `roots`.
     ///
-    /// The cryptography used comes from the default [`CryptoProvider`]: [`crypto::ring::default_provider`].
+    /// The cryptography used comes from the process-default [`CryptoProvider`]: [`CryptoProvider::get_default`].
     /// Use [`Self::builder_with_provider`] if you wish to customize this.
     ///
     /// For more information, see the [`ServerCertVerifierBuilder`] documentation.
-    #[cfg(feature = "ring")]
     pub fn builder(roots: Arc<RootCertStore>) -> ServerCertVerifierBuilder {
-        Self::builder_with_provider(roots, crate::crypto::ring::default_provider().into())
+        Self::builder_with_provider(
+            roots,
+            Arc::clone(CryptoProvider::get_default_or_install_from_crate_features()),
+        )
     }
 
     /// Create a builder for the `webpki` server certificate verifier configuration using

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1324,7 +1324,10 @@ fn test_client_cert_resolve(
     for version in rustls::ALL_VERSIONS {
         let expected_sigschemes = match version.version {
             ProtocolVersion::TLSv1_2 => vec![
-                #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+                #[cfg(all(
+                    not(all(feature = "ring", not(feature = "fips"))),
+                    feature = "aws_lc_rs"
+                ))]
                 SignatureScheme::ECDSA_NISTP521_SHA512,
                 SignatureScheme::ECDSA_NISTP384_SHA384,
                 SignatureScheme::ECDSA_NISTP256_SHA256,
@@ -1337,7 +1340,10 @@ fn test_client_cert_resolve(
                 SignatureScheme::RSA_PKCS1_SHA256,
             ],
             ProtocolVersion::TLSv1_3 => vec![
-                #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+                #[cfg(all(
+                    not(all(feature = "ring", not(feature = "fips"))),
+                    feature = "aws_lc_rs"
+                ))]
                 SignatureScheme::ECDSA_NISTP521_SHA512,
                 SignatureScheme::ECDSA_NISTP384_SHA384,
                 SignatureScheme::ECDSA_NISTP256_SHA256,

--- a/rustls/tests/process_provider.rs
+++ b/rustls/tests/process_provider.rs
@@ -1,0 +1,65 @@
+#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+
+//! Note that the default test runner builds each test file into a separate
+//! executable, and runs tests in an indeterminate order.  That restricts us
+//! to doing all the desired tests, in series, in one function.
+
+use rustls::crypto::CryptoProvider;
+use rustls::ClientConfig;
+
+mod common;
+use crate::common::*;
+
+#[test]
+fn test_process_provider() {
+    if dbg!(cfg!(all(feature = "ring", feature = "aws_lc_rs"))) {
+        test_explicit_choice_required();
+    } else if dbg!(cfg!(all(feature = "ring", not(feature = "aws_lc_rs")))) {
+        test_ring_used_as_implicit_provider();
+    } else if dbg!(cfg!(all(feature = "aws_lc_rs", not(feature = "ring")))) {
+        test_aws_lc_rs_used_as_implicit_provider();
+    } else {
+        panic!("fix feature combinations");
+    }
+}
+
+fn test_explicit_choice_required() {
+    assert!(CryptoProvider::get_default().is_none());
+    provider::default_provider()
+        .install_default()
+        .expect("cannot install");
+    CryptoProvider::get_default().expect("provider missing");
+    provider::default_provider()
+        .install_default()
+        .expect_err("install succeeded a second time");
+    CryptoProvider::get_default().expect("provider missing");
+
+    // does not panic
+    finish_client_config(KeyType::Rsa, ClientConfig::builder());
+}
+
+fn test_ring_used_as_implicit_provider() {
+    assert!(CryptoProvider::get_default().is_none());
+
+    // implicitly installs ring provider
+    finish_client_config(KeyType::Rsa, ClientConfig::builder());
+
+    assert!(format!(
+        "{:?}",
+        CryptoProvider::get_default().expect("provider missing")
+    )
+    .contains("secure_random: Ring"));
+}
+
+fn test_aws_lc_rs_used_as_implicit_provider() {
+    assert!(CryptoProvider::get_default().is_none());
+
+    // implicitly installs aws-lc-rs provider
+    finish_client_config(KeyType::Rsa, ClientConfig::builder());
+
+    assert!(format!(
+        "{:?}",
+        CryptoProvider::get_default().expect("provider missing")
+    )
+    .contains("secure_random: AwsLcRs"));
+}


### PR DESCRIPTION
One can be installed with `CryptoProvider::install_as_process_default`. First call wins.

The current value can be retrieved with `CryptoProvider::process_default()`.

This can be set from the crate features, if any only if they are unambigious, using `CryptoProvider::install_process_default_from_crate_features`.

Use this for `ClientConfig::builder` and `ServerConfig::builder` et al. Naturally, `ClientConfig::builder_with_provider` and co. continue to exist.

--

~~This is for feedback mainly. Theoretically this could fix #1744 and #1642~~

~~Things that make this a draft:~~

- [x] give the same treatment to `WebPkiServerVerifier::builder()`, ditto `WebPkiClientVerifier`
- [x] make `cargo test --all-features` do something other than explode
- [x] `OnceLock` would require an MSRV of 1.70; alternatively we could depend on the `once_cell` crate (its precursor)
- [x] have some basic testing
