### PR TITLE
bogo: fix config rewriting when cpp is clang

### DIFF
--- a/bogo/runme
+++ b/bogo/runme
@@ -8,11 +8,11 @@ set -xe
 case ${BOGO_SHIM_PROVIDER:-ring} in
   ring)
       cargo build -p rustls --example bogo_shim --no-default-features --features ring,tls12,logging,std
-      cpp -P -DRING config.json.in -oconfig.json
+      cpp -P -DRING config.json.in > config.json
       ;;
   aws-lc-rs)
       cargo build -p rustls --example bogo_shim --no-default-features --features aws_lc_rs,tls12,logging,std
-      cpp -P -DAWS_LC_RS config.json.in -oconfig.json
+      cpp -P -DAWS_LC_RS config.json.in > config.json
       ;;
   existing)
       ;;


### PR DESCRIPTION
The previous setup failed for me on macOS, where `cpp` is "Apple clang version 15.0.0 (clang-1500.3.9.4)". I think this approach works with both gcc ("cpp (Gentoo 13.2.1_p20240210 p14) 13.2.1 20240210") and clang.