### PR TITLE
rel-0.22 CI fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,7 +354,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-10-10
+          toolchain: nightly-2024-02-07
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - run: cargo install --locked cargo-check-external-types
       - name: run cargo-check-external-types for rustls/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -7,11 +7,11 @@ use crate::enums::ProtocolVersion;
 /// All possible instances of this class are provided by the library in
 /// the [`ALL_VERSIONS`] array, as well as individually as [`TLS12`]
 /// and [`TLS13`].
+#[non_exhaustive]
 #[derive(Eq, PartialEq)]
 pub struct SupportedProtocolVersion {
     /// The TLS enumeration naming this version.
     pub version: ProtocolVersion,
-    is_private: (),
 }
 
 impl fmt::Debug for SupportedProtocolVersion {
@@ -24,13 +24,11 @@ impl fmt::Debug for SupportedProtocolVersion {
 #[cfg(feature = "tls12")]
 pub static TLS12: SupportedProtocolVersion = SupportedProtocolVersion {
     version: ProtocolVersion::TLSv1_2,
-    is_private: (),
 };
 
 /// TLS1.3
 pub static TLS13: SupportedProtocolVersion = SupportedProtocolVersion {
     version: ProtocolVersion::TLSv1_3,
-    is_private: (),
 };
 
 /// A list of all the protocol versions supported by rustls.


### PR DESCRIPTION
I started looking at backporting https://github.com/rustls/rustls/pull/1811 to rel-0.22, but it has breaking API changes (duh) so isn't appropriate. 

In the meantime, I noticed CI for `rel-0.22` needs some fixes from `main` cherry-picked to resolve some build failures. We might as well land these fixes now in case we do find something worth backporting.