### PR TITLE
deps: update cargo semver compatible deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "asn1"
@@ -304,9 +304,9 @@ checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2598,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "num-conv",


### PR DESCRIPTION
Replaces https://github.com/rustls/rustls/pull/1896

* anyhow 1.0.81 -> 1.0.82 ([diff.rs](https://diff.rs/anyhow/1.0.81/1.0.82/))
* async-trait 0.1.79 -> 0.1.80 ([diff.rs](https://diff.rs/async-trait/0.1.79/0.1.80/))
* time 0.3.34 -> 0.3.36 ([diff.rs](https://diff.rs/time/0.3.34/0.3.36/))

Two updates from https://github.com/rustls/rustls/pull/1896 are deliberately omitted:

* hashbrown 0.13.2 -> 0.14.3 (0.14.x requires 1.63 MSRV)
* env_logger 0.10.2 -> 0.11.3 (0.11 requires 1.71 MSRV)