### PR TITLE
Improve provider and FIPS documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: documentation
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 18 * * *'
+
+jobs:
+  generate:
+    name: Generate pre-release documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Generate version information
+        run: |
+          echo >tag.html \
+            "<script>var version = document.querySelector(\"span.version\");" \
+            "version.innerHTML += \"<br>(pre-release docs from <tt>$GITHUB_REF</tt>)\";" \
+            "version.title = \"commit $GITHUB_SHA\";" \
+            "</script>"
+
+      - name: cargo doc
+        run: cargo doc --locked --all-features --no-deps --package rustls
+        env:
+          RUSTDOCFLAGS: -Dwarnings --cfg=docsrs --html-after-content tag.html
+
+      - name: Massage rustdoc output
+        run: |
+          # lockfile causes deployment step to go wrong, due to permissions
+          rm -f target/doc/.lock
+          # make resulting url be more sensible
+          mv target/doc/rustls target/doc/prerelease
+
+      - name: Package and upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./target/doc/
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: generate
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}prerelease/
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ dependency on aws-lc-rs.
 Rustls requires Rust 1.61 or later.
 
 [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
-[`crypto::CryptoProvider`]: https://docs.rs/rustls/latest/rustls/crypto/trait.CryptoProvider.html
+[`crypto::CryptoProvider`]: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html
 [`ring`]: https://crates.io/crates/ring
 [aws-lc-rs-platforms-faq]: https://aws.github.io/aws-lc-rs/faq.html#can-i-run-aws-lc-rs-on-x-platform-or-architecture
 [`aws-lc-rs`]: https://crates.io/crates/aws-lc-rs

--- a/README.md
+++ b/README.md
@@ -37,52 +37,8 @@ Rustls is a TLS library that aims to provide a good level of cryptographic secur
 requires no configuration to achieve that security, and provides no unsafe features or
 obsolete cryptography by default.
 
-## Current functionality (with default crate features)
-
-* TLS1.2 and TLS1.3.
-* ECDSA, Ed25519 or RSA server authentication by clients.
-* ECDSA, Ed25519 or RSA server authentication by servers.
-* Forward secrecy using ECDHE; with curve25519, nistp256 or nistp384 curves.
-* AES128-GCM and AES256-GCM bulk encryption, with safe nonces.
-* ChaCha20-Poly1305 bulk encryption ([RFC7905](https://tools.ietf.org/html/rfc7905)).
-* ALPN support.
-* SNI support.
-* Tunable fragment size to make TLS messages match size of underlying transport.
-* Optional use of vectored IO to minimise system calls.
-* TLS1.2 session resumption.
-* TLS1.2 resumption via tickets ([RFC5077](https://tools.ietf.org/html/rfc5077)).
-* TLS1.3 resumption via tickets or session storage.
-* TLS1.3 0-RTT data for clients.
-* TLS1.3 0-RTT data for servers.
-* Server and optional client authentication.
-* Extended master secret support ([RFC7627](https://tools.ietf.org/html/rfc7627)).
-* Exporters ([RFC5705](https://tools.ietf.org/html/rfc5705)).
-* OCSP stapling by servers.
-
-## Non-features
-
-For reasons [explained in the manual](https://docs.rs/rustls/latest/rustls/manual/_02_tls_vulnerabilities/index.html),
-rustls does not and will not support:
-
-* SSL1, SSL2, SSL3, TLS1 or TLS1.1.
-* RC4.
-* DES or triple DES.
-* EXPORT ciphersuites.
-* MAC-then-encrypt ciphersuites.
-* Ciphersuites without forward secrecy.
-* Renegotiation.
-* Kerberos.
-* TLS 1.2 protocol compression.
-* Discrete-log Diffie-Hellman.
-* Automatic protocol version downgrade.
-* Using CA certificates directly to authenticate a server/client (often called "self-signed
-certificates"). _Rustls' default certificate verifier does not support using a trust anchor as
-both a CA certificate and an end-entity certificate in order to limit complexity and risk in
-path building. While dangerous, all authentication can be turned off if required --
-see the [example code](https://github.com/rustls/rustls/blob/992e2364a006b2e84a8cf6a7c3eaf0bdb773c9de/examples/src/bin/tlsclient-mio.rs#L318)_.
-
-There are plenty of other libraries that provide these features should you
-need them.
+Rustls implements TLS1.2 and TLS1.3 for both clients and servers. See [the full
+list of protocol features](https://docs.rs/rustls/latest/rustls/manual/_04_features/index.html).
 
 ### Platform support
 

--- a/admin/pull-readme
+++ b/admin/pull-readme
@@ -6,7 +6,7 @@ set -e
 awk 'BEGIN { take=1 }/# Approach/{take=0;print}take' < README.md > README.md.new
 grep '^//!' rustls/src/lib.rs | \
        sed -e 's@^\/\/\! *@@g' | \
-       sed -e 's@manual](manual)@manual](https://docs.rs/rustls/latest/rustls/manual/_02_tls_vulnerabilities/index.html)@' | \
+       sed -e 's@](manual::_04_features)@](https://docs.rs/rustls/latest/rustls/manual/_04_features/index.html)@' | \
        awk '/# Rustls - a modern TLS library/{take=1;next}/## Design overview/{take=0}take' >> README.md.new
 awk '/# Example code/{take=1}take' < README.md >> README.md.new
 mv README.md.new README.md

--- a/admin/pull-readme
+++ b/admin/pull-readme
@@ -7,6 +7,7 @@ awk 'BEGIN { take=1 }/# Approach/{take=0;print}take' < README.md > README.md.new
 grep '^//!' rustls/src/lib.rs | \
        sed -e 's@^\/\/\! *@@g' | \
        sed -e 's@](manual::_04_features)@](https://docs.rs/rustls/latest/rustls/manual/_04_features/index.html)@' | \
+       sed -e 's@\[`crypto::CryptoProvider`\]: crate::crypto::CryptoProvider@[`crypto::CryptoProvider`]: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html@' | \
        awk '/# Rustls - a modern TLS library/{take=1;next}/## Design overview/{take=0}take' >> README.md.new
 awk '/# Example code/{take=1}take' < README.md >> README.md.new
 mv README.md.new README.md

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -218,18 +218,18 @@ pub struct ClientConfig {
 }
 
 impl ClientConfig {
-    /// Create a builder for a client configuration with the process-default
-    /// [`CryptoProvider`]: [`CryptoProvider::get_default`] and safe
-    /// protocol version defaults.
+    /// Create a builder for a client configuration with
+    /// [the process-default `CryptoProvider`][CryptoProvider#using-the-per-process-default-cryptoprovider]
+    /// and safe protocol version defaults.
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
     pub fn builder() -> ConfigBuilder<Self, WantsVerifier> {
         Self::builder_with_protocol_versions(versions::DEFAULT_VERSIONS)
     }
 
-    /// Create a builder for a client configuration with the process-default
-    /// [`CryptoProvider`]: [`CryptoProvider::get_default`] and
-    /// the provided protocol versions.
+    /// Create a builder for a client configuration with
+    /// [the process-default `CryptoProvider`][CryptoProvider#using-the-per-process-default-cryptoprovider]
+    /// and the provided protocol versions.
     ///
     /// Panics if
     /// - the supported versions are not compatible with the provider (eg.

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -504,6 +504,9 @@ impl From<&[u8]> for SharedSecret {
 /// FIPS-approved cryptography, and will not compile if you make
 /// a mistake with cargo features.
 ///
+/// See our [FIPS documentation](crate::manual::_06_fips) for
+/// more detail.
+///
 /// Install this as the process-default provider, like:
 ///
 /// ```rust

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -279,6 +279,8 @@
 //!   on [aws-lc-rs](https://github.com/aws/aws-lc-rs).  It also changes the default
 //!   for [`ServerConfig::require_ems`] and [`ClientConfig::require_ems`].
 //!
+//!   See [manual::_06_fips] for more details.
+//!
 //! - `tls12` (enabled by default): enable support for TLS version 1.2. Note that, due to the
 //!   additive nature of Cargo features and because it is enabled by default, other crates
 //!   in your dependency graph could re-enable it for your application. If you want to disable

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -297,7 +297,7 @@
 //! You can find several client and server examples of varying complexity in the [examples]
 //! directory, including [`tlsserver-mio`](https://github.com/rustls/rustls/blob/main/examples/src/bin/tlsserver-mio.rs)
 //! and [`tlsclient-mio`](https://github.com/rustls/rustls/blob/main/examples/src/bin/tlsclient-mio.rs)
-//! - full worked examples using [`mio`].
+//! \- full worked examples using [`mio`].
 //!
 //! [`mio`]: https://docs.rs/mio/latest/mio/
 //!

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -4,52 +4,8 @@
 //! requires no configuration to achieve that security, and provides no unsafe features or
 //! obsolete cryptography by default.
 //!
-//! ## Current functionality (with default crate features)
-//!
-//! * TLS1.2 and TLS1.3.
-//! * ECDSA, Ed25519 or RSA server authentication by clients.
-//! * ECDSA, Ed25519 or RSA server authentication by servers.
-//! * Forward secrecy using ECDHE; with curve25519, nistp256 or nistp384 curves.
-//! * AES128-GCM and AES256-GCM bulk encryption, with safe nonces.
-//! * ChaCha20-Poly1305 bulk encryption ([RFC7905](https://tools.ietf.org/html/rfc7905)).
-//! * ALPN support.
-//! * SNI support.
-//! * Tunable fragment size to make TLS messages match size of underlying transport.
-//! * Optional use of vectored IO to minimise system calls.
-//! * TLS1.2 session resumption.
-//! * TLS1.2 resumption via tickets ([RFC5077](https://tools.ietf.org/html/rfc5077)).
-//! * TLS1.3 resumption via tickets or session storage.
-//! * TLS1.3 0-RTT data for clients.
-//! * TLS1.3 0-RTT data for servers.
-//! * Server and optional client authentication.
-//! * Extended master secret support ([RFC7627](https://tools.ietf.org/html/rfc7627)).
-//! * Exporters ([RFC5705](https://tools.ietf.org/html/rfc5705)).
-//! * OCSP stapling by servers.
-//!
-//! ## Non-features
-//!
-//! For reasons [explained in the manual](manual),
-//! rustls does not and will not support:
-//!
-//! * SSL1, SSL2, SSL3, TLS1 or TLS1.1.
-//! * RC4.
-//! * DES or triple DES.
-//! * EXPORT ciphersuites.
-//! * MAC-then-encrypt ciphersuites.
-//! * Ciphersuites without forward secrecy.
-//! * Renegotiation.
-//! * Kerberos.
-//! * TLS 1.2 protocol compression.
-//! * Discrete-log Diffie-Hellman.
-//! * Automatic protocol version downgrade.
-//! * Using CA certificates directly to authenticate a server/client (often called "self-signed
-//!   certificates"). _Rustls' default certificate verifier does not support using a trust anchor as
-//!   both a CA certificate and an end-entity certificate in order to limit complexity and risk in
-//!   path building. While dangerous, all authentication can be turned off if required --
-//!   see the [example code](https://github.com/rustls/rustls/blob/992e2364a006b2e84a8cf6a7c3eaf0bdb773c9de/examples/src/bin/tlsclient-mio.rs#L318)_.
-//!
-//! There are plenty of other libraries that provide these features should you
-//! need them.
+//! Rustls implements TLS1.2 and TLS1.3 for both clients and servers. See [the full
+//! list of protocol features](manual::_04_features).
 //!
 //! ### Platform support
 //!

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -27,7 +27,7 @@
 //! Rustls requires Rust 1.61 or later.
 //!
 //! [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
-//! [`crypto::CryptoProvider`]: https://docs.rs/rustls/latest/rustls/crypto/trait.CryptoProvider.html
+//! [`crypto::CryptoProvider`]: crate::crypto::CryptoProvider
 //! [`ring`]: https://crates.io/crates/ring
 //! [aws-lc-rs-platforms-faq]: https://aws.github.io/aws-lc-rs/faq.html#can-i-run-aws-lc-rs-on-x-platform-or-architecture
 //! [`aws-lc-rs`]: https://crates.io/crates/aws-lc-rs

--- a/rustls/src/manual/features.rs
+++ b/rustls/src/manual/features.rs
@@ -2,45 +2,45 @@
 
 ## Current features
 
-* TLS1.2 and TLS1.3.
-* ECDSA, Ed25519 or RSA server authentication by clients.
-* ECDSA, Ed25519 or RSA server authentication by servers.
-* Forward secrecy using ECDHE; with curve25519, nistp256 or nistp384 curves.
-* AES128-GCM and AES256-GCM bulk encryption, with safe nonces.
-* ChaCha20-Poly1305 bulk encryption ([RFC7905](https://tools.ietf.org/html/rfc7905)).
-* ALPN support.
-* SNI support.
-* Tunable fragment size to make TLS messages match size of underlying transport.
-* Optional use of vectored IO to minimise system calls.
-* TLS1.2 session resumption.
-* TLS1.2 resumption via tickets ([RFC5077](https://tools.ietf.org/html/rfc5077)).
-* TLS1.3 resumption via tickets or session storage.
-* TLS1.3 0-RTT data.
-* Server and optional client authentication.
-* Extended master secret support ([RFC7627](https://tools.ietf.org/html/rfc7627)).
-* Exporters ([RFC5705](https://tools.ietf.org/html/rfc5705)).
-* OCSP stapling by servers.
+* TLS1.2 and TLS1.3
+* ECDSA, Ed25519 or RSA server authentication by clients
+* ECDSA, Ed25519 or RSA server authentication by servers
+* Forward secrecy using ECDHE; with curve25519, nistp256 or nistp384 curves
+* AES128-GCM and AES256-GCM bulk encryption, with safe nonces
+* ChaCha20-Poly1305 bulk encryption ([RFC7905](https://tools.ietf.org/html/rfc7905))
+* ALPN support
+* SNI support
+* Tunable fragment size to make TLS messages match size of underlying transport
+* Optional use of vectored IO to minimise system calls
+* TLS1.2 session resumption
+* TLS1.2 resumption via tickets ([RFC5077](https://tools.ietf.org/html/rfc5077))
+* TLS1.3 resumption via tickets or session storage
+* TLS1.3 0-RTT data
+* Server and optional client authentication
+* Extended master secret support ([RFC7627](https://tools.ietf.org/html/rfc7627))
+* Exporters ([RFC5705](https://tools.ietf.org/html/rfc5705))
+* OCSP stapling by servers
 
 ## Non-features
 
 For reasons explained in the other sections of this manual, rustls does not
 and will not support:
 
-* SSL1, SSL2, SSL3, TLS1 or TLS1.1.
-* RC4.
-* DES or triple DES.
-* EXPORT ciphersuites.
-* MAC-then-encrypt ciphersuites.
-* Ciphersuites without forward secrecy.
-* Renegotiation.
-* Kerberos.
-* TLS 1.2 protocol compression.
-* Discrete-log Diffie-Hellman.
-* Automatic protocol version downgrade.
+* SSL1, SSL2, SSL3, TLS1 or TLS1.1
+* RC4
+* DES or triple DES
+* EXPORT ciphersuites
+* MAC-then-encrypt ciphersuites
+* Ciphersuites without forward secrecy
+* Renegotiation
+* Kerberos
+* TLS 1.2 protocol compression
+* Discrete-log Diffie-Hellman
+* Automatic protocol version downgrade
 * Using CA certificates directly to authenticate a server/client (often called "self-signed
   certificates"). _Rustls' default certificate verifier does not support using a trust anchor as
   both a CA certificate and an end-entity certificate in order to limit complexity and risk in
   path building. While dangerous, all authentication can be turned off if required --
-  see the [example code](https://github.com/rustls/rustls/blob/992e2364a006b2e84a8cf6a7c3eaf0bdb773c9de/examples/src/bin/tlsclient-mio.rs#L318)_.
+  see the [example code](https://github.com/rustls/rustls/blob/992e2364a006b2e84a8cf6a7c3eaf0bdb773c9de/examples/src/bin/tlsclient-mio.rs#L318)_
 
 */

--- a/rustls/src/manual/features.rs
+++ b/rustls/src/manual/features.rs
@@ -10,25 +10,17 @@
 * ChaCha20-Poly1305 bulk encryption ([RFC7905](https://tools.ietf.org/html/rfc7905)).
 * ALPN support.
 * SNI support.
-* Tunable MTU to make TLS messages match size of underlying transport.
+* Tunable fragment size to make TLS messages match size of underlying transport.
 * Optional use of vectored IO to minimise system calls.
 * TLS1.2 session resumption.
-* TLS1.2 resumption via tickets (RFC5077).
+* TLS1.2 resumption via tickets ([RFC5077](https://tools.ietf.org/html/rfc5077)).
 * TLS1.3 resumption via tickets or session storage.
 * TLS1.3 0-RTT data for clients.
-* Client authentication by clients.
-* Client authentication by servers.
-* Extended master secret support (RFC7627).
-* Exporters (RFC5705).
+* TLS1.3 0-RTT data for servers.
+* Server and optional client authentication.
+* Extended master secret support ([RFC7627](https://tools.ietf.org/html/rfc7627)).
+* Exporters ([RFC5705](https://tools.ietf.org/html/rfc5705)).
 * OCSP stapling by servers.
-* SCT stapling by servers.
-* SCT verification by clients.
-
-## Possible future features
-
-* PSK support.
-* OCSP verification by clients.
-* Certificate pinning.
 
 ## Non-features
 
@@ -43,8 +35,13 @@ and will not support:
 * Ciphersuites without forward secrecy.
 * Renegotiation.
 * Kerberos.
-* Compression.
+* TLS 1.2 protocol compression.
 * Discrete-log Diffie-Hellman.
 * Automatic protocol version downgrade.
+* Using CA certificates directly to authenticate a server/client (often called "self-signed
+  certificates"). _Rustls' default certificate verifier does not support using a trust anchor as
+  both a CA certificate and an end-entity certificate in order to limit complexity and risk in
+  path building. While dangerous, all authentication can be turned off if required --
+  see the [example code](https://github.com/rustls/rustls/blob/992e2364a006b2e84a8cf6a7c3eaf0bdb773c9de/examples/src/bin/tlsclient-mio.rs#L318)_.
 
 */

--- a/rustls/src/manual/features.rs
+++ b/rustls/src/manual/features.rs
@@ -15,8 +15,7 @@
 * TLS1.2 session resumption.
 * TLS1.2 resumption via tickets ([RFC5077](https://tools.ietf.org/html/rfc5077)).
 * TLS1.3 resumption via tickets or session storage.
-* TLS1.3 0-RTT data for clients.
-* TLS1.3 0-RTT data for servers.
+* TLS1.3 0-RTT data.
 * Server and optional client authentication.
 * Extended master secret support ([RFC7627](https://tools.ietf.org/html/rfc7627)).
 * Exporters ([RFC5705](https://tools.ietf.org/html/rfc5705)).

--- a/rustls/src/manual/features.rs
+++ b/rustls/src/manual/features.rs
@@ -1,13 +1,19 @@
 /*!
 
+The below list reflects the support provided with the default crate features.
+Items marked with an asterisk `*` can be extended or altered via public
+APIs ([`CryptoProvider`] for example).
+
+[`CryptoProvider`]: crate::crypto::CryptoProvider
+
 ## Current features
 
 * TLS1.2 and TLS1.3
-* ECDSA, Ed25519 or RSA server authentication by clients
-* ECDSA, Ed25519 or RSA server authentication by servers
-* Forward secrecy using ECDHE; with curve25519, nistp256 or nistp384 curves
-* AES128-GCM and AES256-GCM bulk encryption, with safe nonces
-* ChaCha20-Poly1305 bulk encryption ([RFC7905](https://tools.ietf.org/html/rfc7905))
+* ECDSA, Ed25519 or RSA server authentication by clients `*`
+* ECDSA, Ed25519 or RSA server authentication by servers `*`
+* Forward secrecy using ECDHE; with curve25519, nistp256 or nistp384 curves `*`
+* AES128-GCM and AES256-GCM bulk encryption, with safe nonces `*`
+* ChaCha20-Poly1305 bulk encryption ([RFC7905](https://tools.ietf.org/html/rfc7905)) `*`
 * ALPN support
 * SNI support
 * Tunable fragment size to make TLS messages match size of underlying transport
@@ -35,12 +41,12 @@ and will not support:
 * Renegotiation
 * Kerberos
 * TLS 1.2 protocol compression
-* Discrete-log Diffie-Hellman
+* Discrete-log Diffie-Hellman `*`
 * Automatic protocol version downgrade
 * Using CA certificates directly to authenticate a server/client (often called "self-signed
   certificates"). _Rustls' default certificate verifier does not support using a trust anchor as
   both a CA certificate and an end-entity certificate in order to limit complexity and risk in
   path building. While dangerous, all authentication can be turned off if required --
-  see the [example code](https://github.com/rustls/rustls/blob/992e2364a006b2e84a8cf6a7c3eaf0bdb773c9de/examples/src/bin/tlsclient-mio.rs#L318)_
+  see the [example code](https://github.com/rustls/rustls/blob/992e2364a006b2e84a8cf6a7c3eaf0bdb773c9de/examples/src/bin/tlsclient-mio.rs#L318)_ `*`
 
 */

--- a/rustls/src/manual/fips.rs
+++ b/rustls/src/manual/fips.rs
@@ -1,0 +1,56 @@
+/*! # Using rustls with FIPS-approved cryptography
+
+To use FIPS-approved cryptography with rustls, you should take
+these actions:
+
+## 1. Enable the `fips` crate feature for rustls.
+
+Use:
+
+```toml
+rustls = { version = "0.23", features = [ "fips" ] }
+```
+
+## 2. Use the FIPS `CryptoProvider`
+
+This is [`default_fips_provider()`]:
+
+```rust,ignore
+rustls::crypto::default_fips_provider()
+    .install_default()
+    .expect("default provider already set elsewhere");
+```
+
+This snippet makes use of the process-default provider,
+and that assumes all your uses of rustls use that.
+See [`CryptoProvider`] documentation for other ways to
+specify which `CryptoProvider` to use.
+
+## 3. Validate the FIPS status of your `ClientConfig`/`ServerConfig` at run-time
+
+See [`ClientConfig::fips()`] or [`ServerConfig::fips()`].
+
+You could, for example:
+
+```rust,ignore
+# let client_config = unreachable!();
+assert!(client_config.fips());
+```
+
+But maybe your application has an error handling
+or health-check strategy better than panicking.
+
+# aws-lc-rs FIPS approval status
+
+At the time of writing, this is pending approval on Linux
+for two architectures (ARM aarch64 and Intel x86-64).
+
+For the most up-to-date details see the latest documentation
+for the [`aws-lc-fips-sys`] crate.
+
+[`aws-lc-fips-sys`]: https://crates.io/crates/aws-lc-fips-sys
+[`default_fips_provider()`]: crate::crypto::default_fips_provider
+[`CryptoProvider`]: crate::crypto::CryptoProvider
+[`ClientConfig::fips()`]: crate::client::ClientConfig::fips
+[`ServerConfig::fips()`]: crate::server::ServerConfig::fips
+*/

--- a/rustls/src/manual/mod.rs
+++ b/rustls/src/manual/mod.rs
@@ -28,3 +28,7 @@ pub mod _04_features;
 /// This section provides rationale for the defaults in rustls.
 #[path = "defaults.rs"]
 pub mod _05_defaults;
+
+/// This section provides guidance on using rustls with FIPS-approved cryptography.
+#[path = "fips.rs"]
+pub mod _06_fips;

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -354,18 +354,18 @@ impl Clone for ServerConfig {
 }
 
 impl ServerConfig {
-    /// Create a builder for a server configuration with the process-default
-    /// [`CryptoProvider`]: [`CryptoProvider::get_default`] and safe
-    /// protocol version defaults.
+    /// Create a builder for a server configuration with
+    /// [the process-default `CryptoProvider`][CryptoProvider#using-the-per-process-default-cryptoprovider]
+    /// and safe protocol version defaults.
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
     pub fn builder() -> ConfigBuilder<Self, WantsVerifier> {
         Self::builder_with_protocol_versions(versions::DEFAULT_VERSIONS)
     }
 
-    /// Create a builder for a server configuration with the process-default
-    /// [`CryptoProvider`]: [`CryptoProvider::get_default`] and
-    /// the provided protocol versions.
+    /// Create a builder for a server configuration with
+    /// [the process-default `CryptoProvider`][CryptoProvider#using-the-per-process-default-cryptoprovider]
+    /// and the provided protocol versions.
     ///
     /// Panics if
     /// - the supported versions are not compatible with the provider (eg.

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -173,7 +173,8 @@ impl ClientCertVerifierBuilder {
 }
 
 /// A client certificate verifier that uses the `webpki` crate[^1] to perform client certificate
-/// validation. It must be created via the [WebPkiClientVerifier::builder()] function.
+/// validation. It must be created via the [`WebPkiClientVerifier::builder()`] or
+/// [`WebPkiClientVerifier::builder_with_provider()`] functions.
 ///
 /// Once built, the provided `Arc<dyn ClientCertVerifier>` can be used with a Rustls [`ServerConfig`]
 /// to configure client certificate validation using [`with_client_cert_verifier`][ConfigBuilder<ClientConfig, WantsVerifier>::with_client_cert_verifier].
@@ -247,7 +248,7 @@ impl WebPkiClientVerifier {
     ///
     /// Client certificate authentication will be offered by the server, and client certificates
     /// will be verified using the trust anchors found in the provided `roots`. If you
-    /// wish to disable client authentication use [WebPkiClientVerifier::no_client_auth()] instead.
+    /// wish to disable client authentication use [`WebPkiClientVerifier::no_client_auth()`] instead.
     ///
     /// The cryptography used comes from the process-default [`CryptoProvider`]: [`CryptoProvider::get_default`].
     /// Use [`Self::builder_with_provider`] if you wish to customize this.

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -244,14 +244,13 @@ pub struct WebPkiClientVerifier {
 
 impl WebPkiClientVerifier {
     /// Create a builder for the `webpki` client certificate verifier configuration using
-    /// the default [`CryptoProvider`].
+    /// the [process-default `CryptoProvider`][CryptoProvider#using-the-per-process-default-cryptoprovider].
     ///
     /// Client certificate authentication will be offered by the server, and client certificates
     /// will be verified using the trust anchors found in the provided `roots`. If you
     /// wish to disable client authentication use [`WebPkiClientVerifier::no_client_auth()`] instead.
     ///
-    /// The cryptography used comes from the process-default [`CryptoProvider`]: [`CryptoProvider::get_default`].
-    /// Use [`Self::builder_with_provider`] if you wish to customize this.
+    /// Use [`Self::builder_with_provider`] if you wish to specify an explicit provider.
     ///
     /// For more information, see the [`ClientCertVerifierBuilder`] documentation.
     pub fn builder(roots: Arc<RootCertStore>) -> ClientCertVerifierBuilder {

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -128,12 +128,11 @@ pub struct WebPkiServerVerifier {
 #[allow(unreachable_pub)]
 impl WebPkiServerVerifier {
     /// Create a builder for the `webpki` server certificate verifier configuration using
-    /// the default [`CryptoProvider`].
+    /// the [process-default `CryptoProvider`][CryptoProvider#using-the-per-process-default-cryptoprovider].
     ///
     /// Server certificates will be verified using the trust anchors found in the provided `roots`.
     ///
-    /// The cryptography used comes from the process-default [`CryptoProvider`]: [`CryptoProvider::get_default`].
-    /// Use [`Self::builder_with_provider`] if you wish to customize this.
+    /// Use [`Self::builder_with_provider`] if you wish to specify an explicit provider.
     ///
     /// For more information, see the [`ServerCertVerifierBuilder`] documentation.
     pub fn builder(roots: Arc<RootCertStore>) -> ServerCertVerifierBuilder {


### PR DESCRIPTION
This:

- builds docs off main nightly, and on changes. Making this work for multiple branches (release branches, etc) is possible, but _not_ for foreign forks or arbitrary branches. This appears at https://rustls.github.io/rustls/prerelease/
- Assorted docs bug fixes
- Beginnings of FIPS-specific docs. I suggest this will extend significantly when the aws-lc FIPS cert is issued, or there are further FIPS options to discuss.
- As suggested by djc in #1780, looking over every use of `CryptoProvider` and ensuring it is pointed towards the docs for that type.