### PR TITLE
Change crate default features to use aws-lc-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,12 @@ need them.
 
 ### Platform support
 
-While Rustls itself is platform independent, by default it uses [`ring`] for implementing
-the cryptography in TLS. As a result, rustls only runs on platforms
-supported by `ring`. At the time of writing, this means 32-bit ARM, Aarch64 (64-bit ARM),
-x86, x86-64, LoongArch64, 32-bit & 64-bit Little Endian MIPS, 32-bit PowerPC (Big Endian),
-64-bit PowerPC (Big and Little Endian), 64-bit RISC-V, and s390x. We do not presently
-support WebAssembly.
-For more information, see [the supported `ring` target platforms][ring-target-platforms].
+While Rustls itself is platform independent, by default it uses [`aws-lc-rs`] for implementing
+the cryptography in TLS.  See [the aws-lc-rs FAQ][aws-lc-rs-platforms-faq] for more details of the
+platform/architecture support constraints in aws-lc-rs.
+
+[`ring`] is also available via the `ring` crate feature: see
+[the supported `ring` target platforms][ring-target-platforms].
 
 By providing a custom instance of the [`crypto::CryptoProvider`] struct, you
 can replace all cryptography dependencies of rustls.  This is a route to being portable
@@ -100,19 +99,21 @@ to a wider set of architectures and environments, or compliance requirements.  S
 [`crypto::CryptoProvider`] documentation for more details.
 
 Specifying `default-features = false` when depending on rustls will remove the
