### PR TITLE
aws-lc-rs: reduce priority of `ECDSA_NISTP521_SHA512`

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -169,10 +169,6 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms
     mapping: &[
         // Note: for TLS1.2 the curve is not fixed by SignatureScheme. For TLS1.3 it is.
         (
-            SignatureScheme::ECDSA_NISTP521_SHA512,
-            &[webpki_algs::ECDSA_P521_SHA512],
-        ),
-        (
             SignatureScheme::ECDSA_NISTP384_SHA384,
             &[
                 webpki_algs::ECDSA_P384_SHA384,
@@ -185,6 +181,10 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms
                 webpki_algs::ECDSA_P256_SHA256,
                 webpki_algs::ECDSA_P384_SHA256,
             ],
+        ),
+        (
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            &[webpki_algs::ECDSA_P521_SHA512],
         ),
         (SignatureScheme::ED25519, &[webpki_algs::ED25519]),
         (

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1129,9 +1129,9 @@ fn server_cert_resolve_reduces_sigalgs_for_ecdsa_ciphersuite() {
         CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
         if provider_is_aws_lc_rs() {
             vec![
-                SignatureScheme::ECDSA_NISTP521_SHA512,
                 SignatureScheme::ECDSA_NISTP384_SHA384,
                 SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::ECDSA_NISTP521_SHA512,
                 SignatureScheme::ED25519,
             ]
         } else {
@@ -1499,10 +1499,6 @@ fn test_client_cert_resolve(
 fn default_signature_schemes(version: ProtocolVersion) -> Vec<SignatureScheme> {
     let mut v = vec![];
 
-    if provider_is_aws_lc_rs() {
-        v.push(SignatureScheme::ECDSA_NISTP521_SHA512);
-    }
-
     v.extend_from_slice(&[
         SignatureScheme::ECDSA_NISTP384_SHA384,
         SignatureScheme::ECDSA_NISTP256_SHA256,
@@ -1511,6 +1507,10 @@ fn default_signature_schemes(version: ProtocolVersion) -> Vec<SignatureScheme> {
         SignatureScheme::RSA_PSS_SHA384,
         SignatureScheme::RSA_PSS_SHA256,
     ]);
+
+    if provider_is_aws_lc_rs() {
+        v.insert(2, SignatureScheme::ECDSA_NISTP521_SHA512);
+    }
 
     if version == ProtocolVersion::TLSv1_2 {
         v.extend_from_slice(&[


### PR DESCRIPTION
In TLS1.2, this actually means ECDSA_SHA512.  If the peer selects that, we get caught out depending on the curve of the public key because we don't support (for example) `ECDSA_NISTP256_SHA512`.

Reducing the preference of this improves matters, because a peer that respects our priority will only select that if nothing else is possible (which includes the cases that SHA256 and SHA384 are not supported, in which case we are hosed, but also if the version is TLS1.3 and public key is on P521).

fixes #1912 though unsatisfyingly