### PR TITLE
Rename `SignatureScheme::sign`

### DIFF
--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -882,11 +882,12 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
 
             // Check the signature is compatible with the ciphersuite.
             let sig = &st.server_kx.kx_sig;
-            if !SupportedCipherSuite::from(suite).usable_for_signature_algorithm(sig.scheme.sign())
+            if !SupportedCipherSuite::from(suite)
+                .usable_for_signature_algorithm(sig.scheme.algorithm())
             {
                 warn!(
                     "peer signed kx with wrong algorithm (got {:?} expect {:?})",
-                    sig.scheme.sign(),
+                    sig.scheme.algorithm(),
                     suite.sign
                 );
                 return Err(PeerMisbehaved::SignedKxWithWrongAlgorithm.into());

--- a/rustls/src/crypto/aws_lc_rs/sign.rs
+++ b/rustls/src/crypto/aws_lc_rs/sign.rs
@@ -248,7 +248,7 @@ impl SigningKey for EcdsaSigningKey {
     }
 
     fn algorithm(&self) -> SignatureAlgorithm {
-        self.scheme.sign()
+        self.scheme.algorithm()
     }
 }
 
@@ -332,7 +332,7 @@ impl SigningKey for Ed25519SigningKey {
     }
 
     fn algorithm(&self) -> SignatureAlgorithm {
-        self.scheme.sign()
+        self.scheme.algorithm()
     }
 }
 

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -286,7 +286,7 @@ impl SigningKey for EcdsaSigningKey {
     }
 
     fn algorithm(&self) -> SignatureAlgorithm {
-        self.scheme.sign()
+        self.scheme.algorithm()
     }
 }
 
@@ -370,7 +370,7 @@ impl SigningKey for Ed25519SigningKey {
     }
 
     fn algorithm(&self) -> SignatureAlgorithm {
-        self.scheme.sign()
+        self.scheme.algorithm()
     }
 }
 

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -513,7 +513,7 @@ enum_builder! {
 }
 
 impl SignatureScheme {
-    pub(crate) fn sign(&self) -> SignatureAlgorithm {
+    pub(crate) fn algorithm(&self) -> SignatureAlgorithm {
         match *self {
             Self::RSA_PKCS1_SHA1
             | Self::RSA_PKCS1_SHA256

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -101,7 +101,7 @@ impl SupportedCipherSuite {
             Self::Tls12(inner) => inner
                 .sign
                 .iter()
-                .any(|scheme| scheme.sign() == _sig_alg),
+                .any(|scheme| scheme.algorithm() == _sig_alg),
         }
     }
 
@@ -164,7 +164,7 @@ pub(crate) fn compatible_sigscheme_for_suites(
     sigscheme: SignatureScheme,
     common_suites: &[SupportedCipherSuite],
 ) -> bool {
-    let sigalg = sigscheme.sign();
+    let sigalg = sigscheme.algorithm();
     common_suites
         .iter()
         .any(|&suite| suite.usable_for_signature_algorithm(sigalg))


### PR DESCRIPTION
The old name doesn't really make sense for me.