### PR TITLE
Cargo.lock: update rustls version under hickory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,7 +1196,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "thiserror",
  "tinyvec",
@@ -1222,7 +1222,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "resolv-conf",
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "smallvec",
  "thiserror",
  "tokio",
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -2662,7 +2662,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls 0.21.12",
  "tokio",
 ]
 


### PR DESCRIPTION
This avoids a dependency on a vulnerable version of ourself.