### PR TITLE
Drop application data received after `close_notify`

### DIFF
--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -399,8 +399,13 @@ impl CommonState {
     }
 
     pub(crate) fn take_received_plaintext(&mut self, bytes: Payload) {
-        self.received_plaintext
-            .append(bytes.into_vec());
+        if !self.has_received_close_notify {
+            self.received_plaintext
+                .append(bytes.into_vec());
+        } else {
+            // "Any data received after a closure alert has been received MUST be ignored."
+            // -- <https://datatracker.ietf.org/doc/html/rfc8446#section-6.1>
+        }
     }
 
     #[cfg(feature = "tls12")]


### PR DESCRIPTION
This addresses #959 

Note this is different to #1950 -- this is ignoring data that was received & decrypted successfully, but came after a `close_notify` and so should not have been sent by the peer. We ignore that, as required by the RFC (weird choice, since it indicates a defect on the part of the peer).

#1950 is fixing a fragment of a message after a `close_notify`, but one that has not yet (or may never) be fully received & decrypted.