### PR TITLE
rel-0.21 branch housekeeping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,6 +294,6 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --package rustls --all-features
-      - run: cargo clippy --package rustls --no-default-features -- --deny warnings
-      - run: cargo clippy --manifest-path=connect-tests/Cargo.toml --all-features -- --deny warnings
-      - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features -- --deny warnings
+      - run: cargo clippy --package rustls --no-default-features
+      - run: cargo clippy --manifest-path=connect-tests/Cargo.toml --all-features
+      - run: cargo clippy --manifest-path=fuzz/Cargo.toml --all-features

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -473,7 +473,7 @@ fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, max_fragment_size: O
 
     do_handshake(&mut client, &mut server);
 
-    let mut buf = vec![0u8; plaintext_size as usize];
+    let buf = vec![0u8; plaintext_size as usize];
 
     let total_data = apply_work_multiplier(if plaintext_size < 8192 {
         64 * 1024 * 1024

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -473,8 +473,7 @@ fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, max_fragment_size: O
 
     do_handshake(&mut client, &mut server);
 
-    let mut buf = Vec::new();
-    buf.resize(plaintext_size as usize, 0u8);
+    let mut buf = vec![0u8; plaintext_size as usize];
 
     let total_data = apply_work_multiplier(if plaintext_size < 8192 {
         64 * 1024 * 1024

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -16,7 +16,6 @@ use rustls::{
 };
 
 use base64::prelude::{Engine, BASE64_STANDARD};
-use env_logger;
 
 use std::io::{self, BufReader, Read, Write};
 use std::sync::Arc;

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -782,8 +782,7 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
         }
 
         if !sess.is_handshaking() && opts.export_keying_material > 0 && !sent_exporter {
-            let mut export = Vec::new();
-            export.resize(opts.export_keying_material, 0u8);
+            let mut export = vec![0u8; opts.export_keying_material];
             sess.export_keying_material(
                 &mut export,
                 opts.export_keying_material_label

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -659,12 +659,9 @@ fn handle_err(err: Error) -> ! {
 
 fn flush(sess: &mut Connection, conn: &mut net::TcpStream) {
     while sess.wants_write() {
-        match sess.write_tls(conn) {
-            Err(err) => {
-                println!("IO error: {:?}", err);
-                process::exit(0);
-            }
-            Ok(_) => {}
+        if let Err(err) = sess.write_tls(conn) {
+            println!("IO error: {:?}", err);
+            process::exit(0);
         }
     }
     conn.flush().unwrap();

--- a/rustls/src/cipher.rs
+++ b/rustls/src/cipher.rs
@@ -30,17 +30,17 @@ impl dyn MessageDecrypter {
 
 /// A write or read IV.
 #[derive(Default)]
-pub(crate) struct Iv(pub(crate) [u8; ring::aead::NONCE_LEN]);
+pub(crate) struct Iv(pub(crate) [u8; aead::NONCE_LEN]);
 
 impl Iv {
     #[cfg(feature = "tls12")]
-    fn new(value: [u8; ring::aead::NONCE_LEN]) -> Self {
+    fn new(value: [u8; aead::NONCE_LEN]) -> Self {
         Self(value)
     }
 
     #[cfg(feature = "tls12")]
     pub(crate) fn copy(value: &[u8]) -> Self {
-        debug_assert_eq!(value.len(), ring::aead::NONCE_LEN);
+        debug_assert_eq!(value.len(), aead::NONCE_LEN);
         let mut iv = Self::new(Default::default());
         iv.0.copy_from_slice(value);
         iv
@@ -68,8 +68,8 @@ impl From<hkdf::Okm<'_, IvLen>> for Iv {
     }
 }
 
-pub(crate) fn make_nonce(iv: &Iv, seq: u64) -> ring::aead::Nonce {
-    let mut nonce = [0u8; ring::aead::NONCE_LEN];
+pub(crate) fn make_nonce(iv: &Iv, seq: u64) -> aead::Nonce {
+    let mut nonce = [0u8; aead::NONCE_LEN];
     codec::put_u64(seq, &mut nonce[4..]);
 
     nonce

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -503,7 +503,7 @@ pub struct WriteEarlyData<'a> {
 }
 
 impl<'a> WriteEarlyData<'a> {
-    fn new(sess: &'a mut ClientConnection) -> WriteEarlyData<'a> {
+    fn new(sess: &'a mut ClientConnection) -> Self {
         WriteEarlyData { sess }
     }
 

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -209,7 +209,6 @@ mod test {
     use crate::msgs::handshake::SessionId;
     use crate::msgs::persist::Tls13ClientSessionValue;
     use crate::suites::SupportedCipherSuite;
-    use std::convert::TryInto;
 
     #[test]
     fn test_noclientsessionstorage_does_nothing() {

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -256,7 +256,7 @@ impl<'a> Writer<'a> {
     ///
     /// This is not an external interface.  Get one of these objects
     /// from [`Connection::writer`].
-    pub(crate) fn new(sink: &'a mut dyn PlaintextSink) -> Writer<'a> {
+    pub(crate) fn new(sink: &'a mut dyn PlaintextSink) -> Self {
         Writer { sink }
     }
 }

--- a/rustls/src/dns_name.rs
+++ b/rustls/src/dns_name.rs
@@ -57,7 +57,7 @@ impl<'a> DnsNameRef<'a> {
 impl<'a> TryFrom<&'a str> for DnsNameRef<'a> {
     type Error = InvalidDnsNameError;
 
-    fn try_from(value: &'a str) -> Result<DnsNameRef<'a>, Self::Error> {
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
         validate(value.as_bytes())?;
         Ok(DnsNameRef(value))
     }

--- a/rustls/src/dns_name.rs
+++ b/rustls/src/dns_name.rs
@@ -145,7 +145,7 @@ enum State {
 
 #[cfg(test)]
 mod test {
-    static TESTS: &[(&'static str, bool)] = &[
+    static TESTS: &[(&str, bool)] = &[
         ("", false),
         ("localhost", true),
         ("LOCALHOST", true),

--- a/rustls/src/key.rs
+++ b/rustls/src/key.rs
@@ -106,7 +106,7 @@ pub struct ParsedCertificate<'a>(pub(crate) webpki::EndEntityCert<'a>);
 
 impl<'a> TryFrom<&'a Certificate> for ParsedCertificate<'a> {
     type Error = Error;
-    fn try_from(value: &'a Certificate) -> Result<ParsedCertificate<'a>, Self::Error> {
+    fn try_from(value: &'a Certificate) -> Result<Self, Self::Error> {
         webpki::EndEntityCert::try_from(value.0.as_ref())
             .map_err(crate::verify::pki_error)
             .map(ParsedCertificate)

--- a/rustls/src/limited_cache.rs
+++ b/rustls/src/limited_cache.rs
@@ -77,26 +77,23 @@ where
         }
     }
 
-    pub(crate) fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub(crate) fn get<Q: Hash + Eq + ?Sized>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
     {
         self.map.get(k)
     }
 
-    pub(crate) fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut V>
+    pub(crate) fn get_mut<Q: Hash + Eq + ?Sized>(&mut self, k: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
     {
         self.map.get_mut(k)
     }
 
-    pub(crate) fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
+    pub(crate) fn remove<Q: Hash + Eq + ?Sized>(&mut self, k: &Q) -> Option<V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
     {
         if let Some(value) = self.map.remove(k) {
             // O(N) search, followed by O(N) removal

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -285,7 +285,6 @@ pub(crate) mod tests {
     //! check panic-safety of relatively unused values.
 
     use super::*;
-    use crate::msgs::codec::Codec;
 
     #[test]
     fn test_enums() {

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -82,12 +82,6 @@ fn alert_is_not_handshake() {
 }
 
 #[test]
-fn alert_is_not_opaque() {
-    let m = Message::build_alert(AlertLevel::Fatal, AlertDescription::DecodeError);
-    assert!(Message::try_from(m).is_ok());
-}
-
-#[test]
 fn construct_all_types() {
     let samples = [
         &b"\x14\x03\x04\x00\x01\x01"[..],

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -406,8 +406,6 @@ impl ServerSessionValue {
 mod tests {
     use super::*;
     use crate::enums::*;
-    use crate::msgs::codec::{Codec, Reader};
-    use crate::ticketer::TimeBase;
 
     #[test]
     fn serversessionvalue_is_debug() {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -386,7 +386,7 @@ pub(crate) struct Quic {
     pub(crate) params: Option<Vec<u8>>,
     pub(crate) alert: Option<AlertDescription>,
     pub(crate) hs_queue: VecDeque<(bool, Vec<u8>)>,
-    pub(crate) early_secret: Option<ring::hkdf::Prk>,
+    pub(crate) early_secret: Option<hkdf::Prk>,
     pub(crate) hs_secrets: Option<Secrets>,
     pub(crate) traffic_secrets: Option<Secrets>,
     /// Whether keys derived from traffic_secrets have been passed to the QUIC implementation
@@ -821,7 +821,7 @@ pub enum KeyChange {
 }
 
 /// Compute the nonce to use for encrypting or decrypting `packet_number`
-fn nonce_for(packet_number: u64, iv: &Iv) -> ring::aead::Nonce {
+fn nonce_for(packet_number: u64, iv: &Iv) -> aead::Nonce {
     let mut out = [0; aead::NONCE_LEN];
     out[4..].copy_from_slice(&packet_number.to_be_bytes());
     for (out, inp) in out.iter_mut().zip(iv.0.iter()) {

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -206,7 +206,7 @@ impl ResolvesServerCertUsingSni {
 impl server::ResolvesServerCert for ResolvesServerCertUsingSni {
     fn resolve(&self, client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
         if let Some(name) = client_hello.server_name() {
-            self.by_name.get(name).map(Arc::clone)
+            self.by_name.get(name).cloned()
         } else {
             // This kind of resolver requires SNI
             None

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -352,7 +352,7 @@ impl<'a> ReadEarlyData<'a> {
     }
 }
 
-impl<'a> std::io::Read for ReadEarlyData<'a> {
+impl<'a> io::Read for ReadEarlyData<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.early_data.read(buf)
     }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -34,10 +34,10 @@ mod client_hello {
     use crate::enums::SignatureScheme;
     use crate::msgs::enums::ECPointFormat;
     use crate::msgs::enums::{ClientCertificateType, Compression};
+    use crate::msgs::handshake::ClientExtension;
     use crate::msgs::handshake::ServerECDHParams;
     use crate::msgs::handshake::{CertificateRequestPayload, ClientSessionTicket, Random};
     use crate::msgs::handshake::{CertificateStatus, ECDHEServerKeyExchange};
-    use crate::msgs::handshake::{ClientExtension, SessionId};
     use crate::msgs::handshake::{ClientHelloPayload, ServerHelloPayload};
     use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
     use crate::sign;

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -351,7 +351,9 @@ mod client_hello {
 
             if let Some(ref resume) = resumedata {
                 cx.data.received_resumption_data = Some(resume.application_data.0.clone());
-                cx.common.peer_certificates = resume.client_cert_chain.clone();
+                cx.common
+                    .peer_certificates
+                    .clone_from(&resume.client_cert_chain);
             }
 
             let full_handshake = resumedata.is_none();

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -605,7 +605,7 @@ mod client_hello {
         common.send_msg(m, false);
     }
 
-    #[allow(clippy::needless_pass_by_ref_mut)] // cx only mutated if cfg(feature = "quic")
+    #[cfg_attr(not(feature = "quic"), allow(clippy::needless_pass_by_ref_mut))]
     fn decide_if_early_data_allowed(
         cx: &mut ServerContext<'_>,
         client_hello: &ClientHelloPayload,

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -191,7 +191,7 @@ impl Signer for RsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error> {
         let mut sig = vec![0; self.key.public().modulus_len()];
 
-        let rng = ring::rand::SystemRandom::new();
+        let rng = SystemRandom::new();
         self.key
             .sign(self.encoding, &rng, message, &mut sig)
             .map(|_| sig)
@@ -312,7 +312,7 @@ struct EcdsaSigner {
 
 impl Signer for EcdsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error> {
-        let rng = ring::rand::SystemRandom::new();
+        let rng = SystemRandom::new();
         self.key
             .sign(&rng, message)
             .map_err(|_| Error::General("signing failed".into()))

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -280,7 +280,6 @@ pub enum ConnectionTrafficSecrets {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::enums::CipherSuite;
 
     #[test]
     fn test_client_pref() {

--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -68,8 +68,8 @@ impl ProducesTickets for AeadTicketer {
         // Random nonce, because a counter is a privacy leak.
         let mut nonce_buf = [0u8; 12];
         rand::fill_random(&mut nonce_buf).ok()?;
-        let nonce = ring::aead::Nonce::assume_unique_for_key(nonce_buf);
-        let aad = ring::aead::Aad::empty();
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_buf);
+        let aad = aead::Aad::empty();
 
         let mut ciphertext =
             Vec::with_capacity(nonce_buf.len() + message.len() + self.key.algorithm().tag_len());
@@ -91,7 +91,7 @@ impl ProducesTickets for AeadTicketer {
         let ciphertext = ciphertext.get(nonce.len()..)?;
 
         // This won't fail since `nonce` has the required length.
-        let nonce = ring::aead::Nonce::try_assume_unique_for_key(nonce).ok()?;
+        let nonce = aead::Nonce::try_assume_unique_for_key(nonce).ok()?;
 
         let mut out = Vec::from(ciphertext);
 
@@ -292,14 +292,14 @@ fn ticketswitcher_switching_test() {
     assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
     {
         // Trigger new ticketer
-        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(10)));
+        t.maybe_roll(TimeBase(now.0 + time::Duration::from_secs(10)));
     }
     let cipher2 = t.encrypt(b"ticket 2").unwrap();
     assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
     assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
     {
         // Trigger new ticketer
-        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(20)));
+        t.maybe_roll(TimeBase(now.0 + time::Duration::from_secs(20)));
     }
     let cipher3 = t.encrypt(b"ticket 3").unwrap();
     assert!(t.decrypt(&cipher1).is_none());
@@ -321,7 +321,7 @@ fn ticketswitcher_recover_test() {
     t.generator = fail_generator;
     {
         // Failed new ticketer
-        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(10)));
+        t.maybe_roll(TimeBase(now.0 + time::Duration::from_secs(10)));
     }
     t.generator = generate_inner;
     let cipher2 = t.encrypt(b"ticket 2").unwrap();
@@ -329,7 +329,7 @@ fn ticketswitcher_recover_test() {
     assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
     {
         // recover
-        t.maybe_roll(TimeBase(now.0 + std::time::Duration::from_secs(20)));
+        t.maybe_roll(TimeBase(now.0 + time::Duration::from_secs(20)));
     }
     let cipher3 = t.encrypt(b"ticket 3").unwrap();
     assert!(t.decrypt(&cipher1).is_none());

--- a/rustls/src/tls12/cipher.rs
+++ b/rustls/src/tls12/cipher.rs
@@ -16,13 +16,13 @@ fn make_tls12_aad(
     typ: ContentType,
     vers: ProtocolVersion,
     len: usize,
-) -> ring::aead::Aad<[u8; TLS12_AAD_SIZE]> {
+) -> aead::Aad<[u8; TLS12_AAD_SIZE]> {
     let mut out = [0; TLS12_AAD_SIZE];
     codec::put_u64(seq, &mut out[0..]);
     out[8] = typ.get_u8();
     codec::put_u16(vers.get_u16(), &mut out[9..]);
     codec::put_u16(len as u16, &mut out[11..]);
-    ring::aead::Aad::from(out)
+    aead::Aad::from(out)
 }
 
 pub(crate) struct AesGcm;

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -26,7 +26,7 @@ pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
             bulk: BulkAlgorithm::Chacha20Poly1305,
-            aead_algorithm: &ring::aead::CHACHA20_POLY1305,
+            aead_algorithm: &aead::CHACHA20_POLY1305,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
@@ -42,7 +42,7 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
             bulk: BulkAlgorithm::Chacha20Poly1305,
-            aead_algorithm: &ring::aead::CHACHA20_POLY1305,
+            aead_algorithm: &aead::CHACHA20_POLY1305,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
@@ -58,7 +58,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
             bulk: BulkAlgorithm::Aes128Gcm,
-            aead_algorithm: &ring::aead::AES_128_GCM,
+            aead_algorithm: &aead::AES_128_GCM,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
@@ -74,7 +74,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             bulk: BulkAlgorithm::Aes256Gcm,
-            aead_algorithm: &ring::aead::AES_256_GCM,
+            aead_algorithm: &aead::AES_256_GCM,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
@@ -90,7 +90,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
             bulk: BulkAlgorithm::Aes128Gcm,
-            aead_algorithm: &ring::aead::AES_128_GCM,
+            aead_algorithm: &aead::AES_128_GCM,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
@@ -106,7 +106,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
             bulk: BulkAlgorithm::Aes256Gcm,
-            aead_algorithm: &ring::aead::AES_256_GCM,
+            aead_algorithm: &aead::AES_256_GCM,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
@@ -411,7 +411,7 @@ impl ConnectionSecrets {
             iv: server_iv,
         };
 
-        let (client_secrets, server_secrets) = if algo == &ring::aead::AES_128_GCM {
+        let (client_secrets, server_secrets) = if algo == &aead::AES_128_GCM {
             let extract = |pair: Pair| -> ConnectionTrafficSecrets {
                 let mut key = [0u8; 16];
                 key.copy_from_slice(pair.key);
@@ -426,7 +426,7 @@ impl ConnectionSecrets {
             };
 
             (extract(client_pair), extract(server_pair))
-        } else if algo == &ring::aead::AES_256_GCM {
+        } else if algo == &aead::AES_256_GCM {
             let extract = |pair: Pair| -> ConnectionTrafficSecrets {
                 let mut key = [0u8; 32];
                 key.copy_from_slice(pair.key);
@@ -441,7 +441,7 @@ impl ConnectionSecrets {
             };
 
             (extract(client_pair), extract(server_pair))
-        } else if algo == &ring::aead::CHACHA20_POLY1305 {
+        } else if algo == &aead::CHACHA20_POLY1305 {
             let extract = |pair: Pair| -> ConnectionTrafficSecrets {
                 let mut key = [0u8; 32];
                 key.copy_from_slice(pair.key);
@@ -511,7 +511,6 @@ pub(crate) const DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common_state::{CommonState, Side};
     use crate::msgs::handshake::{ClientECDHParams, ServerECDHParams};
 
     #[test]

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -535,7 +535,7 @@ impl KeyScheduleTraffic {
         let server_secrets;
 
         let algo = self.ks.suite.common.aead_algorithm;
-        if algo == &ring::aead::AES_128_GCM {
+        if algo == &aead::AES_128_GCM {
             let extract = |secret: &hkdf::Prk| -> Result<ConnectionTrafficSecrets, Error> {
                 let (key, iv_in) = expand::<16, 12>(secret)?;
 
@@ -550,7 +550,7 @@ impl KeyScheduleTraffic {
 
             client_secrets = extract(&self.current_client_traffic_secret)?;
             server_secrets = extract(&self.current_server_traffic_secret)?;
-        } else if algo == &ring::aead::AES_256_GCM {
+        } else if algo == &aead::AES_256_GCM {
             let extract = |secret: &hkdf::Prk| -> Result<ConnectionTrafficSecrets, Error> {
                 let (key, iv_in) = expand::<32, 12>(secret)?;
 
@@ -565,7 +565,7 @@ impl KeyScheduleTraffic {
 
             client_secrets = extract(&self.current_client_traffic_secret)?;
             server_secrets = extract(&self.current_server_traffic_secret)?;
-        } else if algo == &ring::aead::CHACHA20_POLY1305 {
+        } else if algo == &aead::CHACHA20_POLY1305 {
             let extract = |secret: &hkdf::Prk| -> Result<ConnectionTrafficSecrets, Error> {
                 let (key, iv) = expand::<32, 12>(secret)?;
                 Ok(ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv })

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -22,7 +22,7 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
         bulk: BulkAlgorithm::Chacha20Poly1305,
-        aead_algorithm: &ring::aead::CHACHA20_POLY1305,
+        aead_algorithm: &aead::CHACHA20_POLY1305,
     },
     hkdf_algorithm: ring::hkdf::HKDF_SHA256,
     #[cfg(feature = "quic")]
@@ -37,7 +37,7 @@ pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
             bulk: BulkAlgorithm::Aes256Gcm,
-            aead_algorithm: &ring::aead::AES_256_GCM,
+            aead_algorithm: &aead::AES_256_GCM,
         },
         hkdf_algorithm: ring::hkdf::HKDF_SHA384,
         #[cfg(feature = "quic")]
@@ -54,7 +54,7 @@ pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13C
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
         bulk: BulkAlgorithm::Aes128Gcm,
-        aead_algorithm: &ring::aead::AES_128_GCM,
+        aead_algorithm: &aead::AES_128_GCM,
     },
     hkdf_algorithm: ring::hkdf::HKDF_SHA256,
     #[cfg(feature = "quic")]
@@ -129,8 +129,8 @@ fn unpad_tls13(v: &mut Vec<u8>) -> ContentType {
     }
 }
 
-fn make_tls13_aad(len: usize) -> ring::aead::Aad<[u8; TLS13_AAD_SIZE]> {
-    ring::aead::Aad::from([
+fn make_tls13_aad(len: usize) -> aead::Aad<[u8; TLS13_AAD_SIZE]> {
+    aead::Aad::from([
         0x17, // ContentType::ApplicationData
         0x3,  // ProtocolVersion (major)
         0x3,  // ProtocolVersion (minor)

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -110,7 +110,7 @@ impl ChunkVecBuffer {
     pub(crate) fn read_buf(&mut self, mut cursor: core::io::BorrowedCursor<'_>) -> io::Result<()> {
         while !self.is_empty() && cursor.capacity() > 0 {
             let chunk = self.chunks[0].as_slice();
-            let used = std::cmp::min(chunk.len(), cursor.capacity());
+            let used = cmp::min(chunk.len(), cursor.capacity());
             cursor.append(&chunk[..used]);
             self.consume(used);
         }

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -11,8 +11,6 @@ use crate::verify;
 use crate::verify::ServerCertVerifier;
 use crate::{anchors, OwnedTrustAnchor};
 
-use webpki_roots;
-
 fn duration_nanos(d: Duration) -> u64 {
     ((d.as_secs() as f64) * 1e9 + (d.subsec_nanos() as f64)) as u64
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1141,6 +1141,7 @@ fn client_flush_does_nothing() {
     assert!(matches!(client.writer().flush(), Ok(())));
 }
 
+#[allow(clippy::no_effect)]
 #[test]
 fn server_is_send_and_sync() {
     let (_, server) = make_pair(KeyType::Rsa);
@@ -1148,6 +1149,7 @@ fn server_is_send_and_sync() {
     &server as &dyn Sync;
 }
 
+#[allow(clippy::no_effect)]
 #[test]
 fn client_is_send_and_sync() {
     let (client, _) = make_pair(KeyType::Rsa);
@@ -4210,7 +4212,7 @@ fn test_client_mtu_reduction() {
         fn flush(&mut self) -> io::Result<()> {
             panic!()
         }
-        fn write_vectored<'b>(&mut self, b: &[io::IoSlice<'b>]) -> io::Result<usize> {
+        fn write_vectored(&mut self, b: &[io::IoSlice<'_>]) -> io::Result<usize> {
             let writes = b
                 .iter()
                 .map(|slice| slice.len())

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2877,6 +2877,7 @@ impl rustls::server::StoresServerSessions for ServerStorage {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // complete mock, but not 100% used in tests
 enum ClientStorageOp {
     SetKxHint(rustls::ServerName, rustls::NamedGroup),
     GetKxHint(rustls::ServerName, Option<rustls::NamedGroup>),

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use std::io;
-use std::ops::{Deref, DerefMut};
+use std::ops::DerefMut;
 use std::sync::Arc;
 
 use rustls::internal::msgs::codec::Reader;
@@ -99,8 +99,8 @@ embed_files! {
 }
 
 pub fn transfer(
-    left: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
-    right: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
+    left: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
+    right: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
 ) -> usize {
     let mut buf = [0u8; 262144];
     let mut total = 0;
@@ -128,7 +128,7 @@ pub fn transfer(
     total
 }
 
-pub fn transfer_eof(conn: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>)) {
+pub fn transfer_eof(conn: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>) {
     let empty_buf = [0u8; 0];
     let empty_cursor: &mut dyn io::Read = &mut &empty_buf[..];
     let sz = conn.read_tls(empty_cursor).unwrap();
@@ -438,8 +438,8 @@ pub fn make_pair_for_arc_configs(
 }
 
 pub fn do_handshake(
-    client: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
-    server: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
+    client: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
+    server: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
 ) -> (usize, usize) {
     let (mut to_client, mut to_server) = (0, 0);
     while server.is_handshaking() || client.is_handshaking() {

--- a/rustls/tests/key_log_file_env.rs
+++ b/rustls/tests/key_log_file_env.rs
@@ -49,7 +49,7 @@ fn serialized(f: impl FnOnce()) {
     });
     let mutex = unsafe { MUTEX.as_mut() };
 
-    let _guard = mutex.unwrap().lock().unwrap();
+    let _guard = mutex.unwrap().get_mut().unwrap();
 
     // XXX: NOT thread safe.
     env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt");


### PR DESCRIPTION
- "API tests: ignore warnings in ClientStorage mock" cherry-picked from main
- "Fix nightly `unused_qualifications` warnings" is a new commit, but similar to the changes on main.