### PR TITLE
Fix new nightly warnings

### DIFF
--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -32,7 +32,7 @@ use serde::Deserialize;
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use rustls::server::WebPkiClientVerifier;
-use rustls::{self, RootCertStore};
+use rustls::RootCertStore;
 
 // Token for our listening socket.
 const LISTENER: mio::Token = mio::Token(0);

--- a/rustls/examples/internal/bogo_shim_impl.rs
+++ b/rustls/examples/internal/bogo_shim_impl.rs
@@ -12,7 +12,7 @@ use rustls::internal::msgs::persist::ServerSessionValue;
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::server::{ClientHello, ServerConfig, ServerConnection, WebPkiClientVerifier};
 use rustls::{
-    self, client, server, sign, version, AlertDescription, CertificateError, Connection,
+    client, server, sign, version, AlertDescription, CertificateError, Connection,
     DigitallySignedStruct, DistinguishedName, Error, InvalidMessage, NamedGroup, PeerIncompatible,
     PeerMisbehaved, ProtocolVersion, RootCertStore, Side, SignatureAlgorithm, SignatureScheme,
     SupportedProtocolVersion,

--- a/rustls/src/bs_debug.rs
+++ b/rustls/src/bs_debug.rs
@@ -42,6 +42,8 @@ impl<'a> fmt::Debug for BsDebug<'a> {
 #[cfg(test)]
 mod tests {
     use super::BsDebug;
+    use std::format;
+    use std::prelude::v1::*;
 
     #[test]
     fn debug() {

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -233,6 +233,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
 }
 
 test_for_each_provider! {
+    use std::prelude::v1::*;
     use super::NoClientSessionStorage;
     use crate::client::ClientSessionStore;
     use crate::msgs::enums::NamedGroup;

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -552,6 +552,7 @@ pub fn default_fips_provider() -> CryptoProvider {
 #[cfg(test)]
 mod tests {
     use super::SharedSecret;
+    use std::vec;
 
     #[test]
     fn test_shared_secret_strip_leading_zeros() {

--- a/rustls/src/crypto/ring/kx.rs
+++ b/rustls/src/crypto/ring/kx.rs
@@ -107,6 +107,8 @@ impl ActiveKeyExchange for KeyExchange {
 
 #[cfg(test)]
 mod tests {
+    use std::format;
+
     #[test]
     fn kxgroup_fmt_yields_name() {
         assert_eq!("X25519", format!("{:?}", super::X25519));

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -184,6 +184,7 @@ impl crate::quic::Algorithm for KeyBuilder {
 }
 
 test_for_each_provider! {
+    use std::dbg;
     use crate::common_state::Side;
     use crate::crypto::tls13::OkmBlock;
     use crate::quic::*;

--- a/rustls/src/crypto/tls13.rs
+++ b/rustls/src/crypto/tls13.rs
@@ -251,6 +251,7 @@ mod tests {
     // nb: crypto::aws_lc_rs provider doesn't provide (or need) hmac,
     // so cannot be used for this test.
     use crate::crypto::ring::hmac;
+    use std::prelude::v1::*;
 
     struct ByteArray<const N: usize>([u8; N]);
 

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -603,6 +603,8 @@ mod tests {
     use super::{Error, InvalidMessage};
     use crate::error::CertRevocationListError;
     use crate::error::OtherError;
+    use std::prelude::v1::*;
+    use std::{println, vec};
 
     #[test]
     fn certificate_error_equality() {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -344,7 +344,7 @@
 #![cfg_attr(read_buf, feature(read_buf))]
 #![cfg_attr(read_buf, feature(core_io_borrowed_buf))]
 #![cfg_attr(bench, feature(test))]
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 
 extern crate alloc;
 // This `extern crate` plus the `#![no_std]` attribute changes the default prelude from
@@ -352,7 +352,7 @@ extern crate alloc;
 // is in `std::prelude` but not in `core::prelude`. This helps maintain no-std support as even
 // developers that are not interested in, or aware of, no-std support and / or that never run
 // `cargo build --no-default-features` locally will get errors when they rely on `std::prelude` API.
-#[cfg(all(feature = "std", not(test)))]
+#[cfg(any(feature = "std", test))]
 extern crate std;
 
 // Import `test` sysroot crate for `Bencher` definitions.

--- a/rustls/src/limited_cache.rs
+++ b/rustls/src/limited_cache.rs
@@ -124,6 +124,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::prelude::v1::*;
+
     type Test = super::LimitedCache<String, usize>;
 
     #[test]

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -378,6 +378,8 @@ impl<'a> Drop for LengthPrefixedBuffer<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::prelude::v1::*;
+    use std::vec;
 
     #[test]
     fn interrupted_length_prefixed_buffer_leaves_maximum_length() {

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -709,7 +709,8 @@ const READ_SIZE: usize = 4096;
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
-    use std::io;
+    use std::prelude::v1::*;
+    use std::vec;
 
     use crate::crypto::cipher::PlainMessage;
     use crate::msgs::message::Message;

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -350,7 +350,7 @@ pub(crate) mod tests {
     //! check panic-safety of relatively unused values.
 
     use super::*;
-    use crate::msgs::codec::Codec;
+    use std::prelude::v1::*;
 
     #[test]
     fn test_enums() {

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -110,6 +110,8 @@ mod tests {
     use crate::enums::ProtocolVersion;
     use crate::msgs::base::Payload;
     use crate::msgs::message::{OutboundChunks, OutboundPlainMessage, PlainMessage};
+    use std::prelude::v1::*;
+    use std::vec;
 
     fn msg_eq(
         m: &OutboundPlainMessage,

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -22,6 +22,9 @@ use pki_types::{CertificateDer, DnsName};
 
 use super::handshake::{ServerDhParams, ServerKeyExchange, ServerKeyExchangeParams};
 
+use std::prelude::v1::*;
+use std::{format, println, vec};
+
 #[test]
 fn rejects_short_random() {
     let bytes = [0x01; 31];

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -6,9 +6,10 @@ use super::codec::Reader;
 use super::enums::AlertLevel;
 use super::message::{Message, OutboundOpaqueMessage, PlainMessage};
 
-use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::prelude::v1::*;
+use std::{format, fs, println, vec};
 
 #[test]
 fn test_read_fuzz_corpus() {

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -406,11 +406,11 @@ impl ServerSessionValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::msgs::codec::{Codec, Reader};
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "std")] // for UnixTime::now
     #[test]
     fn serversessionvalue_is_debug() {
+        use std::{println, vec};
         let ssv = ServerSessionValue::new(
             None,
             ProtocolVersion::TLSv1_3,

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -923,9 +923,9 @@ impl Default for Version {
 
 #[cfg(test)]
 mod tests {
-    use crate::quic::HeaderProtectionKey;
-
     use super::PacketKey;
+    use crate::quic::HeaderProtectionKey;
+    use std::prelude::v1::*;
 
     #[test]
     fn auto_traits() {

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -262,7 +262,7 @@ mod sni_resolver {
     impl server::ResolvesServerCert for ResolvesServerCertUsingSni {
         fn resolve(&self, client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
             if let Some(name) = client_hello.server_name() {
-                self.by_name.get(name).map(Arc::clone)
+                self.by_name.get(name).cloned()
             } else {
                 // This kind of resolver requires SNI
                 None

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -91,6 +91,7 @@ mod cache {
     mod tests {
         use super::*;
         use crate::server::StoresServerSessions;
+        use std::vec;
 
         #[test]
         fn test_serversessionmemorycache_accepts_put() {
@@ -304,6 +305,7 @@ mod tests {
     use super::*;
     use crate::server::ProducesTickets;
     use crate::server::StoresServerSessions;
+    use std::vec;
 
     #[test]
     fn test_noserversessionstorage_drops_put() {

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1039,6 +1039,7 @@ impl crate::conn::SideData for ServerConnectionData {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::format;
 
     // these branches not reachable externally, unless something else goes wrong.
     #[test]

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -45,11 +45,10 @@ mod client_hello {
     use crate::msgs::enums::ECPointFormat;
     use crate::msgs::enums::{ClientCertificateType, Compression};
     use crate::msgs::handshake::CertificateStatus;
-    use crate::msgs::handshake::{CertificateChain, ServerKeyExchange, ServerKeyExchangeParams};
     use crate::msgs::handshake::{CertificateRequestPayload, ClientSessionTicket, Random};
-    use crate::msgs::handshake::{ClientExtension, SessionId};
-    use crate::msgs::handshake::{ClientHelloPayload, ServerHelloPayload};
+    use crate::msgs::handshake::{ClientExtension, ClientHelloPayload, ServerHelloPayload};
     use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
+    use crate::msgs::handshake::{ServerKeyExchange, ServerKeyExchangeParams};
     use crate::sign;
     use crate::verify::DigitallySignedStruct;
 

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -234,6 +234,7 @@ pub enum ConnectionTrafficSecrets {
 
 test_for_each_provider! {
     use provider::tls13::*;
+    use std::println;
 
     #[test]
     fn test_scs_is_debug() {

--- a/rustls/src/test_macros.rs
+++ b/rustls/src/test_macros.rs
@@ -45,7 +45,7 @@ macro_rules! bench_for_each_provider {
 test_for_each_provider! {
     #[test]
     fn test_each_provider() {
-        println!("provider is {:?}", provider::default_provider());
+        std::println!("provider is {:?}", provider::default_provider());
     }
 }
 

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -830,6 +830,8 @@ where
 
 test_for_each_provider! {
     use core::fmt::Debug;
+    use std::vec;
+    use std::prelude::v1::*;
 
     use super::{derive_traffic_iv, derive_traffic_key, KeySchedule, SecretKind};
     use provider::ring_like::aead;

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -337,6 +337,8 @@ impl Codec<'_> for DigitallySignedStruct {
 
 #[test]
 fn assertions_are_debug() {
+    use std::format;
+
     assert_eq!(
         format!("{:?}", ClientCertVerified::assertion()),
         "ClientCertVerified(())"

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -4,6 +4,7 @@
 #![cfg(bench)]
 
 use core::time::Duration;
+use std::prelude::v1::*;
 
 use crate::crypto::CryptoProvider;
 use crate::verify::ServerCertVerifier;

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -414,7 +414,9 @@ test_for_each_provider! {
 
     use pki_types::{CertificateDer, CertificateRevocationListDer};
 
+    use std::prelude::v1::*;
     use std::sync::Arc;
+    use std::{vec, format, println};
 
     fn load_crls(crls_der: &[&[u8]]) -> Vec<CertificateRevocationListDer<'static>> {
         crls_der

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -283,6 +283,8 @@ impl ServerCertVerifier for WebPkiServerVerifier {
 
 test_for_each_provider! {
     use std::sync::Arc;
+    use std::{vec, println};
+    use std::prelude::v1::*;
 
     use pki_types::{CertificateDer, CertificateRevocationListDer};
 

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -229,6 +229,7 @@ pub(crate) fn verify_server_cert_signed_by_trust_anchor_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::format;
 
     #[test]
     fn certificate_debug() {

--- a/rustls/src/x509.rs
+++ b/rustls/src/x509.rs
@@ -43,6 +43,7 @@ const DER_SEQUENCE_TAG: u8 = 0x30;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::vec;
 
     #[test]
     fn test_empty() {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3503,6 +3503,7 @@ impl rustls::server::StoresServerSessions for ServerStorage {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // complete mock, but not 100% used in tests
 enum ClientStorageOp {
     SetKxHint(ServerName<'static>, rustls::NamedGroup),
     GetKxHint(ServerName<'static>, Option<rustls::NamedGroup>),


### PR DESCRIPTION
This fixes one new nightly clippy lint, plus a heap of new nightly warnings to do with redundant imports.

https://github.com/rustls/webpki/pull/234 is the similar change in webpki.