### PR TITLE
provide codecov token for coverage job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,6 +266,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: final.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
 


### PR DESCRIPTION
This has been broken for a bit, and it's not very visible because we swallow errors from coverage upload. But see, eg, https://github.com/rustls/rustls/actions/runs/7847827063/job/21417647567#step:6:31

See https://github.com/codecov/codecov-action/issues/1274#issuecomment-1934437359 for details of the new requirement for a token.

I have added a new secret named `CODECOV_TOKEN` for the rustls org containing the codecov token.