### PR TITLE
deps: update cargo semver compatible deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.6.4"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f379c4e505c0692333bd90a334baa234990faa06bdabefd3261f765946aa920"
+checksum = "5509d663b2c00ee421bda8d6a24d6c42e15970957de1701b8df9f6fbe5707df1"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -355,11 +355,12 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68aa3d613f42dbf301dbbcaf3dc260805fd33ffd95f6d290ad7231a9e5d877a7"
+checksum = "8d5d317212c2a78d86ba6622e969413c38847b62f48111f8b763af3dac2f9840"
 dependencies = [
  "bindgen",
+ "cc",
  "cmake",
  "dunce",
  "fs_extra",
@@ -495,6 +496,9 @@ name = "cc"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cexpr"
@@ -1141,18 +1145,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -1211,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1353,7 +1351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2181,7 +2179,7 @@ dependencies = [
  "base64 0.22.0",
  "bencher",
  "env_logger",
- "hashbrown 0.13.2",
+ "hashbrown",
  "log",
  "num-bigint",
  "once_cell",
@@ -2189,7 +2187,7 @@ dependencies = [
  "ring",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.3",
  "rustversion",
  "subtle",
  "tikv-jemallocator",
@@ -2313,7 +2311,7 @@ dependencies = [
  "rsa",
  "rustls 0.23.5",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.3",
  "serde",
  "serde_json",
  "sha2",
@@ -2334,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2394,18 +2392,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2414,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -17,7 +17,7 @@ rustversion = { version = "1.0.6", optional = true }
 
 [dependencies]
 aws-lc-rs = { version = "1.6", optional = true, default-features = false, features = ["aws-lc-sys"] }
-hashbrown = { version = "0.13", optional = true } # 0.14+ requires 1.63 MSRV
+hashbrown = { version = "0.14", optional = true, default-features = false, features = ["ahash", "inline-more"] }
 log = { version = "0.4.4", optional = true }
 # remove once our MSRV is >= 1.70
 once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }


### PR DESCRIPTION
Replaces https://github.com/rustls/rustls/pull/1910

Updating hickory-resolver v0.24.0 -> v0.24.1 [diff.rs](https://diff.rs/hickory-resolver/0.24.0/0.24.1/Cargo.toml)
Updating serde v1.0.197 -> v1.0.198  [diff.rs](https://diff.rs/serde/1.0.197/1.0.198/Cargo.toml)
Updating serde_derive v1.0.197 -> v1.0.198  [diff.rs](https://diff.rs/serde_derive/1.0.197/1.0.198/Cargo.toml)
Updating serde_json v1.0.115 -> v1.0.116  [diff.rs](https://diff.rs/serde_json/1.0.115/1.0.116/Cargo.toml)
Updating aws-lc-rs v1.6.4 -> v1.7.0  [diff.rs](https://diff.rs/aws-lc-rs/1.6.4/1.7.0/Cargo.toml)
Updating aws-lc-sys v0.14.1 -> v0.15.0  [diff.rs](https://diff.rs/aws-lc-sys/)
Updating hashbrown v0.13.2 -> v0.14.3  [diff.rs](https://diff.rs/hashbrown/0.13.2/0.14.3/Cargo.toml)
Updating rustls-webpki v0.102.2 -> v0.102.3 [diff.rs](https://diff.rs/rustls-webpki/0.102.2/0.102.3/Cargo.toml)

Note: the `hashbrown` update was one we were previously holding because of an MSRV 1.63 requirement that is now met. However, I also had to adjust the [default features](https://github.com/rust-lang/hashbrown/blob/97c21406c6bc5945d000373f324f7ae5cd25b60f/Cargo.toml#L50C37-L50C51) to exclude `allocator-api2`, it was giving [errors on MSRV](https://github.com/cpu/rustls/actions/runs/8786423954/job/24109266110) of the form:
> error[E0658]: use of unstable library feature 'core_c_str'

