### PR TITLE
deps: use hickory-resolver 0.25 alpha release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,8 +1202,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.1"
-source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
+version = "0.25.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dac1c02877cba0eb1c132ef7bfe13f92aaa44911e89bf9e15eddbb7e4114bed"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -1233,8 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.1"
-source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
+version = "0.25.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d43169d0878d2a8a2f05f21508368d52656947533e1527c4a75148c50421ed"
 dependencies = [
  "cfg-if",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,14 +865,14 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1139,15 +1150,15 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -1188,6 +1199,60 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.1"
+source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "http",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.1"
+source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "rustls 0.21.12",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "webpki-roots 0.25.4",
+]
 
 [[package]]
 name = "hkdf"
@@ -1267,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -1281,17 +1346,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -1516,12 +1570,6 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -2000,7 +2048,7 @@ checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
 dependencies = [
  "aws-lc-rs",
  "pem",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "time",
  "yasna",
@@ -2062,21 +2110,6 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -2165,14 +2198,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.16.20",
+ "ring",
+ "rustls-webpki 0.101.7",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -2191,10 +2224,10 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "rcgen",
- "ring 0.17.8",
+ "ring",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.4",
  "rustversion",
  "serde",
  "serde_json",
@@ -2227,10 +2260,10 @@ dependencies = [
 name = "rustls-connect-tests"
 version = "0.0.1"
 dependencies = [
+ "hickory-resolver",
  "regex",
- "ring 0.17.8",
+ "ring",
  "rustls 0.23.10",
- "trust-dns-resolver",
 ]
 
 [[package]]
@@ -2240,6 +2273,7 @@ dependencies = [
  "async-std",
  "docopt",
  "env_logger",
+ "hickory-resolver",
  "log",
  "mio",
  "rcgen",
@@ -2249,7 +2283,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "tokio",
- "trust-dns-resolver",
  "webpki-roots 0.26.2",
 ]
 
@@ -2321,7 +2354,7 @@ dependencies = [
  "rsa",
  "rustls 0.23.10",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.4",
  "sha2",
  "signature",
  "webpki-roots 0.26.2",
@@ -2341,12 +2374,22 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -2375,7 +2418,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
+ "ring",
  "untrusted 0.9.0",
 ]
 
@@ -2667,13 +2710,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.20.9",
+ "rustls 0.21.12",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -2718,60 +2760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
-source = "git+https://github.com/cpu/trust-dns?rev=9888378726ada266c1a6ac6b2630c2249f3f62cf#9888378726ada266c1a6ac6b2630c2249f3f62cf"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "h2",
- "http",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand",
- "rustls 0.20.9",
- "rustls-pemfile 1.0.4",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tokio-rustls",
- "tracing",
- "url",
- "webpki",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.22.0"
-source = "git+https://github.com/cpu/trust-dns?rev=9888378726ada266c1a6ac6b2630c2249f3f62cf#9888378726ada266c1a6ac6b2630c2249f3f62cf"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "lru-cache",
- "parking_lot",
- "resolv-conf",
- "rustls 0.20.9",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "tracing",
- "trust-dns-proto",
- "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -2830,7 +2818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
 ]
 
@@ -2947,23 +2935,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ lto = true
 [patch.crates-io]
 # TODO(XXX): Remove this once 0.25 is released - we want the ECH fixes from
 #            https://github.com/hickory-dns/hickory-dns/pull/2183
-trust-dns-resolver = { git = "https://github.com/cpu/trust-dns", rev = "9888378726ada266c1a6ac6b2630c2249f3f62cf" }
+hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "6334a01430088ead8642cafaee592ec7bf49831f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,3 @@ resolver = "2"
 [profile.bench]
 codegen-units = 1
 lto = true
-
-[patch.crates-io]
-# TODO(XXX): Remove this once 0.25 is released - we want the ECH fixes from
-#            https://github.com/hickory-dns/hickory-dns/pull/2183
-hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "6334a01430088ead8642cafaee592ec7bf49831f" }

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 rustls = { path = "../rustls", features = [ "logging" ]}
 
 [dev-dependencies]
-hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
+hickory-resolver = { version = "0.25.0-alpha.1", features = ["dns-over-https-rustls", "webpki-roots"] }
 regex = "1.0"
 ring = "0.17"

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 rustls = { path = "../rustls", features = [ "logging" ]}
 
 [dev-dependencies]
-trust-dns-resolver = { version = "0.22", features = ["dns-over-https-rustls", "webpki-roots"] }
+hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
 regex = "1.0"
 ring = "0.17"

