### PR TITLE
server: allow acceptor to send alerts after error

### DIFF
--- a/provider-example/examples/server.rs
+++ b/provider-example/examples/server.rs
@@ -43,8 +43,8 @@ fn main() {
                 conn.write_tls(&mut stream).unwrap();
                 conn.complete_io(&mut stream).unwrap();
             }
-            Err(e) => {
-                eprintln!("{}", e);
+            Err((err, _)) => {
+                eprintln!("{err}");
             }
         }
     }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -593,7 +593,7 @@ pub mod server {
         Accepted, ServerConfig, ServerConnectionData, UnbufferedServerConnection,
     };
     #[cfg(feature = "std")]
-    pub use server_conn::{Acceptor, ReadEarlyData, ServerConnection};
+    pub use server_conn::{AcceptedAlert, Acceptor, ReadEarlyData, ServerConnection};
     pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
 
     /// Dangerous configuration that should be audited and used with extreme care.


### PR DESCRIPTION
Fixes #1792. 

* `Acceptor`'s `accept` and `into_connection` fns now return both an `Error` and an `AcceptedAlert` in the error case. The `AcceptedAlert` can be used to write any TLS alerts produced during processing.
* Test coverage is updated to include:
  * Tests for a junk handshake being rejected in `accept` with an alert produced
  * Tests for an incompatible handshake being rejected in `into_connection` with an alert produced
* The existing `server_acceptor.rs` example program is updated to demonstrate using the `AcceptedAlert` return to write alerts.