### PR TITLE
Update CLI of example tlsserver-mio to support early data and disabling resumption (closes  #2058)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,9 @@ Options:
                         CRLFILE. May be used multiple times.
     --require-auth      Send a fatal alert if the client does not complete client
                         authentication.
-    --resumption        Support session resumption.
-    --tickets           Support tickets.
+    --no-resumption     Disable stateful session resumption.
+    --tickets           Support tickets (stateless resumption).
+    --max-early-data BYTES   Support receiving BYTES many bytes with 0RTT
     --protover VERSION  Disable default TLS version list, and use
                         VERSION instead.  May be used multiple times.
     --suite SUITE       Disable default cipher suite list, and use

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -444,8 +444,8 @@ Options:
                         CRLFILE. May be used multiple times.
     --require-auth      Send a fatal alert if the client does not complete client
                         authentication.
-    --resumption        Support session resumption.
-    --tickets           Support tickets.
+    --no-resumption     Disable stateful session resumption.
+    --tickets           Support tickets (stateless resumption).
     --protover VERSION  Disable default TLS version list, and use
                         VERSION instead.  May be used multiple times.
     --suite SUITE       Disable default cipher suite list, and use
@@ -472,7 +472,7 @@ struct Args {
     flag_ocsp: Option<String>,
     flag_auth: Option<String>,
     flag_require_auth: bool,
-    flag_resumption: bool,
+    flag_no_resumption: bool,
     flag_tickets: bool,
     arg_fport: Option<u16>,
 }
@@ -640,8 +640,8 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
 
     config.key_log = Arc::new(rustls::KeyLogFile::new());
 
-    if args.flag_resumption {
-        config.session_storage = rustls::server::ServerSessionMemoryCache::new(256);
+    if args.flag_no_resumption {
+        config.session_storage = Arc::new(rustls::server::NoServerSessionStorage {});
     }
 
     if args.flag_tickets {


### PR DESCRIPTION
Two changes:
1. Changed `--resumption` flag to `--no-resumption` to have an option to disable stateful resumption as resumption is the default anyways
3. Added new `max-early-data BYTES` flag that allows opting in early data without change example code
    - if `max-early-data`is set to 0 no early data is allowed / for non-zero values the config is adapted to allow a maximum of BYTES bytes of early data (maximum is u32::MAX)
    - early data is only supported for stateful resumption => therefore it cannot be used together with `--ticket` flag