### PR TITLE
Return correct `ConnectionTrafficSecrets` variant when AES-256-GCM is negotiated.

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -179,9 +179,11 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
         write_iv: &[u8],
         explicit: &[u8],
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
-        Ok(ConnectionTrafficSecrets::Aes128Gcm {
-            key,
-            iv: gcm_iv(write_iv, explicit),
+        let iv = gcm_iv(write_iv, explicit);
+        Ok(match self.0.key_len() {
+            16 => ConnectionTrafficSecrets::Aes128Gcm { key, iv },
+            32 => ConnectionTrafficSecrets::Aes256Gcm { key, iv },
+            _ => unreachable!(),
         })
     }
 

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -162,9 +162,11 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
         write_iv: &[u8],
         explicit: &[u8],
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
-        Ok(ConnectionTrafficSecrets::Aes128Gcm {
-            key,
-            iv: gcm_iv(write_iv, explicit),
+        let iv = gcm_iv(write_iv, explicit);
+        Ok(match self.0.key_len() {
+            16 => ConnectionTrafficSecrets::Aes128Gcm { key, iv },
+            32 => ConnectionTrafficSecrets::Aes256Gcm { key, iv },
+            _ => unreachable!(),
         })
     }
 


### PR DESCRIPTION
55bb27953d52eb2762f20aa6e30dc54252b1f77e inadvertently changed `extract_keys` to always return `ConnectionTrafficSecrets::Aes128Gcm`, even when AES-256-GCM was negotiated. This change fixes it by restoring the key length check.

Fixes #1833