### PR TITLE
Use `end_entity` variable when verifying CertificateVerify

### DIFF
--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -895,7 +895,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
 
             st.config
                 .verifier
-                .verify_tls12_signature(&message, &st.server_cert.cert_chain[0], sig)
+                .verify_tls12_signature(&message, end_entity, sig)
                 .map_err(|err| {
                     cx.common
                         .send_cert_verify_error_alert(err)

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -735,7 +735,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
             .verifier
             .verify_tls13_signature(
                 &construct_server_verify_message(&handshake_hash),
-                &self.server_cert.cert_chain[0],
+                end_entity,
                 cert_verify,
             )
             .map_err(|err| {


### PR DESCRIPTION
The function very nicely constructs the `end_entity` variable, use it throughout instead of selecting it again.

This makes it so that we use the position of `end_entity` in the chain only once, and it makes it more clear that we're using the previously-verified certificate.