### PR TITLE
Prepare 0.23.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -2257,7 +2257,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "rayon",
- "rustls 0.23.8",
+ "rustls 0.23.9",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "tikv-jemallocator",
@@ -2270,7 +2270,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.8",
+ "rustls 0.23.9",
 ]
 
 [[package]]
@@ -2283,7 +2283,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.8",
+ "rustls 0.23.9",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -2301,7 +2301,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.8",
+ "rustls 0.23.9",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
 ]
@@ -2337,7 +2337,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.8",
+ "rustls 0.23.9",
  "webpki-roots 0.26.1",
 ]
 
@@ -2358,7 +2358,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.8",
+ "rustls 0.23.9",
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
  "sha2",
@@ -2372,7 +2372,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.23.8",
+ "rustls 0.23.9",
  "rustls-provider-example",
  "serde",
  "serde_json",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.8"
+version = "0.23.9"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Release notes headlines:

* **[RFC8879](https://datatracker.ietf.org/doc/html/rfc8879) certificate compression is now supported.** [Get started](https://rustls.github.io/rustls/prerelease/compress/index.html#getting-started) by enabling the `brotli` and/or `zlib` crate features, which depend on the `brotli` or `zlib-rs` crates. We recommend brotli as it has the widest deployment so far.