### PR TITLE
Extract all straight lookups of suites and kx groups

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,8 +1,8 @@
 use crate::builder::ConfigBuilder;
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCommon, ConnectionCore, UnbufferedConnectionCommon};
-use crate::crypto::{CryptoProvider, SupportedKxGroup};
-use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
+use crate::crypto::CryptoProvider;
+use crate::enums::{ProtocolVersion, SignatureScheme};
 use crate::error::Error;
 #[cfg(feature = "logging")]
 use crate::log::trace;
@@ -310,22 +310,6 @@ impl ClientConfig {
     /// extra care.
     pub fn dangerous(&mut self) -> danger::DangerousClientConfig<'_> {
         danger::DangerousClientConfig { cfg: self }
-    }
-
-    pub(super) fn find_cipher_suite(&self, suite: CipherSuite) -> Option<SupportedCipherSuite> {
-        self.provider
-            .cipher_suites
-            .iter()
-            .copied()
-            .find(|&scs| scs.suite() == suite)
-    }
-
-    pub(super) fn find_kx_group(&self, group: NamedGroup) -> Option<&'static dyn SupportedKxGroup> {
-        self.provider
-            .kx_groups
-            .iter()
-            .copied()
-            .find(|skxg| skxg.name() == group)
     }
 }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -614,6 +614,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
         }
 
         let suite = config
+            .provider
             .find_cipher_suite(server_hello.cipher_suite)
             .ok_or_else(|| {
                 cx.common.send_fatal_alert(
@@ -827,7 +828,10 @@ impl ExpectServerHelloOrHelloRetryRequest {
 
         // Or asks us to use a ciphersuite we didn't offer.
         let config = &self.next.input.config;
-        let cs = match config.find_cipher_suite(hrr.cipher_suite) {
+        let cs = match config
+            .provider
+            .find_cipher_suite(hrr.cipher_suite)
+        {
             Some(cs) => cs,
             None => {
                 return Err({
@@ -857,7 +861,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
 
         let key_share = match req_group {
             Some(group) if group != offered_key_share.group() => {
-                let skxg = match config.find_kx_group(group) {
+                let skxg = match config.provider.find_kx_group(group) {
                     Some(skxg) => skxg,
                     None => {
                         return Err(cx.common.send_fatal_alert(

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -921,7 +921,11 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
         let named_group = kx_params
             .named_group()
             .ok_or(PeerMisbehaved::SelectedUnofferedKxGroup)?;
-        let skxg = match st.config.find_kx_group(named_group) {
+        let skxg = match st
+            .config
+            .provider
+            .find_kx_group(named_group)
+        {
             Some(skxg) => skxg,
             None => {
                 return Err(PeerMisbehaved::SelectedUnofferedKxGroup.into());

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -210,7 +210,11 @@ pub(super) fn initial_key_share(
         .resumption
         .store
         .kx_hint(server_name)
-        .and_then(|group_name| config.find_kx_group(group_name))
+        .and_then(|group_name| {
+            config
+                .provider
+                .find_kx_group(group_name)
+        })
         .unwrap_or_else(|| {
             config
                 .provider

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -1,6 +1,6 @@
 use crate::sign::SigningKey;
 use crate::{suites, ProtocolVersion, SupportedProtocolVersion};
-use crate::{Error, NamedGroup};
+use crate::{CipherSuite, Error, NamedGroup};
 
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -291,6 +291,23 @@ impl CryptoProvider {
             && signature_verification_algorithms.fips()
             && secure_random.fips()
             && key_provider.fips()
+    }
+
+    pub(crate) fn find_cipher_suite(
+        &self,
+        name: CipherSuite,
+    ) -> Option<suites::SupportedCipherSuite> {
+        self.cipher_suites
+            .iter()
+            .find(|suite| suite.suite() == name)
+            .copied()
+    }
+
+    pub(crate) fn find_kx_group(&self, name: NamedGroup) -> Option<&'static dyn SupportedKxGroup> {
+        self.kx_groups
+            .iter()
+            .find(|group| group.name() == name)
+            .copied()
     }
 }
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -429,9 +429,7 @@ impl ExpectClientHello {
             let supported = self
                 .config
                 .provider
-                .kx_groups
-                .iter()
-                .find(|skxg| skxg.name() == *offered_group);
+                .find_kx_group(*offered_group);
 
             match offered_group.key_exchange_algorithm() {
                 KeyExchangeAlgorithm::DHE => {
@@ -510,7 +508,7 @@ impl ExpectClientHello {
             .find_map(|maybe_skxg| match maybe_skxg {
                 Some(skxg) => suite
                     .usable_for_kx_algorithm(skxg.name().key_exchange_algorithm())
-                    .then(|| *skxg),
+                    .then(|| skxg),
                 None => None,
             });
 


### PR DESCRIPTION
Move `find_cipher_suite` and `find_kx_group` from `ClientConfig` to `CryptoProvider` so they can be used in `crate::server` (though there's only one instance as it happens).