### PR TITLE
Prepare 0.23.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2169,7 +2169,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.23.1",
+ "rustls 0.23.2",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
 ]
@@ -2181,7 +2181,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.1",
+ "rustls 0.23.2",
 ]
 
 [[package]]
@@ -2194,7 +2194,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.1",
+ "rustls 0.23.2",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
  "serde",
@@ -2212,7 +2212,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.1",
+ "rustls 0.23.2",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
 ]
@@ -2248,7 +2248,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.1",
+ "rustls 0.23.2",
  "webpki-roots 0.26.1",
 ]
 
@@ -2270,7 +2270,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.1",
+ "rustls 0.23.2",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
  "serde",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The community has also started developing third-party providers for Rustls:
 cryptography.
 * [`rustls-rustcrypto`] - an experimental provider that uses the crypto primitives
 from [`RustCrypto`] for cryptography.
+* [`rustls-post-quantum`]: an experimental provider that adds support for post-quantum
+key exchange to the default aws-lc-rs provider.
 
 [`rustls-mbedtls-provider`]: https://github.com/fortanix/rustls-mbedtls-provider
 [`mbedtls`]: https://github.com/Mbed-TLS/mbedtls
@@ -101,6 +103,7 @@ from [`RustCrypto`] for cryptography.
 [`boringssl`]: https://github.com/google/boringssl
 [`rustls-rustcrypto`]: https://github.com/RustCrypto/rustls-rustcrypto
 [`RustCrypto`]: https://github.com/RustCrypto
+[`rustls-post-quantum`]: https://crates.io/crates/rustls-post-quantum
 
 #### Custom provider
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -61,6 +61,8 @@
 //!     cryptography.
 //!   * [`rustls-rustcrypto`] - an experimental provider that uses the crypto primitives
 //!     from [`RustCrypto`] for cryptography.
+//!   * [`rustls-post-quantum`]: an experimental provider that adds support for post-quantum
+//!     key exchange to the default aws-lc-rs provider.
 //!
 //! [`rustls-mbedtls-provider`]: https://github.com/fortanix/rustls-mbedtls-provider
 //! [`mbedtls`]: https://github.com/Mbed-TLS/mbedtls
@@ -68,6 +70,7 @@
 //! [`boringssl`]: https://github.com/google/boringssl
 //! [`rustls-rustcrypto`]: https://github.com/RustCrypto/rustls-rustcrypto
 //! [`RustCrypto`]: https://github.com/RustCrypto
+//! [`rustls-post-quantum`]: https://crates.io/crates/rustls-post-quantum
 //!
 //! #### Custom provider
 //!


### PR DESCRIPTION
# Release notes

* **Bug fix:** return correct `ConnectionTrafficSecrets` variant from `dangerous_extract_secrets()` when AES-256-GCM is negotiated.
* **New feature:** groundwork for supporting post-quantum key exchange. Experimental support for [X25519Kyber768Draft00](https://datatracker.ietf.org/doc/draft-tls-westerbaan-xyber768d00/03/) will be released as a separate crate: [rustls-post-quantum](https://crates.io/crates/rustls-post-quantum).
* Add `aws-lc-rs` crate feature as alias for `aws_lc_rs` crate feature.