### PR TITLE
Avoid hanging if the client disconnects while self.wants_write()

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -589,7 +589,13 @@ impl<Data> ConnectionCommon<Data> {
             }
 
             while self.wants_write() {
-                wrlen += self.write_tls(io)?;
+                match self.write_tls(io)? {
+                    0 => {
+                        io.flush()?;
+                        return Ok((rdlen, wrlen)); // EOF.
+                    }
+                    n => wrlen += n,
+                }
             }
             io.flush()?;
 


### PR DESCRIPTION
Similarly to how Ok(0) (zero) is treated during reads below, rustls should exit the loop instead of spinning indefinitely upon receiving Ok(0).