### PR TITLE
Tighten up ticketer decryption

### DIFF
--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -7,6 +7,8 @@ use core::fmt;
 use core::fmt::{Debug, Formatter};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+use subtle::ConstantTimeEq;
+
 use super::ring_like::aead;
 use super::ring_like::rand::{SecureRandom, SystemRandom};
 use super::TICKETER_AEAD;
@@ -57,9 +59,15 @@ fn make_ticket_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> 
 
     let key = aead::UnboundKey::new(TICKETER_AEAD, &key).unwrap();
 
+    let mut key_name = [0u8; 16];
+    SystemRandom::new()
+        .fill(&mut key_name)
+        .map_err(|_| GetRandomFailed)?;
+
     Ok(Box::new(AeadTicketer {
         alg: TICKETER_AEAD,
         key: aead::LessSafeKey::new(key),
+        key_name,
         lifetime: 60 * 60 * 12,
         maximum_ciphertext_len: AtomicUsize::new(0),
     }))
@@ -72,6 +80,7 @@ fn make_ticket_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> 
 struct AeadTicketer {
     alg: &'static aead::Algorithm,
     key: aead::LessSafeKey,
+    key_name: [u8; 16],
     lifetime: u32,
 
     /// Tracks the largest ciphertext produced by `encrypt`, and
@@ -101,15 +110,27 @@ impl ProducesTickets for AeadTicketer {
             .fill(&mut nonce_buf)
             .ok()?;
         let nonce = aead::Nonce::assume_unique_for_key(nonce_buf);
-        let aad = aead::Aad::empty();
+        let aad = aead::Aad::from(self.key_name);
 
-        let mut ciphertext =
-            Vec::with_capacity(nonce_buf.len() + message.len() + self.key.algorithm().tag_len());
+        // ciphertext structure is:
+        // key_name: [u8; 16]
+        // nonce: [u8; 12]
+        // message: [u8, _]
+        // tag: [u8; 16]
+
+        let mut ciphertext = Vec::with_capacity(
+            self.key_name.len() + nonce_buf.len() + message.len() + self.key.algorithm().tag_len(),
+        );
+        ciphertext.extend(self.key_name);
         ciphertext.extend(nonce_buf);
         ciphertext.extend(message);
         let ciphertext = self
             .key
-            .seal_in_place_separate_tag(nonce, aad, &mut ciphertext[nonce_buf.len()..])
+            .seal_in_place_separate_tag(
+                nonce,
+                aad,
+                &mut ciphertext[self.key_name.len() + nonce_buf.len()..],
+            )
             .map(|tag| {
                 ciphertext.extend(tag.as_ref());
                 ciphertext
@@ -133,9 +154,26 @@ impl ProducesTickets for AeadTicketer {
             return None;
         }
 
-        // Non-panicking `let (nonce, ciphertext) = ciphertext.split_at(...)`.
-        let nonce = ciphertext.get(..self.alg.nonce_len())?;
-        let ciphertext = ciphertext.get(nonce.len()..)?;
+        let (alleged_key_name, ciphertext) = try_split_at(ciphertext, self.key_name.len())?;
+
+        let (nonce, ciphertext) = try_split_at(ciphertext, self.alg.nonce_len())?;
+
+        // checking the key_name is the expected one, *and* then putting it into the
+        // additionally authenticated data is duplicative.  this check quickly rejects
+        // tickets for a different ticketer (see `TicketSwitcher`), while including it
+        // in the AAD ensures it is authenticated independent of that check and that
+        // any attempted attack on the integrity such as [^1] must happen for each
+        // `key_label`, not over a population of potential keys.  this approach
+        // is overall similar to [^2].
+        //
+        // [^1]: https://eprint.iacr.org/2020/1491.pdf
+        // [^2]: "Authenticated Encryption with Key Identification", fig 6
+        //       <https://eprint.iacr.org/2022/1680.pdf>
+        if ConstantTimeEq::ct_ne(&self.key_name[..], alleged_key_name).into() {
+            #[cfg(debug_assertions)]
+            debug!("rejected ticket with wrong ticket_name");
+            return None;
+        }
 
         // This won't fail since `nonce` has the required length.
         let nonce = aead::Nonce::try_assume_unique_for_key(nonce).ok()?;
@@ -144,7 +182,7 @@ impl ProducesTickets for AeadTicketer {
 
         let plain_len = self
             .key
-            .open_in_place(nonce, aead::Aad::empty(), &mut out)
+            .open_in_place(nonce, aead::Aad::from(alleged_key_name), &mut out)
             .ok()?
             .len();
         out.truncate(plain_len);
@@ -160,6 +198,14 @@ impl Debug for AeadTicketer {
             .field("alg", &self.alg)
             .field("lifetime", &self.lifetime)
             .finish()
+    }
+}
+
+/// Non-panicking `let (nonce, ciphertext) = ciphertext.split_at(...)`.
+fn try_split_at(slice: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
+    match mid > slice.len() {
+        true => None,
+        false => Some(slice.split_at(mid)),
     }
 }
 

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -112,6 +112,8 @@ pub enum Error {
 #[derive(Debug, Clone, Copy, PartialEq)]
 
 pub enum InvalidMessage {
+    /// A certificate payload exceeded rustls's 64KB limit
+    CertificatePayloadTooLarge,
     /// An advertised message was larger then expected.
     HandshakePayloadTooLarge,
     /// The peer sent us a syntactically incorrect ChangeCipherSpec payload.

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -169,9 +169,15 @@ pub trait Codec<'a>: Debug + Sized {
 
     /// Function for wrapping a call to the read function in
     /// a Reader for the slice of bytes provided
+    ///
+    /// Returns `Err(InvalidMessage::ExcessData(_))` if
+    /// `Self::read` does not read the entirety of `bytes`.
     fn read_bytes(bytes: &'a [u8]) -> Result<Self, InvalidMessage> {
         let mut reader = Reader::init(bytes);
-        Self::read(&mut reader)
+        Self::read(&mut reader).and_then(|r| {
+            reader.expect_empty("read_bytes")?;
+            Ok(r)
+        })
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1447,6 +1447,7 @@ impl<'a> Deref for CertificateChain<'a> {
 impl TlsListElement for CertificateDer<'_> {
     const SIZE_LEN: ListLength = ListLength::U24 {
         max: CERTIFICATE_MAX_SIZE_LIMIT,
+        error: InvalidMessage::CertificatePayloadTooLarge,
     };
 }
 
@@ -1583,6 +1584,7 @@ impl<'a> CertificateEntry<'a> {
 impl<'a> TlsListElement for CertificateEntry<'a> {
     const SIZE_LEN: ListLength = ListLength::U24 {
         max: CERTIFICATE_MAX_SIZE_LIMIT,
+        error: InvalidMessage::CertificatePayloadTooLarge,
     };
 }
 
@@ -2726,7 +2728,13 @@ impl<'a> HandshakeMessagePayload<'a> {
         }
         .encode(bytes);
 
-        let nested = LengthPrefixedBuffer::new(ListLength::U24 { max: usize::MAX }, bytes);
+        let nested = LengthPrefixedBuffer::new(
+            ListLength::U24 {
+                max: usize::MAX,
+                error: InvalidMessage::MessageTooLarge,
+            },
+            bytes,
+        );
 
         match &self.payload {
             // for Server Hello and HelloRetryRequest payloads we need to encode the payload

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -884,7 +884,7 @@ fn cannot_decode_huge_certificate() {
     buf[6] = 0x01;
     assert_eq!(
         HandshakeMessagePayload::read_bytes(&buf[..0x10001 + 7]).unwrap_err(),
-        InvalidMessage::TrailingData("HandshakeMessagePayload")
+        InvalidMessage::CertificatePayloadTooLarge
     );
 }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6788,7 +6788,7 @@ fn test_cert_decompression_by_client_produces_invalid_cert_payload() {
     assert_eq!(
         do_handshake_until_error(&mut client, &mut server),
         Err(ErrorFromPeer::Client(Error::InvalidMessage(
-            InvalidMessage::MessageTooShort
+            InvalidMessage::CertificatePayloadTooLarge
         )))
     );
     transfer(&mut client, &mut server);
@@ -6809,7 +6809,7 @@ fn test_cert_decompression_by_server_produces_invalid_cert_payload() {
     assert_eq!(
         do_handshake_until_error(&mut client, &mut server),
         Err(ErrorFromPeer::Server(Error::InvalidMessage(
-            InvalidMessage::MessageTooShort
+            InvalidMessage::CertificatePayloadTooLarge
         )))
     );
     transfer(&mut server, &mut client);


### PR DESCRIPTION
These changes aim to make it harder to mount any theoretical attack against AEAD decryption due to the AEADs we use being not key-committing. The best current attacks against this aren't better than brute force, so there is no security issue here.

The last commit is a little unrelated, but is along for the ride after I noticed the poor error in the test changed in the second commit.

fixes #2023 