### PR TITLE
deps: aws-lc-rs 1.6.2 -> 1.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.6.2"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33e4a55b03f8780ba55041bc7be91a2a8ec8c03517b0379d2d6c96d2c30d95"
+checksum = "9f379c4e505c0692333bd90a334baa234990faa06bdabefd3261f765946aa920"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f269b176dc4aeb593910fa56ed6f956cde19542e496bb0bfc1ad9a6ce18815"
+checksum = "68aa3d613f42dbf301dbbcaf3dc260805fd33ffd95f6d290ad7231a9e5d877a7"
 dependencies = [
  "bindgen",
  "cmake",


### PR DESCRIPTION
Notably this brings in pre-generated bindings for more platforms. See the upstream release notes[^0][^1] for more details. 

[aws-ls-rs diff.rs](https://diff.rs/aws-lc-rs/1.6.2/1.6.4/Cargo.toml)

[^0]: https://github.com/aws/aws-lc-rs/releases/tag/v1.6.3
[^1]: https://github.com/aws/aws-lc-rs/releases/tag/v1.6.4