### PR TITLE
aws_lc_rs: implement RFC 5077 recommended ticketer

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/hpke.rs
+++ b/rustls/src/crypto/aws_lc_rs/hpke.rs
@@ -14,6 +14,7 @@ use aws_lc_rs::encoding::{AsBigEndian, Curve25519SeedBin, EcPrivateKeyBin};
 use zeroize::Zeroize;
 
 use crate::crypto::aws_lc_rs::hmac::{HMAC_SHA256, HMAC_SHA384, HMAC_SHA512};
+use crate::crypto::aws_lc_rs::unspecified_err;
 use crate::crypto::hpke::{
     EncapsulatedSecret, Hpke, HpkeOpener, HpkePrivateKey, HpkePublicKey, HpkeSealer, HpkeSuite,
 };
@@ -921,17 +922,6 @@ struct KemSharedSecret<const KDF_LEN: usize>([u8; KDF_LEN]);
 impl<const KDF_LEN: usize> Drop for KemSharedSecret<KDF_LEN> {
     fn drop(&mut self) {
         self.0.zeroize();
-    }
-}
-
-fn unspecified_err(_e: aws_lc_rs::error::Unspecified) -> Error {
-    #[cfg(feature = "std")]
-    {
-        Error::Other(OtherError(Arc::new(_e)))
-    }
-    #[cfg(not(feature = "std"))]
-    {
-        Error::Other(OtherError())
     }
 }
 

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -15,7 +15,7 @@ use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
 use crate::suites::SupportedCipherSuite;
 use crate::webpki::WebPkiSupportedAlgorithms;
-use crate::Error;
+use crate::{Error, OtherError};
 
 /// Hybrid public key encryption (HPKE).
 pub mod hpke;
@@ -257,6 +257,17 @@ pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead:
 /// Are we in FIPS mode?
 pub(super) fn fips() -> bool {
     aws_lc_rs::try_fips_mode().is_ok()
+}
+
+pub(super) fn unspecified_err(_e: aws_lc_rs::error::Unspecified) -> Error {
+    #[cfg(feature = "std")]
+    {
+        Error::Other(OtherError(Arc::new(_e)))
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        Error::Other(OtherError())
+    }
 }
 
 #[cfg(test)]

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -31,7 +31,6 @@ pub(crate) mod kx;
 #[path = "../ring/quic.rs"]
 pub(crate) mod quic;
 #[cfg(any(feature = "std", feature = "hashbrown"))]
-#[path = "../ring/ticketer.rs"]
 pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
 pub(crate) mod tls12;

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -249,10 +249,6 @@ mod ring_shim {
     }
 }
 
