### PR TITLE
Prepare 0.23.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2176,7 +2176,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.23.3",
+ "rustls 0.23.4",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
  "tikv-jemallocator",
@@ -2189,7 +2189,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.3",
+ "rustls 0.23.4",
 ]
 
 [[package]]
@@ -2202,7 +2202,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.3",
+ "rustls 0.23.4",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
  "serde",
@@ -2220,7 +2220,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.3",
+ "rustls 0.23.4",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
 ]
@@ -2256,7 +2256,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.3",
+ "rustls 0.23.4",
  "webpki-roots 0.26.1",
 ]
 
@@ -2278,7 +2278,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.3",
+ "rustls 0.23.4",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
  "serde",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.3"
+version = "0.23.4"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Release notes:

* **Bug fix:** correct cipher suite filtering if a custom certificate verifier offers support for `SignatureScheme::ECDSA_SHA1_Legacy`.
* Improve documentation and example code around `AcceptedAlert::write`