### PR TITLE
Use jemalloc in benchmarks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,13 +222,13 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Smoke-test benchmark program (ring)
-        run: cargo run -p rustls --release --locked --example bench
+        run: cargo run -p rustls --profile=bench --locked --example bench
 
       - name: Smoke-test benchmark program (aws-lc-rs)
-        run: cargo run -p rustls --release --locked --example bench --no-default-features --features aws_lc_rs,tls12,std
+        run: cargo run -p rustls --profile=bench --locked --example bench --no-default-features --features aws_lc_rs,tls12,std
 
       - name: Smoke-test benchmark program (fips)
-        run: cargo run -p rustls --release --locked --example bench --no-default-features --features fips,tls12,std
+        run: cargo run -p rustls --profile=bench --locked --example bench --no-default-features --features fips,tls12,std
 
       - name: Run micro-benchmarks
         run: cargo bench --locked --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,7 @@ dependencies = [
  "rustls 0.23.2",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -2548,6 +2549,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.50",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,6 +2154,7 @@ dependencies = [
  "rustls-webpki 0.102.2",
  "rustversion",
  "subtle",
+ "tikv-jemallocator",
  "webpki-roots 0.26.1",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ default-members = [
 ]
 exclude = ["admin/rustfmt"]
 resolver = "2"
+
+[profile.bench]
+codegen-units = 1
+lto = "yes"

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -17,3 +17,6 @@ pki-types = { package = "rustls-pki-types", version = "1" }
 rayon = "1.7.0"
 rustls = { path = "../rustls", features = ["ring", "aws_lc_rs"] }
 rustls-pemfile = "2"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -847,3 +847,7 @@ fn table<'a>(diffs: impl Iterator<Item = &'a Diff>, emoji_feedback: bool) {
         )
     }
 }
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -46,6 +46,9 @@ num-bigint = "0.4.4"
 rustls-pemfile = "2"
 webpki-roots = "0.26"
 
+[target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
+tikv-jemallocator = "0.5"
+
 [[example]]
 name = "bogo_shim"
 path = "examples/internal/bogo_shim.rs"

--- a/rustls/examples/internal/bench_impl.rs
+++ b/rustls/examples/internal/bench_impl.rs
@@ -658,3 +658,7 @@ fn all_tests() {
         bench_handshake(test, ClientAuth::Yes, ResumptionParam::Tickets);
     }
 }
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;


### PR DESCRIPTION
This normalises the manual modifications from https://github.com/aochagavia/rustls-bench-results

Third commit adds aggressive LTO to the existing `bench` profile. Full results (`--release` vs `--profile=bench`, run on benchmark box):

```
$ diff-bench rustls.jemalloc.out.txt rustls.jemalloc-lto.out.txt 
bulk	TLSv1_2	TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256	max_fragment_size:default	send	7150.59	7070.55	MB/s	-1.1%
bulk	TLSv1_2	TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256	max_fragment_size:default	recv	6284.95	7018.19	MB/s	+12%
bulk	TLSv1_2	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384	max_fragment_size:default	send	6729.37	6583.54	MB/s	-2.2%
bulk	TLSv1_2	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384	max_fragment_size:default	recv	5942.65	6596.05	MB/s	+11%
bulk	TLSv1_2	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256	max_fragment_size:default	recv	1753.77	1805.13	MB/s	+2.9%
bulk	TLSv1_3	TLS13_AES_256_GCM_SHA384	max_fragment_size:default	recv	6242.48	6971.74	MB/s	+12%
handshakes	TLSv1_2	Rsa	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384	client	server-auth	no-resume	4997.66	5059.81	handshake/s	+1.2%
handshakes	TLSv1_2	Rsa	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384	client	server-auth	sessionid	50515.9	52052.9	handshake/s	+3%
handshakes	TLSv1_2	Rsa	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384	server	server-auth	sessionid	42204.1	43706.3	handshake/s	+3.6%
handshakes	TLSv1_2	Rsa	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384	client	server-auth	tickets	47600.1	50216.2	handshake/s	+5.5%
handshakes	TLSv1_2	Rsa	TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384	server	server-auth	tickets	36821	38705.8	handshake/s	+5.1%
handshakes	TLSv1_3	Rsa	TLS13_AES_256_GCM_SHA384	client	server-auth	no-resume	4697.7	4793.21	handshake/s	+2%
handshakes	TLSv1_3	Rsa	TLS13_AES_256_GCM_SHA384	client	server-auth	sessionid	11383.6	11592.3	handshake/s	+1.8%
handshakes	TLSv1_3	Rsa	TLS13_AES_256_GCM_SHA384	server	server-auth	sessionid	7452.58	7629.46	handshake/s	+2.4%
handshakes	TLSv1_3	Rsa	TLS13_AES_256_GCM_SHA384	client	server-auth	tickets	11240	11630.8	handshake/s	+3.5%
handshakes	TLSv1_3	Rsa	TLS13_AES_256_GCM_SHA384	server	server-auth	tickets	7406.77	7583.08	handshake/s	+2.4%
```

fixes #1722