### PR TITLE
Depend on `aws-lc-rs` with `default-features = false`

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -16,7 +16,7 @@ build = "build.rs"
 rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
-aws-lc-rs = { version = "1.6", optional = true }
+aws-lc-rs = { version = "1.6", optional = true, default-features = false, features = ["aws-lc-sys"] }
 log = { version = "0.4.4", optional = true }
 ring = { version = "0.17", optional = true }
 subtle = { version = "2.5.0", default-features = false }


### PR DESCRIPTION
rustls does not seem to need the ring-io or ring-sig-verify features,
and omitting them avoids a dependency on an old version of the
`untrusted` crate.
