### PR TITLE
Fix ffdhe no common cipher suite bug

### DIFF
--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -476,9 +476,9 @@ impl ExpectClientHello {
                 && suite.version().version == selected_version
                 // And protocol
                 && suite.usable_for_protocol(protocol)
-                // And key exchange groups
-                && (!ecdhe_possible || suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::ECDHE))
-                && (!ffdhe_possible || suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::DHE))
+                // And support one of key exchange groups
+                && (ecdhe_possible && suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::ECDHE)
+                || ffdhe_possible && suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::DHE))
             });
 
         // RFC 7919 (https://datatracker.ietf.org/doc/html/rfc7919#section-4) requires us to send

--- a/rustls/tests/api_ffdhe.rs
+++ b/rustls/tests/api_ffdhe.rs
@@ -248,6 +248,16 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
 
     let test_cases = [
         (
+            // TLS 1.2, have common
+            vec![
+                // this matches:
+                provider::kx_group::SECP256R1,
+                &ffdhe::FFDHE2048_KX_GROUP,
+            ],
+            &TLS12,
+            CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        ),
+        (
             vec![
                 // this matches:
                 provider::kx_group::SECP256R1,
@@ -264,6 +274,16 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ],
             &TLS12,
             CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+        ),
+        (
+            // TLS 1.3, have common
+            vec![
+                // this matches:
+                provider::kx_group::SECP256R1,
+                &ffdhe::FFDHE2048_KX_GROUP,
+            ],
+            &TLS13,
+            CipherSuite::TLS13_AES_128_GCM_SHA256,
         ),
         (
             vec![


### PR DESCRIPTION
# Background

See:

- #1860

# Solution

- Fix the bug that when both FFDHE and DHE ciphersuites are available on client and server, no ciphersuite is choose.
- Add missing test cases.


This PR fixs #1860