### PR TITLE
Fix daily-tests failures

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -48,11 +48,11 @@ jobs:
         if: runner.os == 'Windows'
         uses: seanmiddleditch/gha-setup-ninja@v5
 
-      - name: Build main crate
-        run: cargo build --locked
+      - name: Build example programs
+        run: cargo build --locked -p rustls-examples
 
       - name: Run connect tests
-        run: cargo test --locked --manifest-path=connect-tests/Cargo.toml
+        run: cargo test --locked -p rustls-connect-tests --manifest-path=connect-tests/Cargo.toml
         env:
           RUST_BACKTRACE: 1
 
@@ -93,31 +93,31 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@v5
 
       - name: Check simple client
-        run: cargo run --locked --bin simpleclient
+        run: cargo run --locked -p rustls-examples --bin simpleclient
 
       - name: Check limited client
-        run: cargo run --locked --bin limitedclient
+        run: cargo run --locked -p rustls-examples --bin limitedclient
 
       - name: Check simple 0rtt client
-        run: cargo run --locked --bin simple_0rtt_client
+        run: cargo run --locked -p rustls-examples --bin simple_0rtt_client
 
       - name: Check unbuffered client 
-        run: cargo run --locked --bin unbuffered-client
+        run: cargo run --locked -p rustls-examples --bin unbuffered-client
 
       - name: Check unbuffered tokio client 
-        run: cargo run --locked --bin unbuffered-async-client
+        run: cargo run --locked -p rustls-examples --bin unbuffered-async-client
 
       - name: Check unbuffered async-std client 
-        run: cargo run --locked --bin unbuffered-async-client --features=async-std
+        run: cargo run --locked -p rustls-examples --bin unbuffered-async-client --features=async-std
 
       # Test the server_acceptor binary builds - we invoke with --help since it
       # will run a server process that doesn't exit when invoked with no args
       - name: Check server acceptor
-        run: cargo run --locked --bin server_acceptor -- --help
+        run: cargo run --locked -p rustls-examples --bin server_acceptor -- --help
 
       - name: Check ech-client
         run: >
-          cargo run --locked --bin ech-client -- --host defo.ie defo.ie www.defo.ie | 
+          cargo run --locked -p rustls-examples --bin ech-client -- --host defo.ie defo.ie www.defo.ie |
             grep 'SSL_ECH_STATUS: success'
 
       - name: Check provider-example client

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1029,7 +1029,7 @@ impl<Data> ConnectionCore<Data> {
             let message = unborrowed.reborrow(&Delocator::new(buffer));
             self.hs_deframer
                 .input_message(message, &locator, buffer_progress.processed());
-            self.hs_deframer.coalesce(buffer);
+            self.hs_deframer.coalesce(buffer)?;
 
             self.common_state.aligned_handshake = self.hs_deframer.is_aligned();
 

--- a/rustls/src/msgs/deframer/handshake.rs
+++ b/rustls/src/msgs/deframer/handshake.rs
@@ -3,6 +3,7 @@ use core::mem;
 use core::ops::Range;
 
 use super::buffers::{Coalescer, Delocator, Locator};
+use crate::error::InvalidMessage;
 use crate::msgs::codec::{u24, Codec};
 use crate::msgs::message::InboundPlainMessage;
 use crate::{ContentType, ProtocolVersion};
@@ -155,12 +156,22 @@ impl HandshakeDeframer {
     ///            |
     /// spans = [ { bounds = (5, 18), size = Some(9), .. } ]
     /// ```
-    pub(crate) fn coalesce(&mut self, containing_buffer: &mut [u8]) {
+    pub(crate) fn coalesce(&mut self, containing_buffer: &mut [u8]) -> Result<(), InvalidMessage> {
         // Strategy: while there is work to do, scan `spans`
         // for a pair where the first is not complete.  move
         // the second down towards the first, then reparse the contents.
         while let Some(i) = self.requires_coalesce() {
             self.coalesce_one(i, Coalescer::new(containing_buffer));
+        }
+
+        // check resulting spans pass our imposed length limit
+        match self
+            .spans
+            .iter()
+            .any(|span| span.size.unwrap_or_default() > MAX_HANDSHAKE_SIZE)
+        {
+            true => Err(InvalidMessage::HandshakePayloadTooLarge),
+            false => Ok(()),
         }
     }
 
@@ -354,6 +365,11 @@ impl FragmentSpan {
 
 const HANDSHAKE_HEADER_LEN: usize = 1 + 3;
 
+/// TLS allows for handshake messages of up to 16MB.  We
+/// restrict that to 64KB to limit potential for denial-of-
+/// service.
+const MAX_HANDSHAKE_SIZE: usize = 0xffff;
+
 #[cfg(test)]
 mod tests {
     use std::vec;
@@ -385,7 +401,7 @@ mod tests {
         assert_eq!(hs.requires_coalesce(), Some(0));
 
         std::println!("before: {hs:?}");
-        hs.coalesce(&mut input);
+        hs.coalesce(&mut input).unwrap();
         std::println!("after:  {hs:?}");
 
         let (msg, discard) = hs.iter(&input).next().unwrap();
@@ -407,7 +423,7 @@ mod tests {
         add_bytes(&mut hs, &input[9..14], &input);
         assert_eq!(hs.spans.len(), 2);
 
-        hs.coalesce(&mut input);
+        hs.coalesce(&mut input).unwrap();
         assert_eq!(hs.spans.len(), 1);
 
         let (msg, discard) = std::dbg!(hs.iter(&input).next().unwrap());
@@ -417,6 +433,23 @@ mod tests {
 
         input.drain(..discard);
         assert_eq!(input, &[0]);
+    }
+
+    #[test]
+    fn coalesce_rejects_excess_size_message() {
+        const X: u8 = 0xff;
+        let mut input = vec![0x21, 0x01, 0x00, X, 0x00, 0xab, X];
+        let mut hs = HandshakeDeframer::default();
+
+        // split header over multiple messages, which motivates doing
+        // this check in `coalesce()`
+        add_bytes(&mut hs, &input[0..3], &input);
+        add_bytes(&mut hs, &input[4..6], &input);
+
+        assert_eq!(
+            hs.coalesce(&mut input),
+            Err(InvalidMessage::HandshakePayloadTooLarge)
+        );
     }
 
     #[test]
@@ -455,7 +488,7 @@ mod tests {
             hs.input_message(plain, &locator, iter.bytes_consumed());
         }
 
-        hs.coalesce(&mut input[..]);
+        hs.coalesce(&mut input[..]).unwrap();
 
         let mut iter = hs.iter(&input[..]);
         for _ in 0..4 {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -390,7 +390,7 @@ mod connection {
 
             self.core
                 .hs_deframer
-                .coalesce(self.deframer_buffer.filled_mut());
+                .coalesce(self.deframer_buffer.filled_mut())?;
 
             self.core
                 .process_new_packets(&mut self.deframer_buffer, &mut self.sendable_plaintext)?;


### PR DESCRIPTION
Unfortunately feature unification turned on fips mode for every workspace item. Rather than chase around making that work, just avoid it by specifying the workspace item each time.

Fixing that uncovered a test that wanted to see the `HandshakePayloadTooLarge` error which didn't carry-over in the recent refactor. Restore that.

See passing run: https://github.com/rustls/rustls/actions/runs/10197371458