### PR TITLE
fix lib.rs examples link

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -101,7 +101,7 @@
 //! If you're already using Tokio for an async runtime you may prefer to use [`tokio-rustls`] instead
 //! of interacting with rustls directly.
 //!
-//! [examples]: examples/README.md
+//! [examples]: https://github.com/rustls/rustls/tree/main/examples
 //! [`tokio-rustls`]: https://github.com/rustls/tokio-rustls
 //!
 //! ### Rustls provides encrypted pipes


### PR DESCRIPTION
reading https://docs.rs/rustls/latest/rustls/, i noticed the examples link there links to https://docs.rs/rustls/latest/rustls/examples/README.md which doesn't exist. this link doesn't work when building the documentation locally either

this proposes one simple way to fix that