### PR TITLE
examples: ignore interrupted syscalls for mio poll

### DIFF
--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -534,7 +534,14 @@ fn main() {
     tlsclient.register(poll.registry());
 
     loop {
-        poll.poll(&mut events, None).unwrap();
+        match poll.poll(&mut events, None) {
+            Ok(_) => {}
+            // Polling can be interrupted (e.g. by a debugger) - retry if so.
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => {
+                panic!("poll failed: {:?}", e)
+            }
+        }
 
         for ev in events.iter() {
             tlsclient.ready(ev);

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -702,7 +702,14 @@ fn main() {
 
     let mut events = mio::Events::with_capacity(256);
     loop {
-        poll.poll(&mut events, None).unwrap();
+        match poll.poll(&mut events, None) {
+            Ok(_) => {}
+            // Polling can be interrupted (e.g. by a debugger) - retry if so.
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => {
+                panic!("poll failed: {:?}", e)
+            }
+        }
 
         for event in events.iter() {
             match event.token() {


### PR DESCRIPTION
While in general these examples shouldn't be written to handle errors, the long-running mio poll operation is especially prone to returning interrupted syscall errors when a debugger is attached. 

I often use these examples for testing since they expose the most helpful CLI flags of all of the examples and are great for quick exploratory debugging sessions. This branch updates each mio example to ignore this class of error rather than panicing, improving the debugging experience. 