### PR TITLE
ci: tweak renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,6 @@
   },
   "prCreation": "not-pending",
   "rangeStrategy": "update-lockfile",
-  "stabilityDays": 3,
   "github-actions": {
     "fileMatch": [
       "^ci\\/.*/[^/]+\\.ya?ml$"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
   },
   "prCreation": "not-pending",
   "rangeStrategy": "update-lockfile",
+  "rebaseWhen": "behind-base-branch",
   "github-actions": {
     "fileMatch": [
       "^ci\\/.*/[^/]+\\.ya?ml$"


### PR DESCRIPTION
* Removes `stabilityDays` (since renamed to [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)) This was holding PRs back for 3 days after the dep update was released. We want these PRs basically ASAP and can tolerate subsequent point releases if there are post-release issues that cause the upstream to cut follow-ups.
* Adds [`rebaseWhen`](https://docs.renovatebot.com/configuration-options/#rebasewhen) with the `behind-base-branch` strategy. Previously we used the default (`auto`), but since our repo doesn't require branches be up-to-date for merge, the bot didn't bother rebasing with this strategy. Using `behind-base-branch` will do what we want here: have the bot rebase immediately when `main` updates.

See https://github.com/renovatebot/renovate/discussions/30088 for more discussion.