### PR TITLE
Avoid sending multiple close notifies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -2206,7 +2206,7 @@ dependencies = [
  "fxhash",
  "itertools",
  "rayon",
- "rustls 0.23.6",
+ "rustls 0.23.7",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "tikv-jemallocator",
@@ -2219,7 +2219,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.6",
+ "rustls 0.23.7",
 ]
 
 [[package]]
@@ -2232,7 +2232,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.6",
+ "rustls 0.23.7",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -2250,7 +2250,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.6",
+ "rustls 0.23.7",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
 ]
@@ -2286,7 +2286,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.6",
+ "rustls 0.23.7",
  "webpki-roots 0.26.1",
 ]
 
@@ -2308,7 +2308,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.6",
+ "rustls 0.23.7",
  "rustls-pki-types",
  "rustls-webpki 0.102.3",
  "serde",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.6"
+version = "0.23.7"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -475,14 +475,20 @@ impl CommonState {
         err.into()
     }
 
-    /// Queues a close_notify warning alert to be sent in the next
+    /// Queues a `close_notify` warning alert to be sent in the next
     /// [`Connection::write_tls`] call.  This informs the peer that the
     /// connection is being closed.
     ///
+    /// Does nothing if any `close_notify` or fatal alert was already sent.
+    ///
     /// [`Connection::write_tls`]: crate::Connection::write_tls
     pub fn send_close_notify(&mut self) {
+        if self.sent_fatal_alert {
+            return;
+        }
         debug!("Sending warning alert {:?}", AlertDescription::CloseNotify);
         self.send_warning_alert_no_log(AlertDescription::CloseNotify);
+        self.sent_fatal_alert = true;
     }
 
     pub(crate) fn eager_send_close_notify(

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -793,7 +793,8 @@ impl<Data> ConnectionCore<Data> {
             {
                 // "Any data received after a closure alert has been received MUST be ignored."
                 // -- <https://datatracker.ietf.org/doc/html/rfc8446#section-6.1>
-                discard = borrowed_buffer.filled().len();
+                // This is data that has already been accepted in `read_tls`.
+                discard += borrowed_buffer.filled().len();
                 break;
             }
         }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6390,6 +6390,7 @@ fn test_junk_after_close_notify_received() {
         .read_tls(&mut io::Cursor::new(&client_buffer[..]))
         .unwrap();
     server.process_new_packets().unwrap();
+    server.process_new_packets().unwrap(); // check for desync
 
     // can read data received prior to close_notify
     let mut received_data = [0u8; 128];


### PR DESCRIPTION
This PR also fixes #1950 which caused a desynchronisation after a close notify.

After this PR, tokio-rustls test suite breakage caused in 0.23.6 (see https://github.com/rustls/tokio-rustls/actions/runs/9123001981/job/25084713982) is fixed 

# 0.23.7 draft release notes

- `send_close_notify` is now idempotent, in case it is accidentally called more than once.
- `read_tls` now refuses to read further data after a `close_notify` is received, by returning `Ok(0)` (ie, an EOF).
- Correct fix in 0.23.6 to properly discard data after `close_notify` received, avoiding a spurious `DecryptError` on subsequent calls to `process_new_packets()`.