### PR TITLE
Improve testing when multiple built-in providers are enabled

### DIFF
--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -1,4 +1,8 @@
+#![cfg(feature = "ring")]
+
 use bencher::{benchmark_group, benchmark_main, Bencher};
+
+use rustls::crypto::ring as provider;
 
 #[path = "../tests/common/mod.rs"]
 mod test_utils;

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -218,8 +218,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
     }
 }
 
-#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
-mod tests {
+test_for_each_provider! {
     use super::NoClientSessionStorage;
     use crate::client::ClientSessionStore;
     use crate::msgs::enums::NamedGroup;
@@ -228,7 +227,7 @@ mod tests {
     use crate::msgs::handshake::SessionId;
     use crate::msgs::persist::Tls13ClientSessionValue;
     use crate::suites::SupportedCipherSuite;
-    use crate::test_provider::cipher_suite;
+    use provider::cipher_suite;
 
     use pki_types::{ServerName, UnixTime};
 

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -183,12 +183,11 @@ impl crate::quic::Algorithm for KeyBuilder {
     }
 }
 
-#[cfg(test)]
-mod tests {
+test_for_each_provider! {
     use crate::common_state::Side;
     use crate::crypto::tls13::OkmBlock;
     use crate::quic::*;
-    use crate::test_provider::tls13::{
+    use provider::tls13::{
         TLS13_AES_128_GCM_SHA256_INTERNAL, TLS13_CHACHA20_POLY1305_SHA256_INTERNAL,
     };
 

--- a/rustls/src/crypto/tls12.rs
+++ b/rustls/src/crypto/tls12.rs
@@ -89,7 +89,9 @@ pub(crate) fn prf(out: &mut [u8], hmac_key: &dyn hmac::Key, label: &[u8], seed: 
 #[cfg(all(test, feature = "ring"))]
 mod tests {
     use crate::crypto::hmac::Hmac;
-    use crate::test_provider::hmac;
+    // nb: crypto::aws_lc_rs provider doesn't provide (or need) hmac,
+    // so cannot be used for this test.
+    use crate::crypto::ring::hmac;
 
     // Below known answer tests come from https://mailarchive.ietf.org/arch/msg/tls/fzVCzk-z3FShgGJ6DOXqM1ydxms/
 
@@ -148,12 +150,12 @@ mod tests {
     }
 }
 
-#[cfg(all(bench, any(feature = "ring", feature = "aws_lc_rs")))]
+#[cfg(all(bench, feature = "ring"))]
 mod benchmarks {
     #[bench]
     fn bench_sha256(b: &mut test::Bencher) {
         use crate::crypto::hmac::Hmac;
-        use crate::test_provider::hmac;
+        use crate::crypto::ring::hmac;
 
         let label = &b"extended master secret"[..];
         let seed = [0u8; 32];

--- a/rustls/src/crypto/tls13.rs
+++ b/rustls/src/crypto/tls13.rs
@@ -248,7 +248,9 @@ pub struct OutputLengthError;
 #[cfg(all(test, feature = "ring"))]
 mod tests {
     use super::{expand, Hkdf, HkdfUsingHmac};
-    use crate::test_provider::hmac;
+    // nb: crypto::aws_lc_rs provider doesn't provide (or need) hmac,
+    // so cannot be used for this test.
+    use crate::crypto::ring::hmac;
 
     struct ByteArray<const N: usize>([u8; N]);
 

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -177,10 +177,9 @@ impl Clone for HandshakeHash {
     }
 }
 
-#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
-mod tests {
+test_for_each_provider! {
     use super::HandshakeHashBuffer;
-    use crate::test_provider::hash::SHA256;
+    use provider::hash::SHA256;
 
     #[test]
     fn hashes_correctly() {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -416,6 +416,9 @@ mod log {
 }
 
 #[macro_use]
+mod test_macros;
+
+#[macro_use]
 mod msgs;
 mod common_state;
 mod conn;
@@ -523,13 +526,6 @@ pub mod unbuffered {
     };
     pub use crate::conn::UnbufferedConnectionCommon;
 }
-
-// Have a (non-public) "test provider" mod which supplies
-// tests that need part of a *ring*-compatible provider module.
-#[cfg(all(any(test, bench), not(feature = "ring"), feature = "aws_lc_rs"))]
-use crate::crypto::aws_lc_rs as test_provider;
-#[cfg(all(any(test, bench), feature = "ring"))]
-use crate::crypto::ring as test_provider;
 
 // The public interface is:
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier, WantsVersions};

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -307,12 +307,10 @@ pub enum ConnectionTrafficSecrets {
     },
 }
 
-#[cfg(all(test, feature = "ring"))]
-#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
-mod tests {
+test_for_each_provider! {
     use super::*;
     use crate::enums::CipherSuite;
-    use crate::test_provider::tls13::*;
+    use provider::tls13::*;
 
     #[test]
     fn test_client_pref() {
@@ -342,19 +340,19 @@ mod tests {
     fn test_pref_fails() {
         assert!(choose_ciphersuite_preferring_client(
             &[CipherSuite::TLS_NULL_WITH_NULL_NULL],
-            crypto::ring::ALL_CIPHER_SUITES
+            provider::ALL_CIPHER_SUITES
         )
         .is_none());
         assert!(choose_ciphersuite_preferring_server(
             &[CipherSuite::TLS_NULL_WITH_NULL_NULL],
-            crypto::ring::ALL_CIPHER_SUITES
+            provider::ALL_CIPHER_SUITES
         )
         .is_none());
     }
 
     #[test]
     fn test_scs_is_debug() {
-        println!("{:?}", crypto::ring::ALL_CIPHER_SUITES);
+        println!("{:?}", provider::ALL_CIPHER_SUITES);
     }
 
     #[test]

--- a/rustls/src/test_macros.rs
+++ b/rustls/src/test_macros.rs
@@ -1,0 +1,57 @@
+/// Macros used for unit testing.
+
+/// Instantiate the given test functions once for each built-in provider.
+///
+/// The selected provider module is bound as `provider`; you can rely on this
+/// having the union of the items common to the `crypto::ring` and
+/// `crypto::aws_lc_rs` modules.
+macro_rules! test_for_each_provider {
+    ($($tt:tt)+) => {
+        #[cfg(all(test, feature = "ring"))]
+        mod test_with_ring {
+            use crate::crypto::ring as provider;
+            $($tt)+
+        }
+
+        #[cfg(all(test, feature = "aws_lc_rs"))]
+        mod test_with_aws_lc_rs {
+            use crate::crypto::aws_lc_rs as provider;
+            $($tt)+
+        }
+    };
+}
+
+/// Instantiate the given benchmark functions once for each built-in provider.
+///
+/// The selected provider module is bound as `provider`; you can rely on this
+/// having the union of the items common to the `crypto::ring` and
+/// `crypto::aws_lc_rs` modules.
+macro_rules! bench_for_each_provider {
+    ($($tt:tt)+) => {
+        #[cfg(all(bench, feature = "ring"))]
+        mod bench_with_ring {
+            use crate::crypto::ring as provider;
+            $($tt)+
+        }
+
+        #[cfg(all(bench, feature = "aws_lc_rs"))]
+        mod bench_with_aws_lc_rs {
+            use crate::crypto::aws_lc_rs as provider;
+            $($tt)+
+        }
+    };
+}
+
+test_for_each_provider! {
+    #[test]
+    fn test_each_provider() {
+        println!("provider is {:?}", provider::default_provider());
+    }
+}
+
+bench_for_each_provider! {
+    #[bench]
+    fn bench_each_provider(b: &mut test::Bencher) {
+        b.iter(|| provider::default_provider());
+    }
+}

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -338,12 +338,11 @@ pub(crate) fn decode_kx_params<'a, T: KxDecode<'a>>(
 
 pub(crate) const DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01];
 
-#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
-mod tests {
+test_for_each_provider! {
     use super::*;
     use crate::common_state::{CommonState, Side};
-    use crate::msgs::handshake::ServerEcdhParams;
-    use crate::{msgs::handshake::ServerKeyExchangeParams, test_provider::kx_group::X25519};
+    use crate::msgs::handshake::{ServerEcdhParams, ServerKeyExchangeParams};
+    use provider::kx_group::X25519;
 
     #[test]
     fn server_ecdhe_remaining_bytes() {

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -828,13 +828,12 @@ where
     f(expander, info)
 }
 
-#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
-mod tests {
+test_for_each_provider! {
     use core::fmt::Debug;
 
     use super::{derive_traffic_iv, derive_traffic_key, KeySchedule, SecretKind};
-    use crate::test_provider::ring_like::aead;
-    use crate::test_provider::tls13::{
+    use provider::ring_like::aead;
+    use provider::tls13::{
         TLS13_AES_128_GCM_SHA256_INTERNAL, TLS13_CHACHA20_POLY1305_SHA256_INTERNAL,
     };
     use crate::KeyLog;
@@ -1010,15 +1009,13 @@ mod tests {
     }
 }
 
-#[cfg(bench)]
-mod benchmarks {
-    #[cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+bench_for_each_provider! {
     #[bench]
     fn bench_sha256(b: &mut test::Bencher) {
         use core::fmt::Debug;
 
         use super::{derive_traffic_iv, derive_traffic_key, KeySchedule, SecretKind};
-        use crate::test_provider::tls13::TLS13_CHACHA20_POLY1305_SHA256_INTERNAL;
+        use provider::tls13::TLS13_CHACHA20_POLY1305_SHA256_INTERNAL;
         use crate::KeyLog;
 
         fn extract_traffic_secret(ks: &KeySchedule, kind: SecretKind) {

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -1,194 +1,189 @@
 // This program does benchmarking of the functions in verify.rs,
 // that do certificate chain validation and signature verification.
-//
-// Note: we don't use any of the standard 'cargo bench', 'test::Bencher',
-// etc. because it's unstable at the time of writing.
 
-#![cfg(feature = "ring")]
+#![cfg(bench)]
 
 use core::time::Duration;
-use std::time::Instant;
 
-use crate::crypto::ring;
+use crate::crypto::CryptoProvider;
 use crate::verify::ServerCertVerifier;
 use crate::webpki::{RootCertStore, WebPkiServerVerifier};
 
-use pki_types::{CertificateDer, UnixTime};
+use pki_types::{CertificateDer, ServerName, UnixTime};
 use webpki_roots;
 
-fn duration_nanos(d: Duration) -> u64 {
-    ((d.as_secs() as f64) * 1e9 + (d.subsec_nanos() as f64)) as u64
-}
+bench_for_each_provider! {
+    use super::Context;
 
-#[test]
-fn test_reddit_cert() {
-    Context::new(
-        "reddit",
-        "reddit.com",
-        &[
-            include_bytes!("testdata/cert-reddit.0.der"),
-            include_bytes!("testdata/cert-reddit.1.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn reddit_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "reddit.com",
+            &[
+                include_bytes!("testdata/cert-reddit.0.der"),
+                include_bytes!("testdata/cert-reddit.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_github_cert() {
-    Context::new(
-        "github",
-        "github.com",
-        &[
-            include_bytes!("testdata/cert-github.0.der"),
-            include_bytes!("testdata/cert-github.1.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn github_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "github.com",
+            &[
+                include_bytes!("testdata/cert-github.0.der"),
+                include_bytes!("testdata/cert-github.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_arstechnica_cert() {
-    Context::new(
-        "arstechnica",
-        "arstechnica.com",
-        &[
-            include_bytes!("testdata/cert-arstechnica.0.der"),
-            include_bytes!("testdata/cert-arstechnica.1.der"),
-            include_bytes!("testdata/cert-arstechnica.2.der"),
-            include_bytes!("testdata/cert-arstechnica.3.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn arstechnica_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "arstechnica.com",
+            &[
+                include_bytes!("testdata/cert-arstechnica.0.der"),
+                include_bytes!("testdata/cert-arstechnica.1.der"),
+                include_bytes!("testdata/cert-arstechnica.2.der"),
+                include_bytes!("testdata/cert-arstechnica.3.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_servo_cert() {
-    Context::new(
-        "servo",
-        "servo.org",
-        &[
-            include_bytes!("testdata/cert-servo.0.der"),
-            include_bytes!("testdata/cert-servo.1.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn servo_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "servo.org",
+            &[
+                include_bytes!("testdata/cert-servo.0.der"),
+                include_bytes!("testdata/cert-servo.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_twitter_cert() {
-    Context::new(
-        "twitter",
-        "twitter.com",
-        &[
-            include_bytes!("testdata/cert-twitter.0.der"),
-            include_bytes!("testdata/cert-twitter.1.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn twitter_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "twitter.com",
+            &[
+                include_bytes!("testdata/cert-twitter.0.der"),
+                include_bytes!("testdata/cert-twitter.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_wikipedia_cert() {
-    Context::new(
-        "wikipedia",
-        "wikipedia.org",
-        &[
-            include_bytes!("testdata/cert-wikipedia.0.der"),
-            include_bytes!("testdata/cert-wikipedia.1.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn wikipedia_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "wikipedia.org",
+            &[
+                include_bytes!("testdata/cert-wikipedia.0.der"),
+                include_bytes!("testdata/cert-wikipedia.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_google_cert() {
-    Context::new(
-        "google",
-        "www.google.com",
-        &[
-            include_bytes!("testdata/cert-google.0.der"),
-            include_bytes!("testdata/cert-google.1.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn google_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "www.google.com",
+            &[
+                include_bytes!("testdata/cert-google.0.der"),
+                include_bytes!("testdata/cert-google.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_hn_cert() {
-    Context::new(
-        "hn",
-        "news.ycombinator.com",
-        &[
-            include_bytes!("testdata/cert-hn.0.der"),
-            include_bytes!("testdata/cert-hn.1.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn hn_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "news.ycombinator.com",
+            &[
+                include_bytes!("testdata/cert-hn.0.der"),
+                include_bytes!("testdata/cert-hn.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_stackoverflow_cert() {
-    Context::new(
-        "stackoverflow",
-        "stackoverflow.com",
-        &[
-            include_bytes!("testdata/cert-stackoverflow.0.der"),
-            include_bytes!("testdata/cert-stackoverflow.1.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn stackoverflow_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "stackoverflow.com",
+            &[
+                include_bytes!("testdata/cert-stackoverflow.0.der"),
+                include_bytes!("testdata/cert-stackoverflow.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_duckduckgo_cert() {
-    Context::new(
-        "duckduckgo",
-        "duckduckgo.com",
-        &[
-            include_bytes!("testdata/cert-duckduckgo.0.der"),
-            include_bytes!("testdata/cert-duckduckgo.1.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn duckduckgo_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "duckduckgo.com",
+            &[
+                include_bytes!("testdata/cert-duckduckgo.0.der"),
+                include_bytes!("testdata/cert-duckduckgo.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_rustlang_cert() {
-    Context::new(
-        "rustlang",
-        "www.rust-lang.org",
-        &[
-            include_bytes!("testdata/cert-rustlang.0.der"),
-            include_bytes!("testdata/cert-rustlang.1.der"),
-            include_bytes!("testdata/cert-rustlang.2.der"),
-        ],
-    )
-    .bench(100)
-}
+    #[bench]
+    fn rustlang_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "www.rust-lang.org",
+            &[
+                include_bytes!("testdata/cert-rustlang.0.der"),
+                include_bytes!("testdata/cert-rustlang.1.der"),
+                include_bytes!("testdata/cert-rustlang.2.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 
-#[test]
-fn test_wapo_cert() {
-    Context::new(
-        "wapo",
-        "www.washingtonpost.com",
-        &[
-            include_bytes!("testdata/cert-wapo.0.der"),
-            include_bytes!("testdata/cert-wapo.1.der"),
-        ],
-    )
-    .bench(100)
+    #[bench]
+    fn wapo_cert(b: &mut test::Bencher) {
+        let ctx = Context::new(
+            provider::default_provider(),
+            "www.washingtonpost.com",
+            &[
+                include_bytes!("testdata/cert-wapo.0.der"),
+                include_bytes!("testdata/cert-wapo.1.der"),
+            ],
+        );
+        b.iter(|| ctx.verify_once());
+    }
 }
 
 struct Context {
-    name: &'static str,
-    domain: &'static str,
-    roots: RootCertStore,
+    server_name: ServerName<'static>,
     chain: Vec<CertificateDer<'static>>,
     now: UnixTime,
+    verifier: WebPkiServerVerifier,
 }
 
 impl Context {
-    fn new(name: &'static str, domain: &'static str, certs: &[&'static [u8]]) -> Self {
+    fn new(provider: CryptoProvider, domain: &'static str, certs: &[&'static [u8]]) -> Self {
         let mut roots = RootCertStore::empty();
         roots.extend(
             webpki_roots::TLS_SERVER_ROOTS
@@ -196,46 +191,32 @@ impl Context {
                 .cloned(),
         );
         Self {
-            name,
-            domain,
-            roots,
+            server_name: domain.try_into().unwrap(),
             chain: certs
                 .iter()
                 .copied()
                 .map(|bytes| CertificateDer::from(bytes.to_vec()))
                 .collect(),
             now: UnixTime::since_unix_epoch(Duration::from_secs(1_640_870_720)),
+            verifier: WebPkiServerVerifier::new_without_revocation(
+                roots,
+                provider.signature_verification_algorithms,
+            ),
         }
     }
 
-    fn bench(&self, count: usize) {
-        let verifier = WebPkiServerVerifier::new_without_revocation(
-            self.roots.clone(),
-            ring::default_provider().signature_verification_algorithms,
-        );
+    fn verify_once(&self) {
         const OCSP_RESPONSE: &[u8] = &[];
-        let mut times = Vec::new();
 
         let (end_entity, intermediates) = self.chain.split_first().unwrap();
-        for _ in 0..count {
-            let start = Instant::now();
-            let server_name = self.domain.try_into().unwrap();
-            verifier
-                .verify_server_cert(
-                    end_entity,
-                    intermediates,
-                    &server_name,
-                    OCSP_RESPONSE,
-                    self.now,
-                )
-                .unwrap();
-            times.push(duration_nanos(Instant::now().duration_since(start)));
-        }
-
-        println!(
-            "verify_server_cert({}): min {:?}us",
-            self.name,
-            times.iter().min().unwrap() / 1000
-        );
+        self.verifier
+            .verify_server_cert(
+                end_entity,
+                intermediates,
+                &self.server_name,
+                OCSP_RESPONSE,
+                self.now,
+            )
+            .unwrap();
     }
 }

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -407,11 +407,9 @@ pub(crate) enum AnonymousClientPolicy {
     Deny,
 }
 
-#[cfg(all(test, feature = "ring"))]
-mod tests {
+test_for_each_provider! {
     use super::WebPkiClientVerifier;
     use crate::server::VerifierBuilderError;
-    use crate::test_provider;
     use crate::RootCertStore;
 
     use pki_types::{CertificateDer, CertificateRevocationListDer};
@@ -466,7 +464,7 @@ mod tests {
         // no revocation checking.
         let builder = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         );
         // The builder should be Debug.
         println!("{:?}", builder);
@@ -479,7 +477,7 @@ mod tests {
         // access, and does no revocation checking.
         let builder = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .allow_unauthenticated();
         // The builder should be Debug.
@@ -494,7 +492,7 @@ mod tests {
         // unauthenticated clients yet.
         let builder = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         );
         // The builder should be Debug.
         println!("{:?}", builder);
@@ -507,7 +505,7 @@ mod tests {
         // and anonymous access, that does no revocation checking.
         let builder = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .allow_unauthenticated();
         // The builder should be Debug.
@@ -520,7 +518,7 @@ mod tests {
         // Trying to build a client verifier with invalid CRLs should error at build time.
         let result = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .with_crls(vec![CertificateRevocationListDer::from(vec![0xFF])])
         .build();
@@ -537,7 +535,7 @@ mod tests {
             ]);
         let builder = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .with_crls(initial_crls.clone())
         .with_crls(extra_crls.clone());
@@ -555,7 +553,7 @@ mod tests {
         // revocation checking with CRLs, and that does not allow any anonymous access.
         let builder = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .with_crls(test_crls());
         // The builder should be Debug.
@@ -569,7 +567,7 @@ mod tests {
         // revocation checking with CRLs, and that allows anonymous access.
         let builder = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .with_crls(test_crls())
         .allow_unauthenticated();
@@ -583,7 +581,7 @@ mod tests {
         // We should be able to build a client verifier that only checks EE revocation status.
         let builder = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .with_crls(test_crls())
         .only_check_end_entity_revocation();
@@ -597,7 +595,7 @@ mod tests {
         // We should be able to build a client verifier that allows unknown revocation status
         let builder = WebPkiClientVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .with_crls(test_crls())
         .allow_unknown_revocation_status();
@@ -611,7 +609,7 @@ mod tests {
         // Trying to create a client verifier builder with no trust anchors should fail at build time
         let result = WebPkiClientVerifier::builder_with_provider(
             RootCertStore::empty().into(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .build();
         assert!(matches!(result, Err(VerifierBuilderError::NoRootAnchors)));

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -282,14 +282,13 @@ impl ServerCertVerifier for WebPkiServerVerifier {
     }
 }
 
-#[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
-mod tests {
+test_for_each_provider! {
     use std::sync::Arc;
 
     use pki_types::{CertificateDer, CertificateRevocationListDer};
 
     use super::{VerifierBuilderError, WebPkiServerVerifier};
-    use crate::{test_provider, RootCertStore};
+    use crate::RootCertStore;
 
     fn load_crls(crls_der: &[&[u8]]) -> Vec<CertificateRevocationListDer<'static>> {
         crls_der
@@ -332,7 +331,7 @@ mod tests {
         // Trying to build a server verifier with invalid CRLs should error at build time.
         let result = WebPkiServerVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .with_crls(vec![CertificateRevocationListDer::from(vec![0xFF])])
         .build();
@@ -350,7 +349,7 @@ mod tests {
 
         let builder = WebPkiServerVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .with_crls(initial_crls.clone())
         .with_crls(extra_crls.clone());
@@ -367,7 +366,7 @@ mod tests {
         // Trying to create a server verifier builder with no trust anchors should fail at build time
         let result = WebPkiServerVerifier::builder_with_provider(
             RootCertStore::empty().into(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .build();
         assert!(matches!(result, Err(VerifierBuilderError::NoRootAnchors)));
@@ -378,7 +377,7 @@ mod tests {
         // We should be able to build a server cert. verifier that only checks the EE cert.
         let builder = WebPkiServerVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .only_check_end_entity_revocation();
         // The builder should be Debug.
@@ -392,7 +391,7 @@ mod tests {
         // status.
         let builder = WebPkiServerVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .allow_unknown_revocation_status();
         // The builder should be Debug.
@@ -406,7 +405,7 @@ mod tests {
         // status and only checks the EE cert.
         let builder = WebPkiServerVerifier::builder_with_provider(
             test_roots(),
-            test_provider::default_provider().into(),
+            provider::default_provider().into(),
         )
         .allow_unknown_revocation_status()
         .only_check_end_entity_revocation();

--- a/rustls/tests/api_ffdhe.rs
+++ b/rustls/tests/api_ffdhe.rs
@@ -1,9 +1,14 @@
 #![cfg(feature = "tls12")]
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+
 //! This file contains tests that use the test-only FFDHE KX group (defined in submodule `ffdhe`)
 
+#[macro_use]
+mod macros;
+
+test_for_each_provider! {
+
 mod common;
-use crate::common::*;
+use common::*;
 
 use rustls::crypto::CryptoProvider;
 use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
@@ -315,7 +320,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
 }
 
 mod ffdhe {
-    use crate::common::provider;
+    use super::provider;
     use num_bigint::BigUint;
     use rustls::crypto::{
         ActiveKeyExchange, CipherSuiteCommon, CryptoProvider, KeyExchangeAlgorithm, SharedSecret,
@@ -426,3 +431,5 @@ mod ffdhe {
         bytes
     }
 }
+
+} // test_for_each_provider!

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -1,15 +1,18 @@
 //! Tests for configuring and using a [`ClientCertVerifier`] for a server.
 
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[macro_use]
+mod macros;
+
+test_for_each_provider! {
 
 mod common;
-
-use crate::common::{
+use common::{
     do_handshake_until_both_error, do_handshake_until_error, get_client_root_store,
     make_client_config_with_versions, make_client_config_with_versions_with_auth,
     make_pair_for_arc_configs, server_config_builder, server_name, webpki_client_verifier_builder,
     ErrorFromPeer, KeyType, ALL_KEY_TYPES,
 };
+
 use rustls::client::danger::HandshakeSignatureValid;
 use rustls::internal::msgs::handshake::DistinguishedName;
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
@@ -207,3 +210,5 @@ impl ClientCertVerifier for MockClientVerifier {
         }
     }
 }
+
+} // test_for_each_provider!

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#![allow(clippy::duplicate_mod)]
 
 use std::io;
 use std::ops::{Deref, DerefMut};
@@ -9,6 +9,7 @@ use pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer, Ser
 use webpki::anchor_from_trusted_cert;
 
 use rustls::client::{ServerCertVerifierBuilder, WebPkiServerVerifier};
+use rustls::crypto::CryptoProvider;
 use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, OpaqueMessage, PlainMessage};
 use rustls::server::{ClientCertVerifierBuilder, WebPkiClientVerifier};
@@ -19,11 +20,7 @@ use rustls::{ClientConfig, ClientConnection};
 use rustls::{ConnectionCommon, ServerConfig, ServerConnection, SideData};
 use rustls::{ProtocolVersion, SupportedCipherSuite};
 
-#[cfg(all(any(not(feature = "ring"), feature = "fips"), feature = "aws_lc_rs"))]
-pub use rustls::crypto::aws_lc_rs as provider;
-#[cfg(all(feature = "ring", not(feature = "fips")))]
-pub use rustls::crypto::ring as provider;
-use rustls::crypto::CryptoProvider;
+use super::provider;
 
 macro_rules! embed_files {
     (

--- a/rustls/tests/macros.rs
+++ b/rustls/tests/macros.rs
@@ -1,0 +1,37 @@
+/// Instantiate the given test functions once for each built-in provider.
+///
+/// The selected provider module is bound as `provider`; you can rely on this
+/// having the union of the public items common to the `rustls::crypto::ring`
+/// and `rustls::crypto::aws_lc_rs` modules.
+#[allow(unused_macros)]
+macro_rules! test_for_each_provider {
+    ($($tt:tt)+) => {
+        #[cfg(feature = "ring")]
+        #[path = "."]
+        mod test_with_ring {
+            #[allow(unused_imports)]
+            use rustls::crypto::ring as provider;
+            #[allow(dead_code)]
+            const fn provider_is_aws_lc_rs() -> bool { false }
+            #[allow(dead_code)]
+            const fn provider_is_ring() -> bool { true }
+            #[allow(dead_code)]
+            const fn provider_is_fips() -> bool { false }
+            $($tt)+
+        }
+
+        #[cfg(feature = "aws_lc_rs")]
+        #[path = "."]
+        mod test_with_aws_lc_rs {
+            #[allow(unused_imports)]
+            use rustls::crypto::aws_lc_rs as provider;
+            #[allow(dead_code)]
+            const fn provider_is_aws_lc_rs() -> bool { true }
+            #[allow(dead_code)]
+            const fn provider_is_ring() -> bool { false }
+            #[allow(dead_code)]
+            const fn provider_is_fips() -> bool { cfg!(feature = "fips") }
+            $($tt)+
+        }
+    };
+}

--- a/rustls/tests/process_provider.rs
+++ b/rustls/tests/process_provider.rs
@@ -7,6 +7,13 @@
 use rustls::crypto::CryptoProvider;
 use rustls::ClientConfig;
 
+#[cfg(all(feature = "aws_lc_rs", not(feature = "ring")))]
+use rustls::crypto::aws_lc_rs as provider;
+#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]
+use rustls::crypto::ring as provider;
+#[cfg(all(feature = "ring", feature = "aws_lc_rs"))]
+use rustls::crypto::ring as provider;
+
 mod common;
 use crate::common::*;
 

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -1,9 +1,12 @@
 //! Tests for configuring and using a [`ServerCertVerifier`] for a client.
 
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[macro_use]
+mod macros;
+
+test_for_each_provider! {
 
 mod common;
-use crate::common::{
+use common::{
     do_handshake, do_handshake_until_both_error, make_client_config_with_versions,
     make_pair_for_arc_configs, make_server_config, ErrorFromPeer, ALL_KEY_TYPES,
 };
@@ -275,3 +278,5 @@ impl Default for MockServerVerifier {
         }
     }
 }
+
+} // test_for_each_provider!

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1,4 +1,8 @@
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#[macro_use]
+mod macros;
+
+test_for_each_provider! {
+
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -11,9 +15,8 @@ use rustls::unbuffered::{
 use rustls::version::TLS13;
 use rustls::{ClientConfig, ServerConfig};
 
-use crate::common::*;
-
 mod common;
+use common::*;
 
 const MAX_ITERATIONS: usize = 100;
 
@@ -875,3 +878,5 @@ fn server_receives_incorrect_first_handshake_message() {
         _ => panic!("unexpected alert sending state"),
     };
 }
+
+} // test_for_each_provider!


### PR DESCRIPTION
Prior to this PR, `cargo test --all-features` runs the various unit/integration tests with one arbitrary provider and leaves the other untested. After this PR, `cargo test --all-features` runs tests that depend on a provider twice (once for aws-lc-rs, once for ring).

I'm not super happy about using macros for this. An alternative would be https://crates.io/crates/rstest which uses proc-macros to enable parameterised tests and fixtures.