### PR TITLE
Expose connection resumption details

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -16,7 +16,7 @@ use crate::check::inappropriate_handshake_message;
 use crate::client::client_conn::ClientConnectionData;
 use crate::client::common::ClientHelloDetails;
 use crate::client::{tls13, ClientConfig};
-use crate::common_state::{CommonState, State};
+use crate::common_state::{CommonState, HandshakeKind, State};
 use crate::conn::ConnectionRandoms;
 use crate::crypto::{ActiveKeyExchange, KeyExchangeAlgorithm};
 use crate::enums::{AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion};
@@ -843,6 +843,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
 
         // HRR selects the ciphersuite.
         cx.common.suite = Some(cs);
+        cx.common.handshake_kind = Some(HandshakeKind::FullWithHelloRetryRequest);
 
         // This is the draft19 change where the transcript became a tree
         let transcript = self

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -13,7 +13,7 @@ use super::hs::ClientContext;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::client::common::{ClientAuthDetails, ServerCertDetails};
 use crate::client::{hs, ClientConfig};
-use crate::common_state::{CommonState, Side, State};
+use crate::common_state::{CommonState, HandshakeKind, Side, State};
 use crate::conn::ConnectionRandoms;
 use crate::crypto::KeyExchangeAlgorithm;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
@@ -138,6 +138,7 @@ mod server_hello {
                             .clone()
                             .into_owned(),
                     );
+                    cx.common.handshake_kind = Some(HandshakeKind::Resumed);
                     let cert_verified = verify::ServerCertVerified::assertion();
                     let sig_verified = verify::HandshakeSignatureValid::assertion();
 
@@ -172,6 +173,7 @@ mod server_hello {
                 }
             }
 
+            cx.common.handshake_kind = Some(HandshakeKind::Full);
             Ok(Box::new(ExpectCertificate {
                 config: self.config,
                 resuming_session: None,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -499,7 +499,7 @@ pub mod unbuffered {
 
 // The public interface is:
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier, WantsVersions};
-pub use crate::common_state::{CommonState, IoState, Side};
+pub use crate::common_state::{CommonState, HandshakeKind, IoState, Side};
 #[cfg(feature = "std")]
 pub use crate::conn::{Connection, Reader, Writer};
 pub use crate::conn::{ConnectionCommon, SideData};

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -13,7 +13,7 @@ use super::common::ActiveCertifiedKey;
 use super::hs::{self, ServerContext};
 use super::server_conn::{ProducesTickets, ServerConfig, ServerConnectionData};
 use crate::check::inappropriate_message;
-use crate::common_state::{CommonState, Side, State};
+use crate::common_state::{CommonState, HandshakeKind, Side, State};
 use crate::conn::ConnectionRandoms;
 use crate::crypto::ActiveKeyExchange;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
@@ -192,6 +192,8 @@ mod client_hello {
                 self.session_id = SessionId::random(self.config.provider.secure_random)?;
             }
 
+            cx.common.handshake_kind = Some(HandshakeKind::Full);
+
             self.send_ticket = emit_server_hello(
                 &self.config,
                 &mut self.transcript,
@@ -290,6 +292,7 @@ mod client_hello {
             cx.common
                 .start_encryption_tls12(&secrets, Side::Server);
             cx.common.peer_certificates = resumedata.client_cert_chain;
+            cx.common.handshake_kind = Some(HandshakeKind::Resumed);
 
             if self.send_ticket {
                 let now = self.config.current_time()?;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3377,8 +3377,10 @@ fn vectored_write_for_client_appdata() {
 fn vectored_write_for_server_handshake_with_half_rtt_data() {
     let mut server_config = make_server_config(KeyType::Rsa2048);
     server_config.send_half_rtt_data = true;
-    let (mut client, mut server) =
-        make_pair_for_configs(make_client_config_with_auth(KeyType::Rsa2048), server_config);
+    let (mut client, mut server) = make_pair_for_configs(
+        make_client_config_with_auth(KeyType::Rsa2048),
+        server_config,
+    );
 
     server
         .writer()
@@ -3417,8 +3419,10 @@ fn vectored_write_for_server_handshake_with_half_rtt_data() {
 }
 
 fn check_half_rtt_does_not_work(server_config: ServerConfig) {
-    let (mut client, mut server) =
-        make_pair_for_configs(make_client_config_with_auth(KeyType::Rsa2048), server_config);
+    let (mut client, mut server) = make_pair_for_configs(
+        make_client_config_with_auth(KeyType::Rsa2048),
+        server_config,
+    );
 
     server
         .writer()
@@ -6202,12 +6206,18 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
 
 #[test]
 fn test_client_fips_service_indicator() {
-    assert_eq!(make_client_config(KeyType::Rsa2048).fips(), provider_is_fips());
+    assert_eq!(
+        make_client_config(KeyType::Rsa2048).fips(),
+        provider_is_fips()
+    );
 }
 
 #[test]
 fn test_server_fips_service_indicator() {
-    assert_eq!(make_server_config(KeyType::Rsa2048).fips(), provider_is_fips());
+    assert_eq!(
+        make_server_config(KeyType::Rsa2048).fips(),
+        provider_is_fips()
+    );
 }
 
 #[test]


### PR DESCRIPTION
My goal with this is to support implementation of [`SSL_session_reused`](https://www.openssl.org/docs/man1.1.1/man3/SSL_session_reused.html) but this should also fix #705.

I'm hoping what and how this works is relatively uncontroversial, but I'm not 100% pleased with the naming.