### PR TITLE
Prepare 0.23.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -2215,7 +2215,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "rayon",
- "rustls 0.23.7",
+ "rustls 0.23.8",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "tikv-jemallocator",
@@ -2228,7 +2228,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.7",
+ "rustls 0.23.8",
 ]
 
 [[package]]
@@ -2241,7 +2241,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.7",
+ "rustls 0.23.8",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -2259,7 +2259,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.7",
+ "rustls 0.23.8",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
 ]
@@ -2295,7 +2295,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.7",
+ "rustls 0.23.8",
  "webpki-roots 0.26.1",
 ]
 
@@ -2317,7 +2317,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.7",
+ "rustls 0.23.8",
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
  "serde",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.7"
+version = "0.23.8"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Release notes:

* Add support for enforcing CRL expiration, by @jasperpatterson 

(ulterior motive for this release is to fix the semver compatibility job.)