### PR TITLE
Support for Raw Public Keys (RFC 7250)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -504,6 +504,15 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+  
+      - name: Install pixi
+        run: | 
+          curl -fsSL https://pixi.sh/install.sh | bash
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+
+      - name: Install OpenSSL 3.2 with pixi
+        run: |
+          pixi global install openssl==3.2
 
       - name: openssl version
         run: openssl version
@@ -513,3 +522,4 @@ jobs:
         run: cargo test --locked -- --include-ignored
         env:
           RUST_BACKTRACE: 1
+          

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "rustls 0.23.15",
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,3 +21,7 @@ We recommend new users start by looking at `simpleclient.rs` and `simpleserver.r
 * `simple_0rtt_server.rs` - shows how to make a TLS1.3 that accepts multiple connections and prints early 0RTT data.
 * `server_acceptor.rs` - shows how to use the `Acceptor` API to create a server that generates a unique `ServerConfig` for each client. This example also shows how to use client authentication, CRL revocation checking, and uses `rcgen` to generate its own certificates.
 * `unbuffered-server.rs` - shows an advanced example of using Rustls lower-level APIs to implement a server that does not buffer any data inside Rustls.
+
+## Client-Server examples
+
+* A client-server example using Raw Public Keys (RFC 7250) can be found in [`raw_key_openssl_interop`](../openssl-tests/src/raw_key_openssl_interop.rs).

--- a/openssl-tests/Cargo.toml
+++ b/openssl-tests/Cargo.toml
@@ -12,4 +12,5 @@ base64 = "0.22"
 num-bigint = "0.4.4"
 once_cell = "1.19"
 rustls = {path = "../rustls"}
+rustls-pki-types = { version = "1.10", features = ["alloc"] }
 openssl = "0.10"

--- a/openssl-tests/src/lib.rs
+++ b/openssl-tests/src/lib.rs
@@ -2,5 +2,6 @@
 
 mod ffdhe;
 mod ffdhe_kx_with_openssl;
+mod raw_key_openssl_interop;
 mod utils;
 mod validate_ffdhe_params;

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -1,0 +1,522 @@
+//! This module provides tests for the interoperability of raw public keys with OpenSSL, and also
+//! demonstrates how to set up a client-server architecture that utilizes raw public keys.
+//!
+//! The module also includes example implementations of the `ServerCertVerifier` and `ClientCertVerifier` traits, using  
+//! pre-configured raw public keys for the verification of the peer.  
+
+mod client {
+    use std::io::{self, Read, Write};
+    use std::net::TcpStream;
+    use std::sync::Arc;
+
+    use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+    use rustls::client::AlwaysResolvesClientRawPublicKeys;
+    use rustls::crypto::{
+        aws_lc_rs as provider, verify_tls13_signature_with_raw_key, WebPkiSupportedAlgorithms,
+    };
+    use rustls::sign::CertifiedKey;
+    use rustls::version::TLS13;
+    use rustls::{
+        CertificateError, ClientConfig, ClientConnection, DigitallySignedStruct, Error,
+        InconsistentKeys, PeerIncompatible, SignatureScheme, Stream,
+    };
+    use rustls_pki_types::pem::PemObject;
+    use rustls_pki_types::{
+        CertificateDer, PrivateKeyDer, ServerName, SubjectPublicKeyInfoDer, UnixTime,
+    };
+
+    /// Build a `ClientConfig` with the given client private key and a server public key to trust.
+    pub(super) fn make_config(client_private_key: &str, server_pub_key: &str) -> ClientConfig {
+        let client_private_key = Arc::new(provider::default_provider())
+            .key_provider
+            .load_private_key(
+                PrivateKeyDer::from_pem_file(client_private_key)
+                    .expect("cannot open private key file"),
+            )
+            .expect("cannot load signing key");
+        let client_public_key = client_private_key
+            .public_key()
+            .ok_or(Error::InconsistentKeys(InconsistentKeys::Unknown))
+            .expect("cannot load public key");
+        let client_public_key_as_cert = CertificateDer::from(client_public_key.to_vec());
+
+        let server_raw_key = SubjectPublicKeyInfoDer::from_pem_file(server_pub_key)
+            .expect("cannot open pub key file");
+
+        let certified_key = Arc::new(CertifiedKey::new(
+            vec![client_public_key_as_cert],
+            client_private_key,
+        ));
+
+        ClientConfig::builder_with_protocol_versions(&[&TLS13])
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(SimpleRpkServerCertVerifier::new(vec![
+                server_raw_key,
+            ])))
+            .with_client_cert_resolver(Arc::new(AlwaysResolvesClientRawPublicKeys::new(
+                certified_key,
+            )))
+    }
+
+    /// Run the client and connect to the server at the specified port.
+    ///
+    /// This client reads a message and then writes 'Hello from the client' to the server.
+    pub(super) fn run_client(config: ClientConfig, port: u16) -> Result<String, io::Error> {
+        let server_name = "0.0.0.0".try_into().unwrap();
+        let mut conn = ClientConnection::new(Arc::new(config), server_name).unwrap();
+        let mut sock = TcpStream::connect(format!("[::]:{}", port)).unwrap();
+        let mut tls = Stream::new(&mut conn, &mut sock);
+
+        let mut buf = vec![0; 128];
+        let len = tls.read(&mut buf).unwrap();
+        let received_message = String::from_utf8_lossy(&buf[..len]).to_string();
+
+        let bytes_written = tls
+            .write("Hello from the client".as_bytes())
+            .unwrap_or("".len());
+        assert!(bytes_written > 0);
+        Ok(received_message)
+    }
+
+    /// Verifies the tls handshake signature of the server,
+    /// and that the server's raw public key is in the list of trusted keys.
+    ///
+    /// Note: when the verifier is used for Raw Public Keys the `CertificateDer` argument to the functions contains the SPKI instead of a X509 Certificate
+    #[derive(Debug)]
+    struct SimpleRpkServerCertVerifier {
+        trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>,
+        supported_algs: WebPkiSupportedAlgorithms,
+    }
+
+    impl SimpleRpkServerCertVerifier {
+        fn new(trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>) -> Self {
+            SimpleRpkServerCertVerifier {
+                trusted_spki,
+                supported_algs: Arc::new(provider::default_provider())
+                    .clone()
+                    .signature_verification_algorithms,
+            }
+        }
+    }
+
+    impl ServerCertVerifier for SimpleRpkServerCertVerifier {
+        fn verify_server_cert(
+            &self,
+            end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName<'_>,
+            _ocsp_response: &[u8],
+            _now: UnixTime,
+        ) -> Result<ServerCertVerified, rustls::Error> {
+            let end_entity_as_spki = SubjectPublicKeyInfoDer::from(end_entity.as_ref());
+            match self
+                .trusted_spki
+                .contains(&end_entity_as_spki)
+            {
+                false => Err(rustls::Error::InvalidCertificate(
+                    CertificateError::UnknownIssuer,
+                )),
+                true => Ok(ServerCertVerified::assertion()),
+            }
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Err(rustls::Error::PeerIncompatible(
+                PeerIncompatible::Tls12NotOffered,
+            ))
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            verify_tls13_signature_with_raw_key(
+                message,
+                &SubjectPublicKeyInfoDer::from(cert.as_ref()),
+                dss,
+                &self.supported_algs,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            self.supported_algs.supported_schemes()
+        }
+
+        fn requires_raw_public_keys(&self) -> bool {
+            true
+        }
+    }
+}
+
+mod server {
+    use std::io::{self, ErrorKind, Read, Write};
+    use std::{net::TcpListener, sync::Arc};
+
+    use rustls::client::danger::HandshakeSignatureValid;
+    use rustls::crypto::aws_lc_rs as provider;
+    use rustls::crypto::verify_tls13_signature_with_raw_key;
+    use rustls::crypto::WebPkiSupportedAlgorithms;
+    use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
+    use rustls::server::AlwaysResolvesServerRawPublicKeys;
+    use rustls::sign::CertifiedKey;
+    use rustls::version::TLS13;
+    use rustls::Error;
+    use rustls::InconsistentKeys;
+    use rustls::{
+        CertificateError, DigitallySignedStruct, DistinguishedName, PeerIncompatible, ServerConfig,
+        ServerConnection, SignatureScheme,
+    };
+    use rustls_pki_types::pem::PemObject;
+    use rustls_pki_types::PrivateKeyDer;
+    use rustls_pki_types::{CertificateDer, SubjectPublicKeyInfoDer, UnixTime};
+
+    /// Build a `ServerConfig` with the given server private key and a client public key to trust.
+    pub(super) fn make_config(server_private_key: &str, client_pub_key: &str) -> ServerConfig {
+        let client_raw_key = SubjectPublicKeyInfoDer::from_pem_file(client_pub_key)
+            .expect("cannot open pub key file");
+
+        let server_private_key = provider::default_provider()
+            .key_provider
+            .load_private_key(
+                PrivateKeyDer::from_pem_file(server_private_key)
+                    .expect("cannot open private key file"),
+            )
+            .expect("cannot load signing key");
+        let server_public_key = server_private_key
+            .public_key()
+            .ok_or(Error::InconsistentKeys(InconsistentKeys::Unknown))
+            .expect("cannot load public key");
+        let server_public_key_as_cert = CertificateDer::from(server_public_key.to_vec());
+
+        let certified_key = Arc::new(CertifiedKey::new(
+            vec![server_public_key_as_cert],
+            server_private_key,
+        ));
+
+        let client_cert_verifier = Arc::new(SimpleRpkClientCertVerifier::new(vec![client_raw_key]));
+        let server_cert_resolver = Arc::new(AlwaysResolvesServerRawPublicKeys::new(certified_key));
+
+        ServerConfig::builder_with_protocol_versions(&[&TLS13])
+            .with_client_cert_verifier(client_cert_verifier)
+            .with_cert_resolver(server_cert_resolver)
+    }
+
+    /// Run the server at the specified port and accept a connection from the client.
+    ///
+    /// After the handshake is complete, the server writes 'Hello from the server' to the client.
+    /// The server then waits until reads it receives a message from the client and closes the connection.
+    pub(super) fn run_server(
+        config: ServerConfig,
+        listener: TcpListener,
+    ) -> Result<String, io::Error> {
+        let (mut stream, _) = listener.accept()?;
+
+        let mut conn = ServerConnection::new(Arc::new(config)).unwrap();
+        conn.complete_io(&mut stream)?;
+
+        conn.writer()
+            .write_all(b"Hello from the server")?;
+        conn.complete_io(&mut stream)?;
+
+        let mut buf = [0; 128];
+
+        loop {
+            match conn.reader().read(&mut buf) {
+                Ok(len) => {
+                    conn.send_close_notify();
+                    conn.complete_io(&mut stream)?;
+                    return Ok(String::from_utf8_lossy(&buf[..len]).to_string());
+                }
+                Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                    conn.read_tls(&mut stream)?;
+                    conn.process_new_packets().unwrap();
+                }
+                Err(err) => {
+                    return Err(err);
+                }
+            };
+        }
+    }
+
+    /// Verifies the tls handshake signature of the client,
+    /// and that the client's raw public key is in the list of trusted keys.
+    ///
+    /// Note: when the verifier is used for Raw Public Keys the `CertificateDer` argument to the functions contains the SPKI instead of a X509 Certificate
+    #[derive(Debug)]
+    struct SimpleRpkClientCertVerifier {
+        trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>,
+        supported_algs: WebPkiSupportedAlgorithms,
+    }
+
+    impl SimpleRpkClientCertVerifier {
+        pub fn new(trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>) -> Self {
+            Self {
+                trusted_spki,
+                supported_algs: Arc::new(provider::default_provider())
+                    .clone()
+                    .signature_verification_algorithms,
+            }
+        }
+    }
+
+    impl ClientCertVerifier for SimpleRpkClientCertVerifier {
+        fn root_hint_subjects(&self) -> &[DistinguishedName] {
+            &[]
+        }
+
+        fn verify_client_cert(
+            &self,
+            end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _now: UnixTime,
+        ) -> Result<ClientCertVerified, rustls::Error> {
+            let end_entity_as_spki = SubjectPublicKeyInfoDer::from(end_entity.as_ref());
+            match self
+                .trusted_spki
+                .contains(&end_entity_as_spki)
+            {
+                false => Err(rustls::Error::InvalidCertificate(
+                    CertificateError::UnknownIssuer,
+                )),
+                true => Ok(ClientCertVerified::assertion()),
+            }
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Err(rustls::Error::PeerIncompatible(
+                PeerIncompatible::Tls12NotOffered,
+            ))
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            verify_tls13_signature_with_raw_key(
+                message,
+                &SubjectPublicKeyInfoDer::from(cert.as_ref()),
+                dss,
+                &self.supported_algs,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            self.supported_algs.supported_schemes()
+        }
+
+        fn requires_raw_public_keys(&self) -> bool {
+            true
+        }
+    }
+}
+
+mod tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc::channel;
+    use std::thread;
+
+    use super::{client, server};
+    use crate::utils::verify_openssl3_available;
+
+    const SERVER_PRIV_KEY_FILE: &str = "../test-ca/ecdsa-p256/end.key";
+    const SERVER_PUB_KEY_FILE: &str = "../test-ca/ecdsa-p256/end.spki.pem";
+    const SERVER_CERT_KEY_FILE: &str = "../test-ca/ecdsa-p256/end.cert";
+    const CLIENT_PUB_KEY_FILE: &str = "../test-ca/ecdsa-p256/client.spki.pem";
+    const CLIENT_PRIV_KEY_FILE: &str = "../test-ca/ecdsa-p256/client.key";
+    const CLIENT_CERT_KEY_FILE: &str = "../test-ca/ecdsa-p256/client.cert";
+
+    fn tcp_listener() -> TcpListener {
+        TcpListener::bind("[::]:0").expect("Could not bind to random port")
+    }
+
+    #[test]
+    fn test_rust_server_and_rust_client() {
+        let listener = tcp_listener();
+        let port = listener.local_addr().unwrap().port();
+
+        let (sender, receiver) = channel();
+        let server_thread = thread::spawn(move || {
+            sender
+                .send(server::run_server(
+                    server::make_config(SERVER_PRIV_KEY_FILE, CLIENT_PUB_KEY_FILE),
+                    listener,
+                ))
+                .unwrap();
+        });
+
+        // Start the Rust client
+        let client_config = client::make_config(CLIENT_PRIV_KEY_FILE, SERVER_PUB_KEY_FILE);
+        match client::run_client(client_config, port) {
+            Ok(server_message) => {
+                assert_eq!(server_message, "Hello from the server");
+            }
+            Err(e) => {
+                panic!("Client failed to communicate with the server: {:?}", e);
+            }
+        }
+
+        // Wait for the server to finish and clean up the thread
+        let server_result = receiver.recv().unwrap();
+        server_thread
+            .join()
+            .expect("Failed to join server thread");
+
+        match server_result {
+            Ok(client_message) => {
+                assert_eq!(client_message, "Hello from the client");
+            }
+            Err(e) => {
+                panic!("Server failed to communicate with the client: {:?}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_rust_server_with_openssl_client() {
+        verify_openssl3_available();
+
+        let listener = tcp_listener();
+        let port = listener.local_addr().unwrap().port();
+
+        let server_thread = thread::spawn(move || {
+            server::run_server(
+                server::make_config(SERVER_PRIV_KEY_FILE, CLIENT_PUB_KEY_FILE),
+                listener,
+            )
+            .expect("failed to run server to completion")
+        });
+
+        // Start the OpenSSL client
+        let mut openssl_client = Command::new("openssl")
+            .arg("s_client")
+            .arg("-connect")
+            .arg(format!("[::]:{:?}", port))
+            .arg("-enable_server_rpk")
+            .arg("-enable_client_rpk")
+            .arg("-key")
+            .arg(CLIENT_PRIV_KEY_FILE)
+            .arg("-cert")
+            .arg(CLIENT_CERT_KEY_FILE)
+            .arg("-tls1_3")
+            .arg("-debug")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to execute OpenSSL client");
+
+        let mut stdin = openssl_client.stdin.take().unwrap();
+        let mut stdout = openssl_client.stdout.take().unwrap();
+        let mut stdout_buf = [0; 1024];
+        let mut openssl_stdout = String::new();
+        let mut received_server_msg = false;
+        loop {
+            match stdout.read(&mut stdout_buf) {
+                Ok(0) => break,
+                Ok(len) => {
+                    let read = &stdout_buf[..len];
+
+                    std::io::stdout()
+                        .write_all(read)
+                        .unwrap();
+                    openssl_stdout.push_str(&String::from_utf8_lossy(read));
+                    if openssl_stdout.contains("Hello from the server") {
+                        received_server_msg = true;
+                        stdin
+                            .write_all(b"Hello, from openssl client!")
+                            .expect("Failed to write to stdin");
+                        break;
+                    }
+                }
+                Err(e) => panic!("Error reading from OpenSSL stdin: {e:?}"),
+            }
+        }
+
+        assert!(received_server_msg);
+        assert_eq!(server_thread.join().unwrap(), "Hello, from openssl client!");
+    }
+
+    #[test]
+    fn test_rust_client_with_openssl_server() {
+        verify_openssl3_available();
+
+        let listener = tcp_listener();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        // Start OpenSSL server
+        let mut server_process = Command::new("openssl")
+            .arg("s_server")
+            .arg("-port")
+            .arg(port.to_string())
+            .arg("-cert")
+            .arg(SERVER_CERT_KEY_FILE)
+            .arg("-key")
+            .arg(SERVER_PRIV_KEY_FILE)
+            .arg("-verify")
+            .arg("1")
+            .arg("-enable_server_rpk")
+            .arg("-enable_client_rpk")
+            .arg("-tls1_3")
+            .arg("-debug")
+            .stdout(Stdio::piped())
+            .stdin(Stdio::piped())
+            .spawn()
+            .expect("Failed to start OpenSSL server");
+
+        // Read from the OpenSSL server's stdout and wait for "ACCEPT"
+        if let Some(stdout) = server_process.stdout.take() {
+            let stdout_reader = BufReader::new(stdout);
+            for line in stdout_reader.lines() {
+                match line {
+                    Ok(l) => {
+                        if l.contains("ACCEPT") {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        panic!("Error reading from OpenSSL stdout: {:?}", e);
+                    }
+                }
+            }
+        }
+
+        // Write a message to the OpenSSL server's stdin
+        if let Some(mut stdin) = server_process.stdin.take() {
+            stdin
+                .write_all(b"Hello, from openssl server!")
+                .expect("Failed to write to stdin");
+        }
+
+        // Create the Rust client config and run the client
+        let client_config = client::make_config(CLIENT_PRIV_KEY_FILE, SERVER_PUB_KEY_FILE);
+        match client::run_client(client_config, port) {
+            Ok(server_message) => {
+                assert_eq!(server_message, "Hello, from openssl server!");
+            }
+            Err(_) => {
+                unreachable!("Client failed to communicate with the server");
+            }
+        }
+
+        // Ensure the OpenSSL server process is terminated
+        server_process
+            .kill()
+            .expect("Failed to kill OpenSSL server process");
+    }
+}

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -120,6 +120,13 @@ pub trait ResolvesClientCert: fmt::Debug + Send + Sync {
         sigschemes: &[SignatureScheme],
     ) -> Option<Arc<sign::CertifiedKey>>;
 
+    /// Return true if the client only supports raw public keys.  
+    ///  
+    /// See [RFC 7250](https://www.rfc-editor.org/rfc/rfc7250).  
+    fn only_raw_public_keys(&self) -> bool {
+        false
+    }
+
     /// Return true if any certificates at all are available.
     fn has_certs(&self) -> bool;
 }

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -241,6 +241,41 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
     }
 }
 
+/// An exemplar `ResolvesClientCert` implementation that always resolves to a single
+/// [RFC 7250] raw public key.  
+///
+/// [RFC 7250]: https://tools.ietf.org/html/rfc7250  
+#[derive(Clone, Debug)]
+pub struct AlwaysResolvesClientRawPublicKeys(Arc<sign::CertifiedKey>);
+impl AlwaysResolvesClientRawPublicKeys {
+    /// Create a new `AlwaysResolvesClientRawPublicKeys` instance.
+    pub fn new(certified_key: Arc<sign::CertifiedKey>) -> Self {
+        Self(certified_key)
+    }
+}
+
+impl client::ResolvesClientCert for AlwaysResolvesClientRawPublicKeys {
+    fn resolve(
+        &self,
+        _root_hint_subjects: &[&[u8]],
+        _sigschemes: &[SignatureScheme],
+    ) -> Option<Arc<sign::CertifiedKey>> {
+        Some(Arc::clone(&self.0))
+    }
+
+    fn only_raw_public_keys(&self) -> bool {
+        true
+    }
+
+    /// Returns true if the resolver is ready to present an identity.
+    ///
+    /// Even though the function is called `has_certs`, it returns true  
+    /// although only an RPK (Raw Public Key) is available, not an actual certificate.  
+    fn has_certs(&self) -> bool {
+        true
+    }
+}
+
 test_for_each_provider! {
     use std::prelude::v1::*;
     use alloc::sync::Arc;

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -427,6 +427,8 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
 
         validate_encrypted_extensions(cx.common, &self.hello, exts)?;
         hs::process_alpn_protocol(cx.common, &self.config, exts.alpn_protocol())?;
+        hs::process_client_cert_type_extension(cx.common, &self.config, exts.client_cert_type())?;
+        hs::process_server_cert_type_extension(cx.common, &self.config, exts.server_cert_type())?;
 
         let ech_retry_configs = match (cx.data.ech_status, exts.server_ech_extension()) {
             // If we didn't offer ECH, or ECH was accepted, but the server sent an ECH encrypted

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -11,7 +11,7 @@ use crate::log::{debug, error, warn};
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::{AlertLevel, KeyUpdateRequest};
+use crate::msgs::enums::{AlertLevel, ExtensionType, KeyUpdateRequest};
 use crate::msgs::fragmenter::MessageFragmenter;
 use crate::msgs::handshake::{CertificateChain, HandshakeMessagePayload};
 use crate::msgs::message::{
@@ -24,7 +24,7 @@ use crate::suites::{PartiallyExtractedSecrets, SupportedCipherSuite};
 use crate::tls12::ConnectionSecrets;
 use crate::unbuffered::{EncryptError, InsufficientSizeError};
 use crate::vecbuf::ChunkVecBuffer;
-use crate::{quic, record_layer};
+use crate::{quic, record_layer, PeerIncompatible};
 
 /// Connection state common to both client and server connections.
 pub struct CommonState {
@@ -107,21 +107,27 @@ impl CommonState {
         !(self.may_send_application_data && self.may_receive_application_data)
     }
 
-    /// Retrieves the certificate chain used by the peer to authenticate.
+    /// Retrieves the certificate chain or the raw public key used by the peer to authenticate.
     ///
     /// The order of the certificate chain is as it appears in the TLS
     /// protocol: the first certificate relates to the peer, the
     /// second certifies the first, the third certifies the second, and
     /// so on.
     ///
+    /// When using raw public keys, the first and only element is the raw public key.
+    ///
     /// This is made available for both full and resumed handshakes.
     ///
-    /// For clients, this is the certificate chain of the server.
+    /// For clients, this is the certificate chain or the raw public key of the server.
     ///
-    /// For servers, this is the certificate chain of the client,
+    /// For servers, this is the certificate chain or the raw public key of the client,
     /// if client authentication was completed.
     ///
     /// The return value is None until this value is available.
+    ///
+    /// Note: the return type of the 'certificate', when using raw public keys is `CertificateDer<'static>`
+    /// even though this should technically be a `SubjectPublicKeyInfoDer<'static>`.
+    /// This choice simplifies the API and ensures backwards compatibility.
     pub fn peer_certificates(&self) -> Option<&[CertificateDer<'static>]> {
         self.peer_certificates.as_deref()
     }
