### PR TITLE
Warn on lints, don't deny

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -303,7 +303,7 @@
 // Require docs for public APIs, deny unsafe code, etc.
 #![forbid(unsafe_code, unused_must_use)]
 #![cfg_attr(not(any(read_buf, bench)), forbid(unstable_features))]
-#![deny(
+#![warn(
     clippy::alloc_instead_of_core,
     clippy::clone_on_ref_ptr,
     clippy::std_instead_of_core,


### PR DESCRIPTION
We deny warnings in CI (during clippy runs), which seems sufficient. Denying lints is annoying during development especially when working on a release branches (after the lints have gotten more precise).