### PR TITLE
small no-std CI tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
 
         # this target does _not_ include the libstd crate in its sysroot
         # it will catch unwanted usage of libstd in _dependencies_
-      - name: cargo build (debug; default features; no-std)
+      - name: cargo build (debug; no default features; no-std)
         run: cargo build --locked --no-default-features --target x86_64-unknown-none
         working-directory: rustls
 

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -18,7 +18,7 @@ p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecd
 pkcs8 = "0.10.2"
 pki-types = { package = "rustls-pki-types", version = "1" }
 rand_core = { version = "0.6", features = ["getrandom"] }
-rustls = { path = "../rustls", default-features = false, features = ["logging", "std", "tls12"] }
+rustls = { path = "../rustls", default-features = false, features = ["logging", "tls12"] }
 rsa = { version = "0.9", features = ["sha2"], default-features = false }
 sha2 = { version = "0.10", default-features = false }
 signature = "2"
@@ -35,7 +35,7 @@ webpki-roots = "0.26"
 
 [features]
 default = ["std"]
-std = ["hpke-rs/std", "hpke-rs-crypto/std", "pkcs8/std"]
+std = ["hpke-rs/std", "hpke-rs-crypto/std", "pkcs8/std", "rustls/std"]
 
 [[test]]
 name = "hpke"


### PR DESCRIPTION
Just a couple of small things I noticed picking at the no-std work with fresh eyes.

* ci: fix typo in no-std run name

It uses `--no-default-features` but the name described using default features.

* provider-example: conditionally enable rusts std feat

Previously the `std` feature was in the explicit rustls dependency feature list, and not opted-in by the provider's own `std` feature.
I believe this means when building the provider with `--no-default-features` we were still using Rustls w/ the `std` feature.