### PR TITLE
`key_update` API and automatic key refreshing

### DIFF
--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -96,8 +96,6 @@
     "DelegatedCredentials-*": "not implemented",
     "CECPQ2*": "no PQC experiments",
     "*CECPQ2*": "",
-    "KeyUpdate-FromClient": "not implemented (no API yet)",
-    "KeyUpdate-FromServer": "",
     "ExportTrafficSecrets-*": "",
     "*-InvalidSignature-*-SHA1-*": "no sha1",
     "NoCommonCurves": "nothing to fall back to",

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1554,6 +1554,14 @@ impl State<ClientConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
+    fn send_key_update_request(&mut self, common: &mut CommonState) -> Result<(), Error> {
+        common.check_aligned_handshake()?;
+        common.send_msg(Message::build_key_update_request(), true);
+        self.key_schedule
+            .update_encrypter(common);
+        Ok(())
+    }
+
     fn export_keying_material(
         &self,
         output: &mut [u8],

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -364,7 +364,14 @@ impl CommonState {
 
     // Put m into sendable_tls for writing.
     fn queue_tls_message(&mut self, m: OutboundOpaqueMessage) {
+        self.perhaps_write_key_update();
         self.sendable_tls.append(m.encode());
+    }
+
+    pub(crate) fn perhaps_write_key_update(&mut self) {
+        if let Some(message) = self.queued_key_update_message.take() {
+            self.sendable_tls.append(message);
+        }
     }
 
     /// Send a raw TLS message, fragmenting it if needed.
@@ -703,12 +710,6 @@ impl CommonState {
         }
 
         self.send_plain_non_buffering(payload, limit)
-    }
-
-    pub(crate) fn perhaps_write_key_update(&mut self) {
-        if let Some(message) = self.queued_key_update_message.take() {
-            self.sendable_tls.append(message);
-        }
     }
 }
 

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -428,7 +428,13 @@ impl CommonState {
     pub(crate) fn start_encryption_tls12(&mut self, secrets: &ConnectionSecrets, side: Side) {
         let (dec, enc) = secrets.make_cipher_pair(side);
         self.record_layer
-            .prepare_message_encrypter(enc);
+            .prepare_message_encrypter(
+                enc,
+                secrets
+                    .suite()
+                    .common
+                    .confidentiality_limit,
+            );
         self.record_layer
             .prepare_message_decrypter(dec);
     }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -798,6 +798,10 @@ pub(crate) trait State<Data>: Send + Sync {
         Err(Error::HandshakeNotComplete)
     }
 
+    fn send_key_update_request(&mut self, _common: &mut CommonState) -> Result<(), Error> {
+        Err(Error::HandshakeNotComplete)
+    }
+
     fn handle_decrypt_error(&self) {}
 
     fn into_owned(self: Box<Self>) -> Box<dyn State<Data> + 'static>;

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -228,7 +228,7 @@ impl CommonState {
                     }
                     _ => {
                         error!("Traffic keys exhausted, closing connection to prevent security failure");
-                        self.eager_send_close_notify(outgoing_tls)?;
+                        self.send_close_notify();
                         return Err(EncryptError::EncryptExhausted);
                     }
                 },

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -534,25 +534,9 @@ impl CommonState {
         &mut self,
         outgoing_tls: &mut [u8],
     ) -> Result<usize, EncryptError> {
-        debug_assert!(self.record_layer.is_encrypting());
-
-        let m = Message::build_alert(AlertLevel::Warning, AlertDescription::CloseNotify).into();
-
-        let iter = self
-            .message_fragmenter
-            .fragment_message(&m);
-
-        self.check_required_size(outgoing_tls, iter)?;
-
-        debug!("Sending warning alert {:?}", AlertDescription::CloseNotify);
-
-        let iter = self
-            .message_fragmenter
-            .fragment_message(&m);
-
-        let written = self.write_fragments(outgoing_tls, iter);
-
-        Ok(written)
+        self.send_close_notify();
+        self.check_required_size(outgoing_tls, [].into_iter())?;
+        Ok(self.write_fragments(outgoing_tls, [].into_iter()))
     }
 
     fn send_warning_alert_no_log(&mut self, desc: AlertDescription) {

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -417,6 +417,21 @@ impl<Data> WriteTraffic<'_, Data> {
             .common_state
             .eager_send_close_notify(outgoing_tls)
     }