@@ -885,6 +891,35 @@ enum Limit {
     #[cfg(feature = "std")]
     Yes,
     No,
+}
+
+#[derive(Debug)]
+pub(super) struct RawKeyNegotiationParams {
+    pub(super) peer_supports_raw_key: bool,
+    pub(super) local_expects_raw_key: bool,
+    pub(super) extension_type: ExtensionType,
+}
+
+impl RawKeyNegotiationParams {
+    pub(super) fn validate_raw_key_negotiation(&self) -> RawKeyNegotationResult {
+        match (self.local_expects_raw_key, self.peer_supports_raw_key) {
+            (true, true) => RawKeyNegotationResult::Negotiated(self.extension_type),
+            (false, false) => RawKeyNegotationResult::NotNegotiated,
+            (true, false) => RawKeyNegotationResult::Err(Error::PeerIncompatible(
+                PeerIncompatible::IncorrectCertificateTypeExtension,
+            )),
+            (false, true) => RawKeyNegotationResult::Err(Error::PeerIncompatible(
+                PeerIncompatible::UnsolicitedCertificateTypeExtension,
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum RawKeyNegotationResult {
+    Negotiated(ExtensionType),
+    NotNegotiated,
+    Err(Error),
 }
 
 /// Tracking technically-allowed protocol actions

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -9,7 +9,8 @@ use zeroize::Zeroize;
 use crate::msgs::ffdhe_groups::FfdheGroup;
 use crate::sign::SigningKey;
 pub use crate::webpki::{
-    verify_tls12_signature, verify_tls13_signature, WebPkiSupportedAlgorithms,
+    verify_tls12_signature, verify_tls13_signature, verify_tls13_signature_with_raw_key,
+    WebPkiSupportedAlgorithms,
 };
 #[cfg(all(doc, feature = "tls12"))]
 use crate::Tls12CipherSuite;

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -87,9 +87,15 @@ pub trait Signer: Debug + Send + Sync {
 
 /// A packaged-together certificate chain, matching `SigningKey` and
 /// optional stapled OCSP response.
+///
+/// Note: this struct is also used to represent an [RFC 7250] raw public key,
+/// when the client/server is configured to use raw public keys instead of
+/// certificates.  
+///
+/// [RFC 7250]: https://tools.ietf.org/html/rfc7250
 #[derive(Clone, Debug)]
 pub struct CertifiedKey {
-    /// The certificate chain.
+    /// The certificate chain or raw public key.
     pub cert: Vec<CertificateDer<'static>>,
 
     /// The certified key.

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -97,7 +97,7 @@ pub enum Error {
     /// or too large.
     BadMaxFragmentSize,
 
-    /// Specific failure cases from [`keys_match`].
+    /// Specific failure cases from [`keys_match`] or a [`crate::crypto::signer::SigningKey`] that cannot produce a corresponding public key.
     ///
     /// [`keys_match`]: crate::crypto::signer::CertifiedKey::keys_match
     InconsistentKeys(InconsistentKeys),
@@ -112,7 +112,7 @@ pub enum Error {
     Other(OtherError),
 }
 
-/// Specific failure cases from [`keys_match`].
+/// Specific failure cases from [`keys_match`] or a [`crate::crypto::signer::SigningKey`] that cannot produce a corresponding public key.
 ///
 /// [`keys_match`]: crate::crypto::signer::CertifiedKey::keys_match
 #[non_exhaustive]
@@ -300,6 +300,7 @@ impl From<PeerMisbehaved> for Error {
 pub enum PeerIncompatible {
     EcPointsExtensionRequired,
     ExtendedMasterSecretExtensionRequired,
+    IncorrectCertificateTypeExtension,
     KeyShareExtensionRequired,
     NamedGroupsExtensionRequired,
     NoCertificateRequestSignatureSchemesInCommon,
@@ -317,6 +318,7 @@ pub enum PeerIncompatible {
     Tls12NotOfferedOrEnabled,
     Tls13RequiredForQuic,
     UncompressedEcPointsRequired,
+    UnsolicitedCertificateTypeExtension,
     ServerRejectedEncryptedClientHello(Option<Vec<EchConfigPayload>>),
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -444,7 +444,8 @@ pub mod internal {
         }
         pub mod enums {
             pub use crate::msgs::enums::{
-                AlertLevel, Compression, EchVersion, HpkeAead, HpkeKdf, HpkeKem, NamedGroup,
+                AlertLevel, CertificateType, Compression, EchVersion, HpkeAead, HpkeKdf, HpkeKem,
+                NamedGroup,
             };
         }
         pub mod fragmenter {
@@ -454,8 +455,8 @@ pub mod internal {
             pub use crate::msgs::handshake::{
                 CertificateChain, ClientExtension, ClientHelloPayload, DistinguishedName,
                 EchConfigContents, EchConfigPayload, HandshakeMessagePayload, HandshakePayload,
-                HpkeKeyConfig, HpkeSymmetricCipherSuite, KeyShareEntry, Random, ServerName,
-                SessionId,
+                HpkeKeyConfig, HpkeSymmetricCipherSuite, KeyShareEntry, Random, ServerExtension,
+                ServerName, SessionId,
             };
         }
         pub mod message {
@@ -467,6 +468,8 @@ pub mod internal {
             pub use crate::msgs::persist::ServerSessionValue;
         }
     }
+
+    pub use crate::tls13::key_schedule::{derive_traffic_iv, derive_traffic_key};
 
     pub mod fuzzing {
         pub use crate::msgs::deframer::fuzz_deframer;
@@ -562,6 +565,7 @@ pub mod client {
     #[cfg(feature = "std")]
     pub use client_conn::{ClientConnection, WriteEarlyData};
     pub use ech::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
+    pub use handy::AlwaysResolvesClientRawPublicKeys;
     #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ClientSessionMemoryCache;
 
@@ -595,6 +599,7 @@ pub mod server {
     mod tls13;
 
     pub use builder::WantsServerCert;
+    pub use handy::AlwaysResolvesServerRawPublicKeys;
     pub use handy::NoServerSessionStorage;
     #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ResolvesServerCertUsingSni;

--- a/rustls/src/manual/features.rs
+++ b/rustls/src/manual/features.rs
@@ -26,6 +26,7 @@ APIs ([`CryptoProvider`] for example).
 * Extended master secret support ([RFC7627](https://tools.ietf.org/html/rfc7627))
 * Exporters ([RFC5705](https://tools.ietf.org/html/rfc5705))
 * OCSP stapling by servers
+* [RFC7250](https://tools.ietf.org/html/rfc7250) raw public keys for TLS1.3
 * [RFC8879](https://tools.ietf.org/html/rfc8879) certificate compression by clients
   and servers `*`
 * Client-side Encrypted client hello (ECH)

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -96,6 +96,8 @@ enum_builder! {
         Heartbeat => 0x000f,
         ALProtocolNegotiation => 0x0010,
         SCT => 0x0012,
+        ClientCertificateType => 0x0013,
+        ServerCertificateType => 0x0014,
         Padding => 0x0015,
         ExtendedMasterSecret => 0x0017,
         CompressCertificate => 0x001b,
@@ -306,6 +308,19 @@ enum_builder! {
 }
 
 enum_builder! {
+    /// The `CertificateType` enum sent in the cert_type extensions.
+    /// Values in this enum are taken from the various RFCs covering TLS, and are listed by IANA.
+    ///
+    /// [RFC 6091 Section 5]: <https://datatracker.ietf.org/doc/html/rfc6091#section-5>
+    /// [RFC 7250 Section 7]: <https://datatracker.ietf.org/doc/html/rfc7250#section-7>
+    @U8
+    pub enum CertificateType {
+        X509 => 0x00,
+        RawPublicKey => 0x02,
+    }
+}
+
+enum_builder! {
     /// The Key Encapsulation Mechanism (`Kem`) type for HPKE operations.
     /// Listed by IANA, as specified in [RFC 9180 Section 7.1]
     ///
@@ -437,6 +452,7 @@ pub(crate) mod tests {
             CertificateStatusType::OCSP,
             CertificateStatusType::OCSP,
         );
+        test_enum8::<CertificateType>(CertificateType::X509, CertificateType::RawPublicKey);
     }
 
     pub(crate) fn test_enum8<T: for<'a> Codec<'a>>(first: T, last: T) {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1303,12 +1303,12 @@ impl HelloRetryRequest {
 
 #[derive(Clone, Debug)]
 pub struct ServerHelloPayload {
+    pub extensions: Vec<ServerExtension>,
     pub(crate) legacy_version: ProtocolVersion,
     pub(crate) random: Random,
     pub(crate) session_id: SessionId,
     pub(crate) cipher_suite: CipherSuite,
     pub(crate) compression_method: Compression,
-    pub(crate) extensions: Vec<ServerExtension>,
 }
 
 impl Codec<'_> for ServerHelloPayload {

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -4,6 +4,7 @@ use std::{format, println, vec};
 
 use pki_types::{CertificateDer, DnsName};
 
+use super::enums::CertificateType;
 use super::handshake::{ServerDhParams, ServerKeyExchange, ServerKeyExchangeParams};
 use crate::enums::{
     CertificateCompressionAlgorithm, CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme,
@@ -492,6 +493,22 @@ fn client_alpn_extension() {
 }
 
 #[test]
+fn client_client_certificate_extension() {
+    test_client_extension_getter(ExtensionType::ClientCertificateType, |chp| {
+        chp.client_certificate_extension()
+            .is_some()
+    });
+}
+
+#[test]
+fn client_server_certificate_extension() {
+    test_client_extension_getter(ExtensionType::ServerCertificateType, |chp| {
+        chp.server_certificate_extension()
+            .is_some()
+    });
+}
+
+#[test]
 fn client_quic_params_extension() {
     test_client_extension_getter(ExtensionType::TransportParameters, |chp| {
         chp.quic_params_extension().is_some()
@@ -677,6 +694,20 @@ fn server_ecpoints_extension() {
 fn server_supported_versions() {
     test_server_extension_getter(ExtensionType::SupportedVersions, |shp| {
         shp.supported_versions().is_some()
+    });
+}
+
+#[test]
+fn server_client_certificate_type_extension() {
+    test_server_extension_getter(ExtensionType::ClientCertificateType, |shp| {
+        shp.client_cert_type().is_some()
+    });
+}
+
+#[test]
+fn server_server_certificate_type_extension() {
+    test_server_extension_getter(ExtensionType::ServerCertificateType, |shp| {
+        shp.server_cert_type().is_some()
     });
 }
 
@@ -954,6 +985,8 @@ fn sample_client_hello_payload() -> ClientHelloPayload {
             ClientExtension::Cookie(PayloadU16(vec![1, 2, 3])),
             ClientExtension::ExtendedMasterSecretRequest,
             ClientExtension::CertificateStatusRequest(CertificateStatusRequest::build_ocsp()),
+            ClientExtension::ServerCertTypes(vec![CertificateType::RawPublicKey]),
+            ClientExtension::ClientCertTypes(vec![CertificateType::RawPublicKey]),
             ClientExtension::TransportParameters(vec![1, 2, 3]),
             ClientExtension::EarlyData,
             ClientExtension::CertificateCompressionAlgorithms(vec![
@@ -991,6 +1024,8 @@ fn sample_server_hello_payload() -> ServerHelloPayload {
                 typ: ExtensionType::Unknown(12345),
                 payload: Payload::Borrowed(&[1, 2, 3]),
             }),
+            ServerExtension::ClientCertType(CertificateType::RawPublicKey),
+            ServerExtension::ServerCertType(CertificateType::RawPublicKey),
         ],
     }
 }

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -770,6 +770,21 @@ impl KeySchedule {
     }
 }
 
+/// [HKDF-Expand-Label] where the output is an AEAD key.
+///
+/// [HKDF-Expand-Label]: <https://www.rfc-editor.org/rfc/rfc8446#section-7.1>
+pub(crate) fn derive_traffic_key(expander: &dyn HkdfExpander, aead_key_len: usize) -> AeadKey {
+    hkdf_expand_label_aead_key(expander, aead_key_len, b"key", &[])
+}
+
+/// [HKDF-Expand-Label] where the output is an IV.
+///
+/// [HKDF-Expand-Label]: <https://www.rfc-editor.org/rfc/rfc8446#section-7.1>
+pub(crate) fn derive_traffic_iv(expander: &dyn HkdfExpander) -> Iv {
+    hkdf_expand_label(expander, b"iv", &[])
+}
+
+
 /// [HKDF-Expand-Label] where the output length is a compile-time constant, and therefore
 /// it is infallible.
 ///
@@ -843,13 +858,6 @@ pub(crate) fn server_ech_hrr_confirmation_secret(
     )
 }
 
-pub(crate) fn derive_traffic_key(expander: &dyn HkdfExpander, aead_key_len: usize) -> AeadKey {
-    hkdf_expand_label_aead_key(expander, aead_key_len, b"key", &[])
-}
-
-pub(crate) fn derive_traffic_iv(expander: &dyn HkdfExpander) -> Iv {
-    hkdf_expand_label(expander, b"iv", &[])
-}
 
 fn hkdf_expand_label_inner<F, T>(
     expander: &dyn HkdfExpander,

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -136,6 +136,12 @@ pub trait ServerCertVerifier: Debug + Send + Sync {
     ///
     /// This should be in priority order, with the most preferred first.
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme>;
+
+    /// Returns whether this verifier requires raw public keys as defined
+    /// in [RFC 7250](https://tools.ietf.org/html/rfc7250).
+    fn requires_raw_public_keys(&self) -> bool {
+        false
+    }
 }
 
 /// Something that can verify a client certificate chain
@@ -249,6 +255,12 @@ pub trait ClientCertVerifier: Debug + Send + Sync {
     ///
     /// This should be in priority order, with the most preferred first.
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme>;
+
+    /// Returns whether this verifier requires raw public keys as defined
+    /// in [RFC 7250](https://tools.ietf.org/html/rfc7250).
+    fn requires_raw_public_keys(&self) -> bool {
+        false
+    }
 }
 
 /// Turns off client authentication.

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -21,7 +21,10 @@ pub use server_verifier::{ServerCertVerifierBuilder, WebPkiServerVerifier};
 pub use verify::{
     verify_server_cert_signed_by_trust_anchor, verify_server_name, ParsedCertificate,
 };
-pub use verify::{verify_tls12_signature, verify_tls13_signature, WebPkiSupportedAlgorithms};
+pub use verify::{
+    verify_tls12_signature, verify_tls13_signature, verify_tls13_signature_with_raw_key,
+    WebPkiSupportedAlgorithms,
+};
 
 /// An error that can occur when building a certificate verifier.
 #[derive(Debug, Clone)]

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -8,18 +8,13 @@ mod common;
 use std::sync::Arc;
 
 use common::{
-    do_handshake_until_both_error, do_handshake_until_error, get_client_root_store,
-    make_client_config_with_versions, make_client_config_with_versions_with_auth,
-    make_pair_for_arc_configs, server_config_builder, server_name, webpki_client_verifier_builder,
-    ErrorFromPeer, KeyType, ALL_KEY_TYPES,
+    do_handshake_until_both_error, do_handshake_until_error, make_client_config_with_versions,
+    make_client_config_with_versions_with_auth, make_pair_for_arc_configs, server_config_builder,
+    server_name, ErrorFromPeer, KeyType, MockClientVerifier, ALL_KEY_TYPES,
 };
-use pki_types::{CertificateDer, UnixTime};
-use rustls::client::danger::HandshakeSignatureValid;
-use rustls::internal::msgs::handshake::DistinguishedName;
-use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
+use rustls::server::danger::ClientCertVerified;
 use rustls::{
-    AlertDescription, ClientConnection, DigitallySignedStruct, Error, InvalidMessage, ServerConfig,
-    ServerConnection, SignatureScheme,
+    AlertDescription, ClientConnection, Error, InvalidMessage, ServerConfig, ServerConnection,
 };
 
 // Client is authorized!
@@ -134,76 +129,6 @@ fn client_verifier_fails_properly() {
                 err,
                 Err(ErrorFromPeer::Server(Error::General("test err".into())))
             );
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct MockClientVerifier {
-    parent: Arc<dyn ClientCertVerifier>,
-    pub verified: fn() -> Result<ClientCertVerified, Error>,
-    pub subjects: Vec<DistinguishedName>,
-    pub mandatory: bool,
-    pub offered_schemes: Option<Vec<SignatureScheme>>,
-}
-
-impl MockClientVerifier {
-    pub fn new(verified: fn() -> Result<ClientCertVerified, Error>, kt: KeyType) -> Self {
-        Self {
-            parent: webpki_client_verifier_builder(get_client_root_store(kt))
-                .build()
-                .unwrap(),
-            verified,
-            subjects: get_client_root_store(kt).subjects(),
-            mandatory: true,
-            offered_schemes: None,
-        }
-    }
-}
-
-impl ClientCertVerifier for MockClientVerifier {
-    fn client_auth_mandatory(&self) -> bool {
-        self.mandatory
-    }
-
-    fn root_hint_subjects(&self) -> &[DistinguishedName] {
-        &self.subjects
-    }
-
-    fn verify_client_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _now: UnixTime,
-    ) -> Result<ClientCertVerified, Error> {
-        (self.verified)()
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, Error> {
-        self.parent
-            .verify_tls12_signature(message, cert, dss)
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        message: &[u8],
-        cert: &CertificateDer<'_>,
-        dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, Error> {
-        self.parent
-            .verify_tls13_signature(message, cert, dss)
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        if let Some(schemes) = &self.offered_schemes {
-            schemes.clone()
-        } else {
-            self.parent.supported_verify_schemes()
         }
     }
 }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -9,20 +9,25 @@ use once_cell::sync::OnceCell;
 use pki_types::pem::PemObject;
 use pki_types::{
     CertificateDer, CertificateRevocationListDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName,
-    UnixTime,
+    SubjectPublicKeyInfoDer, UnixTime,
 };
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-use rustls::client::{ServerCertVerifierBuilder, WebPkiServerVerifier};
+use rustls::client::{
+    AlwaysResolvesClientRawPublicKeys, ServerCertVerifierBuilder, WebPkiServerVerifier,
+};
 use rustls::crypto::cipher::{InboundOpaqueMessage, MessageDecrypter, MessageEncrypter};
-use rustls::crypto::CryptoProvider;
+use rustls::crypto::{verify_tls13_signature_with_raw_key, CryptoProvider};
 use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::message::{Message, OutboundOpaqueMessage, PlainMessage};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
-use rustls::server::{ClientCertVerifierBuilder, WebPkiClientVerifier};
+use rustls::server::{
+    AlwaysResolvesServerRawPublicKeys, ClientCertVerifierBuilder, WebPkiClientVerifier,
+};
+use rustls::sign::CertifiedKey;
 use rustls::{
     ClientConfig, ClientConnection, Connection, ConnectionCommon, ContentType,
-    DigitallySignedStruct, DistinguishedName, Error, NamedGroup, ProtocolVersion, RootCertStore,
-    ServerConfig, ServerConnection, SideData, SignatureScheme, SupportedCipherSuite,
+    DigitallySignedStruct, DistinguishedName, Error, InconsistentKeys, NamedGroup, ProtocolVersion,
+    RootCertStore, ServerConfig, ServerConnection, SideData, SignatureScheme, SupportedCipherSuite,
 };
 use webpki::anchor_from_trusted_cert;
 
@@ -51,6 +56,8 @@ macro_rules! embed_files {
 }
 
 embed_files! {
+    (ECDSA_P256_END_PEM_SPKI, "ecdsa-p256", "end.spki.pem");
+    (ECDSA_P256_CLIENT_PEM_SPKI, "ecdsa-p256", "client.spki.pem");
     (ECDSA_P256_CA_CERT, "ecdsa-p256", "ca.cert");
     (ECDSA_P256_CA_DER, "ecdsa-p256", "ca.der");
     (ECDSA_P256_CA_KEY, "ecdsa-p256", "ca.key");
@@ -69,6 +76,8 @@ embed_files! {
     (ECDSA_P256_INTER_CERT, "ecdsa-p256", "inter.cert");
     (ECDSA_P256_INTER_KEY, "ecdsa-p256", "inter.key");
 
+    (ECDSA_P384_END_PEM_SPKI, "ecdsa-p384", "end.spki.pem");
+    (ECDSA_P384_CLIENT_PEM_SPKI, "ecdsa-p384", "client.spki.pem");
     (ECDSA_P384_CA_CERT, "ecdsa-p384", "ca.cert");
     (ECDSA_P384_CA_DER, "ecdsa-p384", "ca.der");
     (ECDSA_P384_CA_KEY, "ecdsa-p384", "ca.key");
@@ -87,6 +96,8 @@ embed_files! {
     (ECDSA_P384_INTER_CERT, "ecdsa-p384", "inter.cert");
     (ECDSA_P384_INTER_KEY, "ecdsa-p384", "inter.key");
 
+    (ECDSA_P521_END_PEM_SPKI, "ecdsa-p521", "end.spki.pem");
+    (ECDSA_P521_CLIENT_PEM_SPKI, "ecdsa-p521", "client.spki.pem");
     (ECDSA_P521_CA_CERT, "ecdsa-p521", "ca.cert");
     (ECDSA_P521_CA_DER, "ecdsa-p521", "ca.der");
     (ECDSA_P521_CA_KEY, "ecdsa-p521", "ca.key");
@@ -105,6 +116,8 @@ embed_files! {
     (ECDSA_P521_INTER_CERT, "ecdsa-p521", "inter.cert");
     (ECDSA_P521_INTER_KEY, "ecdsa-p521", "inter.key");
 
+    (EDDSA_END_PEM_SPKI, "eddsa", "end.spki.pem");
+    (EDDSA_CLIENT_PEM_SPKI, "eddsa", "client.spki.pem");
     (EDDSA_CA_CERT, "eddsa", "ca.cert");
     (EDDSA_CA_DER, "eddsa", "ca.der");
     (EDDSA_CA_KEY, "eddsa", "ca.key");
@@ -123,6 +136,8 @@ embed_files! {
     (EDDSA_INTER_CERT, "eddsa", "inter.cert");
     (EDDSA_INTER_KEY, "eddsa", "inter.key");
 
+    (RSA_2048_END_PEM_SPKI, "rsa-2048", "end.spki.pem");
+    (RSA_2048_CLIENT_PEM_SPKI, "rsa-2048", "client.spki.pem");
     (RSA_2048_CA_CERT, "rsa-2048", "ca.cert");
     (RSA_2048_CA_DER, "rsa-2048", "ca.der");
     (RSA_2048_CA_KEY, "rsa-2048", "ca.key");
@@ -141,6 +156,8 @@ embed_files! {
     (RSA_2048_INTER_CERT, "rsa-2048", "inter.cert");
     (RSA_2048_INTER_KEY, "rsa-2048", "inter.key");
 
+    (RSA_3072_END_PEM_SPKI, "rsa-3072", "end.spki.pem");
+    (RSA_3072_CLIENT_PEM_SPKI, "rsa-3072", "client.spki.pem");
     (RSA_3072_CA_CERT, "rsa-3072", "ca.cert");
     (RSA_3072_CA_DER, "rsa-3072", "ca.der");
     (RSA_3072_CA_KEY, "rsa-3072", "ca.key");
@@ -159,6 +176,8 @@ embed_files! {
     (RSA_3072_INTER_CERT, "rsa-3072", "inter.cert");
     (RSA_3072_INTER_KEY, "rsa-3072", "inter.key");
 
+    (RSA_4096_END_PEM_SPKI, "rsa-4096", "end.spki.pem");
+    (RSA_4096_CLIENT_PEM_SPKI, "rsa-4096", "client.spki.pem");
     (RSA_4096_CA_CERT, "rsa-4096", "ca.cert");
     (RSA_4096_CA_DER, "rsa-4096", "ca.der");
     (RSA_4096_CA_KEY, "rsa-4096", "ca.key");
@@ -311,6 +330,10 @@ impl KeyType {
             .collect()
     }
 
+    pub fn get_spki(&self) -> SubjectPublicKeyInfoDer<'static> {
+        SubjectPublicKeyInfoDer::from_pem_slice(self.bytes_for("end.spki.pem")).unwrap()
+    }
+
     pub fn get_key(&self) -> PrivateKeyDer<'static> {
         PrivatePkcs8KeyDer::from_pem_slice(self.bytes_for("end.key"))
             .unwrap()
@@ -343,6 +366,38 @@ impl KeyType {
         PrivatePkcs8KeyDer::from_pem_slice(self.bytes_for("client.key"))
             .unwrap()
             .into()
+    }
+
+    pub fn get_client_spki(&self) -> SubjectPublicKeyInfoDer<'static> {
+        SubjectPublicKeyInfoDer::from_pem_slice(self.bytes_for("client.spki.pem")).unwrap()
+    }
+
+    pub fn get_certified_client_key(&self) -> Result<Arc<CertifiedKey>, Error> {
+        let private_key = provider::default_provider()
+            .key_provider
+            .load_private_key(self.get_client_key())?;
+        let public_key = private_key
+            .public_key()
+            .ok_or(Error::InconsistentKeys(InconsistentKeys::Unknown))?;
+        let public_key_as_cert = CertificateDer::from(public_key.to_vec());
+        Ok(Arc::new(CertifiedKey::new(
+            vec![public_key_as_cert],
+            private_key,
+        )))
+    }
+
+    pub fn get_certified_key(&self) -> Result<Arc<CertifiedKey>, Error> {
+        let private_key = provider::default_provider()
+            .key_provider
+            .load_private_key(self.get_key())?;
+        let public_key = private_key
+            .public_key()
+            .ok_or(Error::InconsistentKeys(InconsistentKeys::Unknown))?;
+        let public_key_as_cert = CertificateDer::from(public_key.to_vec());
+        Ok(Arc::new(CertifiedKey::new(
+            vec![public_key_as_cert],
+            private_key,
+        )))
     }
 
     fn get_crl(&self, role: &str, r#type: &str) -> CertificateRevocationListDer<'static> {
@@ -516,6 +571,52 @@ pub fn make_server_config_with_client_verifier(
         .unwrap()
 }
 
+pub fn make_server_config_with_raw_key_support(kt: KeyType) -> ServerConfig {
+    let mut client_verifier = MockClientVerifier::new(|| Ok(ClientCertVerified::assertion()), kt);
+    let server_cert_resolver = Arc::new(AlwaysResolvesServerRawPublicKeys::new(
+        kt.get_certified_key().unwrap(),
+    ));
+    client_verifier.expect_raw_public_keys = true;
+    // We don't support tls1.2 for Raw Public Keys, hence the version is hard-coded.
+    server_config_builder_with_versions(&[&rustls::version::TLS13])
+        .with_client_cert_verifier(Arc::new(client_verifier))
+        .with_cert_resolver(server_cert_resolver)
+}
+
+pub fn make_client_config_with_raw_key_support(kt: KeyType) -> ClientConfig {
+    let server_verifier = Arc::new(MockServerVerifier::expects_raw_public_keys());
+    let client_cert_resolver = Arc::new(AlwaysResolvesClientRawPublicKeys::new(
+        kt.get_certified_client_key().unwrap(),
+    ));
+    // We don't support tls1.2 for Raw Public Keys, hence the version is hard-coded.
+    client_config_builder_with_versions(&[&rustls::version::TLS13])
+        .dangerous()
+        .with_custom_certificate_verifier(server_verifier)
+        .with_client_cert_resolver(client_cert_resolver)
+}
+
+pub fn make_client_config_with_cipher_suite_and_raw_key_support(
+    kt: KeyType,
+    cipher_suite: SupportedCipherSuite,
+) -> ClientConfig {
+    let server_verifier = Arc::new(MockServerVerifier::expects_raw_public_keys());
+    let client_cert_resolver = Arc::new(AlwaysResolvesClientRawPublicKeys::new(
+        kt.get_certified_client_key().unwrap(),
+    ));
+    ClientConfig::builder_with_provider(
+        CryptoProvider {
+            cipher_suites: vec![cipher_suite],
+            ..provider::default_provider()
+        }
+        .into(),
+    )
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .unwrap()
+    .dangerous()
+    .with_custom_certificate_verifier(server_verifier)
+    .with_client_cert_resolver(client_cert_resolver)
+}
+
 pub fn finish_client_config(
     kt: KeyType,
     config: rustls::ConfigBuilder<ClientConfig, rustls::WantsVerifier>,
@@ -660,6 +761,32 @@ pub fn do_handshake_until_error(
             .process_new_packets()
             .map_err(ErrorFromPeer::Server)?;
         transfer(server, client);
+        client
+            .process_new_packets()
+            .map_err(ErrorFromPeer::Client)?;
+    }
+
+    Ok(())
+}
+
+pub fn do_handshake_altered(
+    client: ClientConnection,
+    alter_server_message: impl Fn(&mut Message) -> Altered,
+    alter_client_message: impl Fn(&mut Message) -> Altered,
+    server: ServerConnection,
+) -> Result<(), ErrorFromPeer> {
+    let mut client: Connection = Connection::Client(client);
+    let mut server: Connection = Connection::Server(server);
+
+    while server.is_handshaking() || client.is_handshaking() {
+        transfer_altered(&mut client, &alter_client_message, &mut server);
+
+        server
+            .process_new_packets()
+            .map_err(ErrorFromPeer::Server)?;
+
+        transfer_altered(&mut server, &alter_server_message, &mut client);
+
         client
             .process_new_packets()
             .map_err(ErrorFromPeer::Client)?;
@@ -839,6 +966,7 @@ pub struct MockServerVerifier {
     tls13_signature_error: Option<Error>,
     signature_schemes: Vec<SignatureScheme>,
     expected_ocsp_response: Option<Vec<u8>>,
+    requires_raw_public_keys: bool,
 }
 
 impl ServerCertVerifier for MockServerVerifier {
@@ -893,6 +1021,13 @@ impl ServerCertVerifier for MockServerVerifier {
         );
         if let Some(error) = &self.tls13_signature_error {
             Err(error.clone())
+        } else if self.requires_raw_public_keys {
+            verify_tls13_signature_with_raw_key(
+                message,
+                &SubjectPublicKeyInfoDer::from(cert.as_ref()),
+                dss,
+                &provider::default_provider().signature_verification_algorithms,
+            )
         } else {
             Ok(HandshakeSignatureValid::assertion())
         }
@@ -900,6 +1035,10 @@ impl ServerCertVerifier for MockServerVerifier {
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
         self.signature_schemes.clone()
+    }
+
+    fn requires_raw_public_keys(&self) -> bool {
+        self.requires_raw_public_keys
     }
 }
 
@@ -945,6 +1084,13 @@ impl MockServerVerifier {
             ..Default::default()
         }
     }
+
+    pub fn expects_raw_public_keys() -> Self {
+        MockServerVerifier {
+            requires_raw_public_keys: true,
+            ..Default::default()
+        }
+    }
 }
 
 impl Default for MockServerVerifier {
@@ -962,6 +1108,7 @@ impl Default for MockServerVerifier {
                 SignatureScheme::ECDSA_NISTP521_SHA512,
             ],
             expected_ocsp_response: None,
+            requires_raw_public_keys: false,
         }
     }
 }
@@ -972,6 +1119,7 @@ pub struct MockClientVerifier {
     pub subjects: Vec<DistinguishedName>,
     pub mandatory: bool,
     pub offered_schemes: Option<Vec<SignatureScheme>>,
+    pub expect_raw_public_keys: bool,
     parent: Arc<dyn ClientCertVerifier>,
 }
 
@@ -985,6 +1133,7 @@ impl MockClientVerifier {
             subjects: get_client_root_store(kt).subjects(),
             mandatory: true,
             offered_schemes: None,
+            expect_raw_public_keys: false,
         }
     }
 }
@@ -1013,8 +1162,12 @@ impl ClientCertVerifier for MockClientVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
+        if self.expect_raw_public_keys {
+            Ok(HandshakeSignatureValid::assertion())
+        } else {
             self.parent
                 .verify_tls12_signature(message, cert, dss)
+        }
     }
 
     fn verify_tls13_signature(
@@ -1023,8 +1176,17 @@ impl ClientCertVerifier for MockClientVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
+        if self.expect_raw_public_keys {
+            verify_tls13_signature_with_raw_key(
+                message,
+                &SubjectPublicKeyInfoDer::from(cert.as_ref()),
+                dss,
+                &provider::default_provider().signature_verification_algorithms,
+            )
+        } else {
             self.parent
                 .verify_tls13_signature(message, cert, dss)
+        }
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
@@ -1033,6 +1195,10 @@ impl ClientCertVerifier for MockClientVerifier {
         } else {
             self.parent.supported_verify_schemes()
         }
+    }
+
+    fn requires_raw_public_keys(&self) -> bool {
+        self.expect_raw_public_keys
     }
 }
 


### PR DESCRIPTION
This PR implements [RFC 7250](https://datatracker.ietf.org/doc/html/rfc7250) (Raw Public Key support) for TLS 1.3. The relevant discussion can be found in [this issue](https://github.com/rustls/rustls/issues/423), with a [detailed comment](https://github.com/rustls/rustls/issues/423#issuecomment-1908082743) by @ctz explaining the necessary steps.

### Main API changes:

1. The `ServerCertVerifier` and `ClientCertVerifier` traits now include a `requires_raw_public_keys()` function, while the `ServerResolveCert` and `ClientResolveCert` traits now have a `only_raw_public_keys()` function. Both functions have default implementations that return `false`.
2. We provide implementations for `ServerResolveCert` and `ClientResolveCert` that always resolve to a specific raw public key (`AlwaysResolvesServerRawPublicKeys`, `AlwaysResolvesClientRawPublicKeys`).
3. We introduce `webpki::verify::verify_tls13_signature_with_spki()` for signature verification. These functions use `webpki::RawPublicKeyEntity`, which was added to `rustls-webpki` in [this PR](https://github.com/rustls/webpki/pull/275).
4. Two error values were added to `PeerIncompatible`: 
   - `IncorrectCertificateTypeExtension`, raised when the local side expects Raw Public Keys but the peer sends an incorrect certificate type extension.
   - `UnsolicitedCertificateTypeExtension`, raised when the peer sends a certificate type extension, but the local side does not expect Raw Public Keys.
5. New values were added to `handshake::ServerExtension` and `handshake::ClientExtension`:
   - `ClientExtension::ServerCertTypes` and `ClientExtension::ClientCertTypes` are used to communicate the `CertificateType`s supported by the client.
   - `ServerExtension::ServerCertType` and `ServerExtension::ClientCertType` are used to communicate the `CertificateType` chosen by the server.
6. The two certificate type extensions, `ServerExtension::ServerCertType` and `ServerExtension::ClientCertType`, are added to `server_conn::ClientHello` for use in the `Acceptor` API.
7. We needed to decrypt, modify, and re-encrypt the `ServerHello` message to test our implementation. For this, `tls13::key_schedule::derive_traffic_key()` and `tls13::key_schedule::derive_traffic_iv()` were made public.

### Interoperability testing and example implementation:

1. An example implementation of a server and client using Raw Public Keys can be found in `raw_key_openssl_interop.rs`. This implementation is tested against an OpenSSL client and server to ensure interoperability with our implementation.

### Considerations:

1. To minimize the impact on the API and ensure backward compatibility, we sometimes use a `CertificateDer` type for a Raw Public Key instead of the more concise `SubjectPublicKeyInfoDer`. This approach is used in:
   - `CommonState::peer_certificates()`
   - The `cert` field of the `CertifiedKey` struct.
2. Our implementation closely follows RFC 7250. The main deviation is our assumption of a-priori knowledge about the peer’s authentication method when using Raw Public Keys (as explained in [this comment](https://github.com/rustls/rustls/issues/423#issuecomment-1908082743)). This means we never offer a `RawPublicKey` alongside `X509`, though the RFC permits it.

### Contributors:

This PR was created in collaboration with @aochagavia.