### PR TITLE
connect-tests: ignore rsa8192.badssl.com

### DIFF
--- a/connect-tests/tests/badssl.rs
+++ b/connect-tests/tests/badssl.rs
@@ -106,6 +106,7 @@ mod online {
             .unwrap();
     }
 
+    #[ignore] // https://github.com/chromium/badssl.com/issues/530
     #[test]
     fn rsa8192() {
         connect("rsa8192.badssl.com")


### PR DESCRIPTION
This test server's certificate has expired, breaking the connect tests portion of the daily CI jobs since March 27th. The issue has been flagged with the upstream project (https://github.com/chromium/badssl.com/issues/530, https://github.com/chromium/badssl.com/issues/499#issuecomment-2027555009). Until resolved let's ignore this test.