### PR TITLE
Support for X25519Kyber768Draft00 post-quantum key exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,6 +2248,7 @@ checksum = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf"
 name = "rustls-postquantum"
 version = "0.1.0"
 dependencies = [
+ "aws-lc-rs",
  "rustls 0.23.0-alpha.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,6 +2245,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf"
 
 [[package]]
+name = "rustls-postquantum"
+version = "0.1.0"
+dependencies = [
+ "rustls 0.23.0-alpha.0",
+]
+
+[[package]]
 name = "rustls-provider-example"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,7 +2249,9 @@ name = "rustls-postquantum"
 version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
+ "env_logger",
  "rustls 0.23.0-alpha.0",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,13 @@ members = [
   "rustls",
   # example of custom provider
   "provider-example",
+  # experimental post-quantum algorithm support
+  "rustls-postquantum",
 ]
 default-members = [
   "examples",
   "rustls",
+  "rustls-postquantum",
 ]
 exclude = ["admin/rustfmt"]
 resolver = "2"

--- a/rustls-postquantum/Cargo.toml
+++ b/rustls-postquantum/Cargo.toml
@@ -6,3 +6,4 @@ publish = false
 
 [dependencies]
 rustls = { path = "../rustls", features = [ "aws_lc_rs" ]}
+aws-lc-rs = { version = "1.6", features = [ "unstable" ], default-features = false }

--- a/rustls-postquantum/Cargo.toml
+++ b/rustls-postquantum/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rustls-postquantum"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+rustls = { path = "../rustls", features = [ "aws_lc_rs" ]}

--- a/rustls-postquantum/Cargo.toml
+++ b/rustls-postquantum/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 [dependencies]
 rustls = { path = "../rustls", features = [ "aws_lc_rs" ]}
 aws-lc-rs = { version = "1.6", features = [ "unstable" ], default-features = false }
+
+[dev-dependencies]
+env_logger = "0.10"
+webpki-roots = "0.26"

--- a/rustls-postquantum/examples/client.rs
+++ b/rustls-postquantum/examples/client.rs
@@ -1,0 +1,51 @@
+use std::io::{stdout, Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+fn main() {
+    env_logger::init();
+
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.extend(
+        webpki_roots::TLS_SERVER_ROOTS
+            .iter()
+            .cloned(),
+    );
+
+    let config = rustls::ClientConfig::builder_with_provider(rustls_postquantum::provider().into())
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    let server_name = "pq.cloudflareresearch.com"
+        .try_into()
+        .unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    let mut sock = TcpStream::connect("pq.cloudflareresearch.com:443").unwrap();
+    let mut tls = rustls::Stream::new(&mut conn, &mut sock);
+    tls.write_all(
+        concat!(
+            "GET / HTTP/1.1\r\n",
+            "Host: pq.cloudflareresearch.com\r\n",
+            "Connection: close\r\n",
+            "Accept-Encoding: identity\r\n",
+            "\r\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    let ciphersuite = tls
+        .conn
+        .negotiated_cipher_suite()
+        .unwrap();
+    writeln!(
+        &mut std::io::stderr(),
+        "Current ciphersuite: {:?}",
+        ciphersuite.suite()
+    )
+    .unwrap();
+    let mut plaintext = Vec::new();
+    tls.read_to_end(&mut plaintext).unwrap();
+    stdout().write_all(&plaintext).unwrap();
+}

--- a/rustls-postquantum/src/lib.rs
+++ b/rustls-postquantum/src/lib.rs
@@ -1,9 +1,15 @@
-use rustls::crypto::aws_lc_rs::default_provider;
-use rustls::crypto::CryptoProvider;
+use rustls::crypto::aws_lc_rs::{default_provider, kx_group};
+use rustls::crypto::{
+    ActiveKeyExchange, CompletedKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup,
+};
+use rustls::{Error, NamedGroup, PeerMisbehaved};
+
+use aws_lc_rs::kem;
+use aws_lc_rs::unstable::kem::{get_algorithm, AlgorithmId};
 
 pub fn provider() -> CryptoProvider {
     let parent = default_provider();
-    let mut kx_groups = vec![];
+    let mut kx_groups = vec![&X25519Kyber768Draft00 as &dyn SupportedKxGroup];
     kx_groups.extend(parent.kx_groups);
 
     CryptoProvider {
@@ -11,3 +17,116 @@ pub fn provider() -> CryptoProvider {
         ..parent
     }
 }
+
+///
+#[derive(Debug)]
+pub struct X25519Kyber768Draft00;
+
+impl SupportedKxGroup for X25519Kyber768Draft00 {
+    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
+        let x25519 = kx_group::X25519.start()?;
+
+        let kyber = kem::DecapsulationKey::generate(kyber768_r3())
+            .map_err(|_| Error::FailedToGetRandomBytes)?;
+
+        let kyber_pub = kyber
+            .encapsulation_key()
+            .map_err(|_| Error::FailedToGetRandomBytes)?;
+
+        let mut combined_pub_key = Vec::with_capacity(COMBINED_PUBKEY_LEN);
+        combined_pub_key.extend_from_slice(x25519.pub_key());
+        combined_pub_key.extend_from_slice(kyber_pub.key_bytes().unwrap().as_ref());
+
+        Ok(Box::new(Active {
+            x25519,
+            decap_key: Box::new(kyber),
+            combined_pub_key,
+        }))
+    }
+
+    fn start_and_complete(&self, client_share: &[u8]) -> Result<CompletedKeyExchange, Error> {
+        if client_share.len() != COMBINED_PUBKEY_LEN {
+            return Err(INVALID_KEY_SHARE);
+        }
+
+        let x25519 = kx_group::X25519.start_and_complete(&client_share[..X25519_LEN])?;
+        let mut combined_secret = [0u8; 64];
+        combined_secret[..X25519_LEN].copy_from_slice(x25519.secret.secret_bytes());
+        let mut combined_share = [0u8; COMBINED_CIPHERTEXT_LEN];
+        combined_share[..X25519_LEN].copy_from_slice(&x25519.pub_key);
+
+        let kyber_pub = kem::EncapsulationKey::new(kyber768_r3(), &client_share[X25519_LEN..])
+            .map_err(|_| INVALID_KEY_SHARE)?;
+
+        let (kyber_share, kyber_secret) = kyber_pub
+            .encapsulate()
+            .map_err(|_| INVALID_KEY_SHARE)?;
+
+        combined_share[X25519_LEN..].copy_from_slice(kyber_share.as_ref());
+        combined_secret[X25519_LEN..].copy_from_slice(kyber_secret.as_ref());
+
+        Ok(CompletedKeyExchange {
+            group: self.name(),
+            pub_key: combined_share.to_vec(),
+            secret: SharedSecret::from(&combined_secret[..]),
+        })
+    }
+
+    fn name(&self) -> NamedGroup {
+        NAMED_GROUP
+    }
+}
+
+struct Active {
+    x25519: Box<dyn ActiveKeyExchange>,
+    decap_key: Box<kem::DecapsulationKey<AlgorithmId>>,
+    combined_pub_key: Vec<u8>,
+}
+
+impl ActiveKeyExchange for Active {
+    fn complete(self: Box<Self>, peer_pub_key: &[u8]) -> Result<SharedSecret, Error> {
+        if peer_pub_key.len() != COMBINED_CIPHERTEXT_LEN {
+            return Err(INVALID_KEY_SHARE);
+        }
+
+        let x25519_ss = self
+            .x25519
+            .complete(&peer_pub_key[..X25519_LEN])?;
+
+        let mut result = [0u8; COMBINED_SHARED_SECRET_LEN];
+        result[..X25519_LEN].copy_from_slice(x25519_ss.secret_bytes());
+
+        let mut ciphertext = [0u8; KYBER_CIPHERTEXT_LEN];
+        ciphertext.clone_from_slice(&peer_pub_key[X25519_LEN..]);
+
+        let secret = self
+            .decap_key
+            .decapsulate(ciphertext[..].into())
+            .map_err(|_| INVALID_KEY_SHARE)?;
+        result[X25519_LEN..].copy_from_slice(secret.as_ref());
+
+        Ok(SharedSecret::from(&result[..]))
+    }
+
+    fn pub_key(&self) -> &[u8] {
+        &self.combined_pub_key
+    }
+
+    fn group(&self) -> NamedGroup {
+        NAMED_GROUP
+    }
+}
+
+fn kyber768_r3() -> &'static kem::Algorithm<AlgorithmId> {
+    get_algorithm(AlgorithmId::Kyber768_R3).expect("Kyber768_R3 not available")
+}
+
+const NAMED_GROUP: NamedGroup = NamedGroup::Unknown(0x6399);
+
+const INVALID_KEY_SHARE: Error = Error::PeerMisbehaved(PeerMisbehaved::InvalidKeyShare);
+
+const X25519_LEN: usize = 32;
+const KYBER_CIPHERTEXT_LEN: usize = 1088;
+const COMBINED_PUBKEY_LEN: usize = X25519_LEN + 1184;
+const COMBINED_CIPHERTEXT_LEN: usize = X25519_LEN + KYBER_CIPHERTEXT_LEN;
+const COMBINED_SHARED_SECRET_LEN: usize = X25519_LEN + 32;

--- a/rustls-postquantum/src/lib.rs
+++ b/rustls-postquantum/src/lib.rs
@@ -1,0 +1,13 @@
+use rustls::crypto::aws_lc_rs::default_provider;
+use rustls::crypto::CryptoProvider;
+
+pub fn provider() -> CryptoProvider {
+    let parent = default_provider();
+    let mut kx_groups = vec![];
+    kx_groups.extend(parent.kx_groups);
+
+    CryptoProvider {
+        kx_groups,
+        ..parent
+    }
+}

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -149,8 +149,9 @@ pub(super) fn handle_server_hello(
         KeySchedulePreHandshake::new(suite)
     };
 
-    let key_schedule =
-        key_schedule_pre_handshake.into_handshake(our_key_share, &their_key_share.payload.0)?;
+    let shared_secret = our_key_share.complete(&their_key_share.payload.0)?;
+
+    let key_schedule = key_schedule_pre_handshake.into_handshake(shared_secret);
 
     // Remember what KX group the server liked for next time.
     config

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -371,6 +371,28 @@ pub trait SupportedKxGroup: Send + Sync + Debug {
     /// This can fail if the random source fails during ephemeral key generation.
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error>;
 
+    /// Start and complete a key exchange, in one operation.
+    ///
+    /// The default implementation for this calls `start()` and then calls
+    /// `complete()` on the result.  This is suitable for Diffie-Hellman-like
+    /// key exchange algorithms, where there is not a data dependency between
+    /// our key share (named "pub_key" in this API) and the peer's (`peer_pub_key`).
+    ///
+    /// If there is such a data dependency (like key encapsulation mechanisms), this
+    /// function should be implemented.
+    fn start_and_complete(&self, peer_pub_key: &[u8]) -> Result<CompletedKeyExchange, Error> {
+        let kx = self.start()?;
+        let group = kx.group();
+        let pub_key = kx.pub_key().to_vec();
+        let secret = kx.complete(peer_pub_key)?;
+
+        Ok(CompletedKeyExchange {
+            group,
+            pub_key,
+            secret,
+        })
+    }
+
     /// Named group the SupportedKxGroup operates in.
     ///
     /// If the `NamedGroup` enum does not have a name for the algorithm you are implementing,
@@ -453,6 +475,18 @@ pub trait ActiveKeyExchange: Send + Sync {
 
     /// Return the group being used.
     fn group(&self) -> NamedGroup;
+}
+
+/// The result from [`SupportedKxGroup::start_and_complete()`].
+pub struct CompletedKeyExchange {
+    /// Which group was used.
+    pub group: NamedGroup,
+
+    /// Our key share (sometimes a public key).
+    pub pub_key: Vec<u8>,
+
+    /// The computed shared secret.
+    pub secret: SharedSecret,
 }
 
 /// The result from [`ActiveKeyExchange::complete`].

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -358,10 +358,10 @@ pub struct KeyShareEntry {
 }
 
 impl KeyShareEntry {
-    pub fn new(group: NamedGroup, payload: &[u8]) -> Self {
+    pub fn new(group: NamedGroup, payload: impl Into<Vec<u8>>) -> Self {
         Self {
             group,
-            payload: PayloadU16::new(payload.to_vec()),
+            payload: PayloadU16::new(payload.into()),
         }
     }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -374,7 +374,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::SessionTicket(ClientSessionTicket::Offer(Payload::Borrowed(&[]))),
             ClientExtension::Protocols(vec![ProtocolName::from(vec![0])]),
             ClientExtension::SupportedVersions(vec![ProtocolVersion::TLSv1_3]),
-            ClientExtension::KeyShare(vec![KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3])]),
+            ClientExtension::KeyShare(vec![KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3][..])]),
             ClientExtension::PresharedKeyModes(vec![PSKKeyExchangeMode::PSK_DHE_KE]),
             ClientExtension::PresharedKey(PresharedKeyOffer {
                 identities: vec![
@@ -750,7 +750,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
             ServerExtension::SessionTicketAck,
             ServerExtension::RenegotiationInfo(PayloadU8(vec![0])),
             ServerExtension::Protocols(vec![ProtocolName::from(vec![0])]),
-            ServerExtension::KeyShare(KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3])),
+            ServerExtension::KeyShare(KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3][..])),
             ServerExtension::PresharedKey(3),
             ServerExtension::ExtendedMasterSecretAck,
             ServerExtension::CertificateStatusAck,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -486,10 +486,12 @@ mod client_hello {
         // Prepare key exchange; the caller already found the matching SupportedKxGroup
         let (share, kxgroup) = share_and_kxgroup;
         debug_assert_eq!(kxgroup.name(), share.group);
-        let kx = kxgroup.start()?;
+        let ckx = kxgroup.start_and_complete(&share.payload.0)?;
 
-        let kse = KeyShareEntry::new(share.group, kx.pub_key());
-        extensions.push(ServerExtension::KeyShare(kse));
+        extensions.push(ServerExtension::KeyShare(KeyShareEntry::new(
+            ckx.group,
+            ckx.pub_key,
+        )));
         extensions.push(ServerExtension::SupportedVersions(ProtocolVersion::TLSv1_3));
 
         if let Some(psk_idx) = chosen_psk_idx {
@@ -535,7 +537,7 @@ mod client_hello {
         };
 
         // Do key exchange
-        let key_schedule = key_schedule_pre_handshake.into_handshake(kx, &share.payload.0)?;
+        let key_schedule = key_schedule_pre_handshake.into_handshake(ckx.secret);
 
         let handshake_hash = transcript.current_hash();
         let key_schedule = key_schedule.derive_server_handshake_secrets(

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -1,7 +1,7 @@
 use crate::common_state::{CommonState, Side};
 use crate::crypto::cipher::{AeadKey, Iv, MessageDecrypter};
 use crate::crypto::tls13::{expand, Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
-use crate::crypto::{hash, hmac, ActiveKeyExchange};
+use crate::crypto::{hash, hmac, SharedSecret};
 use crate::error::Error;
 use crate::quic;
 use crate::suites::PartiallyExtractedSecrets;
@@ -143,12 +143,11 @@ impl KeySchedulePreHandshake {
 
     pub(crate) fn into_handshake(
         mut self,
-        kx: Box<dyn ActiveKeyExchange>,
-        peer_public_key: &[u8],
-    ) -> Result<KeyScheduleHandshakeStart, Error> {
+        shared_secret: SharedSecret,
+    ) -> KeyScheduleHandshakeStart {
         self.ks
-            .input_from_key_exchange(kx, peer_public_key)?;
-        Ok(KeyScheduleHandshakeStart { ks: self.ks })
+            .input_secret(shared_secret.secret_bytes());
+        KeyScheduleHandshakeStart { ks: self.ks }
     }
 }
 
@@ -607,27 +606,12 @@ impl KeySchedule {
     }
 
     /// Input the given secret.
-    #[cfg(all(test, any(feature = "ring", feature = "aws_lc_rs")))]
     fn input_secret(&mut self, secret: &[u8]) {
         let salt = self.derive_for_empty_hash(SecretKind::DerivedSecret);
         self.current = self
             .suite
             .hkdf_provider
             .extract_from_secret(Some(salt.as_ref()), secret);
-    }
-
-    /// Input the shared secret resulting from completing the given key exchange.
-    fn input_from_key_exchange(
-        &mut self,
-        kx: Box<dyn ActiveKeyExchange>,
-        peer_public_key: &[u8],
-    ) -> Result<(), Error> {
-        let salt = self.derive_for_empty_hash(SecretKind::DerivedSecret);
-        self.current = self
-            .suite
-            .hkdf_provider
-            .extract_from_kx_shared_secret(Some(salt.as_ref()), kx, peer_public_key)?;
-        Ok(())
     }
 
     /// Derive a secret of given `kind`, using current handshake hash `hs_hash`.


### PR DESCRIPTION
Draft for the moment.  This is on top of #1784.

I probably won't do `rustls-postquantum` as a separate crate, but it made sense at the time.

Most likely this will end up inside rustls/crypto/aws_lc_rs/ somewhere. I don't think it should be used by default for now, given it is pre-standardisation.