### PR TITLE
unbuffered: add missing deref for `CommonState`

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -772,6 +772,14 @@ impl<Data> From<ConnectionCore<Data>> for UnbufferedConnectionCommon<Data> {
     }
 }
 
+impl<T> Deref for UnbufferedConnectionCommon<T> {
+    type Target = CommonState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.core.common_state
+    }
+}
+
 pub(crate) struct ConnectionCore<Data> {
     pub(crate) state: Result<Box<dyn State<Data>>, Error>,
     pub(crate) data: Data,

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -401,6 +401,20 @@ fn run(
         assert!(count <= MAX_ITERATIONS, "handshake was not completed");
     }
 
+    println!("finished with:");
+    println!(
+        "  client: {:?} {:?} {:?}",
+        client.protocol_version(),
+        client.negotiated_cipher_suite(),
+        client.handshake_kind()
+    );
+    println!(
+        "  server: {:?} {:?} {:?}",
+        server.protocol_version(),
+        server.negotiated_cipher_suite(),
+        server.handshake_kind()
+    );
+
     outcome.server = Some(server);
     outcome.client = Some(client);
     outcome


### PR DESCRIPTION
This has a number of important APIs, especially `alpn_protocol`, which are currently missing in the unbuffered API.