### PR TITLE
ci: update cargo-check-external-types toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -436,7 +436,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-07
+          toolchain: nightly-2024-05-01
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - run: cargo install --locked cargo-check-external-types
       - name: run cargo-check-external-types for rustls/


### PR DESCRIPTION
The upstream project cut a [0.1.12 release](https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.1.12) that now pins Rust nightly-2024-05-01. This commit updates CI to match.
