### PR TITLE
Fix docs.rs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,8 @@ jobs:
             "</script>"
 
       - name: cargo doc
-        run: cargo doc --locked --all-features --no-deps --package rustls
+        # keep features in sync with Cargo.toml `[package.metadata.docs.rs]` section
+        run: cargo doc --locked --features read_buf,ring --no-deps --package rustls
         env:
           RUSTDOCFLAGS: -Dwarnings --cfg=docsrs --html-after-content tag.html
 

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -61,7 +61,8 @@ harness = false
 required-features = ["ring"]
 
 [package.metadata.docs.rs]
-all-features = true
+# all non-default features except fips (cannot build on docs.rs environment)
+features = ["read_buf", "ring"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo_check_external_types]

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -544,7 +544,8 @@ impl From<&[u8]> for SharedSecret {
 ///     .with_no_client_auth();
 /// # }
 /// ```
-#[cfg(feature = "fips")]
+#[cfg(any(feature = "fips", docsrs))]
+#[cfg_attr(docsrs, doc(cfg(feature = "fips")))]
 pub fn default_fips_provider() -> CryptoProvider {
     crate::crypto::aws_lc_rs::default_provider()
 }


### PR DESCRIPTION
See https://github.com/rust-lang/docs.rs/issues/1303: docs.rs's build environment has a golang package but doesn't set the environment variables needed to make it usable.

This PR avoids that by not generating docs with the `fips` feature, and then directly addressing the one API item we have under the `fips` feature.

fixes #1826 