### PR TITLE
Prepare rustls-post-quantum 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbdb5ddfafe3040e01fe9dced711e27b5336ac97d4a9b2089f0066a04b5846"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-ci-bench"
 version = "0.0.1"
 dependencies = [
@@ -2248,7 +2263,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.2",
+ "rustls 0.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.26.1",
 ]
 

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -2,10 +2,15 @@
 name = "rustls-post-quantum"
 version = "0.1.0"
 edition = "2021"
-publish = false
+license = "Apache-2.0 OR ISC OR MIT"
+readme = "README.md"
+description = "Experimental support for post-quantum key exchange in rustls"
+homepage = "https://github.com/rustls/rustls"
+repository = "https://github.com/rustls/rustls"
+categories = ["network-programming", "cryptography"]
 
 [dependencies]
-rustls = { path = "../rustls", features = ["aws_lc_rs"] }
+rustls = { version = "0.23.2", features = ["aws_lc_rs"] }
 aws-lc-rs = { version = "1.6", features = ["unstable"], default-features = false }
 
 [dev-dependencies]

--- a/rustls-post-quantum/README.md
+++ b/rustls-post-quantum/README.md
@@ -1,0 +1,18 @@
+<p align="center">
+  <img width="460" height="300" src="https://raw.githubusercontent.com/rustls/rustls/main/admin/rustls-logo-web.png">
+</p>
+
+<p align="center">
+Rustls is a modern TLS library written in Rust.
+</p>
+
+# rustls-post-quantum
+
+This crate provides experimental support for [X25519Kyber768Draft00] post-quantum
+key exchange. See [the documentation][docs] for more details.
+
+This crate is release under the same licenses as the [main rustls crate][rustls].
+
+[X25519Kyber768Draft00]: https://datatracker.ietf.org/doc/draft-tls-westerbaan-xyber768d00/03/
+[docs]: https://docs.rs/rustls-post-quantum/latest/
+[rustls]: https://crates.io/crates/rustls


### PR DESCRIPTION
Will make a github release for this like usual, but _not_ set it to the "latest release", and will call it "rustls-post-quantum 0.1.0". I'll copy the README text for the release notes.