### PR TITLE
docs: update ROADMAP post-quantum kex item

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,12 +29,14 @@ In rough order of priority:
   consider implementing limits for TLS over TCP as well.
   rustls/rustls#755
 
+## Past priorities
+
+Delivered in 0.23.2:
+
 * **Support Post-Quantum Hybrid Key Exchange**.
   Experimental, optional support for the `X25519Kyber768Draft00` key exchange.
   This should track [the draft](https://datatracker.ietf.org/doc/draft-tls-westerbaan-xyber768d00/).
   rustls/rustls#1687
-
-## Past priorities
 
 Delivered in 0.23:
 


### PR DESCRIPTION
[Rustls 0.23.2](https://github.com/rustls/rustls/releases/tag/v%2F0.23.2) added the groundwork for opting in to experimental post-quantum key exchange support using `X25519Kyber768Draft00`. Afterwards the remaining required pieces were released in a separate crate, [`rustls-post-quantum`](https://docs.rs/rustls-post-quantum/latest/rustls_post_quantum/). As a result this commit moves the post-quantum KEX feature from the Future priorities to the Past priorities.