--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -43,7 +43,7 @@ mod ech_config {
             .expect("failed to lookup HTTPS record type")
             .record_iter()
             .find_map(|r| match r.data() {
-                Some(RData::HTTPS(svcb)) => svcb
+                RData::HTTPS(svcb) => svcb
                     .svc_params()
                     .iter()
                     .find_map(|sp| match sp {

--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -1,11 +1,11 @@
 mod ech_config {
+    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+    use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
+    use hickory_resolver::proto::rr::{RData, RecordType};
+    use hickory_resolver::Resolver;
     use rustls::internal::msgs::codec::{Codec, Reader};
     use rustls::internal::msgs::handshake::EchConfigPayload;
     use rustls::pki_types::EchConfigListBytes;
-    use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-    use trust_dns_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
-    use trust_dns_resolver::proto::rr::{RData, RecordType};
-    use trust_dns_resolver::Resolver;
 
     #[test]
     fn cloudflare() {
@@ -24,7 +24,8 @@ mod ech_config {
 
     /// Lookup the ECH config list for a domain and deserialize it.
     fn test_deserialize_ech_config_list(domain: &str) {
-        let resolver = Resolver::new(ResolverConfig::google(), ResolverOpts::default()).unwrap();
+        let resolver =
+            Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
         let tls_encoded_list = lookup_ech(&resolver, domain);
         let parsed_configs = Vec::<EchConfigPayload>::read(&mut Reader::init(&tls_encoded_list))
             .expect("failed to deserialize ECH config list");

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 docopt = "~1.1"
 env_logger = "0.10" # 0.11 requires 1.71 MSRV even as a dev-dep (due to manifest features)
-trust-dns-resolver = { version = "0.22", features = ["dns-over-https-rustls", "webpki-roots"] }
+hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 docopt = "~1.1"
 env_logger = "0.10" # 0.11 requires 1.71 MSRV even as a dev-dep (due to manifest features)
-hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
+hickory-resolver = { version = "0.25.0-alpha.1", features = ["dns-over-https-rustls", "webpki-roots"] }
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -27,6 +27,10 @@ use std::sync::Arc;
 
 use docopt::Docopt;
 use log::trace;
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
+use hickory_resolver::proto::rr::{RData, RecordType};
+use hickory_resolver::Resolver;
 use rustls::client::{EchConfig, EchGreaseConfig, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
@@ -34,10 +38,6 @@ use rustls::crypto::hpke::Hpke;
 use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
 use serde_derive::Deserialize;
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-use trust_dns_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
-use trust_dns_resolver::proto::rr::{RData, RecordType};
-use trust_dns_resolver::Resolver;
 
 fn main() {
     let version = env!("CARGO_PKG_NAME").to_string() + ", version: " + env!("CARGO_PKG_VERSION");
@@ -51,7 +51,7 @@ fn main() {
     let resolver_config = if args.flag_cloudflare_dns {
         ResolverConfig::cloudflare_https()
     } else {
-        ResolverConfig::google()
+        ResolverConfig::google_https()
     };
     let resolver = Resolver::new(resolver_config, ResolverOpts::default()).unwrap();
     let server_ech_config = match args.flag_grease {

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -26,11 +26,11 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 
 use docopt::Docopt;
-use log::trace;
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::Resolver;
+use log::trace;
 use rustls::client::{EchConfig, EchGreaseConfig, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
@@ -211,7 +211,7 @@ fn lookup_ech_configs(
         .ok()?
         .record_iter()
         .find_map(|r| match r.data() {
-            Some(RData::HTTPS(svcb)) => svcb
+            RData::HTTPS(svcb) => svcb
                 .svc_params()
                 .iter()
                 .find_map(|sp| match sp {


### PR DESCRIPTION
In https://github.com/rustls/rustls/pull/1718 we had to use a workspace cargo patch to have a workable hickory-dns dependency for the `connect-test` and `examples` crates where we needed yet-to-be-released SVCB/HTTPS record fixes for ECH support. 

To clean up we first revert the commit that switched the examples to use an older patched trust-dns release to avoid MSRV complications related to the hickory-dns workspace (see https://github.com/hickory-dns/hickory-dns/issues/2229 for additional context). 

After this revert commit we can tack on a second commit that removes the cargo patch for the hickory-dns dependency, replacing it with a dependency on the just-released `0.25.0-alpha.1`. This also requires one small `match` arm code change in the two crates using the dependency. 


