### PR TITLE
(Examples) Bugfix: Use normal brackets to avoid docopt literal default

### DIFF
--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -175,7 +175,7 @@ Options:
     -p, --port PORT       Connect to PORT [default: 443].
     --cafile CAFILE       Read root certificates from CAFILE.
     --path PATH           HTTP GET this PATH [default: ech-check.php].
-    --host HOST           HTTP HOST to use for GET request [default: inner-hostname].
+    --host HOST           HTTP HOST to use for GET request (defaults to value of inner-hostname).
     --google-dns          Use Google DNS for the DNS-over-HTTPS lookup [default].
     --cloudflare-dns      Use Cloudflare DNS for the DNS-over-HTTPS lookup.
     --grease              Skip looking up an ECH config and send a GREASE placeholder.


### PR DESCRIPTION
The current text will make the docopt parsing use the literal value `"inner-hostname"` as the default.

From the application code: https://github.com/rustls/rustls/blob/7d998cd7efb6ef9d4350aa397d974db72b7e9ef5/examples/src/bin/ech-client.rs#L138

it seems like the intention was to use the value OF `inner-hostname` if no override is provided.

## Observed Behavior

```
$ cargo run --package rustls-examples --bin ech-client -- rfc5746.mywaifu.best rfc5746.mywaifu.best

HTTP/1.1 307 Temporary Redirect
Server: nginx/1.25.4
Date: Tue, 18 Jun 2024 09:54:50 GMT
Content-Type: text/html
Content-Length: 171
Location: https://inner-hostname/result/index.html?ech_status=success&ech_inner_sni=rfc5746.mywaifu.best&ech_outer_sni=example.com
Connection: close

<html>
<head><title>307 Temporary Redirect</title></head>
<body>
<center><h1>307 Temporary Redirect</h1></center>
<hr><center>nginx/1.25.4</center>
</body>
</html>
```

## Expected Behavior

The hostname should have defaulted to `rfc5746.mywaifu.best` instead of `inner-hostname` .