### PR TITLE
v0.23.10 release preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -2217,7 +2217,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "rayon",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "tikv-jemallocator",
@@ -2229,7 +2229,7 @@ version = "0.0.1"
 dependencies = [
  "regex",
  "ring 0.17.8",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "trust-dns-resolver",
 ]
 
@@ -2243,7 +2243,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -2262,7 +2262,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
 ]
@@ -2298,7 +2298,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "webpki-roots 0.26.2",
 ]
 
@@ -2319,7 +2319,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "rustls-pki-types",
  "rustls-webpki",
  "sha2",
@@ -2333,7 +2333,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.23.9",
+ "rustls 0.23.10",
  "rustls-provider-example",
  "serde",
  "serde_json",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.9"
+version = "0.23.10"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -135,10 +135,11 @@ pub trait ResolvesClientCert: fmt::Debug + Send + Sync {
 /// These must be created via the [`ClientConfig::builder()`] or [`ClientConfig::builder_with_provider()`]
 /// function.
 ///
-/// Note that using [`ClientConfig::with_ech]` will produce a common configuration specific to
-/// the provided [`crate::client::EchConfig`] that may not be appropriate for all connections made
-/// by the program. In this case the configuration should only be shared by connections intended
-/// for domains that offer the provided [`crate::client::EchConfig`] in their DNS zone.
+/// Note that using [`ConfigBuilder<ClientConfig, WantsVersions>::with_ech()`] will produce a common
+/// configuration specific to the provided [`crate::client::EchConfig`] that may not be appropriate
+/// for all connections made by the program. In this case the configuration should only be shared
+/// by connections intended for domains that offer the provided [`crate::client::EchConfig`] in
+/// their DNS zone.
 ///
 /// # Defaults
 ///

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -96,7 +96,7 @@ impl EchConfig {
     ///
     /// See the [ech-client.rs] example for a complete example of fetching ECH configs from DNS.
     ///
-    /// [ech-client.rs]: https://github.com/rustls/rustls/blob/main/provider-example/examples/ech-client.rs
+    /// [ech-client.rs]: https://github.com/rustls/rustls/blob/main/examples/src/bin/ech-client.rs
     pub fn new(
         ech_config_list: EchConfigListBytes<'_>,
         hpke_suites: &[&'static dyn Hpke],


### PR DESCRIPTION
### Proposed release notes

* **[draft-ietf-tls-esni-18](https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18) encrypted client hello (ECH) is now supported** for client applications. See the `ech-client.rs` example for a complete end-to-end demonstration using DNS-over-HTTPS to retrieve a server's ECH configuration for building a Rustls `ClientConfig` using `with_ech()`.
* Additional safety limits guarding against fruitless processing of small messages have been added. Rustls will now limit excessive warning-level alerts, post-handshake renegotiation attempts, key update requests, and empty plaintext fragments.
* FIPS mode has been updated to exclude X25519 key exchange.