+
+    /// Arranges for a TLS1.3 `key_update` to be sent.
+    ///
+    /// This consumes the `WriteTraffic` state:  to actually send the message,
+    /// call [`UnbufferedConnectionCommon::process_tls_records`] again which will
+    /// return a `ConnectionState::EncodeTlsData` that emits the `key_update`
+    /// message.
+    ///
+    /// See [`ConnectionCommon::refresh_traffic_keys()`] for full documentation,
+    /// including why you might call this and in what circumstances it will fail.
+    ///
+    /// [`ConnectionCommon::refresh_traffic_keys()`]: crate::ConnectionCommon::refresh_traffic_keys
+    pub fn refresh_traffic_keys(self) -> Result<(), Error> {
+        self.conn.core.refresh_traffic_keys()
+    }
 }
 
 /// A handshake record must be encoded

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -400,6 +400,9 @@ impl<Data> WriteTraffic<'_, Data> {
     ) -> Result<usize, EncryptError> {
         self.conn
             .core
+            .maybe_refresh_traffic_keys();
+        self.conn
+            .core
             .common_state
             .write_plaintext(application_data.into(), outgoing_tls)
     }

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -52,7 +52,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
             hash_provider: &super::hash::SHA256,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
@@ -66,7 +66,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
@@ -80,7 +80,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
             hash_provider: &super::hash::SHA256,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
@@ -94,7 +94,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
             hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,

--- a/rustls/src/crypto/aws_lc_rs/tls13.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls13.rs
@@ -25,6 +25,7 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
         hash_provider: &super::hash::SHA256,
+        // ref: <https://www.ietf.org/archive/id/draft-irtf-cfrg-aead-limits-08.html#section-5.2.1>
         confidentiality_limit: u64::MAX,
     },
     hkdf_provider: &RingHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
@@ -32,7 +33,9 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
     quic: Some(&super::quic::KeyBuilder {
         packet_alg: &aead::CHACHA20_POLY1305,
         header_alg: &aead::quic::CHACHA20,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-6.6>
         confidentiality_limit: u64::MAX,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-6.6>
         integrity_limit: 1 << 36,
     }),
 };
@@ -43,14 +46,16 @@ pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
             hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         hkdf_provider: &RingHkdf(hkdf::HKDF_SHA384, hmac::HMAC_SHA384),
         aead_alg: &Aes256GcmAead(AeadAlgorithm(&aead::AES_256_GCM)),
         quic: Some(&super::quic::KeyBuilder {
             packet_alg: &aead::AES_256_GCM,
             header_alg: &aead::quic::AES_256,
+            // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.1>
             confidentiality_limit: 1 << 23,
+            // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.2>
             integrity_limit: 1 << 52,
         }),
     });
@@ -63,14 +68,16 @@ pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13C
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
         hash_provider: &super::hash::SHA256,
-        confidentiality_limit: 1 << 23,
+        confidentiality_limit: 1 << 24,
     },
     hkdf_provider: &RingHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
     aead_alg: &Aes128GcmAead(AeadAlgorithm(&aead::AES_128_GCM)),
     quic: Some(&super::quic::KeyBuilder {
         packet_alg: &aead::AES_128_GCM,
         header_alg: &aead::quic::AES_128,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.1>
         confidentiality_limit: 1 << 23,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.2>
         integrity_limit: 1 << 52,
     }),
 };

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -50,7 +50,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
             hash_provider: &super::hash::SHA256,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
@@ -64,7 +64,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
@@ -78,7 +78,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
             hash_provider: &super::hash::SHA256,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
@@ -92,7 +92,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
             hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -24,6 +24,7 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
         hash_provider: &super::hash::SHA256,
