### PR TITLE
(Examples) Feature: Use port-prefix naming to lookup correct ECHConfig

### DIFF
--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -144,8 +144,8 @@ impl EchConfig {
                     .find(|hpke| hpke.suite() == suite)
                 {
                     debug!(
-                        "selected ECH config ID {:?} suite {:?}",
-                        key_config.config_id, suite
+                        "selected ECH config ID {:?} suite {:?} public_name {:?}",
+                        key_config.config_id, suite, contents.public_name
                     );
                     return Ok(Self {
                         config: config.clone(),


### PR DESCRIPTION
# Background

When looking up SVCB records, a port and scheme may be prefixed to the QNAME for non-standard ports. For HTTPS records, this practice is followed, except for the standard port (443). (Ref: https://datatracker.ietf.org/doc/html/rfc9460#section-9.1)

I.e. to connect to a HTTPS server (say, `example.com`) on port `4443` as an example, one should lookup the config of the QNAME `_4443._https.example.com` , rather than just `example.com` .

## Old Behavior

Even when the port is explicitly specified, the resolver picks the standard ECHConfig (note the config_id):

```
$ cargo run --package rustls-examples --bin ech-client -- rfc5746.mywaifu.best -p 4443 rfc5746.mywaifu.best

...[truncated]...

[2024-06-19T05:13:21Z DEBUG rustls::client::ech] selected ECH config ID 132 suite HpkeSuite { kem: DHKEM_X25519_HKDF_SHA256, sym: HpkeSymmetricCipherSuite { kdf_id: HKDF_SHA256, aead_id: AES_128_GCM } }
```

## After Fix

Correctly fetches the ECHConfig for port 4443 with correct config ID / public_name

```
$ cargo run --package rustls-examples --bin ech-client -- rfc5746.mywaifu.best -p 4443 rfc5746.mywaifu.best

...[truncated]...

[2024-06-19T05:05:23Z DEBUG rustls::client::ech] selected ECH config ID 240 suite HpkeSuite { kem: DHKEM_X25519_HKDF_SHA256, sym: HpkeSymmetricCipherSuite { kdf_id: HKDF_SHA256, aead_id: AES_128_GCM } } public_name DnsName("cia.gov")
```

## Miscellaneous

I also updated the debug log to print the `public_name` , I think it kinda helps for debugging purposes. I can remove that commit if its better to not have it.