### PR TITLE
Add feature to build for web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,8 +1075,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -34,6 +34,7 @@ logging = ["log"]
 aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
 ring = ["dep:ring", "webpki/ring"]
+web = ["ring/wasm32_unknown_unknown_js"]
 tls12 = []
 read_buf = ["rustversion", "std"]
 fips = ["aws_lc_rs", "aws-lc-rs?/fips"]


### PR DESCRIPTION
The build for wasm32-unknown-unknown with ring used to fail, but with this feature it works out of the box