### PR TITLE
docs: add OpenSSF best practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 [![Coverage Status (codecov.io)](https://codecov.io/gh/rustls/rustls/branch/main/graph/badge.svg)](https://codecov.io/gh/rustls/rustls/)
 [![Documentation](https://docs.rs/rustls/badge.svg)](https://docs.rs/rustls/)
 [![Chat](https://img.shields.io/discord/976380008299917365?logo=discord)](https://discord.gg/MCSB76RU96)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9034/badge)](https://www.bestpractices.dev/projects/9034)
 
 ## Changelog
 


### PR DESCRIPTION
Many thanks to @mspi21 for doing the majority of the legwork to make applying to the [OpenSSF best practices project](https://www.bestpractices.dev/en) as painless as possible.

Resolves https://github.com/rustls/rustls/issues/1901

