### PR TITLE
Fix cargo powerset build for ring w/o tls1.2 feature

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   schedule:
     # We run these tests on a daily basis (at a time slightly offset from the
     # top of the hour), as their runtime is either too long for the usual per-PR

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -78,11 +78,13 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 


### PR DESCRIPTION
It looks like the `#[cfg(feature = "tls12")]` gates on the non-fips CHACHA20_POLY1305 ciphersuites were accidentally dropped in https://github.com/rustls/rustls/pull/1732, breaking the [cargo powerset](https://github.com/rustls/rustls/actions/runs/7759992932/job/21165237944) daily builds that use `--no-default-features --features ring` unless feature unification kicks in to bring along the `tls12` feature. This branch restores the `cfg` gates.

Also tacks on a commit to make it easier to run the daily tests on-demand [through the GitHub UI](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow).