### PR TITLE
v0.21.12 release preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.61"
+          toolchain: "1.63"
 
       - run: cargo check --lib --all-features -p rustls
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ x86, x86-64, LoongArch64, 32-bit & 64-bit Little Endian MIPS, 32-bit PowerPC (Bi
 support WebAssembly.
 For more information, see [the supported `ring` target platforms][ring-target-platforms].
 
-Rustls requires Rust 1.61 or later.
+Rustls requires Rust 1.63 or later.
 
 [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls"
 version = "0.21.11"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -65,7 +65,7 @@
 //! support WebAssembly.
 //! For more information, see [the supported `ring` target platforms][ring-target-platforms].
 //!
-//! Rustls requires Rust 1.61 or later.
+//! Rustls requires Rust 1.63 or later.
 //!
 //! [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 //!

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -48,7 +48,7 @@ fn test_read_fuzz_corpus() {
 }
 
 #[test]
-fn can_read_safari_client_hello() {
+fn can_read_safari_client_hello_with_ip_address_in_sni_extension() {
     let _ = env_logger::Builder::new()
         .filter(None, log::LevelFilter::Trace)
         .try_init();
@@ -72,7 +72,7 @@ fn can_read_safari_client_hello() {
     let mut rd = Reader::init(bytes);
     let m = OpaqueMessage::read(&mut rd).unwrap();
     println!("m = {:?}", m);
-    assert!(Message::try_from(m.into_plain_message()).is_err());
+    Message::try_from(m.into_plain_message()).unwrap();
 }
 
 #[test]

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -84,7 +84,7 @@ impl Tls13CipherSuite {
 
     /// Can a session using suite self resume from suite prev?
     pub fn can_resume_from(&self, prev: &'static Self) -> Option<&'static Self> {
-        (prev.hash_algorithm() == self.hash_algorithm()).then(|| prev)
+        (prev.hash_algorithm() == self.hash_algorithm()).then_some(prev)
     }
 }
 


### PR DESCRIPTION
## Proposed release notes

* The server name indication (SNI) client extension is now ignored when it contains an out-of-specification IP address value.
* MSRV is now 1.63.

### Backports https://github.com/rustls/rustls/pull/1881 to the rel-0.21 branch.

> This PR makes us ignore the `server_name` ClientHello extension if it contains a literal IP address. We don't indicate support for the `server_name` extension if we ignored it, and it is not available via any API -- it is as if the client did not send the extension at all. Other illegal names continue to be rejected as before.
>
> This is necessary to deal with non-compliant extension data sent by OpenSSL (https://github.com/openssl/openssl/issues/20041) and Apple SecureTransport (#1878).

Code changes in each commit were required to adjust for API differences between the releases. 

Hopefully this will help with https://github.com/dart-lang/http/issues/1161 and a couple other instances of folks stuck on 0.21 for various reasons.