### PR TITLE
refactor: avoid pretty printing used in logging beyond debug level

### DIFF
--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -434,7 +434,7 @@ impl CommonState {
             if self.is_tls13() && alert.description != AlertDescription::UserCanceled {
                 return Err(self.send_fatal_alert(AlertDescription::DecodeError, err));
             } else {
-                warn!("TLS alert warning received: {:#?}", alert);
+                warn!("TLS alert warning received: {:?}", alert);
                 return Ok(());
             }
         }


### PR DESCRIPTION
# Problem

When using `rustls` in a web server, I monitored there is multiple line `warn` level logging, which is not ideal.

Logging should be one line so it could be easy processed later. (log process tools or other integration services)

# Solution

Just not use `#?` in any logging whose level >= `info`.