+        // ref: <https://www.ietf.org/archive/id/draft-irtf-cfrg-aead-limits-08.html#section-5.2.1>
         confidentiality_limit: u64::MAX,
     },
     hkdf_provider: &RingHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
@@ -31,7 +32,9 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
     quic: Some(&super::quic::KeyBuilder {
         packet_alg: &aead::CHACHA20_POLY1305,
         header_alg: &aead::quic::CHACHA20,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-6.6>
         confidentiality_limit: u64::MAX,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-6.6>
         integrity_limit: 1 << 36,
     }),
 };
@@ -42,14 +45,16 @@ pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
         common: CipherSuiteCommon {
             suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
             hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 23,
+            confidentiality_limit: 1 << 24,
         },
         hkdf_provider: &RingHkdf(hkdf::HKDF_SHA384, hmac::HMAC_SHA384),
         aead_alg: &Aes256GcmAead(AeadAlgorithm(&aead::AES_256_GCM)),
         quic: Some(&super::quic::KeyBuilder {
             packet_alg: &aead::AES_256_GCM,
             header_alg: &aead::quic::AES_256,
+            // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.1>
             confidentiality_limit: 1 << 23,
+            // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.2>
             integrity_limit: 1 << 52,
         }),
     });
@@ -62,14 +67,16 @@ pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13C
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
         hash_provider: &super::hash::SHA256,
-        confidentiality_limit: 1 << 23,
+        confidentiality_limit: 1 << 24,
     },
     hkdf_provider: &RingHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
     aead_alg: &Aes128GcmAead(AeadAlgorithm(&aead::AES_128_GCM)),
     quic: Some(&super::quic::KeyBuilder {
         packet_alg: &aead::AES_128_GCM,
         header_alg: &aead::quic::AES_128,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.1>
         confidentiality_limit: 1 << 23,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.2>
         integrity_limit: 1 << 52,
     }),
 };

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -380,6 +380,7 @@ mod log {
     macro_rules! trace    ( ($($tt:tt)*) => {{}} );
     macro_rules! debug    ( ($($tt:tt)*) => {{}} );
     macro_rules! warn     ( ($($tt:tt)*) => {{}} );
+    macro_rules! error    ( ($($tt:tt)*) => {{}} );
 }
 
 #[macro_use]

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2703,6 +2703,13 @@ impl<'a> HandshakeMessagePayload<'a> {
         }
     }
 
+    pub(crate) fn build_key_update_request() -> Self {
+        Self {
+            typ: HandshakeType::KeyUpdate,
+            payload: HandshakePayload::KeyUpdate(KeyUpdateRequest::UpdateRequested),
+        }
+    }
+
     pub(crate) fn encoding_for_binder_signing(&self) -> Vec<u8> {
         let mut ret = self.get_encoding();
 

--- a/rustls/src/msgs/message/mod.rs
+++ b/rustls/src/msgs/message/mod.rs
@@ -179,6 +179,13 @@ impl Message<'_> {
         }
     }
 
