### PR TITLE
Add path for rustls-post-quantum -> rustls dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,21 +2145,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbdb5ddfafe3040e01fe9dced711e27b5336ac97d4a9b2089f0066a04b5846"
-dependencies = [
- "aws-lc-rs",
- "log",
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki 0.102.2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.3"
 dependencies = [
  "aws-lc-rs",
@@ -2271,7 +2256,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.2",
+ "rustls 0.23.3",
  "webpki-roots 0.26.1",
 ]
 

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rustls/rustls"
 categories = ["network-programming", "cryptography"]
 
 [dependencies]
-rustls = { version = "0.23.2", features = ["aws_lc_rs"] }
+rustls = { version = "0.23.2", features = ["aws_lc_rs"], path = "../rustls" }
 aws-lc-rs = { version = "1.6", features = ["unstable"], default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This avoids our Cargo.lock containing a previous version of this crate, and means a local `cargo build` is sufficient to check rustls-post-quantum/ builds against the current rustls/.