### PR TITLE
Make peer-certificates lifetime explicit

### DIFF
--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -111,7 +111,7 @@ impl CommonState {
     /// if client authentication was completed.
     ///
     /// The return value is None until this value is available.
-    pub fn peer_certificates(&self) -> Option<&[CertificateDer<'_>]> {
+    pub fn peer_certificates(&self) -> Option<&[CertificateDer<'static>]> {
         self.peer_certificates.as_deref()
     }
 


### PR DESCRIPTION
I was having some issues with the inferred lifetimes here. I think `CertificateDer<'_>` is elided as `CertificateDer<'a>` because `'static: 'a`. If we explicitly set the lifetime as `'static`, this solves the issue.

With my change, this works:
```rust
fn get_first_cert_from_chain(conn: &rustls::ClientConnection) -> Option<rustls::pki_types::CertificateDer<'static>> {
    let certs = conn.peer_certificates();
    match certs {
        Some(certs) if certs.len() > 0 => Some(certs[0].clone()),
        _ => None,
    }
}
```
Without it, I get the following error:
```sh
error: lifetime may not live long enough
   --> src/rustls-test.rs:131:43
    |
127 |     conn: &rustls::ClientConnection,
    |           - let's call the lifetime of this reference `'1`
...
131 |         Some(certs) if certs.len() > 0 => Some(certs[0].clone()),
    |                                           ^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
```