### PR TITLE
Add auto build to bench-measure

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -24,12 +24,12 @@ benchmarks](https://github.com/ctz/openssl-bench), which produce similar measure
 #### Building
 
 The benchmarks are implemented in the form of "example code" in `rustls/examples/internal/bench.rs`.
-Use `cargo build --release -p rustls --example bench` to obtain the corresponding binary (you can
-toggle conditionally compiled code with the `--no-default-features` and `--features` flags).
+Use `cargo build --profile=bench -p rustls --example bench` to obtain the corresponding binary (you can
+toggle conditionally compiled code with the `--no-default-features` and `--features` flags) or simply run below, which will build and run the benchmark.
 
 Note: while `cargo build --release --example bench` also works, it results in surprises when used
 together with `--no-default-features` because of how Cargo's feature unification works (some
-features get enabled automatically by other subcrates).
+features get enabled automatically by other subcrates). It is also less performant than `--profile=bench`.
 
 #### Running
 

--- a/admin/bench-measure.mk
+++ b/admin/bench-measure.mk
@@ -1,29 +1,31 @@
+.PHONY: perf perffull perf13 measure memory clean
+
 RECORD=perf record -F2000 --call-graph dwarf,16000 --
 FLAMEGRAPH=perf script | ~/FlameGraph/stackcollapse-perf.pl | ~/FlameGraph/flamegraph.pl >
 MEMUSAGE=/usr/bin/env time -f %M
+BENCH:=./target/release/examples/bench
 
-perf: ./target/release/examples/bench
-	$(RECORD) ./target/release/examples/bench bulk TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+perf: $(BENCH)
+	$(RECORD) $(BENCH) bulk TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 	$(FLAMEGRAPH) perf-aes128-rustls.svg
 
-perffull: ./target/release/examples/bench
-	$(RECORD) ./target/release/examples/bench bulk TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+perffull: $(BENCH)
+	$(RECORD) $(BENCH) bulk TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 	$(FLAMEGRAPH) perf-aes256-rustls.svg
-	$(RECORD) ./target/release/examples/bench bulk TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+	$(RECORD) $(BENCH) bulk TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 	$(FLAMEGRAPH) perf-chacha-rustls.svg
-	
-	$(RECORD) ./target/release/examples/bench handshake TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	$(RECORD) $(BENCH) handshake TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 	$(FLAMEGRAPH) perf-fullhs-rustls.svg
-	$(RECORD) ./target/release/examples/bench handshake-resume TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	$(RECORD) $(BENCH) handshake-resume TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 	$(FLAMEGRAPH) perf-resume-rustls.svg
-	$(RECORD) ./target/release/examples/bench handshake-ticket TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+	$(RECORD) $(BENCH) handshake-ticket TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 	$(FLAMEGRAPH) perf-ticket-rustls.svg
 
 perf13:
-	$(RECORD) ./target/release/examples/bench handshake-ticket TLS13_AES_256_GCM_SHA384
+	$(RECORD) $(BENCH) handshake-ticket TLS13_AES_256_GCM_SHA384
 	$(FLAMEGRAPH) perf-ticket13-rustls.svg
 
-measure: ./target/release/examples/bench
+measure: $(BENCH)
 	$^ bulk TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 	$^ bulk TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 	$^ bulk TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
@@ -35,10 +37,19 @@ measure: ./target/release/examples/bench
 	$^ handshake-resume TLS13_AES_256_GCM_SHA384
 	$^ handshake-ticket TLS13_AES_256_GCM_SHA384
 
-memory: ./target/release/examples/bench
+memory: $(BENCH)
 	$(MEMUSAGE) $^ memory TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 100
 	$(MEMUSAGE) $^ memory TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 1000
 	$(MEMUSAGE) $^ memory TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 5000
 	$(MEMUSAGE) $^ memory TLS13_AES_256_GCM_SHA384 100
 	$(MEMUSAGE) $^ memory TLS13_AES_256_GCM_SHA384 1000
 	$(MEMUSAGE) $^ memory TLS13_AES_256_GCM_SHA384 5000
+
+clean:
+	rm -f perf-*.svg
+	cargo clean
+
+$(BENCH):
+	cargo build --profile=bench -p rustls --example bench
+
+


### PR DESCRIPTION
To allow for easy running and simplification of benchmarking, add cargo build to the bench measure.

Also add .PHONY for recipes with no output that are always expected to run.