### PR TITLE
MSRV 1.61 -> 1.63

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.61"
+          toolchain: "1.63"
 
       - run: cargo check --locked --lib --all-features -p rustls
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to a wider set of architectures and environments, or compliance requirements.  S
 Specifying `default-features = false` when depending on rustls will remove the
 dependency on aws-lc-rs.
 
-Rustls requires Rust 1.61 or later.
+Rustls requires Rust 1.63 or later.
 
 [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 [`crypto::CryptoProvider`]: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls"
 version = "0.23.4"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -24,7 +24,7 @@
 //! Specifying `default-features = false` when depending on rustls will remove the
 //! dependency on aws-lc-rs.
 //!
-//! Rustls requires Rust 1.61 or later.
+//! Rustls requires Rust 1.63 or later.
 //!
 //! [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 //! [`crypto::CryptoProvider`]: crate::crypto::CryptoProvider

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -509,7 +509,7 @@ impl ExpectClientHello {
             .find_map(|maybe_skxg| match maybe_skxg {
                 Some(skxg) => suite
                     .usable_for_kx_algorithm(skxg.name().key_exchange_algorithm())
-                    .then(|| *skxg),
+                    .then_some(*skxg),
                 None => None,
             });
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -174,7 +174,7 @@ mod client_hello {
 
             // See if there is a KeyShare for the selected kx group.
             let chosen_share_and_kxg = shares_ext.iter().find_map(|share| {
-                (share.group == selected_kxg.name()).then(|| (share, selected_kxg))
+                (share.group == selected_kxg.name()).then_some((share, selected_kxg))
             });
 
             let chosen_share_and_kxg = match chosen_share_and_kxg {

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -40,7 +40,7 @@ impl Tls13CipherSuite {
     /// Can a session using suite self resume from suite prev?
     pub fn can_resume_from(&self, prev: &'static Self) -> Option<&'static Self> {
         (prev.common.hash_provider.algorithm() == self.common.hash_provider.algorithm())
-            .then(|| prev)
+            .then_some(prev)
     }
 
     /// Return `true` if this is backed by a FIPS-approved implementation.


### PR DESCRIPTION
We're seeing more of our deps move to this MSRV or higher (e.g. `webpki`, `rustls-platform-verifier`) and it's shipped in Debian stable. Time to move our MSRV to 1.63.
