### PR TITLE
ci: fixup fmt unstable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
 
-fmt-unstable = ["fmt", "--", "--config-path", ".rustfmt.unstable.toml"]
+fmt-unstable = ["fmt", "--all", "--", "--config-path", ".rustfmt.unstable.toml"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,13 +361,13 @@ jobs:
           components: rustfmt
           toolchain: nightly-2024-02-21
       - name: Check formatting (unstable)
-        run: cargo fmt-unstable --all -- --check
+        run: cargo fmt --all -- --check --config-path .rustfmt.unstable.toml
         continue-on-error: true
       - name: Check formatting (unstable, connect-tests workspace)
-        run: cargo fmt-unstable --all --manifest-path=connect-tests/Cargo.toml -- --check
+        run: cargo fmt --all --manifest-path=connect-tests/Cargo.toml -- --check --config-path .rustfmt.unstable.toml
         continue-on-error: true
       - name: Check formatting (unstable, fuzz workspace)
-        run: cargo fmt-unstable --all --manifest-path=fuzz/Cargo.toml -- --check
+        run: cargo fmt --all --manifest-path=fuzz/Cargo.toml -- --check --config-path .rustfmt.unstable.toml
         continue-on-error: true
 
   clippy:

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -3,9 +3,10 @@
 extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::{ClientConfig, ClientConnection, RootCertStore};
 use std::io;
 use std::sync::Arc;
+
+use rustls::{ClientConfig, ClientConnection, RootCertStore};
 
 fuzz_target!(|data: &[u8]| {
     let root_store = RootCertStore::empty();

--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -3,10 +3,11 @@
 extern crate libfuzzer_sys;
 extern crate rustls;
 
+use std::io;
+
 use rustls::internal::msgs::deframer;
 use rustls::internal::msgs::message::Message;
 use rustls::internal::record_layer::RecordLayer;
-use std::io;
 
 fuzz_target!(|data: &[u8]| {
     let mut buf = deframer::DeframerVecBuffer::default();

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -3,11 +3,11 @@
 extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::server::ResolvesServerCert;
-use rustls::{ServerConfig, ServerConnection};
-
 use std::io;
 use std::sync::Arc;
+
+use rustls::server::ResolvesServerCert;
+use rustls::{ServerConfig, ServerConnection};
 
 #[derive(Debug)]
 struct Fail;


### PR DESCRIPTION
I noticed while trying to replicate what CI was doing on my local box that the fmt-unstable alias added in https://github.com/rustls/rustls/pull/1577 doesn't work like you'd hope w.r.t adding arguments before the `--`, like `--all` and `--manifest-path`. There were a couple of files in `fuzz` that weren't formatted correctly as a result. If you expand out the [format unstable job tasks](https://github.com/rustls/rustls/actions/runs/8115301189/job/22182886275) in a recent build you'll see they're erroring with:

```
> Run cargo fmt-unstable --all --manifest-path=connect-tests/Cargo.toml -- --check
Unrecognized option: 'all'
```

We have that job configured to `continue-on-error` so the errors weren't being surfaced.

To fix CI I've changed the tasks to not use the alias. For local development I've tweaked the alias slightly to include `--all`. The alias still isn't sufficient to format the two auxiliary crates (`fuzz` and `connect-tests`) but I'm not sure what the best fix is. We could add two more aliases? Or a bash helper script? Or leave it as-is since changes in those crates are rare?