### PR TITLE
Add an `aws-lc-rs` feature as an alias for `aws_lc_rs`

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -31,6 +31,7 @@ default = ["aws_lc_rs", "logging", "std", "tls12"]
 std = ["webpki/std", "pki-types/std", "once_cell/std"]
 logging = ["log"]
 aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
+aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
 ring = ["dep:ring", "webpki/ring"]
 tls12 = []
 read_buf = ["rustversion", "std"]


### PR DESCRIPTION
The vast majority of Cargo features in the crates ecosystem use dashes
to separate words, rather than underscores. The fact that `aws_lc_rs`
uses underscores, and some crates depending on rustls naturally use the
same name for the feature that rustls does, has led some crates to end
up with inconsistent feature naming that throws people off (e.g. using
the wrong feature name and being surprised at the resulting compilation
failures), and has led other crates to use `aws-lc-rs` for consistency
with their other features which causes inconsistency with rustls.

Add an alias, so that it works either way, and people can reference
either one.
