### PR TITLE
Experiment: allow state machine to become blocked by extension point traits

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -10,7 +10,7 @@ use super::handy::NoClientSessionStorage;
 use super::hs;
 use crate::builder::ConfigBuilder;
 use crate::client::{EchMode, EchStatus};
-use crate::common_state::{CommonState, Protocol, Side};
+use crate::common_state::{CommonState, Protocol, Side, Transition};
 use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
@@ -815,7 +815,9 @@ impl ConnectionCore<ClientConnectionData> {
             sendable_plaintext: None,
         };
 
-        let state = hs::start_handshake(name, extra_exts, config, &mut cx)?;
+        let state = match hs::start_handshake(name, extra_exts, config, &mut cx)? {
+            Transition::Next(current) | Transition::Blocked { current, .. } => current,
+        };
         Ok(Self::new(state, data, common_state))
     }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -139,7 +139,7 @@ mod server_hello {
                             .into_owned(),
                     );
                     cx.common.handshake_kind = Some(HandshakeKind::Resumed);
-                    let cert_verified = verify::ServerCertVerified::assertion();
+                    let cert_verified = verify::PeerCertVerified::assertion();
                     let sig_verified = verify::HandshakeSignatureValid::assertion();
 
                     return if must_issue_new_ticket {
@@ -1028,7 +1028,7 @@ struct ExpectNewTicket {
     using_ems: bool,
     transcript: HandshakeHash,
     resuming: bool,
-    cert_verified: verify::ServerCertVerified,
+    cert_verified: verify::PeerCertVerified,
     sig_verified: verify::HandshakeSignatureValid,
 }
 
@@ -1080,7 +1080,7 @@ struct ExpectCcs {
     transcript: HandshakeHash,
     ticket: Option<NewSessionTicketPayload>,
     resuming: bool,
-    cert_verified: verify::ServerCertVerified,
+    cert_verified: verify::PeerCertVerified,
     sig_verified: verify::HandshakeSignatureValid,
 }
 
@@ -1141,7 +1141,7 @@ struct ExpectFinished {
     ticket: Option<NewSessionTicketPayload>,
     secrets: ConnectionSecrets,
     resuming: bool,
-    cert_verified: verify::ServerCertVerified,
+    cert_verified: verify::PeerCertVerified,
     sig_verified: verify::HandshakeSignatureValid,
 }
 
@@ -1269,7 +1269,7 @@ impl State<ClientConnectionData> for ExpectFinished {
 // -- Traffic transit state --
 struct ExpectTraffic {
     secrets: ConnectionSecrets,
-    _cert_verified: verify::ServerCertVerified,
+    _cert_verified: verify::PeerCertVerified,
     _sig_verified: verify::HandshakeSignatureValid,
     _fin_verified: verify::FinishedMessageVerified,
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -838,16 +838,15 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
         let suite = st.suite;
 
         // 1. Verify the cert chain.
-        // 2. Verify any SCTs provided with the certificate.
-        // 3. Verify that the top certificate signed their kx.
-        // 4. If doing client auth, send our Certificate.
-        // 5. Complete the key exchange:
+        // 2. Verify that the top certificate signed their kx.
+        // 3. If doing client auth, send our Certificate.
+        // 4. Complete the key exchange:
         //    a) generate our kx pair
         //    b) emit a ClientKeyExchange containing it
         //    c) if doing client auth, emit a CertificateVerify
         //    d) emit a CCS
         //    e) derive the shared keys, and start encryption
-        // 6. emit a Finished, our first encrypted message under the new keys.
+        // 5. emit a Finished, our first encrypted message under the new keys.
 
         // 1.
         let (end_entity, intermediates) = st
@@ -873,7 +872,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
                     .send_cert_verify_error_alert(err)
             })?;
 
-        // 3.
+        // 2.
         // Build up the contents of the signed message.
         // It's ClientHello.random || ServerHello.random || ServerKeyExchange.params
         let sig_verified = {
@@ -905,7 +904,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
         };
         cx.common.peer_certificates = Some(st.server_cert.cert_chain.into_owned());
 
-        // 4.
+        // 3.
         if let Some(client_auth) = &st.client_auth {
             let certs = match client_auth {
                 ClientAuthDetails::Empty { .. } => CertificateChain::default(),
@@ -914,7 +913,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
             emit_certificate(&mut st.transcript, certs, cx.common);
         }
 
-        // 5a.
+        // 4a.
         let kx_params = tls12::decode_kx_params::<ServerKeyExchangeParams>(
             st.suite.kx,
             cx.common,
@@ -932,7 +931,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
         cx.common.kx_state = KxState::Start(skxg);
         let kx = skxg.start()?;
 
-        // 5b.
+        // 4b.
         let mut transcript = st.transcript;
         emit_client_kx(&mut transcript, st.suite.kx, cx.common, kx.pub_key());
         // Note: EMS handshake hash only runs up to ClientKeyExchange.
@@ -940,15 +939,15 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
             .using_ems
             .then(|| transcript.current_hash());
 
-        // 5c.
+        // 4c.
         if let Some(ClientAuthDetails::Verify { signer, .. }) = &st.client_auth {
             emit_certverify(&mut transcript, signer.as_ref(), cx.common)?;
         }
 
-        // 5d.
+        // 4d.
         emit_ccs(cx.common);
 
-        // 5e. Now commit secrets.
+        // 4e. Now commit secrets.
         let secrets = ConnectionSecrets::from_key_exchange(
             kx,
             kx_params.pub_key(),
@@ -969,7 +968,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
             .record_layer
             .start_encrypting();
 
-        // 6.
+        // 5.
         emit_finished(&secrets, &mut transcript, cx.common);
 
         if st.must_issue_new_ticket {

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -476,7 +476,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
 
             // We *don't* reverify the certificate chain here: resumption is a
             // continuation of the previous session in terms of security policy.
-            let cert_verified = verify::ServerCertVerified::assertion();
+            let cert_verified = verify::PeerCertVerified::assertion();
             let sig_verified = verify::HandshakeSignatureValid::assertion();
             Ok(Box::new(ExpectFinished {
                 config: self.config,
@@ -1276,7 +1276,7 @@ struct ExpectFinished {
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     client_auth: Option<ClientAuthDetails>,
-    cert_verified: verify::ServerCertVerified,
+    cert_verified: verify::PeerCertVerified,
     sig_verified: verify::HandshakeSignatureValid,
     ech_retry_configs: Option<Vec<EchConfigPayload>>,
 }
@@ -1431,7 +1431,7 @@ struct ExpectTraffic {
     suite: &'static Tls13CipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleTraffic,
-    _cert_verified: verify::ServerCertVerified,
+    _cert_verified: verify::PeerCertVerified,
     _sig_verified: verify::HandshakeSignatureValid,
     _fin_verified: verify::FinishedMessageVerified,
 }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -563,7 +563,9 @@ pub mod client {
     pub mod danger {
         pub use super::builder::danger::DangerousClientConfigBuilder;
         pub use super::client_conn::danger::DangerousClientConfig;
-        pub use crate::verify::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+        pub use crate::verify::{
+            HandshakeSignatureValid, PeerCertVerified, ServerCertVerified, ServerCertVerifier,
+        };
     }
 
     pub use crate::msgs::persist::{Tls12ClientSessionValue, Tls13ClientSessionValue};
@@ -608,7 +610,7 @@ pub mod server {
 
     /// Dangerous configuration that should be audited and used with extreme care.
     pub mod danger {
-        pub use crate::verify::{ClientCertVerified, ClientCertVerifier};
+        pub use crate::verify::{ClientCertVerified, ClientCertVerifier, PeerCertVerified};
     }
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -514,7 +514,7 @@ pub use crate::enums::{
 };
 pub use crate::error::{
     CertRevocationListError, CertificateError, EncryptedClientHelloError, Error, InconsistentKeys,
-    InvalidMessage, OtherError, PeerIncompatible, PeerMisbehaved,
+    InvalidMessage, OtherError, PeerIncompatible, PeerMisbehaved, PendingOperation,
 };
 pub use crate::key_log::{KeyLog, NoKeyLog};
 #[cfg(feature = "std")]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -565,6 +565,7 @@ pub mod client {
         pub use super::client_conn::danger::DangerousClientConfig;
         pub use crate::verify::{
             HandshakeSignatureValid, PeerCertVerified, ServerCertVerified, ServerCertVerifier,
+            StoringServerVerifier,
         };
     }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -564,8 +564,8 @@ pub mod client {
         pub use super::builder::danger::DangerousClientConfigBuilder;
         pub use super::client_conn::danger::DangerousClientConfig;
         pub use crate::verify::{
-            HandshakeSignatureValid, PeerCertVerified, ServerCertVerified, ServerCertVerifier,
-            StoringServerVerifier,
+            HandshakeSignatureValid, IncrementalVerifier, PeerCertVerified, ServerCertVerified,
+            ServerCertVerifier, StoringServerVerifier,
         };
     }
 

--- a/rustls/src/msgs/message/mod.rs
+++ b/rustls/src/msgs/message/mod.rs
@@ -193,7 +193,6 @@ impl Message<'_> {
         }
     }
 
-    #[cfg(feature = "std")]
     pub(crate) fn into_owned(self) -> Message<'static> {
         let Self { version, payload } = self;
         Message {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -8,7 +8,7 @@ use pki_types::DnsName;
 use super::server_conn::ServerConnectionData;
 #[cfg(feature = "tls12")]
 use super::tls12;
-use crate::common_state::{KxState, Protocol, State};
+use crate::common_state::{KxState, Protocol, State, Transition};
 use crate::conn::ConnectionRandoms;
 use crate::crypto::SupportedKxGroup;
 use crate::enums::{
@@ -33,7 +33,7 @@ use crate::server::{tls13, ClientHello, ServerConfig};
 use crate::{suites, SupportedCipherSuite};
 
 pub(super) type NextState<'a> = Box<dyn State<ServerConnectionData> + 'a>;
-pub(super) type NextStateOrError<'a> = Result<NextState<'a>, Error>;
+pub(super) type NextStateOrError<'a> = Result<Transition<'a, ServerConnectionData>, Error>;
 pub(super) type ServerContext<'a> = crate::common_state::Context<'a, ServerConnectionData>;
 
 pub(super) fn can_resume(

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -40,24 +40,19 @@ impl FinishedMessageVerified {
 }
 
 /// Zero-sized marker type representing verification of a server cert chain.
-#[allow(unreachable_pub)]
-#[derive(Debug)]
-pub struct ServerCertVerified(());
-
-#[allow(unreachable_pub)]
-impl ServerCertVerified {
-    /// Make a `ServerCertVerified`
-    pub fn assertion() -> Self {
-        Self(())
-    }
-}
+pub type ServerCertVerified = PeerCertVerified;
 
 /// Zero-sized marker type representing verification of a client cert chain.
-#[derive(Debug)]
-pub struct ClientCertVerified(());
+pub type ClientCertVerified = PeerCertVerified;
 
-impl ClientCertVerified {
-    /// Make a `ClientCertVerified`
+/// Zero-sized marker type representing verification of the peer's cert chain.
+#[allow(unreachable_pub)]
+#[derive(Debug)]
+pub struct PeerCertVerified(());
+
+#[allow(unreachable_pub)]
+impl PeerCertVerified {
+    /// Make a `PeerCertVerified`
     pub fn assertion() -> Self {
         Self(())
     }
@@ -341,7 +336,7 @@ fn assertions_are_debug() {
 
     assert_eq!(
         format!("{:?}", ClientCertVerified::assertion()),
-        "ClientCertVerified(())"
+        "PeerCertVerified(())"
     );
     assert_eq!(
         format!("{:?}", HandshakeSignatureValid::assertion()),
@@ -353,6 +348,6 @@ fn assertions_are_debug() {
     );
     assert_eq!(
         format!("{:?}", ServerCertVerified::assertion()),
-        "ServerCertVerified(())"
+        "PeerCertVerified(())"
     );
 }


### PR DESCRIPTION
This is an experiment about how we could allow extension point traits called within the state machine to not produce their results immediately.

While that happens, the state machine is blocked, and attempts to move it forward return a non-fused error (in the buffered API) or a new `ConnectionState` variant (in the unbuffered API -- NYI).

When the application sees that, they have several options:

1. just blindly retry -- obvious, but also not helpful,
2. learn when the underlying operation completes, and then retry

There is a reasonable amount of plumbing required to make (2) work. Basically, the verifier (or whatever) and application need to know more about each other than they currently do.

Then the application could do:

```rust
match conn.process_new_packets() {
  Err(Error::PendingOperation(PendingOperation::ServerCertificateVerification)) => {
    rustls_platform_verifier::completion_future().await;
    break 'retry;
  },
...
}
```
 
A context-free `completion_future` like that would need to know which `ServerCertVerifier` impl it is concerned with. That could be done with thread local storage.

Alternatively the application could retain the concrete verifier used and ask it directly (not currently possible with `rustls-platform-verifier` because it hides its types behind the trait, but IMO a feasible API change.)

The extension point traits I'm thinking are in scope are: `Signer`, `ServerCertVerifier` and `ClientCertVerifier` for sure. Perhaps `ResolvesClientCert` and `ResolvesServerCert` (but I think `Acceptor` is a better solution) as a follow up. `ProducesTickets`, `StoresServerSessions`, `ClientSessionStore`, could theoretically come later but given the high performance requirements on those, I'd suggest a synchronous facade on top of a asynchronous backing store.

Things not called inside the state machine are not in scope: that includes all the low-level provider interfaces. I think the work there is a long tail, and needs compiler support for turning the whole library async -- this would require using things like RPITIT and AFIT.
