### PR TITLE
Prepare 0.23.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -2207,7 +2207,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.23.5",
+ "rustls 0.23.6",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "tikv-jemallocator",
@@ -2220,7 +2220,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.5",
+ "rustls 0.23.6",
 ]
 
 [[package]]
@@ -2233,7 +2233,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.5",
+ "rustls 0.23.6",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -2251,7 +2251,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.5",
+ "rustls 0.23.6",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
 ]
@@ -2287,7 +2287,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.5",
+ "rustls 0.23.6",
  "webpki-roots 0.26.1",
 ]
 
@@ -2309,7 +2309,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.5",
+ "rustls 0.23.6",
  "rustls-pki-types",
  "rustls-webpki 0.102.3",
  "serde",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.5"
+version = "0.23.6"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
# Release notes

- Improve interop with TLS1.2 servers having ECDSA certificates when using aws-lc-rs provider (#1924)
- Ignore data received after `close_notify` (#1950)