### PR TITLE
update cargo deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "asn1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1422,6 +1422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,7 +2213,7 @@ dependencies = [
  "byteorder",
  "clap",
  "fxhash",
- "itertools",
+ "itertools 0.13.0",
  "rayon",
  "rustls 0.23.7",
  "rustls-pemfile 2.1.2",

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = "0.1.74"
 byteorder = "1.4.3"
 clap = { version = "4.3.21", features = ["derive"] }
 fxhash = "0.2.1"
-itertools = "0.12"
+itertools = "0.13"
 pki-types = { package = "rustls-pki-types", version = "1.4.1" }
 rayon = "1.7.0"
 rustls = { path = "../rustls", features = ["ring", "aws_lc_rs"] }


### PR DESCRIPTION
* Updating anyhow v1.0.83 -> v1.0.86 - [diff.rs](https://diff.rs/anyhow/1.0.83/1.0.86/Cargo.toml)
* Updating itertools 0.12 -> 0.13 -  [diff.rs](https://diff.rs/itertools/0.12/0.13/Cargo.toml) - the `ci-bench` code is not affected by the [breaking changes](https://github.com/rust-itertools/itertools/blob/master/CHANGELOG.md#breaking) in this release.
* env_logger 0.10.2 -> 0.11.3 update is skipped due to MSRV 1.73 req of 0.11.x

Replaces https://github.com/rustls/rustls/pull/1959