### PR TITLE
deps: update cargo semver compatible deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
 ]
@@ -2277,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
 name = "rustls-post-quantum"
@@ -2392,18 +2392,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
* serde v1.0.198 -> v1.0.199 - [diff.rs](https://diff.rs/serde/1.0.198/1.0.199/Cargo.toml)
* serde_derive v1.0.198 -> v1.0.199 - [diff.rs](https://diff.rs/serde_derive/1.0.198/1.0.199/Cargo.toml)
* rustls-pki-types v1.4.1 -> v1.5.0 - [diff.rs](https://diff.rs/rustls-pki-types/1.4.1/1.5.0/Cargo.toml)
* hashbrown v0.14.3 -> v0.14.5 - [diff.rs](https://diff.rs/hashbrown/0.14.3/0.14.5/Cargo.toml)
* env_logger 0.10.2 -> 0.11.3 update is skipped due to MSRV 1.73 req of 0.11.x

Replaces https://github.com/rustls/rustls/pull/1914 