-dependency on *ring*.
+dependency on aws-lc-rs.
 
 Rustls requires Rust 1.61 or later.
 
 [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 [`crypto::CryptoProvider`]: https://docs.rs/rustls/latest/rustls/crypto/trait.CryptoProvider.html
 [`ring`]: https://crates.io/crates/ring
+[aws-lc-rs-platforms-faq]: https://aws.github.io/aws-lc-rs/faq.html#can-i-run-aws-lc-rs-on-x-platform-or-architecture
+[`aws-lc-rs`]: https://crates.io/crates/aws-lc-rs
 
 ### Cryptography providers
 
 Since Rustls 0.22 it has been possible to choose the provider of the cryptographic primitives
 that Rustls uses. This may be appealing if you have specific platform, compliance or feature
-requirements that aren't met by the default provider, [`ring`].
+requirements that aren't met by the default provider, [`aws-lc-rs`].
 
 Users that wish to customize the provider in use can do so when constructing `ClientConfig`
 and `ServerConfig` instances using the `with_crypto_provider` method on the respective config
@@ -122,11 +123,11 @@ builder types. See the [`crypto::CryptoProvider`] documentation for more details
 
 Rustls ships with two built-in providers controlled with associated feature flags:
 
-* [`ring`] - enabled by default, available with the `ring` feature flag enabled. This
-provider is used by default when an explicit provider is not specified.
-* [`aws-lc-rs`] - available with the `aws_lc_rs` feature flag enabled.
+* [`aws-lc-rs`] - enabled by default, available with the `aws_lc_rs` feature flag enabled.
+* [`ring`] - available with the `ring` feature flag enabled.
 
-[`aws-lc-rs`]: https://github.com/aws/aws-lc-rs
+See the documentation for [`crypto::CryptoProvider`] for details on how providers are
+selected.
 
 #### Third-party providers
 

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -2,7 +2,7 @@
 //! so that unused cryptography in rustls can be discarded by the linker.  You can
 //! observe using `nm` that the binary of this program does not contain any AES code.
 
-use rustls::crypto::{ring, CryptoProvider};
+use rustls::crypto::{ring as provider, CryptoProvider};
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
@@ -16,9 +16,9 @@ fn main() {
 
     let config = rustls::ClientConfig::builder_with_provider(
         CryptoProvider {
-            cipher_suites: vec![ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256],
-            kx_groups: vec![ring::kx_group::X25519],
-            ..ring::default_provider()
+            cipher_suites: vec![provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256],
+            kx_groups: vec![provider::kx_group::X25519],
+            ..provider::default_provider()
         }
         .into(),
     )

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -2,7 +2,7 @@
 //! so that unused cryptography in rustls can be discarded by the linker.  You can
 //! observe using `nm` that the binary of this program does not contain any AES code.
 
-use rustls::crypto::{ring as provider, CryptoProvider};
+use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -28,7 +28,7 @@ use docopt::Docopt;
 use mio::net::TcpStream;
 use serde::Deserialize;
 
-use rustls::crypto::CryptoProvider;
+use rustls::crypto::{ring as provider, CryptoProvider};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 use rustls::RootCertStore;
 
@@ -258,7 +258,7 @@ struct Args {
 
 /// Find a ciphersuite with the given name
 fn find_suite(name: &str) -> Option<rustls::SupportedCipherSuite> {
-    for suite in rustls::crypto::ring::ALL_CIPHER_SUITES {
+    for suite in provider::ALL_CIPHER_SUITES {
         let sname = format!("{:?}", suite.suite()).to_lowercase();
 
         if sname == name.to_string().to_lowercase() {
@@ -417,7 +417,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     let suites = if !args.flag_suite.is_empty() {
         lookup_suites(&args.flag_suite)
     } else {
-        rustls::crypto::ring::DEFAULT_CIPHER_SUITES.to_vec()
+        provider::DEFAULT_CIPHER_SUITES.to_vec()
     };
 
     let versions = if !args.flag_protover.is_empty() {
@@ -429,7 +429,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     let config = rustls::ClientConfig::builder_with_provider(
         CryptoProvider {
             cipher_suites: suites,
-            ..rustls::crypto::ring::default_provider()
+            ..provider::default_provider()
         }
         .into(),
     )
@@ -474,7 +474,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
         config
             .dangerous()
             .set_certificate_verifier(Arc::new(danger::NoCertificateVerification::new(
-                rustls::crypto::ring::default_provider(),
+                provider::default_provider(),
             )));
     }
 

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -28,7 +28,7 @@ use docopt::Docopt;
 use mio::net::TcpStream;
 use serde::Deserialize;
 
-use rustls::crypto::{ring as provider, CryptoProvider};
+use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 use rustls::RootCertStore;
 

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -29,7 +29,7 @@ use log::{debug, error};
 use mio::net::{TcpListener, TcpStream};
 use serde::Deserialize;
 
-use rustls::crypto::{ring, CryptoProvider};
+use rustls::crypto::{ring as provider, CryptoProvider};
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use rustls::server::WebPkiClientVerifier;
 use rustls::{self, RootCertStore};
@@ -479,7 +479,7 @@ struct Args {
 }
 
 fn find_suite(name: &str) -> Option<rustls::SupportedCipherSuite> {
-    for suite in rustls::crypto::ring::ALL_CIPHER_SUITES {
+    for suite in provider::ALL_CIPHER_SUITES {
         let sname = format!("{:?}", suite.suite()).to_lowercase();
 
         if sname == name.to_string().to_lowercase() {
@@ -605,7 +605,7 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
     let suites = if !args.flag_suite.is_empty() {
         lookup_suites(&args.flag_suite)
     } else {
-        rustls::crypto::ring::ALL_CIPHER_SUITES.to_vec()
+        provider::ALL_CIPHER_SUITES.to_vec()
     };
 
     let versions = if !args.flag_protover.is_empty() {
@@ -629,7 +629,7 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
     let mut config = rustls::ServerConfig::builder_with_provider(
         CryptoProvider {
             cipher_suites: suites,
-            ..ring::default_provider()
+            ..provider::default_provider()
         }
         .into(),
     )
@@ -646,7 +646,7 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
     }
 
     if args.flag_tickets {
-        config.ticketer = rustls::crypto::ring::Ticketer::new().unwrap();
+        config.ticketer = provider::Ticketer::new().unwrap();
     }
 
     config.alpn_protocols = args

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -29,7 +29,7 @@ use log::{debug, error};
 use mio::net::{TcpListener, TcpStream};
 use serde::Deserialize;
 
-use rustls::crypto::{ring as provider, CryptoProvider};
+use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use rustls::server::WebPkiClientVerifier;
 use rustls::{self, RootCertStore};

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,10 +3,74 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arbitrary"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cf76cb6e2222ed0ea86b2b0ee2f71c96ec6edd5af42e84d59160e91b836ec4"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb94ba389c4c48d9dc1983f8653cb92f7d9fc50b261e0501be2b7a636cbcbc4a"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e564487156f6ea22217c06263abd92ee65e4d9ff3dbc1f99f703f060f94715"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "cc"
@@ -18,10 +82,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "getrandom"
@@ -33,6 +154,42 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -50,16 +207,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ring"
@@ -72,16 +336,35 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
 version = "0.23.0-alpha.0"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -109,10 +392,17 @@ version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "spin"
@@ -127,6 +417,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
+name = "syn"
+version = "2.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,12 +446,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -153,13 +481,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -169,10 +512,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -181,10 +536,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -193,16 +560,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zeroize"

--- a/openssl-tests/src/ffdhe.rs
+++ b/openssl-tests/src/ffdhe.rs
@@ -1,7 +1,7 @@
 use num_bigint::BigUint;
 use rustls::crypto::{
-    ring as provider, ActiveKeyExchange, CipherSuiteCommon, KeyExchangeAlgorithm, SharedSecret,
-    SupportedKxGroup,
+    aws_lc_rs as provider, ActiveKeyExchange, CipherSuiteCommon, KeyExchangeAlgorithm,
+    SharedSecret, SupportedKxGroup,
 };
 use rustls::ffdhe_groups::FfdheGroup;
 use rustls::{CipherSuite, NamedGroup, SupportedCipherSuite, Tls12CipherSuite};

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -4,8 +4,7 @@ use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
 use std::{str, thread};
 
-use rustls::crypto::ring::default_provider;
-use rustls::crypto::CryptoProvider;
+use rustls::crypto::{ring as provider, CryptoProvider};
 use rustls::version::{TLS12, TLS13};
 use rustls::{ClientConfig, RootCertStore, ServerConfig, SupportedProtocolVersion};
 use rustls_pemfile::Item;
@@ -211,10 +210,10 @@ fn ffdhe_provider() -> CryptoProvider {
     CryptoProvider {
         cipher_suites: vec![
             ffdhe::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
-            rustls::crypto::ring::cipher_suite::TLS13_AES_128_GCM_SHA256,
+            provider::cipher_suite::TLS13_AES_128_GCM_SHA256,
         ],
         kx_groups: vec![&FfdheKxGroup(rustls::NamedGroup::FFDHE2048)],
-        ..default_provider()
+        ..provider::default_provider()
     }
 }
 

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -4,7 +4,7 @@ use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
 use std::{str, thread};
 
-use rustls::crypto::{ring as provider, CryptoProvider};
+use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::version::{TLS12, TLS13};
 use rustls::{ClientConfig, RootCertStore, ServerConfig, SupportedProtocolVersion};
 use rustls_pemfile::Item;

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -27,7 +27,7 @@ pki-types = { package = "rustls-pki-types", version = "1.2", features = ["std"] 
 zeroize = "1.7"
 
 [features]
-default = ["logging", "ring", "tls12"]
+default = ["aws_lc_rs", "logging", "tls12"]
 logging = ["log"]
 aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 ring = ["dep:ring", "webpki/ring"]

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -28,8 +28,8 @@ use crate::{ClientConfig, ServerConfig};
 /// supported protocol versions.
 ///
 /// ```
-/// # #[cfg(feature = "ring")] {
-/// # rustls::crypto::ring::default_provider().install_default();
+/// # #[cfg(feature = "aws_lc_rs")] {
+/// # rustls::crypto::aws_lc_rs::default_provider().install_default();
 /// use rustls::{ClientConfig, ServerConfig};
 /// ClientConfig::builder()
 /// //  ...
@@ -44,8 +44,8 @@ use crate::{ClientConfig, ServerConfig};
 /// You may also override the choice of protocol versions:
 ///
 /// ```no_run
-/// # #[cfg(feature = "ring")] {
-/// # rustls::crypto::ring::default_provider().install_default();
+/// # #[cfg(feature = "aws_lc_rs")] {
+/// # rustls::crypto::aws_lc_rs::default_provider().install_default();
 /// # use rustls::ServerConfig;
 /// ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
 /// //  ...
@@ -80,8 +80,8 @@ use crate::{ClientConfig, ServerConfig};
 /// For example:
 ///
 /// ```
-/// # #[cfg(feature = "ring")] {
-/// # rustls::crypto::ring::default_provider().install_default();
+/// # #[cfg(feature = "aws_lc_rs")] {
+/// # rustls::crypto::aws_lc_rs::default_provider().install_default();
 /// # use rustls::ClientConfig;
 /// # let root_certs = rustls::RootCertStore::empty();
 /// ClientConfig::builder()
@@ -104,8 +104,8 @@ use crate::{ClientConfig, ServerConfig};
 /// For example:
 ///
 /// ```no_run
-/// # #[cfg(feature = "ring")] {
-/// # rustls::crypto::ring::default_provider().install_default();
+/// # #[cfg(feature = "aws_lc_rs")] {
+/// # rustls::crypto::aws_lc_rs::default_provider().install_default();
 /// # use rustls::ServerConfig;
 /// # let certs = vec![];
 /// # let private_key = pki_types::PrivateKeyDer::from(
@@ -141,7 +141,7 @@ use crate::{ClientConfig, ServerConfig};
 /// Additionally, ServerConfig and ClientConfig carry a private field containing a
 /// [`CryptoProvider`], from [`ClientConfig::builder_with_provider()`] or
 /// [`ServerConfig::builder_with_provider()`]. This determines which cryptographic backend
-/// is used. The default is [`ring::provider`].
+/// is used. The default is [the process-default provider](`CryptoProvider::get_default`).
 ///
 /// [builder]: https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 /// [typestate]: http://cliffle.com/blog/rust-typestate/
@@ -156,7 +156,7 @@ use crate::{ClientConfig, ServerConfig};
 /// [`ConfigBuilder<ServerConfig, WantsVerifier>`]: struct.ConfigBuilder.html#impl-6
 /// [`WantsClientCert`]: crate::client::WantsClientCert
 /// [`WantsServerCert`]: crate::server::WantsServerCert
-/// [`ring::provider`]: crate::crypto::ring::default_provider
+/// [`CryptoProvider::get_default`]: crate::crypto::CryptoProvider::get_default
 /// [`DangerousClientConfigBuilder::with_custom_certificate_verifier`]: crate::client::danger::DangerousClientConfigBuilder::with_custom_certificate_verifier
 #[derive(Clone)]
 pub struct ConfigBuilder<Side: ConfigSide, State> {

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -66,12 +66,12 @@ pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 /// This crate comes with two built-in options, provided as
 /// `CryptoProvider` structures:
 ///
-/// - [`crypto::ring::default_provider`]: (behind the `ring` crate feature, which
-///   is enabled by default).  This provider uses the [*ring*](https://github.com/briansmith/ring)
-///   crate.
 /// - [`crypto::aws_lc_rs::default_provider`]: (behind the `aws_lc_rs` feature,
-///   which is optional).  This provider uses the [aws-lc-rs](https://github.com/aws/aws-lc-rs)
+///   which is enabled by default).  This provider uses the [aws-lc-rs](https://github.com/aws/aws-lc-rs)
 ///   crate.  The `fips` crate feature makes this option use FIPS140-3-approved cryptography.
+/// - [`crypto::ring::default_provider`]: (behind the `ring` crate feature, which
+///   is optional).  This provider uses the [*ring*](https://github.com/briansmith/ring)
+///   crate.
 ///
 /// This structure provides defaults. Everything in it can be overridden at
 /// runtime by replacing field values as needed.
@@ -123,15 +123,15 @@ pub use crate::msgs::handshake::KeyExchangeAlgorithm;
 /// API ([`ConfigBuilder::with_single_cert`] etc.), it might look like this:
 ///
 /// ```
-/// # #[cfg(feature = "ring")] {
+/// # #[cfg(feature = "aws_lc_rs")] {
 /// # use std::sync::Arc;
 /// # mod fictious_hsm_api { pub fn load_private_key(key_der: pki_types::PrivateKeyDer<'static>) -> ! { unreachable!(); } }
-/// use rustls::crypto::ring;
+/// use rustls::crypto::aws_lc_rs;
 ///
 /// pub fn provider() -> rustls::crypto::CryptoProvider {
 ///   rustls::crypto::CryptoProvider{
 ///     key_provider: &HsmKeyLoader,
-///     ..ring::default_provider()
+///     ..aws_lc_rs::default_provider()
 ///   }
 /// }
 ///

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -500,7 +500,20 @@ impl From<&[u8]> for SharedSecret {
 /// This function returns a [`CryptoProvider`] that uses
 /// FIPS140-3-approved cryptography.
 ///
-/// You can use this like:
+/// Using this function expresses in your code that you require
+/// FIPS-approved cryptography, and will not compile if you make
+/// a mistake with cargo features.
+///
+/// Install this as the process-default provider, like:
+///
+/// ```rust
+/// # #[cfg(feature = "fips")] {
+/// rustls::crypto::default_fips_provider().install_default()
+///     .expect("default provider already set elsewhere");
+/// # }
+/// ```
+///
+/// You can also use this explicitly, like:
 ///
 /// ```rust
 /// # #[cfg(feature = "fips")] {
@@ -514,10 +527,6 @@ impl From<&[u8]> for SharedSecret {
 ///     .with_no_client_auth();
 /// # }
 /// ```
-///
-/// This expresses in your code that you require FIPS-approved
-/// cryptography, and will not compile if you make a mistake
-/// with cargo features.
 #[cfg(feature = "fips")]
 pub fn default_fips_provider() -> CryptoProvider {
     crate::crypto::aws_lc_rs::default_provider()

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -53,13 +53,12 @@
 //!
 //! ### Platform support
 //!
-//! While Rustls itself is platform independent, by default it uses [`ring`] for implementing
-//! the cryptography in TLS. As a result, rustls only runs on platforms
-//! supported by `ring`. At the time of writing, this means 32-bit ARM, Aarch64 (64-bit ARM),
-//! x86, x86-64, LoongArch64, 32-bit & 64-bit Little Endian MIPS, 32-bit PowerPC (Big Endian),
-//! 64-bit PowerPC (Big and Little Endian), 64-bit RISC-V, and s390x. We do not presently
-//! support WebAssembly.
-//! For more information, see [the supported `ring` target platforms][ring-target-platforms].
+//! While Rustls itself is platform independent, by default it uses [`aws-lc-rs`] for implementing
+//! the cryptography in TLS.  See [the aws-lc-rs FAQ][aws-lc-rs-platforms-faq] for more details of the
+//! platform/architecture support constraints in aws-lc-rs.
+//!
+//! [`ring`] is also available via the `ring` crate feature: see
+//! [the supported `ring` target platforms][ring-target-platforms].
 //!
 //! By providing a custom instance of the [`crypto::CryptoProvider`] struct, you
 //! can replace all cryptography dependencies of rustls.  This is a route to being portable
@@ -67,19 +66,21 @@
 //! [`crypto::CryptoProvider`] documentation for more details.
 //!
 //! Specifying `default-features = false` when depending on rustls will remove the
-//! dependency on *ring*.
+//! dependency on aws-lc-rs.
 //!
 //! Rustls requires Rust 1.61 or later.
 //!
 //! [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 //! [`crypto::CryptoProvider`]: https://docs.rs/rustls/latest/rustls/crypto/trait.CryptoProvider.html
 //! [`ring`]: https://crates.io/crates/ring
+//! [aws-lc-rs-platforms-faq]: https://aws.github.io/aws-lc-rs/faq.html#can-i-run-aws-lc-rs-on-x-platform-or-architecture
+//! [`aws-lc-rs`]: https://crates.io/crates/aws-lc-rs
 //!
 //! ### Cryptography providers
 //!
 //! Since Rustls 0.22 it has been possible to choose the provider of the cryptographic primitives
 //! that Rustls uses. This may be appealing if you have specific platform, compliance or feature
-//! requirements that aren't met by the default provider, [`ring`].
+//! requirements that aren't met by the default provider, [`aws-lc-rs`].
 //!
 //! Users that wish to customize the provider in use can do so when constructing `ClientConfig`
 //! and `ServerConfig` instances using the `with_crypto_provider` method on the respective config
@@ -89,11 +90,11 @@
 //!
 //! Rustls ships with two built-in providers controlled with associated feature flags:
 //!
-//!   * [`ring`] - enabled by default, available with the `ring` feature flag enabled. This
-//!     provider is used by default when an explicit provider is not specified.
-//!   * [`aws-lc-rs`] - available with the `aws_lc_rs` feature flag enabled.
+//!   * [`aws-lc-rs`] - enabled by default, available with the `aws_lc_rs` feature flag enabled.
+//!   * [`ring`] - available with the `ring` feature flag enabled.
 //!
-//! [`aws-lc-rs`]: https://github.com/aws/aws-lc-rs
+//! See the documentation for [`crypto::CryptoProvider`] for details on how providers are
+//! selected.
 //!
 //! #### Third-party providers
 //!
@@ -176,7 +177,7 @@
 //! the Mozilla set of root certificates.
 //!
 //! ```rust,no_run
-//! # #[cfg(feature = "ring")] {
+//! # #[cfg(feature = "aws-lc-rs")] {
 //! let root_store = rustls::RootCertStore::from_iter(
 //!     webpki_roots::TLS_SERVER_ROOTS
 //!         .iter()
@@ -191,7 +192,7 @@
 //! and use it for all connections made by that process.
 //!
 //! ```rust,no_run
-//! # #[cfg(feature = "ring")] {
+//! # #[cfg(feature = "aws_lc_rs")] {
 //! # let root_store: rustls::RootCertStore = panic!();
 //! let config = rustls::ClientConfig::builder()
 //!     .with_root_certificates(root_store)
@@ -203,11 +204,11 @@
 //! know what to expect to find in the server's certificate.
 //!
 //! ```rust
-//! # #[cfg(feature = "ring")] {
+//! # #[cfg(feature = "aws_lc_rs")] {
 //! # use rustls;
 //! # use webpki;
 //! # use std::sync::Arc;
-//! # rustls::crypto::ring::default_provider().install_default();
+//! # rustls::crypto::aws_lc_rs::default_provider().install_default();
 //! # let root_store = rustls::RootCertStore::from_iter(
 //! #  webpki_roots::TLS_SERVER_ROOTS
 //! #      .iter()
@@ -246,7 +247,7 @@
 //! errors.
 //!
 //! ```rust,no_run
-//! # #[cfg(feature = "ring")] {
+//! # #[cfg(feature = "aws_lc_rs")] {
 //! # let mut client = rustls::ClientConnection::new(panic!(), panic!()).unwrap();
 //! # struct Socket { }
 //! # impl Socket {
@@ -304,17 +305,18 @@
 //! Here's a list of what features are exposed by the rustls crate and what
 //! they mean.
 //!
-//! - `ring` (enabled by default): makes the rustls crate depend on the *ring* crate, which is
-//!    used for cryptography by default. Without this feature, these items must be provided
-//!    externally to the core rustls crate: see [`CryptoProvider`].
-//!
-//! - `aws_lc_rs`: makes the rustls crate depend on the aws-lc-rs crate,
-//!   which can be used for cryptography as an alternative to *ring*.
-//!   Use `rustls::crypto::aws_lc_rs::default_provider()` as a `CryptoProvider`
-//!   when making a `ClientConfig` or `ServerConfig` to use aws-lc-rs
+//! - `aws_lc_rs` (enabled by default): makes the rustls crate depend on the [`aws-lc-rs`] crate.
+//!   Use `rustls::crypto::aws_lc_rs::default_provider().install_default()` to
+//!   use it as the default `CryptoProvider`, or provide it explicitly
+//!   when making a `ClientConfig` or `ServerConfig`.
 //!
 //!   Note that aws-lc-rs has additional build-time dependencies like cmake.
 //!   See [the documentation](https://aws.github.io/aws-lc-rs/requirements/index.html) for details.
+//!
+//! - `ring`: makes the rustls crate depend on the *ring* crate for cryptography.
+//!   Use `rustls::crypto::ring::default_provider().install_default()` to
+//!   use it as the default `CryptoProvider`, or provide it explicitly
+//!   when making a `ClientConfig` or `ServerConfig`.
 //!
 //! - `fips`: enable support for FIPS140-3-approved cryptography, via the aws-lc-rs crate.
 //!   This feature enables the `aws_lc_rs` feature, which makes the rustls crate depend

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -654,7 +654,7 @@ impl UnbufferedConnectionCommon<ServerConnectionData> {
 /// # Example
 ///
 /// ```no_run
-/// # #[cfg(feature = "ring")] {
+/// # #[cfg(feature = "aws_lc_rs")] {
 /// # fn choose_server_config(
 /// #     _: rustls::server::ClientHello,
 /// # ) -> std::sync::Arc<rustls::ServerConfig> {


### PR DESCRIPTION
The goal here is to provide the optimum performance by default. Naturally the `ring` feature remains available.