### PR TITLE
Limit fruitless processing of small messages

### DIFF
--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -19,8 +19,6 @@
     "DummyPQPadding-*": "not supported",
     "MTU*": "dtls only",
     "DisableEverything": "not useful",
-    "SendEmptyRecords": "non-standard openssl/boringssl behaviour",
-    "SendEmptyRecords-Async": "",
     "CheckLeafCurve": "",
     "SendWarningAlerts": "",
     "SendWarningAlerts-*": "",

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -101,7 +101,6 @@
     "FallbackSCSV*": "fallback countermeasure not yet implemented",
     "RequireAnyClientCertificate-TLS12": "we don't send an alert in this case",
     "TooManyKeyUpdates": "no limit implemented",
-    "SendUserCanceledAlerts-TooMany-TLS13": "",
     "ServerBogusVersion": "we ignore legacy_version if there's an extension",
     "Renegotiate-Client-*": "no reneg",
     "Shutdown-Shim-Renegotiate-*": "",

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -100,7 +100,6 @@
     "Resume-Server-OmitPSKsOnSecondClientHello": "not required by RFC",
     "FallbackSCSV*": "fallback countermeasure not yet implemented",
     "RequireAnyClientCertificate-TLS12": "we don't send an alert in this case",
-    "TooManyKeyUpdates": "no limit implemented",
     "ServerBogusVersion": "we ignore legacy_version if there's an extension",
     "Renegotiate-Client-*": "no reneg",
     "Shutdown-Shim-Renegotiate-*": "",

--- a/rustls/examples/internal/bogo_shim_impl.rs
+++ b/rustls/examples/internal/bogo_shim_impl.rs
@@ -1376,6 +1376,7 @@ pub fn main() {
             "-expect-no-session" |
             "-expect-ticket-renewal" |
             "-enable-ocsp-stapling" |
+            "-forbid-renegotiation-after-handshake" |
             // internal openssl details:
             "-async" |
             "-implicit-handshake" |

--- a/rustls/examples/internal/bogo_shim_impl.rs
+++ b/rustls/examples/internal/bogo_shim_impl.rs
@@ -827,6 +827,9 @@ fn handle_err(err: Error) -> ! {
         Error::PeerMisbehaved(PeerMisbehaved::TooManyWarningAlertsReceived) => {
             quit(":TOO_MANY_WARNING_ALERTS:")
         }
+        Error::PeerMisbehaved(PeerMisbehaved::TooManyKeyUpdateRequests) => {
+            quit(":TOO_MANY_KEY_UPDATES:")
+        }
         Error::PeerMisbehaved(_) => quit(":PEER_MISBEHAVIOUR:"),
         Error::NoCertificatesPresented => quit(":NO_CERTS:"),
         Error::AlertReceived(AlertDescription::UnexpectedMessage) => quit(":BAD_ALERT:"),

--- a/rustls/examples/internal/bogo_shim_impl.rs
+++ b/rustls/examples/internal/bogo_shim_impl.rs
@@ -830,6 +830,9 @@ fn handle_err(err: Error) -> ! {
         Error::PeerMisbehaved(PeerMisbehaved::TooManyKeyUpdateRequests) => {
             quit(":TOO_MANY_KEY_UPDATES:")
         }
+        Error::PeerMisbehaved(PeerMisbehaved::TooManyEmptyFragments) => {
+            quit(":TOO_MANY_EMPTY_FRAGMENTS:")
+        }
         Error::PeerMisbehaved(_) => quit(":PEER_MISBEHAVIOUR:"),
         Error::NoCertificatesPresented => quit(":NO_CERTS:"),
         Error::AlertReceived(AlertDescription::UnexpectedMessage) => quit(":BAD_ALERT:"),

--- a/rustls/examples/internal/bogo_shim_impl.rs
+++ b/rustls/examples/internal/bogo_shim_impl.rs
@@ -824,6 +824,9 @@ fn handle_err(err: Error) -> ! {
         Error::PeerMisbehaved(PeerMisbehaved::SelectedUnofferedCipherSuite) => {
             quit(":WRONG_CIPHER_RETURNED:")
         }
+        Error::PeerMisbehaved(PeerMisbehaved::TooManyWarningAlertsReceived) => {
+            quit(":TOO_MANY_WARNING_ALERTS:")
+        }
         Error::PeerMisbehaved(_) => quit(":PEER_MISBEHAVIOUR:"),
         Error::NoCertificatesPresented => quit(":NO_CERTS:"),
         Error::AlertReceived(AlertDescription::UnexpectedMessage) => quit(":BAD_ALERT:"),

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -233,6 +233,7 @@ pub enum PeerMisbehaved {
     ServerNameMustContainOneHostName,
     SignedKxWithWrongAlgorithm,
     SignedHandshakeWithUnadvertisedSigScheme,
+    TooManyEmptyFragments,
     TooManyKeyUpdateRequests,
     TooManyRenegotiationRequests,
     TooManyWarningAlertsReceived,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -233,6 +233,7 @@ pub enum PeerMisbehaved {
     ServerNameMustContainOneHostName,
     SignedKxWithWrongAlgorithm,
     SignedHandshakeWithUnadvertisedSigScheme,
+    TooManyWarningAlertsReceived,
     TooMuchEarlyDataReceived,
     UnexpectedCleartextExtension,
     UnsolicitedCertExtension,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -233,6 +233,7 @@ pub enum PeerMisbehaved {
     ServerNameMustContainOneHostName,
     SignedKxWithWrongAlgorithm,
     SignedHandshakeWithUnadvertisedSigScheme,
+    TooManyKeyUpdateRequests,
     TooManyRenegotiationRequests,
     TooManyWarningAlertsReceived,
     TooMuchEarlyDataReceived,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -233,6 +233,7 @@ pub enum PeerMisbehaved {
     ServerNameMustContainOneHostName,
     SignedKxWithWrongAlgorithm,
     SignedHandshakeWithUnadvertisedSigScheme,
+    TooManyRenegotiationRequests,
     TooManyWarningAlertsReceived,
     TooMuchEarlyDataReceived,
     UnexpectedCleartextExtension,

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -203,7 +203,7 @@ impl Codec<'_> for u16 {
     fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
         match r.take(2) {
             Some(&[b1, b2]) => Ok(Self::from_be_bytes([b1, b2])),
-            _ => Err(InvalidMessage::MissingData("u8")),
+            _ => Err(InvalidMessage::MissingData("u16")),
         }
     }
 }


### PR DESCRIPTION
This PR tightens up a number of cases where we can receive large numbers of small messages that do not make any progress and are not surfaced to the application.

These are:

- excessive warning-level alerts
- post-handshake renegotiation attempts
- key_update requests
- empty `TLSPlaintext` fragments

fixes #717
fixes #952
