### PR TITLE
enums: rename Unknown variant to Other

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -118,6 +118,10 @@ jobs:
       - name: Check provider-example client
         run: cargo run --locked -p rustls-provider-example --example client
 
+      - name: Check rustls-post-quantum client
+        run: cargo run --locked -p rustls-post-quantum --example client
+        #| grep 'You are using <em>X25519Kyber768Draft00</em>'
+
 
   feature-powerset:
     name: Feature Powerset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,7 +2247,9 @@ name = "rustls-post-quantum"
 version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
+ "env_logger",
  "rustls 0.23.1",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 [dependencies]
 rustls = { path = "../rustls", features = ["aws_lc_rs"] }
 aws-lc-rs = { version = "1.6", features = ["unstable"], default-features = false }
+
+[dev-dependencies]
+env_logger = "0.10" # 0.11 requires 1.71 MSRV even as a dev-dep (due to manifest features)
+webpki-roots = "0.26"

--- a/rustls-post-quantum/examples/client.rs
+++ b/rustls-post-quantum/examples/client.rs
@@ -1,9 +1,8 @@
-//! This is the simplest possible client using rustls that does something useful:
-//! it accepts the default configuration, loads some root certs, and then connects
-//! to rust-lang.org and issues a basic HTTP request.  The response is printed to stdout.
+//! This is the simplest possible client using rustls-postquantum, based on
+//! `simpleclient.rs`.
 //!
-//! It makes use of rustls::Stream to treat the underlying TLS connection as a basic
-//! bi-directional stream -- the underlying IO is performed transparently.
+//! It sends a HTTP request to pq.cloudflareresearch.com and prints the response to
+//! stdout.  Observe in that output: `You are using <em>X25519Kyber768Draft00</em>`
 //!
 //! Note that `unwrap()` is used to deal with networking errors; this is not something
 //! that is sensible outside of example code.
