### PR TITLE
Enable one more bogo ECH test, update skip reason for another

### DIFF
--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -29,7 +29,7 @@
 #else
     "TLS-ECH-Server*": "ECH server support NYI",
     "TLS-ECH-Client-SelectECHConfig": "TODO(XXX): re-enable after upstream bogo fix",
-    "TLS-ECH-Client-NoSupportedConfigs": "TODO(XXX): re-enable after upstream bogo fix",
+    "TLS-ECH-Client-NoSupportedConfigs": "we don't fallback to TLS w/o ECH for no supported configs",
     "TLS-ECH-Client-SkipInvalidPublicName*": "we allow underscore names, don't fallback on no ECH configs",
     "TLS-ECH-Client-NoSupportedConfigs-GREASE": "we don't fallback to GREASE for no ECH configs",
     "TLS-ECH-Client-TLS12-RejectRetryConfigs": "we disable TLS1.2 w/ ECH",

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -28,7 +28,6 @@
     "TLS-ECH-*": "ECH test suites use non-FIPS approved algos",
 #else
     "TLS-ECH-Server*": "ECH server support NYI",
-    "TLS-ECH-Client-SelectECHConfig": "TODO(XXX): re-enable after upstream bogo fix",
     "TLS-ECH-Client-NoSupportedConfigs": "we don't fallback to TLS w/o ECH for no supported configs",
     "TLS-ECH-Client-SkipInvalidPublicName*": "we allow underscore names, don't fallback on no ECH configs",
     "TLS-ECH-Client-NoSupportedConfigs-GREASE": "we don't fallback to GREASE for no ECH configs",


### PR DESCRIPTION
Following https://github.com/rustls/rustls/pull/2057 I remembered there were two ECH related tests we marked skipped in https://github.com/rustls/rustls/commit/b4eba48fccc80c9e9584c4e027d7aa6a5c966c1c, pending upstream fixes. 

Specifically there were two tests we couldn't handle (`TLS-ECH-Client-SelectECHConfig` and `TLS-ECH-Client-NoSupportedConfigs`) because the test cases were using an "unsupported KEM" that we happened to support. This was fixed upstream w/ https://github.com/rustls/boringssl/commit/d8d1c6a2d034df2a62bcf75604a4824f0e20e19e to use an unknown KEM ID that no implementations should happen to support.

We can now enable `TLS-ECH-Client-SelectECHConfig` without any required code changes on our side. Unfortunately `TLS-ECH-Client-NoSupportedConfigs` still isn't workable because the test assumes if no ECH configs are supported the client will do a TLS handshake w/o offering ECH, where-as we prefer to fail the client configuration construction, returning an error about unsupported configs.

As a result this branch enables `TLS-ECH-Client-SelectECHConfig` and updates the reason for why we ignore `TLS-ECH-Client-NoSupportedConfigs`.