### PR TITLE
Fix flickery unbuffered examples

### DIFF
--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let config = Arc::new(config);
 
-    let mut incoming_tls = [0; INCOMING_TLS_BUFSIZE];
+    let mut incoming_tls = vec![0; INCOMING_TLS_BUFSIZE];
     let mut outgoing_tls = vec![0; OUTGOING_TLS_INITIAL_BUFSIZE];
 
     converse(&config, &mut incoming_tls, &mut outgoing_tls).await?;

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -50,13 +50,14 @@ fn converse(
     let mut incoming_used = 0;
     let mut outgoing_used = 0;
 
-    let mut open_connection = true;
+    let mut we_closed = false;
+    let mut peer_closed = false;
     let mut sent_request = false;
     let mut received_response = false;
     let mut sent_early_data = false;
 
     let mut iter_count = 0;
-    while open_connection {
+    while !(peer_closed || (we_closed && incoming_used == 0)) {
         let UnbufferedStatus { mut discard, state } =
             conn.process_tls_records(&mut incoming_tls[..incoming_used]);
 
@@ -147,7 +148,7 @@ fn converse(
                     // `TransmitTlsData` state. the server should have already written a
                     // response which we can read out from the socket
                     recv_tls(&mut sock, incoming_tls, &mut incoming_used)?;
-                } else {
+                } else if !we_closed {
                     try_or_resize_and_retry(
                         |out_buffer| may_encrypt.queue_close_notify(out_buffer),
                         |e| {
@@ -161,12 +162,14 @@ fn converse(
                         &mut outgoing_used,
                     )?;
                     send_tls(&mut sock, outgoing_tls, &mut outgoing_used)?;
-                    open_connection = false;
+                    we_closed = true;
+                } else {
+                    recv_tls(&mut sock, incoming_tls, &mut incoming_used)?;
                 }
             }
 
             ConnectionState::Closed => {
-                open_connection = false;
+                peer_closed = true;
             }
 
             // other states are not expected in this example

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let config = Arc::new(config);
 
-    let mut incoming_tls = [0; INCOMING_TLS_BUFSIZE];
+    let mut incoming_tls = vec![0; INCOMING_TLS_BUFSIZE];
     let mut outgoing_tls = vec![0; OUTGOING_TLS_INITIAL_BUFSIZE];
 
     converse(&config, false, &mut incoming_tls, &mut outgoing_tls)?;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5344,6 +5344,14 @@ fn connection_types_are_not_huge() {
     // Arbitrary sizes
     assert_lt(mem::size_of::<ServerConnection>(), 1600);
     assert_lt(mem::size_of::<ClientConnection>(), 1600);
+    assert_lt(
+        mem::size_of::<rustls::server::UnbufferedServerConnection>(),
+        1600,
+    );
+    assert_lt(
+        mem::size_of::<rustls::client::UnbufferedClientConnection>(),
+        1600,
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR is aiming to fix flickeryness in daily-tests:

- https://github.com/rustls/rustls/actions/runs/9602495561/job/26483466289 - windows stack exhaustion: I don't really understand this, apparently the windows main thread is 1MB but I neither understand why this isn't enough, and why it isn't grown on a fault? It seems to only affect the `unbuffered-async-client` example, but I've fixed both for completeness.
- https://github.com/rustls/rustls/actions/runs/9570253282/job/26384594746 - the unbuffered-*-client tests are flickery in certain network conditions, explained the commit message.