### PR TITLE
Prepare 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2169,7 +2169,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.23.0",
+ "rustls 0.23.1",
  "rustls-pemfile 2.1.0",
  "rustls-pki-types",
 ]
@@ -2181,7 +2181,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.0",
+ "rustls 0.23.1",
 ]
 
 [[package]]
@@ -2194,7 +2194,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.0",
+ "rustls 0.23.1",
  "rustls-pemfile 2.1.0",
  "rustls-pki-types",
  "serde",
@@ -2212,7 +2212,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.0",
+ "rustls 0.23.1",
  "rustls-pemfile 2.1.0",
  "rustls-pki-types",
 ]
@@ -2260,7 +2260,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.0",
+ "rustls 0.23.1",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
  "serde",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Release notes:

- Fix build with `aws_lc_rs` feature enabled but `std` feature disabled.
- Fix build for docs.rs.