### PR TITLE
Correct `complete_io` behaviour when `close_notify` alert is received (0.22 edition)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1752,7 +1752,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pemfile 2.0.0",
  "rustls-pki-types",
 ]
@@ -1764,7 +1764,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring 0.17.6",
- "rustls 0.22.3",
+ "rustls 0.22.4",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pemfile 2.0.0",
  "rustls-pki-types",
  "serde",
@@ -1827,7 +1827,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "rustls-webpki 0.102.1",
  "serde",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "log",
  "ring",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 edition = "2021"
 rust-version = "1.61"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -439,8 +439,8 @@ impl CommonState {
         }
 
         // If we get a CloseNotify, make a note to declare EOF to our
-        // caller.
-        if alert.description == AlertDescription::CloseNotify {
+        // caller.  But do not treat unauthenticated alerts like this.
+        if self.may_receive_application_data && alert.description == AlertDescription::CloseNotify {
             self.has_received_close_notify = true;
             return Ok(());
         }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -391,6 +391,11 @@ impl<Data> ConnectionCommon<Data> {
         loop {
             let until_handshaked = self.is_handshaking();
 
+            if !self.wants_write() && !self.wants_read() {
+                // We will make no further progress.
+                return Ok((rdlen, wrlen));
+            }
+
             while self.wants_write() {
                 wrlen += self.write_tls(io)?;
             }


### PR DESCRIPTION
Release notes:

- This release corrects a denial-of-service condition in `rustls::ConnectionCommon::complete_io`, reachable via network input. If a `close_notify` alert is received during a handshake, `complete_io` did not terminate. Callers which do not call `complete_io` are not affected.