@@ -12,27 +11,30 @@ use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls::RootCertStore;
-
 fn main() {
-    let root_store = RootCertStore {
+    env_logger::init();
+    rustls_post_quantum::provider()
+        .install_default()
+        .unwrap();
+
+    let root_store = rustls::RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.into(),
     };
-    let mut config = rustls::ClientConfig::builder()
+
+    let config = rustls::ClientConfig::builder()
         .with_root_certificates(root_store)
         .with_no_client_auth();
 
-    // Allow using SSLKEYLOGFILE.
-    config.key_log = Arc::new(rustls::KeyLogFile::new());
-
-    let server_name = "www.rust-lang.org".try_into().unwrap();
+    let server_name = "pq.cloudflareresearch.com"
+        .try_into()
+        .unwrap();
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
-    let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
+    let mut sock = TcpStream::connect("pq.cloudflareresearch.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write_all(
         concat!(
             "GET / HTTP/1.1\r\n",
-            "Host: www.rust-lang.org\r\n",
+            "Host: pq.cloudflareresearch.com\r\n",
             "Connection: close\r\n",
             "Accept-Encoding: identity\r\n",
             "\r\n"

--- a/rustls-post-quantum/src/lib.rs
+++ b/rustls-post-quantum/src/lib.rs
@@ -217,7 +217,7 @@ fn kyber768_r3() -> &'static kem::Algorithm<AlgorithmId> {
     get_algorithm(AlgorithmId::Kyber768_R3).expect("Kyber768_R3 not available")
 }
 
-const NAMED_GROUP: NamedGroup = NamedGroup::Unknown(0x6399);
+const NAMED_GROUP: NamedGroup = NamedGroup::Other(0x6399);
 
 const INVALID_KEY_SHARE: Error = Error::PeerMisbehaved(PeerMisbehaved::InvalidKeyShare);
 

--- a/rustls/examples/internal/bogo_shim_impl.rs
+++ b/rustls/examples/internal/bogo_shim_impl.rs
@@ -961,7 +961,7 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
             }
             if opts.expect_version == 0x0304 {
                 match sess.protocol_version() {
-                    Some(ProtocolVersion::TLSv1_3) | Some(ProtocolVersion::Unknown(0x7f17)) => {}
+                    Some(ProtocolVersion::TLSv1_3) | Some(ProtocolVersion::Other(0x7f17)) => {}
                     _ => quit_err("wrong protocol version"),
                 }
             }
@@ -1054,11 +1054,11 @@ pub fn main() {
             }
             "-min-version" => {
                 let min = args.remove(0).parse::<u16>().unwrap();
-                opts.min_version = Some(ProtocolVersion::Unknown(min));
+                opts.min_version = Some(ProtocolVersion::Other(min));
             }
             "-max-version" => {
                 let max = args.remove(0).parse::<u16>().unwrap();
-                opts.max_version = Some(ProtocolVersion::Unknown(max));
+                opts.max_version = Some(ProtocolVersion::Other(max));
             }
             "-max-send-fragment" => {
                 let max_fragment = args.remove(0).parse::<usize>().unwrap();

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -411,7 +411,7 @@ impl CommonState {
 
     pub(crate) fn process_alert(&mut self, alert: &AlertMessagePayload) -> Result<(), Error> {
         // Reject unknown AlertLevels.
-        if let AlertLevel::Unknown(_) = alert.level {
+        if let AlertLevel::Other(_) = alert.level {
             return Err(self.send_fatal_alert(
                 AlertDescription::IllegalParameter,
                 Error::AlertReceived(alert.description),

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -401,7 +401,7 @@ pub trait SupportedKxGroup: Send + Sync + Debug {
     /// Named group the SupportedKxGroup operates in.
     ///
     /// If the `NamedGroup` enum does not have a name for the algorithm you are implementing,
-    /// you can use [`NamedGroup::Unknown`].
+    /// you can use [`NamedGroup::Other`].
     fn name(&self) -> NamedGroup;
 
     /// Return `true` if this is backed by a FIPS-approved implementation.

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -527,7 +527,7 @@ impl SignatureScheme {
             | Self::ECDSA_NISTP521_SHA512 => SignatureAlgorithm::ECDSA,
             Self::ED25519 => SignatureAlgorithm::ED25519,
             Self::ED448 => SignatureAlgorithm::ED448,
-            _ => SignatureAlgorithm::Unknown(0),
+            _ => SignatureAlgorithm::Other(0),
         }
     }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1080,7 +1080,7 @@ impl Codec<'_> for HelloRetryRequest {
         }
 
         Ok(Self {
-            legacy_version: ProtocolVersion::Unknown(0),
+            legacy_version: ProtocolVersion::Other(0),
             session_id,
             cipher_suite,
             extensions: Vec::read(r)?,
@@ -1175,7 +1175,7 @@ impl Codec<'_> for ServerHelloPayload {
         let extensions = if r.any_left() { Vec::read(r)? } else { vec![] };
 
         let ret = Self {
-            legacy_version: ProtocolVersion::Unknown(0),
+            legacy_version: ProtocolVersion::Other(0),
             random: ZERO_RANDOM,
             session_id,
             cipher_suite: suite,

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -117,7 +117,7 @@ fn can_roundtrip_unknown_client_ext() {
     let ext = ClientExtension::read(&mut rd).unwrap();
 
     println!("{:?}", ext);
-    assert_eq!(ext.ext_type(), ExtensionType::Unknown(0x1234));
+    assert_eq!(ext.ext_type(), ExtensionType::Other(0x1234));
     assert_eq!(bytes.to_vec(), ext.get_encoding());
 }
 
@@ -393,7 +393,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::CertificateStatusRequest(CertificateStatusRequest::build_ocsp()),
             ClientExtension::TransportParameters(vec![1, 2, 3]),
             ClientExtension::Unknown(UnknownExtension {
-                typ: ExtensionType::Unknown(12345),
+                typ: ExtensionType::Other(12345),
                 payload: Payload::Borrowed(&[1, 2, 3]),
             }),
         ],
@@ -472,7 +472,7 @@ fn test_truncated_client_extension_is_detected() {
 
         // these extension types don't have any internal encoding that rustls validates:
         match ext.ext_type() {
-            ExtensionType::TransportParameters | ExtensionType::Unknown(_) => {
+            ExtensionType::TransportParameters | ExtensionType::Other(_) => {
                 continue;
             }
             _ => {}
@@ -589,7 +589,7 @@ fn test_truncated_helloretry_extension_is_detected() {
         }
 
         // these extension types don't have any internal encoding that rustls validates:
-        if let ExtensionType::Unknown(_) = ext.ext_type() {
+        if let ExtensionType::Other(_) = ext.ext_type() {
             continue;
         }
 
@@ -656,7 +656,7 @@ fn test_truncated_server_extension_is_detected() {
 
         // these extension types don't have any internal encoding that rustls validates:
         match ext.ext_type() {
-            ExtensionType::TransportParameters | ExtensionType::Unknown(_) => {
+            ExtensionType::TransportParameters | ExtensionType::Other(_) => {
                 continue;
             }
             _ => {}
@@ -759,7 +759,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
             ServerExtension::SupportedVersions(ProtocolVersion::TLSv1_2),
             ServerExtension::TransportParameters(vec![1, 2, 3]),
             ServerExtension::Unknown(UnknownExtension {
-                typ: ExtensionType::Unknown(12345),
+                typ: ExtensionType::Other(12345),
                 payload: Payload::Borrowed(&[1, 2, 3]),
             }),
         ],
@@ -786,7 +786,7 @@ fn get_sample_helloretryrequest() -> HelloRetryRequest {
             HelloRetryExtension::Cookie(PayloadU16(vec![0])),
             HelloRetryExtension::SupportedVersions(ProtocolVersion::TLSv1_2),
             HelloRetryExtension::Unknown(UnknownExtension {
-                typ: ExtensionType::Unknown(12345),
+                typ: ExtensionType::Other(12345),
                 payload: Payload::Borrowed(&[1, 2, 3]),
             }),
         ],
@@ -803,7 +803,7 @@ fn get_sample_certificatepayloadtls13() -> CertificatePayloadTls13 {
                     ocsp_response: PayloadU24(vec![1, 2, 3]),
                 }),
                 CertificateExtension::Unknown(UnknownExtension {
-                    typ: ExtensionType::Unknown(12345),
+                    typ: ExtensionType::Other(12345),
                     payload: Payload::Borrowed(&[1, 2, 3]),
                 }),
             ],
@@ -854,7 +854,7 @@ fn get_sample_certificaterequestpayloadtls13() -> CertificateRequestPayloadTls13
             CertReqExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
             CertReqExtension::AuthorityNames(vec![DistinguishedName::from(vec![1, 2, 3])]),
             CertReqExtension::Unknown(UnknownExtension {
-                typ: ExtensionType::Unknown(12345),
+                typ: ExtensionType::Other(12345),
                 payload: Payload::Borrowed(&[1, 2, 3]),
             }),
         ],
@@ -875,7 +875,7 @@ fn get_sample_newsessionticketpayloadtls13() -> NewSessionTicketPayloadTls13 {
         nonce: PayloadU8(vec![1, 2, 3]),
         ticket: PayloadU16(vec![4, 5, 6]),
         exts: vec![NewSessionTicketExtension::Unknown(UnknownExtension {
-            typ: ExtensionType::Unknown(12345),
+            typ: ExtensionType::Other(12345),
             payload: Payload::Borrowed(&[1, 2, 3]),
         })],
     }
@@ -968,7 +968,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload<'static>> {
             payload: HandshakePayload::CertificateStatus(get_sample_certificatestatus()),
         },
         HandshakeMessagePayload {
-            typ: HandshakeType::Unknown(99),
+            typ: HandshakeType::Other(99),
             payload: HandshakePayload::Unknown(Payload::Borrowed(&[1, 2, 3])),
         },
     ]
@@ -1011,7 +1011,7 @@ fn can_detect_truncation_of_all_tls12_handshake_payloads() {
                 | (HandshakeType::ServerKeyExchange, _)
                 | (HandshakeType::ClientKeyExchange, _)
                 | (HandshakeType::Finished, _)
-                | (HandshakeType::Unknown(_), _) => continue,
+                | (HandshakeType::Other(_), _) => continue,
                 _ => {}
             };
 
@@ -1111,7 +1111,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload<'static>> {
             payload: HandshakePayload::CertificateStatus(get_sample_certificatestatus()),
         },
         HandshakeMessagePayload {
-            typ: HandshakeType::Unknown(99),
+            typ: HandshakeType::Other(99),
             payload: HandshakePayload::Unknown(Payload::Borrowed(&[1, 2, 3])),
         },
     ]
@@ -1162,7 +1162,7 @@ fn can_detect_truncation_of_all_tls13_handshake_payloads() {
                 | (HandshakeType::ServerKeyExchange, _)
                 | (HandshakeType::ClientKeyExchange, _)
                 | (HandshakeType::Finished, _)
-                | (HandshakeType::Unknown(_), _) => continue,
+                | (HandshakeType::Other(_), _) => continue,
                 _ => {}
             };
 

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -17,7 +17,7 @@ macro_rules! enum_builder {
         #[derive(Debug, PartialEq, Eq, Clone, Copy)]
         $enum_vis enum $enum_name {
             $( $enum_var),*
-            ,Unknown($uint)
+            ,Other($uint)
         }
 
         impl $enum_name {
@@ -32,7 +32,7 @@ macro_rules! enum_builder {
             $enum_vis fn as_str(&self) -> Option<&'static str> {
                 match self {
                     $( $enum_name::$enum_var => Some(stringify!($enum_var))),*
-                    ,$enum_name::Unknown(_) => None,
+                    ,$enum_name::Other(_) => None,
                 }
             }
         }
@@ -56,7 +56,7 @@ macro_rules! enum_builder {
             fn from(x: $uint) -> Self {
                 match x {
                     $($enum_val => $enum_name::$enum_var),*
-                    , x => $enum_name::Unknown(x),
+                    , x => $enum_name::Other(x),
                 }
             }
         }
@@ -65,7 +65,7 @@ macro_rules! enum_builder {
             fn from(value: $enum_name) -> Self {
                 match value {
                     $( $enum_name::$enum_var => $enum_val),*
-                    ,$enum_name::Unknown(x) => x
+                    ,$enum_name::Other(x) => x
                 }
             }
         }

--- a/rustls/src/msgs/message/inbound.rs
+++ b/rustls/src/msgs/message/inbound.rs
@@ -53,7 +53,7 @@ impl<'a> InboundOpaqueMessage<'a> {
         }
 
         self.typ = unpad_tls13_payload(payload);
-        if self.typ == ContentType::Unknown(0) {
+        if self.typ == ContentType::Other(0) {
             return Err(PeerMisbehaved::IllegalTlsInnerPlaintext.into());
         }
 
@@ -173,7 +173,7 @@ fn unpad_tls13_payload(p: &mut BorrowedPayload) -> ContentType {
         match p.pop() {
             Some(0) => {}
             Some(content_type) => return ContentType::from(content_type),
-            None => return ContentType::Unknown(0),
+            None => return ContentType::Other(0),
         }
     }
 }

--- a/rustls/src/msgs/message/outbound.rs
+++ b/rustls/src/msgs/message/outbound.rs
@@ -276,14 +276,14 @@ pub(crate) fn read_opaque_message_header(
 ) -> Result<(ContentType, ProtocolVersion, u16), MessageError> {
     let typ = ContentType::read(r).map_err(|_| MessageError::TooShortForHeader)?;
     // Don't accept any new content-types.
-    if let ContentType::Unknown(_) = typ {
+    if let ContentType::Other(_) = typ {
         return Err(MessageError::InvalidContentType);
     }
 
     let version = ProtocolVersion::read(r).map_err(|_| MessageError::TooShortForHeader)?;
     // Accept only versions 0x03XX for any XX.
     match version {
-        ProtocolVersion::Unknown(ref v) if (v & 0xff00) != 0x0300 => {
+        ProtocolVersion::Other(ref v) if (v & 0xff00) != 0x0300 => {
             return Err(MessageError::UnknownProtocolVersion);
         }
         _ => {}

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -862,7 +862,7 @@ fn server_receives_incorrect_first_handshake_message() {
     assert_eq!(discard, junk_buffer_len);
     assert_eq!(
         format!("{state:?}"),
-        "Err(InappropriateHandshakeMessage { expect_types: [ClientHello], got_type: Unknown(255) })"
+        "Err(InappropriateHandshakeMessage { expect_types: [ClientHello], got_type: Other(255) })"
     );
 
     let UnbufferedStatus { discard, state } = server.process_tls_records(&mut []);


### PR DESCRIPTION
Previously the `enum_builder` macro created an `Unknown` variant as a catch all for unsupported values. Now that we've introduced new extension points for Rustls via the crypto provider interfaces some of these "Unknown" values are known and supported via extension.

This commit renames the `Unknown` variant to `Other` to better reflect that they may be known to code outside of the core of Rustls.

Opened as a draft for now becuase:

* The base branch is `jbp-hybrid-kx`.
* It's a breaking change (as called out by the semver check failing), and we might want to keep `main` for maintenance of 0.23 for now?
* It's scope is larger than just the `NamedGroup` enum that inspired the discussion in https://github.com/rustls/rustls/pull/1785, since the change happens at the level of the enum builder macro.

Maybe the juice isn't worth the squeeze, but it felt easier to decide with a diff to look at :shrug: 