### PR TITLE
Install golang on macos runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,12 @@ jobs:
         if: runner.os == 'Windows'
         uses: seanmiddleditch/gha-setup-ninja@v4
 
+      - name: Install golang for aws-lc-fips-sys on macos
+        if: runner.os == 'MacOS'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.2"
+
       - name: cargo build (debug; default features)
         run: cargo build --locked
 


### PR DESCRIPTION
The macos-latest runner no longer comes with golang preinstalled.

Note that the fips build is not technically certified on macos, but it is still nonetheless useful to defend the ability to do `cargo test --all-features` on developer laptops.

I chose version 1.22.2 as the [latest version documented as cached on the macos-latest runner](https://github.com/actions/runner-images/blob/macos-14-arm64/20240415.6/images/macos/macos-14-arm64-Readme.md). No idea if that's a good choice or not.