### PR TITLE
build: emit rustc-check-cfg for bench, read_buf

### DIFF
--- a/rustls/build.rs
+++ b/rustls/build.rs
@@ -9,5 +9,7 @@ fn main() {}
 #[cfg(feature = "read_buf")]
 #[rustversion::nightly]
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(bench)");
+    println!("cargo:rustc-check-cfg=cfg(read_buf)");
     println!("cargo:rustc-cfg=read_buf");
 }


### PR DESCRIPTION
Fixes warnings generated with nightly when generating cargo docs ([example](https://github.com/rustls/rustls/actions/runs/8960127818/job/24606293905))  of the form:

```
error: unexpected `cfg` condition name: `bench`
   --> rustls/src/lib.rs:305:31
    |
305 | #![cfg_attr(not(any(read_buf, bench)), forbid(unstable_features))]
    |                               ^^^^^
    |
    = help: consider using a Cargo feature instead or adding `println!("cargo::rustc-check-cfg=cfg(bench)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
```

We also need to apply this suggestion for `read_buf`, because of a workaround documented for another upstream rust issue: https://github.com/rustls/rustls/blob/1265e55111b8c8d3ee5df221fb8a67ed7a4d493d/rustls/src/lib.rs#L339-L348

Note, because our MSRV is 1.63 we have to add the new `build.rs` directives with the prefix `cargo:` instead of `cargo::` as described in the warning output, or we get a new error of the form:

```
error: the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, but the minimum supported Rust version of `rustls v0.23.5 (/home/daniel/Code/Rust/rustls/rustls)` is 1.63.
See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script for more information about build script outputs.
```