### PR TITLE
Fix newly found `unused_qualifications` warnings

### DIFF
--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -52,10 +52,10 @@ mod cache {
 
         // Zero or one TLS1.2 sessions.
         #[cfg(feature = "tls12")]
-        tls12: Option<super::persist::Tls12ClientSessionValue>,
+        tls12: Option<persist::Tls12ClientSessionValue>,
 
         // Up to MAX_TLS13_TICKETS_PER_SERVER TLS1.3 tickets, oldest first.
-        tls13: VecDeque<super::persist::Tls13ClientSessionValue>,
+        tls13: VecDeque<persist::Tls13ClientSessionValue>,
     }
 
     impl Default for ServerData {

--- a/rustls/src/crypto/aws_lc_rs/sign.rs
+++ b/rustls/src/crypto/aws_lc_rs/sign.rs
@@ -267,7 +267,7 @@ struct EcdsaSigner {
 
 impl Signer for EcdsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error> {
-        let rng = super::ring_like::rand::SystemRandom::new();
+        let rng = SystemRandom::new();
         self.key
             .sign(&rng, message)
             .map_err(|_| Error::General("signing failed".into()))

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -541,7 +541,7 @@ impl From<&[u8]> for SharedSecret {
 #[cfg(any(feature = "fips", docsrs))]
 #[cfg_attr(docsrs, doc(cfg(feature = "fips")))]
 pub fn default_fips_provider() -> CryptoProvider {
-    crate::crypto::aws_lc_rs::default_provider()
+    aws_lc_rs::default_provider()
 }
 
 #[cfg(test)]

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -188,9 +188,9 @@ pub(crate) struct KeyBuilder {
     pub(crate) integrity_limit: u64,
 }
 
-impl crate::quic::Algorithm for KeyBuilder {
+impl quic::Algorithm for KeyBuilder {
     fn packet_key(&self, key: AeadKey, iv: Iv) -> Box<dyn quic::PacketKey> {
-        Box::new(super::quic::PacketKey::new(
+        Box::new(PacketKey::new(
             key,
             iv,
             self.confidentiality_limit,
@@ -200,7 +200,7 @@ impl crate::quic::Algorithm for KeyBuilder {
     }
 
     fn header_protection_key(&self, key: AeadKey) -> Box<dyn quic::HeaderProtectionKey> {
-        Box::new(super::quic::HeaderProtectionKey::new(key, self.header_alg))
+        Box::new(HeaderProtectionKey::new(key, self.header_alg))
     }
 
     fn aead_key_len(&self) -> usize {

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -305,7 +305,7 @@ struct EcdsaSigner {
 
 impl Signer for EcdsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error> {
-        let rng = super::ring_like::rand::SystemRandom::new();
+        let rng = SystemRandom::new();
         self.key
             .sign(&rng, message)
             .map_err(|_| Error::General("signing failed".into()))

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -529,7 +529,7 @@ mod connection {
         }
     }
 
-    impl<'a> std::io::Read for ReadEarlyData<'a> {
+    impl<'a> io::Read for ReadEarlyData<'a> {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
             self.early_data.read(buf)
         }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -85,7 +85,7 @@ impl ChunkVecBuffer {
     pub(crate) fn read_buf(&mut self, mut cursor: core::io::BorrowedCursor<'_>) -> io::Result<()> {
         while !self.is_empty() && cursor.capacity() > 0 {
             let chunk = self.chunks[0].as_slice();
-            let used = core::cmp::min(chunk.len(), cursor.capacity());
+            let used = cmp::min(chunk.len(), cursor.capacity());
             cursor.append(&chunk[..used]);
             self.consume(used);
         }


### PR DESCRIPTION
eg.

```
error: unnecessary qualification
  --> rustls/src/vecbuf.rs:88:24
   |
88 |             let used = core::cmp::min(chunk.len(), cursor.capacity());
   |                        ^^^^^^^^^^^^^^
   |
help: remove the unnecessary path segments
   |
88 -             let used = core::cmp::min(chunk.len(), cursor.capacity());
88 +             let used = cmp::min(chunk.len(), cursor.capacity());
   |
```