### PR TITLE
ech: implement inner hello extension compression

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -115,6 +115,11 @@ jobs:
       - name: Check server acceptor
         run: cargo run --locked --bin server_acceptor -- --help
 
+      - name: Check ech-client
+        run: >
+          cargo run --locked --bin ech-client -- --host defo.ie defo.ie www.defo.ie | 
+            grep 'SSL_ECH_STATUS: success'
+
       - name: Check provider-example client
         run: cargo run --locked -p rustls-provider-example --example client
 

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -34,8 +34,6 @@
     "TLS-ECH-*": "ECH test suites use non-FIPS approved algos",
 #else
     "TLS-ECH-Server*": "ECH server support NYI",
-    "TLS-ECH-Client-ExpectECHOuterExtensions": "ECH extension compression NYI",
-    "TLS-ECH-Client-CompressSupportedVersions": "ECH extension compression NYI",
     "TLS-ECH-Client-SelectECHConfig": "TODO(XXX): re-enable after upstream bogo fix",
     "TLS-ECH-Client-NoSupportedConfigs": "TODO(XXX): re-enable after upstream bogo fix",
     "TLS-ECH-Client-SkipInvalidPublicName*": "we allow underscore names, don't fallback on no ECH configs",

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -168,6 +168,9 @@ Usage:
   ech-client (--version | -v)
   ech-client (--help | -h)
 
+Example:
+  ech-client --host defo.ie defo.ie www.defo.ie
+
 Options:
     -p, --port PORT       Connect to PORT [default: 443].
     --cafile CAFILE       Read root certificates from CAFILE.

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -6,7 +6,7 @@
 //!
 //! Example usage:
 //! ```
-//! cargo run --package rustls-provider-example --example ech-client -- --host defo.ie defo.ie www.defo.ie
+//! cargo run --package rustls-examples --bin ech-client -- --host defo.ie defo.ie www.defo.ie
 //! ```
 //!
 //! This will perform a DNS-over-HTTPS lookup for the defo.ie ECH config, using it to determine

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -26,6 +26,7 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 
 use docopt::Docopt;
+use log::trace;
 use rustls::client::{EchConfig, EchGreaseConfig, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
@@ -115,7 +116,7 @@ fn main() {
         .unwrap();
 
     for i in 0..args.flag_num_reqs {
-        println!("\nRequest {}", i);
+        trace!("\nRequest {} of {}", i + 1, args.flag_num_reqs);
         let mut conn = rustls::ClientConnection::new(config.clone(), server_name.clone()).unwrap();
         // The "outer" server that we're connecting to.
         let sock_addr = (


### PR DESCRIPTION
This commit extends the initial client-side ECH support from https://github.com/rustls/rustls/pull/1718 to enable the "SHOULD" recommendation of compressing extensions that are identical between the outer client hello and the inner client hello. This optimization reduces the overhead of ECH, shrinking the total client hello size.

Achieving this is a bit tricky (which is why it was done separately at the end!). To-be-compressed extensions must be in a contiguous block in the inner hello. When we encode that contiguous block for the encoded inner hello, we replace the block with a marker extension listing all of the extension types that were replaced. In the outer hello the compressed extensions must be present in the same relative order (but don't need to be contiguous). We also need the uncompressed inner hello with the uncompressed extensions in place to update the inner transcript.

With this feature implemented we can also activate a couple of bogo tests that were previously excluded.