### PR TITLE
common_state: expose key exchange group

### DIFF
--- a/rustls-post-quantum/examples/client.rs
+++ b/rustls-post-quantum/examples/client.rs
@@ -52,6 +52,15 @@ fn main() {
         ciphersuite.suite()
     )
     .unwrap();
+    let kx_group = tls
+        .conn
+        .negotiated_key_exchange_group()
+        .unwrap();
+    writeln!(
+        &mut std::io::stderr(),
+        "Current key exchange group: {kx_group:?}",
+    )
+    .unwrap();
     let mut plaintext = Vec::new();
     tls.read_to_end(&mut plaintext).unwrap();
     stdout().write_all(&plaintext).unwrap();

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -13,7 +13,7 @@ use super::hs::ClientContext;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::client::common::{ClientAuthDetails, ServerCertDetails};
 use crate::client::{hs, ClientConfig};
-use crate::common_state::{CommonState, HandshakeKind, Side, State};
+use crate::common_state::{CommonState, HandshakeKind, KxState, Side, State};
 use crate::conn::ConnectionRandoms;
 use crate::crypto::KeyExchangeAlgorithm;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
@@ -929,6 +929,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
                 return Err(PeerMisbehaved::SelectedUnofferedKxGroup.into());
             }
         };
+        cx.common.kx_state = KxState::Start(skxg);
         let kx = skxg.start()?;
 
         // 5b.
@@ -955,6 +956,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
             st.randoms,
             suite,
         )?;
