### PR TITLE
Prepare 0.23.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.11"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -2252,7 +2252,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "rayon",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "tikv-jemallocator",
@@ -2265,7 +2265,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.10",
+ "rustls 0.23.11",
 ]
 
 [[package]]
@@ -2279,7 +2279,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -2297,7 +2297,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
 ]
@@ -2333,7 +2333,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "webpki-roots 0.26.3",
 ]
 
@@ -2354,7 +2354,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-pki-types",
  "rustls-webpki 0.102.5",
  "sha2",
@@ -2368,7 +2368,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-provider-example",
  "serde",
  "serde_json",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,12 +4,6 @@
 
 Specific features, in rough order of priority:
 
-* **Enforce Confidentiality / Integrity Limits**.
-  The QUIC use of TLS mandates limited usage of AEAD keys. While TLS 1.3 and 1.2
-  do not require this, the same kinds of issues can apply here, and we should
-  consider implementing limits for TLS over TCP as well.
-  rustls/rustls#755
-
 * **Address asynchronous handshake interruption**.
   Allow completion of user-provided operations to be deferred.
   rustls/rustls#850
@@ -33,6 +27,14 @@ General priorities:
   Continue to improve the Rustls API. Aim for ease of use, clarity.
 
 ## Past priorities
+
+Delivered in 0.23.11:
+
+* **Enforce Confidentiality / Integrity Limits**.
+  The QUIC use of TLS mandates limited usage of AEAD keys. While TLS 1.3 and 1.2
+  do not require this, the same kinds of issues can apply here, and we should
+  consider implementing limits for TLS over TCP as well.
+  rustls/rustls#755
 
 Delivered in 0.23.10:
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.11"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.11"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Draft release notes:

* **New feature**: API for determining whether a `CertifiedKey`'s certificate and private key matches: [`keys_match()`](https://rustls.github.io/rustls/prerelease/sign/struct.CertifiedKey.html#method.keys_match). This is called from existing fallible functions that accept a private key and certificate (for example, [`with_single_cert()`](https://rustls.github.io/rustls/prerelease/struct.ConfigBuilder.html#method.with_single_cert)) so these functions now detect this misconfiguration.
  
  This relies on a new -- optional -- member of the `SigningKey` trait: [`public_key()`](https://rustls.github.io/rustls/prerelease/sign/trait.SigningKey.html#method.public_key) -- downstream implementers of this trait can opt-in to this behavior by implementing this method.

* **New feature**: API for determining which key exchange group a connection used: [`negotiated_key_exchange_group()`](https://rustls.github.io/rustls/prerelease/server/struct.ServerConnection.html#method.negotiated_key_exchange_group)

* **New feature**: Automatic sending of TLS1.3 `key_update` messages  to avoid exceeding AEAD confidentiality limits. This is complemented with a new API for manual use, [`refresh_traffic_keys()`](https://rustls.github.io/rustls/prerelease/client/struct.ClientConnection.html#method.refresh_traffic_keys)
* Expose common connection items in unbuffered API ([docs](https://rustls.github.io/rustls/prerelease/client/struct.UnbufferedClientConnection.html#deref-methods-CommonState))