### PR TITLE
Prepare 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.0-alpha.0"
+version = "0.23.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2169,7 +2169,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.23.0-alpha.0",
+ "rustls 0.23.0",
  "rustls-pemfile 2.1.0",
  "rustls-pki-types",
 ]
@@ -2181,7 +2181,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.0-alpha.0",
+ "rustls 0.23.0",
 ]
 
 [[package]]
@@ -2194,7 +2194,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.0-alpha.0",
+ "rustls 0.23.0",
  "rustls-pemfile 2.1.0",
  "rustls-pki-types",
  "serde",
@@ -2212,7 +2212,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.0-alpha.0",
+ "rustls 0.23.0",
  "rustls-pemfile 2.1.0",
  "rustls-pki-types",
 ]
@@ -2260,7 +2260,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.0-alpha.0",
+ "rustls 0.23.0",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
  "serde",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.0-alpha.0"
+version = "0.23.0"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.0-alpha.0"
+version = "0.23.0"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
# Release notes (proposed)

- **Default cryptography provider changed** to [`aws-lc-rs`]. Note that this has some implications on [platform support and build-time tool requirements][aws-lc-rs-reqs] such as `cmake` on all platforms and `nasm` on Windows.
  Support for `ring` continues to be available: set the `ring` crate feature.

- **Support for FIPS validated mode** with [`aws-lc-rs`]: see [the manual section][fips-manual] and [aws-lc-rs's FIPS documentation][aws-fips-docs]. Note that `aws-lc-rs` in FIPS mode has further build-time requirements as detailed in the FIPS documentation.

- **Support for process-wide selection of `CryptoProvider`s**.  See [the documentation][process-provider]. Note that callers of `ClientConfig::builder()`, `ServerConfig::builder()`, `WebPkiServerVerifier::builder()` and `WebPkiClientVerifier::builder()` must now ensure that the crate's features are unambiguous or explicitly select a process-level provider using `CryptoProvider::install_default()`. Otherwise, these calls will panic with:
  > `no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point`
  
  **We recommend that libraries rely on the process-level provider by default**, and that applications use this new API to select the provider they wish to use.

- **New unbuffered API.** [`UnbufferedClientConnection`] and [`UnbufferedServerConnection`] offer a [low-level, event-driven API which does not internally buffer data][unbuffered].
  Thanks to the team from Ferrous Systems.

- **New `no_std` support.**  A new (enabled by default) `std` crate feature now gates all APIs that depend on `std`. The above [unbuffered] APIs must be used for `no_std` support. Note that `alloc` continues to be required. Work is ongoing to reintroduce certain APIs for `no_std` users (see #1688) -- please file issues for other `no_std` use cases.
  Thanks to the team from Ferrous Systems.

- **Performance improvement: internal copying while sending data is reduced.**
  Thanks to the team from the Sōzu project.

- **Performance improvement: `write_vectored` now produces less on-the-wire overhead**, which will dramatically improve throughput if it is used with a large number of small messages.
  Thanks to the team from the Sōzu project.
  
- **`Acceptor` API error handling improvement**. If a TLS alert should be sent to inform the peer of a connection failure, this is now made available in the `Err()` variant returned from [`Acceptor::accept`] and [`Accepted::into_connection`] (which is also a **breaking change**).  Applications should write this data to the peer. See the [server_acceptor] example.

- **Support for FFDHE key exchange**: custom `CryptoProviders` can now support FFDHE key exchange, in accordance with [RFC7919]. Note that the default providers do not do this.
  Thanks to the team from Fortanix.

- **Support for servers requiring `extended_master_secret` support** from clients. See [`ServerConfig::require_ems`].
  Thanks to the team from Fortanix.

- **Extension ordering in ClientHello messages are now randomised** as an anti-fingerprinting measure. We do not foresee any interoperability issues [as Chrome has already rolled out the same change][chrome-ext-order].
  Thanks to @GomesGoncalo.
  
- **Breaking change**: `CipherSuiteCommon::integrity_limit` field removed (this was QUIC-specific, it has moved to `quic::PacketKey::integrity_limit()`).

- **Breaking change**: `crypto::cipher::BorrowedPlainMessage` and `crypto::cipher::OpaqueMessage` have been renamed (to `OutboundPlainMessage` and `OutboundOpaqueMessage`) and altered to support performance improvements.  See [the example code][provider-example-aead].

- **Breaking change**: all protocol enum types (eg. [`CipherSuite`]) have had their `get_u8`/`get_u16` accessor removed; use `u8::from()` / `u16::from()` instead.

[`aws-lc-rs`]: https://crates.io/crates/aws-lc-rs
[aws-lc-rs-reqs]: https://aws.github.io/aws-lc-rs/requirements/index.html
[fips-manual]: https://rustls.github.io/rustls/prerelease/manual/_06_fips/index.html
[aws-fips-docs]: https://github.com/aws/aws-lc-rs/tree/main/aws-lc-fips-sys#fips
[process-provider]: https://rustls.github.io/rustls/prerelease/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider
[unbuffered]: https://rustls.github.io/rustls/prerelease/unbuffered/index.html
[`UnbufferedClientConnection`]: https://rustls.github.io/rustls/prerelease/client/struct.UnbufferedClientConnection.html
[`UnbufferedServerConnection`]: https://rustls.github.io/rustls/prerelease/server/struct.UnbufferedServerConnection.html
[provider-example-aead]: https://github.com/rustls/rustls/blob/main/provider-example/src/aead.rs
[server_acceptor]: https://github.com/rustls/rustls/blob/main/examples/src/bin/server_acceptor.rs
[`CipherSuite`]: https://rustls.github.io/rustls/prerelease/enum.CipherSuite.html
[`Acceptor::accept`]: https://rustls.github.io/rustls/prerelease/server/struct.Acceptor.html#method.accept
[`Accepted::into_connection`]: https://rustls.github.io/rustls/prerelease/server/struct.Accepted.html#method.into_connection
[RFC7919]: https://datatracker.ietf.org/doc/html/rfc7919
[`ServerConfig::require_ems`]: https://rustls.github.io/rustls/prerelease/server/struct.ServerConfig.html#structfield.require_ems
[chrome-ext-order]: https://chromestatus.com/feature/5124606246518784