### PR TITLE
Default to `require_ems` in FIPS mode

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -160,7 +160,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             enable_secret_extraction: false,
             enable_early_data: false,
             #[cfg(feature = "tls12")]
-            require_ems: false,
+            require_ems: cfg!(feature = "fips"),
         }
     }
 }

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -194,6 +194,11 @@ pub struct CryptoProvider {
 
 impl CryptoProvider {
     /// Returns `true` if this `CryptoProvider` is operating in FIPS mode.
+    ///
+    /// This covers only the cryptographic parts of FIPS approval.  There are
+    /// also TLS protocol-level recommendations made by NIST.  You should
+    /// prefer to call [`ClientConfig::fips()`] or [`ServerConfig::fips()`]
+    /// which take these into account.
     pub fn fips(&self) -> bool {
         let Self {
             cipher_suites,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -313,7 +313,8 @@
 //!
 //! - `fips`: enable support for FIPS140-3-approved cryptography, via the aws-lc-rs crate.
 //!   This feature enables the `aws_lc_rs` feature, which makes the rustls crate depend
-//!   on [aws-lc-rs](https://github.com/aws/aws-lc-rs).
+//!   on [aws-lc-rs](https://github.com/aws/aws-lc-rs).  It also changes the default
+//!   for [`ServerConfig::require_ems`] and [`ClientConfig::require_ems`].
 //!
 //! - `tls12` (enabled by default): enable support for TLS version 1.2. Note that, due to the
 //!   additive nature of Cargo features and because it is enabled by default, other crates

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -125,7 +125,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             send_half_rtt_data: false,
             send_tls13_tickets: 4,
             #[cfg(feature = "tls12")]
-            require_ems: false,
+            require_ems: cfg!(feature = "fips"),
         }
     }
 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -321,7 +321,8 @@ pub struct ServerConfig {
     /// If set to `true`, requires the client to support the extended
     /// master secret extraction method defined in [RFC 7627].
     ///
-    /// The default is `false`.
+    /// The default is `true` if the "fips" crate feature is enabled,
+    /// `false` otherwise.
     ///
     /// It must be set to `true` to meet FIPS requirement mentioned in section
     /// **D.Q Transition of the TLS 1.2 KDF to Support the Extended Master
@@ -416,8 +417,20 @@ impl ServerConfig {
 
     /// Return `true` if connections made with this `ServerConfig` will
     /// operate in FIPS mode.
+    ///
+    /// This is different from [`CryptoProvider::fips()`]: [`CryptoProvider::fips()`]
+    /// is concerned only with cryptography, whereas this _also_ covers TLS-level
+    /// configuration that NIST recommends.
     pub fn fips(&self) -> bool {
-        self.provider.fips()
+        #[cfg(feature = "tls12")]
+        {
+            self.provider.fips() && self.require_ems
+        }
+
+        #[cfg(not(feature = "tls12"))]
+        {
+            self.provider.fips()
+        }
     }
 
     /// We support a given TLS version if it's quoted in the configured


### PR DESCRIPTION
Change default for `require_ems` based on `fips` crate feature, generalising the existing tests for `require_ems` to verify this too.

Include `require_ems` in `fips()` determination.