### PR TITLE
ci: temp. pin nightly to 2024-05-22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Install ${{ matrix.rust }} toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
+          # TODO(XXX): Revert to "matrix.rust" after rust-lang/rust#125474 is fixed.
+          toolchain: ${{ matrix.rust == 'nightly' && 'nightly-2024-05-22' || matrix.rust }}
 
       - name: Install NASM for aws-lc-rs on Windows
         if: runner.os == 'Windows'


### PR DESCRIPTION
There is an upstream issue (rust-lang/rust#125474) that causes an ICE building Rustls tests with current nightly ([example](https://github.com/rustls/rustls/actions/runs/9245183158/job/25431321782)):

> thread 'rustc' panicked at compiler/rustc_codegen_ssa/src/back/link.rs:2700:27:
> index out of bounds: the len is 53 but the index is 53

`2024-05-22` looks to be the last nightly that worked without error. Let's pin CI to that for now while upstream sorts out the bug.