+        cx.common.kx_state.complete();
 
         st.config.key_log.log(
             "CLIENT_RANDOM",

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use pki_types::CertificateDer;
 
+use crate::crypto::SupportedKxGroup;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 #[cfg(feature = "logging")]
@@ -31,6 +32,7 @@ pub struct CommonState {
     pub(crate) side: Side,
     pub(crate) record_layer: record_layer::RecordLayer,
     pub(crate) suite: Option<SupportedCipherSuite>,
+    pub(crate) kx_state: KxState,
     pub(crate) alpn_protocol: Option<Vec<u8>>,
     pub(crate) aligned_handshake: bool,
     pub(crate) may_send_application_data: bool,
@@ -63,6 +65,7 @@ impl CommonState {
             side,
             record_layer: record_layer::RecordLayer::new(),
             suite: None,
+            kx_state: KxState::default(),
             alpn_protocol: None,
             aligned_handshake: true,
             may_send_application_data: false,
@@ -136,6 +139,22 @@ impl CommonState {
     /// This returns None until the ciphersuite is agreed.
     pub fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
         self.suite
+    }
+
+    /// Retrieves the key exchange group agreed with the peer.
+    ///
+    /// This function may return `None` depending on the state of the connection,
+    /// the type of handshake, and the protocol version.
+    ///
+    /// If [`CommonState::is_handshaking()`] is true this function will return `None`.
+    /// Similarly, if the [`CommonState::handshake_kind()`] is [`HandshakeKind::Resumed`]
+    /// and the [`CommonState::protocol_version()`] is TLS 1.2, then no key exchange will have
+    /// occurred and this function will return `None`.
+    pub fn negotiated_key_exchange_group(&self) -> Option<&'static dyn SupportedKxGroup> {
+        match self.kx_state {
+            KxState::Complete(group) => Some(group),
+            _ => None,
+        }
     }
 
     /// Retrieves the protocol version agreed with the peer.
@@ -935,6 +954,23 @@ impl Default for TemperCounters {
             //
             // note BoringSSL allows up to 32.
             allowed_middlebox_ccs: 2,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) enum KxState {
+    #[default]
+    None,
+    Start(&'static dyn SupportedKxGroup),
+    Complete(&'static dyn SupportedKxGroup),
+}
+
+impl KxState {
+    pub(crate) fn complete(&mut self) {
+        debug_assert!(matches!(self, Self::Start(_)));
+        if let Self::Start(group) = self {
+            *self = Self::Complete(*group);
         }
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -8,7 +8,7 @@ use pki_types::DnsName;
 use super::server_conn::ServerConnectionData;
 #[cfg(feature = "tls12")]
 use super::tls12;
-use crate::common_state::{Protocol, State};
+use crate::common_state::{KxState, Protocol, State};
 use crate::conn::ConnectionRandoms;
 use crate::crypto::SupportedKxGroup;
 use crate::enums::{
@@ -352,6 +352,7 @@ impl ExpectClientHello {
 
         debug!("decided upon suite {:?}", suite);
         cx.common.suite = Some(suite);
+        cx.common.kx_state = KxState::Start(skxg);
 
         // Start handshake hash.
         let starting_hash = suite.hash_provider();

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -37,6 +37,7 @@ mod client_hello {
     use pki_types::CertificateDer;
 
     use super::*;
+    use crate::common_state::KxState;
     use crate::crypto::SupportedKxGroup;
     use crate::enums::SignatureScheme;
     use crate::msgs::enums::{ClientCertificateType, Compression, ECPointFormat};
@@ -191,6 +192,7 @@ mod client_hello {
                 self.session_id = SessionId::random(self.config.provider.secure_random)?;
             }
 
+            cx.common.kx_state = KxState::Start(selected_kxg);
             cx.common.handshake_kind = Some(HandshakeKind::Full);
 
             self.send_ticket = emit_server_hello(
@@ -613,6 +615,7 @@ impl State<ServerConnectionData> for ExpectClientKx<'_> {
             self.randoms,
             self.suite,
         )?;
+        cx.common.kx_state.complete();
 
         self.config.key_log.log(
             "CLIENT_RANDOM",

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -351,6 +351,7 @@ mod client_hello {
                 cx.common
                     .handshake_kind
                     .get_or_insert(HandshakeKind::Full);
+                cx.common.kx_state.complete();
             } else {
                 cx.common.handshake_kind = Some(HandshakeKind::Resumed);
             }

--- a/rustls/tests/api_ffdhe.rs
+++ b/rustls/tests/api_ffdhe.rs
@@ -10,7 +10,7 @@ use rustls::internal::msgs::codec::Codec;
 use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
 use rustls::internal::msgs::message::{Message, MessagePayload};
 use rustls::version::{TLS12, TLS13};
-use rustls::{CipherSuite, ClientConfig};
+use rustls::{CipherSuite, ClientConfig, NamedGroup};
 
 use super::*;
 
@@ -61,10 +61,11 @@ fn ffdhe_ciphersuite() {
                 .with_safe_default_protocol_versions()
                 .unwrap(),
         );
-        do_suite_test(
+        do_suite_and_kx_test(
             client_config,
             server_config,
             expected_cipher_suite,
+            NamedGroup::FFDHE2048,
             expected_protocol.version,
         );
     }
@@ -179,8 +180,7 @@ fn server_avoids_dhe_cipher_suites_when_client_has_no_known_dhe_in_groups_ext() 
     );
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    transfer(&mut client, &mut server);
-    assert!(server.process_new_packets().is_ok());
+    do_handshake(&mut client, &mut server);
     assert_eq!(
         server
             .negotiated_cipher_suite()
@@ -188,6 +188,13 @@ fn server_avoids_dhe_cipher_suites_when_client_has_no_known_dhe_in_groups_ext() 
             .suite(),
         CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     );
+    assert_eq!(
+        server
+            .negotiated_key_exchange_group()
+            .unwrap()
+            .name(),
+        NamedGroup::secp256r1,
+    )
 }
 
 #[test]
@@ -253,6 +260,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ],
             &TLS12,
             CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            Some(NamedGroup::secp256r1),
         ),
         (
             vec![
@@ -262,6 +270,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ],
             &TLS12,
             CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            Some(NamedGroup::secp256r1),
         ),
         (
             vec![
@@ -271,6 +280,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ],
             &TLS12,
             CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+            Some(NamedGroup::FFDHE2048),
         ),
         (
             // TLS 1.3, have common
@@ -281,6 +291,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ],
             &TLS13,
             CipherSuite::TLS13_AES_128_GCM_SHA256,
+            Some(NamedGroup::secp256r1),
         ),
         (
             vec![
@@ -290,6 +301,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ],
             &TLS13,
             CipherSuite::TLS13_AES_128_GCM_SHA256,
+            Some(NamedGroup::secp256r1),
         ),
         (
             vec![
@@ -299,10 +311,11 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ],
             &TLS13,
             CipherSuite::TLS13_AES_128_GCM_SHA256,
+            Some(NamedGroup::FFDHE2048),
         ),
     ];
 
-    for (client_kx_groups, protocol_version, expected_cipher_suite) in test_cases {
+    for (client_kx_groups, protocol_version, expected_cipher_suite, expected_group) in test_cases {
         let client_config = finish_client_config(
             KeyType::Rsa2048,
             rustls::ClientConfig::builder_with_provider(
@@ -323,8 +336,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
         .into();
 
         let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-        transfer(&mut client, &mut server);
-        assert!(dbg!(server.process_new_packets()).is_ok());
+        do_handshake(&mut client, &mut server);
         assert_eq!(
             server
                 .negotiated_cipher_suite()
@@ -333,6 +345,12 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             expected_cipher_suite
         );
         assert_eq!(server.protocol_version(), Some(protocol_version.version));
+        assert_eq!(
+            server
+                .negotiated_key_exchange_group()
+                .map(|kx| kx.name()),
+            expected_group,
+        );
     }
 }
 


### PR DESCRIPTION
Similar to [`negotiated_cipher_suite()`](https://docs.rs/rustls/latest/rustls/struct.CommonState.html#method.negotiated_cipher_suite) it feels like there's utility in knowing the key exchange group that was used for the connection. In particular it also let us tighten up some FFHDE related unit tests where the expected key exchange was implied by success/failure but not verified precisely.  Both those unit tests, some similar ones interrogating the negotiated ciphersuite, and the post-quantum example binary were updated to also interrogate the KEX group.

Resolves https://github.com/rustls/rustls/issues/2019