### PR TITLE
Minor `#[allow()]` cleanups

### DIFF
--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -14,8 +14,7 @@ use rustls::unbuffered::{
     AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,
     UnbufferedStatus, WriteTraffic,
 };
-#[allow(unused_imports)]
-use rustls::version::{TLS12, TLS13};
+use rustls::version::TLS13;
 use rustls::{ClientConfig, RootCertStore};
 #[cfg(not(feature = "async-std"))]
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -11,8 +11,7 @@ use rustls::unbuffered::{
     AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,
     UnbufferedStatus, WriteTraffic,
 };
-#[allow(unused_imports)]
-use rustls::version::{TLS12, TLS13};
+use rustls::version::TLS13;
 use rustls::{ClientConfig, RootCertStore};
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -45,7 +45,6 @@ fn find_session(
     config: &ClientConfig,
     cx: &mut ClientContext<'_>,
 ) -> Option<persist::Retrieved<ClientSessionValue>> {
-    #[allow(clippy::let_and_return, clippy::unnecessary_lazy_evaluations)]
     let found = config
         .resumption
         .store

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -113,24 +113,26 @@ pub(super) fn start_handshake(
         None
     };
 
-    #[cfg_attr(not(feature = "tls12"), allow(unused_mut))]
-    let mut session_id = None;
-    if let Some(_resuming) = &mut resuming {
-        #[cfg(feature = "tls12")]
-        if let ClientSessionValue::Tls12(inner) = &mut _resuming.value {
-            // If we have a ticket, we use the sessionid as a signal that
-            // we're  doing an abbreviated handshake.  See section 3.4 in
-            // RFC5077.
-            if !inner.ticket().is_empty() {
-                inner.session_id = SessionId::random(config.provider.secure_random)?;
-            }
-            session_id = Some(inner.session_id);
-        }
-
+    let session_id = if let Some(_resuming) = &mut resuming {
         debug!("Resuming session");
+
+        match &mut _resuming.value {
+            #[cfg(feature = "tls12")]
+            ClientSessionValue::Tls12(inner) => {
+                // If we have a ticket, we use the sessionid as a signal that
+                // we're  doing an abbreviated handshake.  See section 3.4 in
+                // RFC5077.
+                if !inner.ticket().is_empty() {
+                    inner.session_id = SessionId::random(config.provider.secure_random)?;
+                }
+                Some(inner.session_id)
+            }
+            _ => None,
+        }
     } else {
         debug!("Not resuming any session");
-    }
+        None
+    };
 
     // https://tools.ietf.org/html/rfc8446#appendix-D.4
     // https://tools.ietf.org/html/draft-ietf-quic-tls-34#section-8.4

--- a/rustls/src/crypto/aws_lc_rs/hpke.rs
+++ b/rustls/src/crypto/aws_lc_rs/hpke.rs
@@ -890,8 +890,7 @@ static RING_HKDF_HMAC_SHA512: &HkdfUsingHmac = &HkdfUsingHmac(&HMAC_SHA512);
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
-    use alloc::vec;
+    use alloc::{format, vec};
 
     use super::*;
 
@@ -987,13 +986,13 @@ mod tests {
 
 #[cfg(test)]
 mod rfc_tests {
-    use super::*;
-
     use alloc::string::String;
     use std::fs::File;
     use std::println;
 
     use serde::Deserialize;
+
+    use super::*;
 
     /// Confirm open/seal operations work using the test vectors from [RFC 9180 Appendix A].
     ///

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -324,7 +324,6 @@ impl MessageDeframer {
     }
 
     /// Read some bytes from `rd`, and add them to our internal buffer.
-    #[allow(clippy::comparison_chain)]
     pub fn read(
         &mut self,
         rd: &mut dyn io::Read,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1,5 +1,3 @@
-#![allow(non_camel_case_types)]
-
 use alloc::collections::BTreeSet;
 #[cfg(feature = "logging")]
 use alloc::string::String;

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::upper_case_acronyms)]
 #![allow(missing_docs)]
 
 #[macro_use]

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -875,7 +875,6 @@ impl Keys {
 /// Once the 1-RTT keys have been exchanged, either side may initiate a key update. Progressive
 /// update keys can be obtained from the [`Secrets`] returned in [`KeyChange::OneRtt`]. Note that
 /// only packet keys are updated by key updates; header protection keys remain the same.
-#[allow(clippy::large_enum_variant)]
 pub enum KeyChange {
     /// Keys for the handshake space
     Handshake {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -640,7 +640,6 @@ pub(super) fn process_client_hello<'a>(
     Ok((client_hello, sig_schemes.to_owned()))
 }
 
-#[allow(clippy::large_enum_variant)]
 pub(crate) enum HandshakeHashOrBuffer {
     Buffer(HandshakeHashBuffer),
     Hash(HandshakeHash),


### PR DESCRIPTION
This is mostly just seeing what `#[allow()]`s we have that are no longer needed, by removing them all and seeing what warnings appear.