### PR TITLE
Revert "ci: temp. pin nightly to 2024-05-22"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Install ${{ matrix.rust }} toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          # TODO(XXX): Revert to "matrix.rust" after rust-lang/rust#125474 is fixed.
-          toolchain: ${{ matrix.rust == 'nightly' && 'nightly-2024-05-22' || matrix.rust }}
+          toolchain: ${{ matrix.rust }}
 
       - name: Install NASM for aws-lc-rs on Windows
         if: runner.os == 'Windows'


### PR DESCRIPTION
Reverts the nightly compiler pinning we added in https://github.com/rustls/rustls/pull/1971 - latest nightly builds/tests without issue.