### PR TITLE
deps: update semver compatible deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2274,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-post-quantum"
@@ -2409,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2627,9 +2627,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
Replaces https://github.com/rustls/rustls/pull/1882

* clap v4.5.3 -> v4.5.4 ([diff.rs](https://diff.rs/clap/4.5.3/4.5.4))
* rustls-pki-types v1.4.0 -> v1.4.1 ([diff.rs](https://diff.rs/rustls-pki-types/1.4.0/1.4.1))
* tokio v1.36.0 -> v1.37.0 ([diff.rs](https://diff.rs/tokio/1.36.0/1.37.0))
* serde_json v1.0.114 -> v1.0.115 ([diff.rs](https://diff.rs/serde_json/1.0.114/1.0.115))

Three updates from #1882 are deliberately omitted:

* hashbrown 0.13.2 -> 0.14.3 (0.14.x requires 1.63 MSRV)
* env_logger 0.10.2 -> 0.11.3 (0.11 requires 1.71 MSRV)
* rcgen 0.12.1 -> 0.13.0 (requires fixing breaking changes, in progress in https://github.com/rustls/rustls/pull/1852)