### PR TITLE
apply nightly formatting

### DIFF
--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -2,10 +2,10 @@ use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
-use hpke_rs_crypto::HpkeCrypto;
 use std::error::Error as StdError;
 
 use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
+use hpke_rs_crypto::HpkeCrypto;
 use hpke_rs_rust_crypto::HpkeRustCrypto;
 use rustls::crypto::hpke::{
     EncapsulatedSecret, Hpke, HpkeOpener, HpkePrivateKey, HpkePublicKey, HpkeSealer, HpkeSuite,

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -608,10 +608,10 @@ mod connection {
     use core::ops::{Deref, DerefMut};
     use std::io;
 
-    use crate::client::EchStatus;
     use pki_types::ServerName;
 
     use super::ClientConnectionData;
+    use crate::client::EchStatus;
     use crate::common_state::Protocol;
     use crate::conn::{ConnectionCommon, ConnectionCore};
     use crate::error::Error;


### PR DESCRIPTION
Applies the results of:

```
cargo fmt --all -- --config-path .rustfmt.unstable.toml
```

We run this in a CI job that doesn't block when it fails, and so a couple of import order reformats slipped through unformatted in the ECH work.