-/// AEAD algorithm that is used by `mod ticketer`.
-#[cfg(any(feature = "std", feature = "hashbrown"))]
-pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::AES_256_GCM;
-
 /// Are we in FIPS mode?
 pub(super) fn fips() -> bool {
     aws_lc_rs::try_fips_mode().is_ok()

--- a/rustls/src/crypto/aws_lc_rs/ticketer.rs
+++ b/rustls/src/crypto/aws_lc_rs/ticketer.rs
@@ -90,7 +90,7 @@ impl AeadTicketer {
             .fill(&mut key_name)
             .map_err(|_| GetRandomFailed)?;
 
-        Ok(Self {
+        Ok(AeadTicketer {
             alg: TICKETER_AEAD,
             key: aead::LessSafeKey::new(key),
             key_name,

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -190,10 +190,6 @@ mod ring_shim {
     }
 }
 
-/// AEAD algorithm that is used by `mod ticketer`.
-#[cfg(any(feature = "std", feature = "hashbrown"))]
-pub(super) static TICKETER_AEAD: &ring_like::aead::Algorithm = &ring_like::aead::CHACHA20_POLY1305;
-
 pub(super) fn fips() -> bool {
     false
 }

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -15,6 +15,7 @@ use super::TICKETER_AEAD;
 use crate::error::Error;
 #[cfg(feature = "logging")]
 use crate::log::debug;
+use crate::polyfill::try_split_at;
 use crate::rand::GetRandomFailed;
 use crate::server::ProducesTickets;
 
@@ -198,14 +199,6 @@ impl Debug for AeadTicketer {
             .field("alg", &self.alg)
             .field("lifetime", &self.lifetime)
             .finish()
-    }
-}
-
-/// Non-panicking `let (nonce, ciphertext) = ciphertext.split_at(...)`.
-fn try_split_at(slice: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
-    match mid > slice.len() {
-        true => None,
-        false => Some(slice.split_at(mid)),
     }
 }
 

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -23,10 +23,10 @@ use crate::server::ProducesTickets;
 pub struct Ticketer {}
 
 impl Ticketer {
-    /// Make the recommended Ticketer.  This produces tickets
+    /// Make the recommended `Ticketer`.  This produces tickets
     /// with a 12 hour life and randomly generated keys.
     ///
-    /// The encryption mechanism used is injected via TICKETER_AEAD;
+    /// The encryption mechanism used is injected via `TICKETER_AEAD`;
     /// it must take a 256-bit key and 96-bit nonce.
     #[cfg(feature = "std")]
     pub fn new() -> Result<Arc<dyn ProducesTickets>, Error> {
@@ -36,10 +36,11 @@ impl Ticketer {
         )?))
     }
 
-    /// Make the recommended Ticketer.  This produces tickets
+    /// Make the recommended `Ticketer`.  This produces tickets
     /// with a 12 hour life and randomly generated keys.
     ///
-    /// The encryption mechanism used is Chacha20Poly1305.
+    /// The encryption mechanism used is injected via `TICKETER_AEAD`;
+    /// it must take a 256-bit key and 96-bit nonce.
     #[cfg(not(feature = "std"))]
     pub fn new<M: crate::lock::MakeMutex>(
         time_provider: &'static dyn TimeProvider,

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -9,7 +9,6 @@ use subtle::ConstantTimeEq;
 
 use super::ring_like::aead;
 use super::ring_like::rand::{SecureRandom, SystemRandom};
-use super::TICKETER_AEAD;
 use crate::error::Error;
 #[cfg(feature = "logging")]
 use crate::log::debug;
@@ -24,8 +23,7 @@ impl Ticketer {
     /// Make the recommended `Ticketer`.  This produces tickets
     /// with a 12 hour life and randomly generated keys.
     ///
-    /// The encryption mechanism used is injected via `TICKETER_AEAD`;
-    /// it must take a 256-bit key and 96-bit nonce.
+    /// The encryption mechanism used is Chacha20Poly1305.
     #[cfg(feature = "std")]
     pub fn new() -> Result<Arc<dyn ProducesTickets>, Error> {
         Ok(Arc::new(crate::ticketer::TicketSwitcher::new(
@@ -37,8 +35,7 @@ impl Ticketer {
     /// Make the recommended `Ticketer`.  This produces tickets
     /// with a 12 hour life and randomly generated keys.
     ///
-    /// The encryption mechanism used is injected via `TICKETER_AEAD`;
-    /// it must take a 256-bit key and 96-bit nonce.
+    /// The encryption mechanism used is Chacha20Poly1305.
     #[cfg(not(feature = "std"))]
     pub fn new<M: crate::lock::MakeMutex>(
         time_provider: &'static dyn TimeProvider,
@@ -207,6 +204,8 @@ impl Debug for AeadTicketer {
             .finish()
     }
 }
+
+static TICKETER_AEAD: &aead::Algorithm = &aead::CHACHA20_POLY1305;
 
 #[cfg(test)]
 mod tests {

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -100,6 +100,7 @@ impl ProducesTickets for AeadTicketer {
     fn enabled(&self) -> bool {
         true
     }
+
     fn lifetime(&self) -> u32 {
         self.lifetime
     }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -650,6 +650,9 @@ pub mod time_provider;
 /// APIs abstracting over locking primitives.
 pub mod lock;
 
+/// Polyfills for features that are not yet stabilized or available with current MSRV.
+pub(crate) mod polyfill;
+
 #[cfg(any(feature = "std", feature = "hashbrown"))]
 mod hash_map {
     #[cfg(feature = "std")]

--- a/rustls/src/polyfill.rs
+++ b/rustls/src/polyfill.rs
@@ -1,0 +1,8 @@
+/// Non-panicking `let (nonce, ciphertext) = ciphertext.split_at(...)`.
+// TODO(XXX): remove once stabilized in https://github.com/rust-lang/rust/issues/119128
+pub(crate) fn try_split_at(slice: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
+    match mid > slice.len() {
+        true => None,
+        false => Some(slice.split_at(mid)),
+    }
+}


### PR DESCRIPTION
Previously the `aws_lc_rs` crypto module shared its `Ticketer` implementation with `ring` using the "ring-like" mechanism we use for other shared implementations. This branch replaces it with an [RFC 5077](https://www.rfc-editor.org/rfc/rfc5077) based design that we believe addresses some theoretical concerns (https://github.com/rustls/rustls/issues/2023) with the design of the ring specific `Ticketer`, using APIs only available with `aws-lc-rs`.

For background, the ring ticketer is designed around an AEAD using random nonces. We must use an AEAD with `*ring*` because it doesn't expose an unauthenticated cipher/modes we could use for the RFC 5077 design. We must use random nonces with the AEAD design to avoid privacy leaks. The combination of these two constraints results in a design that has a more limited security margin (due to the size of the nonces and the implications of re-use).

This commit adds an `aws-lc-rs` Ticketer implementation that is a direct translation of the [RFC 5077 "Recommended Ticket Construction"](https://www.rfc-editor.org/rfc/rfc5077#section-4). It uses AES-256 in CBC mode w/ PKCS#7 padding for encryption and HMAC-SHA-256 for message authentication.

Resolves https://github.com/rustls/rustls/issues/2021