### PR TITLE
Verify CertifiedKey consistency in ConfigBuilder with_single_cert methods

### DIFF
--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -11,7 +11,7 @@ use crate::server::{handy, ResolvesServerCert, ServerConfig};
 use crate::sign::CertifiedKey;
 use crate::time_provider::TimeProvider;
 use crate::verify::{ClientCertVerifier, NoClientAuth};
-use crate::{compress, versions, NoKeyLog};
+use crate::{compress, versions, InconsistentKeys, NoKeyLog};
 
 impl ConfigBuilder<ServerConfig, WantsVerifier> {
     /// Choose how to verify client certificates.
@@ -63,7 +63,9 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
     /// `aws-lc-rs` and `ring` [`CryptoProvider`]s support all three encodings,
     /// but other `CryptoProviders` may not.
     ///
-    /// This function fails if `key_der` is invalid.
+    /// This function fails if `key_der` is invalid, or if the
+    /// `SubjectPublicKeyInfo` from the private key does not match the public
+    /// key for the end-entity certificate from the `cert_chain`.
     pub fn with_single_cert(
         self,
         cert_chain: Vec<CertificateDer<'static>>,
@@ -74,7 +76,14 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             .provider
             .key_provider
             .load_private_key(key_der)?;
+
         let certified_key = CertifiedKey::new(cert_chain, private_key);
+        match certified_key.keys_match() {
+            // Don't treat unknown consistency as an error
+            Ok(()) | Err(Error::InconsistentKeys(InconsistentKeys::Unknown)) => (),
+            Err(err) => return Err(err),
+        }
+
         let resolver = handy::AlwaysResolvesChain::new(certified_key);
         Ok(self.with_cert_resolver(Arc::new(resolver)))
     }
@@ -89,7 +98,9 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
     /// but other `CryptoProviders` may not.
     /// `ocsp` is a DER-encoded OCSP response.  Ignored if zero length.
     ///
-    /// This function fails if `key_der` is invalid.
+    /// This function fails if `key_der` is invalid, or if the
+    /// `SubjectPublicKeyInfo` from the private key does not match the public
+    /// key for the end-entity certificate from the `cert_chain`.
     pub fn with_single_cert_with_ocsp(
         self,
         cert_chain: Vec<CertificateDer<'static>>,
@@ -101,7 +112,14 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             .provider
             .key_provider
             .load_private_key(key_der)?;
+
         let certified_key = CertifiedKey::new(cert_chain, private_key);
+        match certified_key.keys_match() {
+            // Don't treat unknown consistency as an error
+            Ok(()) | Err(Error::InconsistentKeys(InconsistentKeys::Unknown)) => (),
+            Err(err) => return Err(err),
+        }
+
         let resolver = handy::AlwaysResolvesChain::new_with_extras(certified_key, ocsp);
         Ok(self.with_cert_resolver(Arc::new(resolver)))
     }

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -2,7 +2,6 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
-use crate::msgs::handshake::CertificateChain;
 use crate::server::ClientHello;
 use crate::{server, sign};
 
@@ -172,23 +171,16 @@ impl server::ProducesTickets for NeverProducesTickets {
 pub(super) struct AlwaysResolvesChain(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesChain {
-    /// Creates an `AlwaysResolvesChain`, using the supplied key and certificate chain.
-    pub(super) fn new(
-        private_key: Arc<dyn sign::SigningKey>,
-        chain: CertificateChain<'static>,
-    ) -> Self {
-        Self(Arc::new(sign::CertifiedKey::new(chain.0, private_key)))
+    /// Creates an `AlwaysResolvesChain`, using the supplied `CertifiedKey`.
+    pub(super) fn new(certified_key: sign::CertifiedKey) -> Self {
+        Self(Arc::new(certified_key))
     }
 
-    /// Creates an `AlwaysResolvesChain`, using the supplied key, certificate chain and OCSP response.
+    /// Creates an `AlwaysResolvesChain`, using the supplied `CertifiedKey` and OCSP response.
     ///
     /// If non-empty, the given OCSP response is attached.
-    pub(super) fn new_with_extras(
-        private_key: Arc<dyn sign::SigningKey>,
-        chain: CertificateChain<'static>,
-        ocsp: Vec<u8>,
-    ) -> Self {
-        let mut r = Self::new(private_key, chain);
+    pub(super) fn new_with_extras(certified_key: sign::CertifiedKey, ocsp: Vec<u8>) -> Self {
+        let mut r = Self::new(certified_key);
 
         {
             let cert = Arc::make_mut(&mut r.0);


### PR DESCRIPTION
## Summary 

Building off of https://github.com/rustls/rustls/pull/1954, this PR updates `ConfigBuilder`'s `with_single_cert` functions to verify public and private key consistency using `CertifiedKey::keys_match`. This is part of a larger effort to verify `CertifiedKey` consistency over at https://github.com/rustls/rustls/issues/1918.

## Changes

* Refactor `AlwaysResolvesChain::new` to take an existing owned `CertifiedKey` instead of creating one
* Refactor `AlwaysResolvesChain::new_with_extras` to take an existing owned `CertifiedKey` instead of creating one
* Update `ConfigBuilder::with_single_cert` to verify key consistency with `CertifiedKey::keys_match`
* Update `ConfigBuilder::with_single_cert_with_ocsp` to verify key consistency with `CertifiedKey::keys_match`