### PR TITLE
ci: add Windows aws-lc-rs build reqs to daily-tests

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -40,6 +40,14 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v4
+
       - name: Build main crate
         run: cargo build --locked
 
@@ -75,6 +83,14 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v4
 
       - name: Check simple client
         run: cargo run --locked --bin simpleclient


### PR DESCRIPTION
Fixes [daily test failures](https://github.com/rustls/rustls/actions/runs/7876205514) for the Windows builds that are failing with:
>   -- The ASM_NASM compiler identification is unknown
>   -- Didn't find assembler