### PR TITLE
admin/coverage: pass script args to all llvm-cov calls

### DIFF
--- a/admin/coverage
+++ b/admin/coverage
@@ -2,7 +2,7 @@
 
 set -e
 
-source <(cargo llvm-cov show-env --export-prefix)
+source <(cargo llvm-cov show-env --export-prefix "$@")
 cargo llvm-cov clean --workspace
 
 cargo build --locked --all-targets --all-features


### PR DESCRIPTION
This allows the new, nightly-only, `--branch` argument to get everywhere it needs to.  That enables branch coverage tracking.

Example use:

```
$ ./admin/coverage --branch --html --open
```

Example output for highlight uncovered error handling branches:

![image](https://github.com/rustls/rustls/assets/579363/3f3f35e9-98a8-4424-82c8-5d664f204a5f)

But I'm not sure what this table is intended to convey:

![image](https://github.com/rustls/rustls/assets/579363/d309b511-c919-48a0-a03c-deb4457026f1)


(nb. available only on nightly & experimental at present, so probably not going to make CI use it yet.)