### PR TITLE
Remove `default_fips_provider()` item without aws_lc_rs

### DIFF
--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -568,7 +568,7 @@ impl From<&[u8]> for SharedSecret {
 ///     .with_no_client_auth();
 /// # }
 /// ```
-#[cfg(any(feature = "fips", docsrs))]
+#[cfg(all(feature = "aws_lc_rs", any(feature = "fips", docsrs)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "fips")))]
 pub fn default_fips_provider() -> CryptoProvider {
     aws_lc_rs::default_provider()


### PR DESCRIPTION
fixes #2063 