### PR TITLE
deps: update cargo semver compatible deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,9 +726,9 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -2183,7 +2183,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "ring",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
  "rustversion",
@@ -2205,7 +2205,7 @@ dependencies = [
  "itertools",
  "rayon",
  "rustls 0.23.4",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "tikv-jemallocator",
 ]
@@ -2231,7 +2231,7 @@ dependencies = [
  "mio",
  "rcgen",
  "rustls 0.23.4",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_derive",
@@ -2249,7 +2249,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "rustls 0.23.4",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
 ]
 
@@ -2264,11 +2264,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "rustls-pki-types",
 ]
 
@@ -2341,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ryu"


### PR DESCRIPTION
Replaces https://github.com/rustls/rustls/pull/1891

* rustls-pemfile 2.1.1 -> 2.1.2 ([diff.rs](https://diff.rs/rustls-pemfile/2.1.1/2.1.2/Cargo.toml))
* rustversion 1.0.14 -> 1.0.15 ([diff.rs](https://diff.rs/rustversion/1.0.14/1.0.15/Cargo.toml))
* der 0.7.8 -> 0.7.9 ([diff.rs](https://diff.rs/der/0.7.8/0.7.9/Cargo.toml))

Three updates from https://github.com/rustls/rustls/pull/1891 are deliberately omitted:

* hashbrown 0.13.2 -> 0.14.3 (0.14.x requires 1.63 MSRV)
* env_logger 0.10.2 -> 0.11.3 (0.11 requires 1.71 MSRV)
* rcgen 0.12.1 -> 0.13.0 (requires fixing breaking changes, in progress in https://github.com/rustls/rustls/pull/1852)