### PR TITLE
aws_lc_rs: fix unused import w/ no-std

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/hpke.rs
+++ b/rustls/src/crypto/aws_lc_rs/hpke.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+#[cfg(feature = "std")]
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug, Formatter};


### PR DESCRIPTION
I noticed the [powerset daily build task](https://github.com/cpu/rustls/actions/runs/9405945282/job/25908254380) has been failing. This PR fixes an unused import warning when building w/ `aws-lc-rs` but not `std`:

```
warning: unused import: `alloc::sync::Arc`
 --> rustls/src/crypto/aws_lc_rs/hpke.rs:2:5
  |
2 | use alloc::sync::Arc;
  |     ^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```