### PR TITLE
ring: cfg-gate the hmac module

### DIFF
--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -16,6 +16,7 @@ use crate::Error;
 pub mod sign;
 
 pub(crate) mod hash;
+#[cfg(any(test, feature = "tls12"))]
 pub(crate) mod hmac;
 pub(crate) mod kx;
 pub(crate) mod quic;


### PR DESCRIPTION
When building with `--no-default-features --features ring` w/ Rust1.80 there are a couple clippy warnings produced (e.g. see this [daily tests CI powerset failure](https://github.com/rustls/rustls/actions/runs/8943266353/job/24567596682):

```
$ cargo check --manifest-path=rustls/Cargo.toml --no-default-features --features=ring
  error: struct `Hmac` is never constructed
    --> rustls/src/crypto/ring/hmac.rs:16:19
     |
  16 | pub(crate) struct Hmac(&'static ring_like::hmac::Algorithm);
     |                   ^^^^
     |
     = note: `-D dead-code` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(dead_code)]`

  error: struct `Key` is never constructed
    --> rustls/src/crypto/ring/hmac.rs:32:8
     |
  32 | struct Key(ring_like::hmac::Key);
     |        ^^^
```

This is fixed in this branch by conditionally compiling the `crypto/ring/hmac.rs` mod based on whether we're building tests, or have the `tls12` feature enabled. The [powerset test](https://github.com/cpu/rustls/actions/runs/8943485057/job/24568498934) then begins to pass again.