### PR TITLE
crypto: gate ticketer module on std for aws-lc-rs

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod hash;
 pub(crate) mod kx;
 #[path = "../ring/quic.rs"]
 pub(crate) mod quic;
+#[cfg(feature = "std")]
 #[path = "../ring/ticketer.rs"]
 pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
@@ -224,6 +225,7 @@ pub mod kx_group {
 }
 
 pub use kx::ALL_KX_GROUPS;
+#[cfg(feature = "std")]
 pub use ticketer::Ticketer;
 
 use super::SupportedKxGroup;
@@ -244,6 +246,7 @@ mod ring_shim {
 }
 
 /// AEAD algorithm that is used by `mod ticketer`.
+#[cfg(feature = "std")]
 pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::AES_256_GCM;
 
 /// Are we in FIPS mode?

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -193,6 +193,7 @@ mod ring_shim {
 }
 
 /// AEAD algorithm that is used by `mod ticketer`.
+#[cfg(feature = "std")]
 pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::CHACHA20_POLY1305;
 
 pub(super) fn fips() -> bool {


### PR DESCRIPTION
Fixes a missing import error when building without `std` and with `aws_lc_rs` flagged by the [daily CI powerset tests](https://github.com/rustls/rustls/actions/runs/8100804284/job/22139591511):
```
$ cargo check -p rustls --no-default-features --features aws_lc_rs
   Compiling rustls v0.23.0 (/home/daniel/Code/Rust/rustls/rustls)
error[E0432]: unresolved import `ticketer`
   --> rustls/src/crypto/aws_lc_rs/mod.rs:228:9
    |
228 | pub use ticketer::Ticketer;
    |         ^^^^^^^^ use of undeclared crate or module `ticketer`
```

Adding a `std` gate on `TICKETER_AEAD` was also required to fix unused warnings for builds w/o `std` using either `ring` or `aws_lc_rs`:

```
$ cargo check -p rustls --no-default-features --features aws_lc_rs
   Compiling rustls v0.23.0 (/home/daniel/Code/Rust/rustls/rustls)
warning: static `TICKETER_AEAD` is never used
   --> rustls/src/crypto/aws_lc_rs/mod.rs:249:19
    |
249 | pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::AES_256_GCM;
    |                   ^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```

```
$ cargo check -p rustls --no-default-features --features ring
warning: static `TICKETER_AEAD` is never used
   --> rustls/src/crypto/ring/mod.rs:196:19
    |
196 | pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::CHACHA20_POLY1305;
    |                   ^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```