### PR TITLE
Certificate compression preparation

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -143,7 +143,7 @@ pub trait ResolvesClientCert: fmt::Debug + Send + Sync {
 /// * [`ClientConfig::key_log`]: key material is not logged.
 ///
 /// [`RootCertStore`]: crate::RootCertStore
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ClientConfig {
     /// Which ALPN protocols we include in our client hello.
     /// If empty, no ALPN extension is sent.
@@ -370,27 +370,6 @@ impl ClientConfig {
         self.time_provider
             .current_time()
             .ok_or(Error::FailedToGetCurrentTime)
-    }
-}
-
-impl Clone for ClientConfig {
-    fn clone(&self) -> Self {
-        Self {
-            provider: Arc::<CryptoProvider>::clone(&self.provider),
-            resumption: self.resumption.clone(),
-            alpn_protocols: self.alpn_protocols.clone(),
-            max_fragment_size: self.max_fragment_size,
-            client_auth_cert_resolver: Arc::clone(&self.client_auth_cert_resolver),
-            versions: self.versions,
-            enable_sni: self.enable_sni,
-            verifier: Arc::clone(&self.verifier),
-            key_log: Arc::clone(&self.key_log),
-            enable_secret_extraction: self.enable_secret_extraction,
-            enable_early_data: self.enable_early_data,
-            #[cfg(feature = "tls12")]
-            require_ems: self.require_ems,
-            time_provider: Arc::clone(&self.time_provider),
-        }
     }
 }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -25,9 +25,9 @@ use crate::msgs::base::{Payload, PayloadU8};
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::enums::{ExtensionType, KeyUpdateRequest};
 use crate::msgs::handshake::{
-    CertificateEntry, CertificatePayloadTls13, ClientExtension, HandshakeMessagePayload,
-    HandshakePayload, HasServerExtensions, NewSessionTicketPayloadTls13, PresharedKeyIdentity,
-    PresharedKeyOffer, ServerExtension, ServerHelloPayload,
+    CertificatePayloadTls13, ClientExtension, HandshakeMessagePayload, HandshakePayload,
+    HasServerExtensions, NewSessionTicketPayloadTls13, PresharedKeyIdentity, PresharedKeyOffer,
+    ServerExtension, ServerHelloPayload,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -786,20 +786,11 @@ fn emit_certificate_tls13(
     auth_context: Option<Vec<u8>>,
     common: &mut CommonState,
 ) {
-    let context = auth_context.unwrap_or_default();
-
-    let mut cert_payload = CertificatePayloadTls13 {
-        context: PayloadU8::new(context),
-        entries: Vec::new(),
-    };
-
-    if let Some(certkey) = certkey {
-        for cert in &certkey.cert {
-            cert_payload
-                .entries
-                .push(CertificateEntry::new(cert.clone()));
-        }
-    }
+    let certs = certkey
+        .map(|ck| ck.cert.as_ref())
+        .unwrap_or(&[][..]);
+    let mut cert_payload = CertificatePayloadTls13::new(certs.iter(), None);
+    cert_payload.context = PayloadU8::new(auth_context.unwrap_or_default());
 
     let m = Message {
         version: ProtocolVersion::TLSv1_3,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -419,6 +419,7 @@ mod webpki;
 /// Internal classes that are used in integration tests.
 /// The contents of this section DO NOT form part of the stable interface.
 #[allow(missing_docs)]
+#[doc(hidden)]
 pub mod internal {
     /// Low-level TLS message parsing and encoding functions.
     pub mod msgs {

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -84,10 +84,6 @@ impl fmt::Debug for Payload<'_> {
 pub(crate) struct PayloadU24<'a>(pub(crate) Payload<'a>);
 
 impl<'a> PayloadU24<'a> {
-    pub(crate) fn new(bytes: Vec<u8>) -> PayloadU24<'static> {
-        PayloadU24(Payload::Owned(bytes))
-    }
-
     pub(crate) fn into_owned(self) -> PayloadU24<'static> {
         PayloadU24(self.0.into_owned())
     }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2236,7 +2236,7 @@ impl<'a> Codec<'a> for CertificateStatus<'a> {
 impl<'a> CertificateStatus<'a> {
     pub(crate) fn new(ocsp: Vec<u8>) -> CertificateStatus<'static> {
         CertificateStatus {
-            ocsp_response: PayloadU24::new(ocsp),
+            ocsp_response: PayloadU24(Payload::Owned(ocsp)),
         }
     }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -800,7 +800,7 @@ fn get_sample_certificatepayloadtls13() -> CertificatePayloadTls13<'static> {
             cert: CertificateDer::from(vec![3, 4, 5]),
             exts: vec![
                 CertificateExtension::CertificateStatus(CertificateStatus {
-                    ocsp_response: PayloadU24::new(vec![1, 2, 3]),
+                    ocsp_response: PayloadU24(Payload::new(vec![1, 2, 3])),
                 }),
                 CertificateExtension::Unknown(UnknownExtension {
                     typ: ExtensionType::Unknown(12345),
@@ -887,7 +887,7 @@ fn get_sample_encryptedextensions() -> Vec<ServerExtension> {
 
 fn get_sample_certificatestatus() -> CertificateStatus<'static> {
     CertificateStatus {
-        ocsp_response: PayloadU24::new(vec![1, 2, 3]),
+        ocsp_response: PayloadU24(Payload::new(vec![1, 2, 3])),
     }
 }
 

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -105,6 +105,6 @@ fn debug_payload() {
     assert_eq!("01020304", format!("{:?}", PayloadU16(vec![1, 2, 3, 4])));
     assert_eq!(
         "01020304",
-        format!("{:?}", PayloadU24::new(vec![1, 2, 3, 4]))
+        format!("{:?}", PayloadU24(Payload::new(vec![1, 2, 3, 4])))
     );
 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -221,7 +221,7 @@ impl<'a> ClientHello<'a> {
 ///
 /// [`RootCertStore`]: crate::RootCertStore
 /// [`ServerSessionMemoryCache`]: crate::server::handy::ServerSessionMemoryCache
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ServerConfig {
     /// Source of randomness and other crypto.
     pub(super) provider: Arc<CryptoProvider>,
@@ -337,31 +337,6 @@ pub struct ServerConfig {
 
     /// Provides the current system time
     pub time_provider: Arc<dyn TimeProvider>,
-}
-
-// Avoid a `Clone` bound on `C`.
-impl Clone for ServerConfig {
-    fn clone(&self) -> Self {
-        Self {
-            provider: Arc::<CryptoProvider>::clone(&self.provider),
-            ignore_client_order: self.ignore_client_order,
-            max_fragment_size: self.max_fragment_size,
-            session_storage: Arc::clone(&self.session_storage),
-            ticketer: Arc::clone(&self.ticketer),
-            cert_resolver: Arc::clone(&self.cert_resolver),
-            alpn_protocols: self.alpn_protocols.clone(),
-            versions: self.versions,
-            verifier: Arc::clone(&self.verifier),
-            key_log: Arc::clone(&self.key_log),
-            enable_secret_extraction: self.enable_secret_extraction,
-            max_early_data_size: self.max_early_data_size,
-            send_half_rtt_data: self.send_half_rtt_data,
-            send_tls13_tickets: self.send_tls13_tickets,
-            #[cfg(feature = "tls12")]
-            require_ems: self.require_ems,
-            time_provider: Arc::clone(&self.time_provider),
-        }
-    }
 }
 
 impl ServerConfig {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::string::ToString;
 use alloc::sync::Arc;
@@ -380,13 +379,11 @@ mod client_hello {
     }
 
     fn emit_cert_status(transcript: &mut HandshakeHash, common: &mut CommonState, ocsp: &[u8]) {
-        let st = CertificateStatus::new(ocsp.to_owned());
-
         let c = Message {
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::handshake(HandshakeMessagePayload {
                 typ: HandshakeType::CertificateStatus,
-                payload: HandshakePayload::CertificateStatus(st),
+                payload: HandshakePayload::CertificateStatus(CertificateStatus::new(ocsp)),
             }),
         };
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -9,16 +9,12 @@ use std::cell::RefCell;
 mod macros;
 
 test_for_each_provider! {
-use super::*;
-
-use std::fmt;
 use std::fmt::Debug;
 use std::io::{self, IoSlice, Read, Write};
-use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+use std::{fmt, mem};
 
 use pki_types::{CertificateDer, IpAddr, ServerName, UnixTime};
 use rustls::client::{verify_server_cert_signed_by_trust_anchor, ResolvesClientCert, Resumption};
@@ -32,20 +28,18 @@ use rustls::internal::msgs::handshake::{
 };
 use rustls::internal::msgs::message::{Message, MessagePayload};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
-use rustls::SupportedCipherSuite;
 use rustls::{
-    sign, AlertDescription, CertificateError, ConnectionCommon, ContentType, Error, HandshakeKind,
-    InvalidMessage, KeyLog, PeerIncompatible, PeerMisbehaved, SideData,
+    sign, AlertDescription, CertificateError, CipherSuite, ClientConfig, ClientConnection,
+    ConnectionCommon, ConnectionTrafficSecrets, ContentType, DistinguishedName, Error,
+    HandshakeKind, InvalidMessage, KeyLog, PeerIncompatible, PeerMisbehaved, ProtocolVersion,
+    ServerConfig, ServerConnection, SideData, SignatureScheme, Stream, StreamOwned,
+    SupportedCipherSuite,
 };
-use rustls::{CipherSuite, ProtocolVersion, SignatureScheme};
-use rustls::{ClientConfig, ClientConnection};
-use rustls::{ConnectionTrafficSecrets, DistinguishedName};
-use rustls::{ServerConfig, ServerConnection};
-use rustls::{Stream, StreamOwned};
+
+use super::*;
 
 mod common;
 use common::*;
-
 use provider::cipher_suite;
 use provider::sign::RsaSigningKey;
 
@@ -1392,7 +1386,8 @@ fn client_check_server_certificate_ee_crl_expired() {
             .only_check_end_entity_revocation();
 
         for version in rustls::ALL_VERSIONS {
-            let client_config = make_client_config_with_verifier(&[version], enforce_expiration_builder.clone());
+            let client_config =
+                make_client_config_with_verifier(&[version], enforce_expiration_builder.clone());
             let mut client =
                 ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
             let mut server = ServerConnection::new(Arc::clone(&server_config)).unwrap();
@@ -1406,7 +1401,8 @@ fn client_check_server_certificate_ee_crl_expired() {
                 )))
             );
 
-            let client_config = make_client_config_with_verifier(&[version], ignore_expiration_builder.clone());
+            let client_config =
+                make_client_config_with_verifier(&[version], ignore_expiration_builder.clone());
             let mut client =
                 ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
             let mut server = ServerConnection::new(Arc::clone(&server_config)).unwrap();
@@ -4023,8 +4019,9 @@ fn early_data_can_be_rejected_by_server() {
 }
 
 mod test_quic {
-    use super::*;
     use rustls::quic::{self, ConnectionCommon};
+
+    use super::*;
 
     // Returns the sender's next secrets to use, or the receiver's error.
     fn step<L: SideData, R: SideData>(
@@ -4738,10 +4735,9 @@ mod test_quic {
 
 #[test]
 fn test_client_does_not_offer_sha1() {
-    use rustls::internal::msgs::{
-        codec::Reader, handshake::HandshakePayload, message::MessagePayload,
-        message::OutboundOpaqueMessage,
-    };
+    use rustls::internal::msgs::codec::Reader;
+    use rustls::internal::msgs::handshake::HandshakePayload;
+    use rustls::internal::msgs::message::{MessagePayload, OutboundOpaqueMessage};
     use rustls::HandshakeType;
 
     for kt in ALL_KEY_TYPES {

--- a/rustls/tests/api_ffdhe.rs
+++ b/rustls/tests/api_ffdhe.rs
@@ -9,11 +9,11 @@ test_for_each_provider! {
 
 mod common;
 use common::*;
-
 use rustls::crypto::CryptoProvider;
+use rustls::internal::msgs::base::Payload;
+use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
 use rustls::internal::msgs::message::{Message, MessagePayload};
-use rustls::internal::msgs::{base::Payload, codec::Codec};
 use rustls::version::{TLS12, TLS13};
 use rustls::{CipherSuite, ClientConfig};
 
@@ -340,15 +340,15 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
 }
 
 mod ffdhe {
-    use super::provider;
     use num_bigint::BigUint;
     use rustls::crypto::{
         ActiveKeyExchange, CipherSuiteCommon, CryptoProvider, KeyExchangeAlgorithm, SharedSecret,
         SupportedKxGroup,
     };
-    use rustls::{
-        ffdhe_groups::FfdheGroup, CipherSuite, NamedGroup, SupportedCipherSuite, Tls12CipherSuite,
-    };
+    use rustls::ffdhe_groups::FfdheGroup;
+    use rustls::{CipherSuite, NamedGroup, SupportedCipherSuite, Tls12CipherSuite};
+
+    use super::provider;
 
     /// A test-only `CryptoProvider`, only supporting FFDHE key exchange
     pub fn ffdhe_provider() -> CryptoProvider {

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -6,13 +6,15 @@ mod macros;
 test_for_each_provider! {
 
 mod common;
+use std::sync::Arc;
+
 use common::{
     do_handshake_until_both_error, do_handshake_until_error, get_client_root_store,
     make_client_config_with_versions, make_client_config_with_versions_with_auth,
     make_pair_for_arc_configs, server_config_builder, server_name, webpki_client_verifier_builder,
     ErrorFromPeer, KeyType, ALL_KEY_TYPES,
 };
-
+use pki_types::{CertificateDer, UnixTime};
 use rustls::client::danger::HandshakeSignatureValid;
 use rustls::internal::msgs::handshake::DistinguishedName;
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
@@ -20,10 +22,6 @@ use rustls::{
     AlertDescription, ClientConnection, DigitallySignedStruct, Error, InvalidMessage, ServerConfig,
     ServerConnection, SignatureScheme,
 };
-
-use pki_types::{CertificateDer, UnixTime};
-
-use std::sync::Arc;
 
 // Client is authorized!
 fn ver_ok() -> Result<ClientCertVerified, Error> {

--- a/rustls/tests/key_log_file_env.rs
+++ b/rustls/tests/key_log_file_env.rs
@@ -53,17 +53,16 @@ fn serialized(f: impl FnOnce()) {
 
 test_for_each_provider! {
 
-use super::*;
-
-use std::sync::Arc;
 use std::io::Write;
+use std::sync::Arc;
+
+use super::*;
 
 mod common;
 use common::{
     do_handshake, make_client_config_with_versions, make_pair_for_arc_configs, make_server_config,
     transfer, KeyType,
 };
-
 
 #[test]
 fn exercise_key_log_file_for_client() {

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -6,13 +6,14 @@ mod macros;
 test_for_each_provider! {
 
 mod common;
+use std::sync::Arc;
+
 use common::{
     do_handshake, do_handshake_until_both_error, make_client_config_with_versions,
-    make_pair_for_arc_configs, make_server_config, ErrorFromPeer, ALL_KEY_TYPES, MockServerVerifier,
+    make_pair_for_arc_configs, make_server_config, ErrorFromPeer, MockServerVerifier,
+    ALL_KEY_TYPES,
 };
 use rustls::{AlertDescription, Error, InvalidMessage};
-
-use std::sync::Arc;
 
 #[test]
 fn client_can_override_certificate_verification() {


### PR DESCRIPTION
This is, like #1962, some commits that I think can be landed separate from certificate compression itself.

The last commit will upset the semver checks job. We could cut 0.23.8 shortly after this, or else drop that commit until later.