+    pub fn build_key_update_request() -> Self {
+        Self {
+            version: ProtocolVersion::TLSv1_3,
+            payload: MessagePayload::handshake(HandshakeMessagePayload::build_key_update_request()),
+        }
+    }
+
     #[cfg(feature = "std")]
     pub(crate) fn into_owned(self) -> Message<'static> {
         let Self { version, payload } = self;

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -200,7 +200,7 @@ impl RecordLayer {
     pub(crate) fn pre_encrypt_action(&self, add: u64) -> PreEncryptAction {
         let value = self.write_seq.saturating_add(add);
         if value == self.write_seq_max {
-            PreEncryptAction::Close
+            PreEncryptAction::RefreshOrClose
         } else if value >= SEQ_HARD_LIMIT {
             PreEncryptAction::Refuse
         } else {
@@ -259,8 +259,11 @@ pub(crate) enum PreEncryptAction {
     /// No action is needed before calling `encrypt_outgoing`
     Nothing,
 
-    /// A `close_notify` alert should be sent ASAP
-    Close,
+    /// A `key_update` request should be sent ASAP.
+    ///
+    /// If that is not possible (for example, the connection is TLS1.2), a `close_notify`
+    /// alert should be sent instead.
+    RefreshOrClose,
 
     /// Do not call `encrypt_outgoing` further, it will panic rather than
     /// over-use the key.

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1536,6 +1536,14 @@ impl State<ServerConnectionData> for ExpectTraffic {
             .extract_secrets(Side::Server)
     }
 
+    fn send_key_update_request(&mut self, common: &mut CommonState) -> Result<(), Error> {
+        common.check_aligned_handshake()?;
+        common.send_msg(Message::build_key_update_request(), true);
+        self.key_schedule
+            .update_encrypter(common);
+        Ok(())
+    }
+
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
         self
     }

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -27,9 +27,25 @@ pub struct CipherSuiteCommon {
     /// from an ideal pseudorandom permutation (PRP).
     ///
     /// This is to be set on the assumption that messages are maximally sized --
-    /// at least 2 ** 14 bytes. It **does not** consider confidentiality limits for
+    /// each is 2<sup>14</sup> bytes. It **does not** consider confidentiality limits for
     /// QUIC connections - see the [`quic::KeyBuilder.confidentiality_limit`] field for
     /// this context.
+    ///
+    /// For AES-GCM implementations, this should be set to 2<sup>24</sup> to limit attack
+    /// probability to one in 2<sup>60</sup>.  See [AEBounds] (Table 1) and [draft-irtf-aead-limits-08]:
+    ///
+    /// ```python
+    /// >>> p = 2 ** -60
+    /// >>> L = (2 ** 14 // 16) + 1
+    /// >>> qlim = (math.sqrt(p) * (2 ** (129 // 2)) - 1) / (L + 1)
+    /// >>> print(int(qlim).bit_length())
+    /// 24
+    /// ```
+    /// [AEBounds]: https://eprint.iacr.org/2024/051.pdf
+    /// [draft-irtf-aead-limits-08]: https://www.ietf.org/archive/id/draft-irtf-cfrg-aead-limits-08.html#section-5.1.1
+    ///
+    /// For chacha20-poly1305 implementations, this should be set to `u64::MAX`:
+    /// see <https://www.ietf.org/archive/id/draft-irtf-cfrg-aead-limits-08.html#section-5.2.1>
     pub confidentiality_limit: u64,
 }
 

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -496,6 +496,11 @@ impl KeyScheduleTraffic {
         self.ks.set_encrypter(&secret, common);
     }
 
+    pub(crate) fn update_encrypter(&mut self, common: &mut CommonState) {
+        let secret = self.next_application_traffic_secret(common.side);
+        self.ks.set_encrypter(&secret, common);
+    }
+
     pub(crate) fn update_decrypter(&mut self, common: &mut CommonState) {
         let secret = self.next_application_traffic_secret(common.side.peer());
         self.ks.set_decrypter(&secret, common);

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -602,7 +602,10 @@ impl KeySchedule {
 
         common
             .record_layer
-            .set_message_encrypter(self.suite.aead_alg.encrypter(key, iv));
+            .set_message_encrypter(
+                self.suite.aead_alg.encrypter(key, iv),
+                self.suite.common.confidentiality_limit,
+            );
     }
 
     fn set_decrypter(&self, secret: &OkmBlock, common: &mut CommonState) {

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -711,6 +711,77 @@ fn refresh_traffic_keys_automatically() {
     };
 }
 
+#[test]
+fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
+    const CONFIDENTIALITY_LIMIT: usize = 1024;
+
+    let client_config = finish_client_config(
+        KeyType::Ed25519,
+        ClientConfig::builder_with_provider(aes_128_gcm_with_1024_confidentiality_limit())
+            .with_protocol_versions(&[&rustls::version::TLS12])
+            .unwrap(),
+    );
+
+    let server_config = make_server_config(KeyType::Ed25519);
+    let mut outcome = run(
+        Arc::new(client_config),
+        &mut NO_ACTIONS.clone(),
+        Arc::new(server_config),
+        &mut NO_ACTIONS.clone(),
+    );
+    let mut server = outcome.server.take().unwrap();
+    let mut client = outcome.client.take().unwrap();
+
+    match client.process_tls_records(&mut []) {
+        UnbufferedStatus {
+            discard: 0,
+            state: Ok(ConnectionState::WriteTraffic(mut wt)),
+        } => {
+            for i in 0..CONFIDENTIALITY_LIMIT {
+                let message = format!("{i:08}");
+
+                let mut buffer = [0u8; 64];
+                let used = match wt.encrypt(message.as_bytes(), &mut buffer) {
+                    Ok(used) => used,
+                    Err(EncryptError::EncryptExhausted) if i == CONFIDENTIALITY_LIMIT - 1 => {
+                        break;
+                    }
+                    rc @ Err(_) => rc.unwrap(),
+                };
+
+                match server.process_tls_records(&mut buffer[..used]) {
+                    UnbufferedStatus {
+                        discard: actual_used,
+                        state: Ok(ConnectionState::ReadTraffic(mut rt)),
+                    } => {
+                        assert_eq!(used, actual_used);
+                        let record = rt.next_record().unwrap().unwrap();
+                        assert_eq!(record.payload, message.as_bytes());
+                    }
+                    st => {
+                        panic!("unexpected server state {st:?}");
+                    }
+                };
+                println!("{i}: wrote {used}");
+            }
+        }
+        st => {
+            panic!("unexpected client state {st:?}");
+        }
+    };
+
+    let mut data = encode_tls_data(client.process_tls_records(&mut []));
+    let data_len = data.len();
+
+    match server.process_tls_records(&mut data) {
+        UnbufferedStatus {
+            discard,
+            state: Ok(ConnectionState::Closed),
+        } if discard == data_len => {}
+        st => panic!("unexpected server state {st:?}"),
+    }
+}
+
 fn write_traffic<T: SideData, R, F: FnMut(WriteTraffic<T>) -> R>(
     status: UnbufferedStatus<'_, '_, T>,
     mut f: F,
@@ -722,6 +793,28 @@ fn write_traffic<T: SideData, R, F: FnMut(WriteTraffic<T>) -> R>(
         f(state)
     } else {
         panic!("unexpected client state {state:?} (wanted WriteTraffic)");
+    }
+}
+
+fn encode_tls_data<T: SideData>(status: UnbufferedStatus<'_, '_, T>) -> Vec<u8> {
+    match status {
+        UnbufferedStatus {
+            discard: 0,
+            state: Ok(ConnectionState::EncodeTlsData(mut etd)),
+        } => {
+            let len = match etd.encode(&mut []) {
+                Err(EncodeError::InsufficientSize(InsufficientSizeError { required_size })) => {
+                    required_size
+                }
+                e => panic!("unexpected encode {e:?}"),
+            };
+            let mut buf = vec![0u8; len];
+            etd.encode(&mut buf).unwrap();
+            buf
+        }
+        _ => {
+            panic!("unexpected state {status:?} (wanted EncodeTlsData)");
+        }
     }
 }
 

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -648,7 +648,7 @@ fn refresh_traffic_keys_automatically() {
 
     let client_config = finish_client_config(
         KeyType::Rsa2048,
-        ClientConfig::builder_with_provider(tls13_aes_128_gcm_with_1024_confidentiality_limit())
+        ClientConfig::builder_with_provider(aes_128_gcm_with_1024_confidentiality_limit())
             .with_safe_default_protocol_versions()
             .unwrap(),
     );


### PR DESCRIPTION
This PR:

- adds a new public API for sending TLS1.3 `key_update` requests. This is available in both the unbuffered and classic APIs.
- automatically sends TLS1.3 `key_update` requests when our encryption key approaches "exhaustion" due to the birthday bound[^1]

[^1]: Note: as before, we track this with the sequence number rather than counting blocks, so sending small messages underestimates the limit significantly. This errs on the side of safety: (for AES-GCM suites) we update keys each 16 million messages whether that represents 16MB or 256GB of data transfer.

fixes #946 
fixes #755 