### PR TITLE
Cargo.toml: disentangle std/aws_lc_rs features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,12 +67,12 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; aws-lc-rs)
-        run: cargo test --no-default-features --features aws_lc_rs,tls12,read_buf,logging --all-targets
+        run: cargo test --no-default-features --features aws_lc_rs,tls12,read_buf,logging,std --all-targets
         env:
           RUST_BACKTRACE: 1
 
       - name: cargo test (release; fips)
-        run: cargo test --release --no-default-features --features fips,tls12,read_buf,logging --all-targets
+        run: cargo test --release --no-default-features --features fips,tls12,read_buf,logging,std --all-targets
         env:
           RUST_BACKTRACE: 1
 
@@ -132,15 +132,15 @@ jobs:
         working-directory: rustls
 
       - name: cargo test (debug; no default features; tls12)
-        run: cargo test --locked --no-default-features --features tls12
+        run: cargo test --locked --no-default-features --features tls12,std
         working-directory: rustls
 
       - name: cargo test (debug; no default features; aws-lc-rs,tls12)
-        run: cargo test --no-default-features --features aws_lc_rs,tls12
+        run: cargo test --no-default-features --features aws_lc_rs,tls12,std
         working-directory: rustls
 
       - name: cargo test (debug; no default features; fips,tls12)
-        run: cargo test --no-default-features --features fips,tls12
+        run: cargo test --no-default-features --features fips,tls12,std
         working-directory: rustls
 
       - name: cargo test (release; no run)
@@ -216,10 +216,10 @@ jobs:
         run: cargo run -p rustls --release --locked --example bench
 
       - name: Smoke-test benchmark program (aws-lc-rs)
-        run: cargo run -p rustls --release --locked --example bench --no-default-features --features aws_lc_rs,tls12
+        run: cargo run -p rustls --release --locked --example bench --no-default-features --features aws_lc_rs,tls12,std
 
       - name: Smoke-test benchmark program (fips)
-        run: cargo run -p rustls --release --locked --example bench --no-default-features --features fips,tls12
+        run: cargo run -p rustls --release --locked --example bench --no-default-features --features fips,tls12,std
 
       - name: Run micro-benchmarks
         run: cargo bench --locked --all-features

--- a/admin/coverage
+++ b/admin/coverage
@@ -7,8 +7,8 @@ cargo llvm-cov clean --workspace
 
 cargo build --locked --all-targets --all-features
 cargo test --locked --all-features
-cargo test --locked --no-default-features --features tls12,logging,aws_lc_rs,fips
-cargo test --locked --no-default-features --features tls12,logging,ring
+cargo test --locked --no-default-features --features tls12,logging,aws_lc_rs,fips,std
+cargo test --locked --no-default-features --features tls12,logging,ring,std
 
 ## bogo
 cargo test --locked --all-features run_bogo_tests_ring -- --ignored

--- a/bogo/runme
+++ b/bogo/runme
@@ -7,11 +7,11 @@ set -xe
 
 case ${BOGO_SHIM_PROVIDER:-ring} in
   ring)
-      cargo build -p rustls --example bogo_shim
+      cargo build -p rustls --example bogo_shim --no-default-features --features ring,tls12,logging,std
       cpp -P -DRING config.json.in -oconfig.json
       ;;
   aws-lc-rs)
-      cargo build -p rustls --example bogo_shim --no-default-features --features aws_lc_rs,tls12,logging
+      cargo build -p rustls --example bogo_shim --no-default-features --features aws_lc_rs,tls12,logging,std
       cpp -P -DAWS_LC_RS config.json.in -oconfig.json
       ;;
   existing)

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -27,10 +27,10 @@ pki-types = { package = "rustls-pki-types", version = "1.2", features = ["alloc"
 zeroize = "1.7"
 
 [features]
-default = ["logging", "std", "tls12"]
-std = ["aws_lc_rs", "webpki/std", "pki-types/std", "once_cell/std"]
+default = ["aws_lc_rs", "logging", "std", "tls12"]
+std = ["webpki/std", "pki-types/std", "once_cell/std"]
 logging = ["log"]
-aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs", "std"]
+aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 ring = ["dep:ring", "webpki/ring"]
 tls12 = []
 read_buf = ["rustversion", "std"]


### PR DESCRIPTION
(will see what this breaks, but I think this should be orthogonal? I know aws-lc-rs itself requires std, but that should be unrelated to this crate's features.)