### PR TITLE
fix rustc-check-cfg

### DIFF
--- a/rustls/build.rs
+++ b/rustls/build.rs
@@ -4,7 +4,10 @@
 /// See the comment in lib.rs to understand why we need this.
 
 #[cfg_attr(feature = "read_buf", rustversion::not(nightly))]
-fn main() {}
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(bench)");
+    println!("cargo:rustc-check-cfg=cfg(read_buf)");
+}
 
 #[cfg(feature = "read_buf")]
 #[rustversion::nightly]


### PR DESCRIPTION
Previously (https://github.com/rustls/rustls/pull/1942) we updated `build.rs` to emit the `rustc-check-cfg` directive required to indicate `bench` and `read_buf` are expected `cfg` conditions.

Unfortunately I only did that in one of the two `main` impls, meaning in some build configurations the clippy warnings persisted.

This commit updates both `main`s to do the correct thing.