### PR TITLE
Fix clippy lints stabilised in 1.80

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1783,11 +1783,13 @@ impl KxDecode<'_> for ClientKeyExchangeParams {
     }
 }
 
+#[cfg(feature = "tls12")]
 #[derive(Debug)]
 pub(crate) struct ClientEcdhParams {
     pub(crate) public: PayloadU8,
 }
 
+#[cfg(feature = "tls12")]
 impl Codec<'_> for ClientEcdhParams {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.public.encode(bytes);
@@ -1799,11 +1801,13 @@ impl Codec<'_> for ClientEcdhParams {
     }
 }
 
+#[cfg(feature = "tls12")]
 #[derive(Debug)]
 pub(crate) struct ClientDhParams {
     pub(crate) public: PayloadU16,
 }
 
+#[cfg(feature = "tls12")]
 impl Codec<'_> for ClientDhParams {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.public.encode(bytes);

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -12,9 +12,9 @@ use pki_types::{DnsName, UnixTime};
 
 use super::hs;
 use crate::builder::ConfigBuilder;
+use crate::common_state::{CommonState, Side};
 #[cfg(feature = "std")]
-use crate::common_state::Protocol;
-use crate::common_state::{CommonState, Side, State};
+use crate::common_state::{Protocol, State};
 use crate::conn::{ConnectionCommon, ConnectionCore, UnbufferedConnectionCommon};
 #[cfg(doc)]
 use crate::crypto;
@@ -971,8 +971,10 @@ impl Debug for Accepted {
     }
 }
 
+#[cfg(feature = "std")]
 struct Accepting;
 
+#[cfg(feature = "std")]
 impl State<ServerConnectionData> for Accepting {
     fn handle<'m>(
         self: Box<Self>,


### PR DESCRIPTION
Recall we deny warnings in stable clippy; today's 1.80 release improved detection of unused types --  fixed in the first commit.

Second commit is addressing others visible with current nightly clippy.