### PR TITLE
Reinstate coverage of `CryptoProvider` provider fns

### DIFF
--- a/admin/coverage
+++ b/admin/coverage
@@ -7,8 +7,8 @@ cargo llvm-cov clean --workspace
 
 cargo build --locked --all-targets --all-features
 cargo test --locked --all-features
-cargo test --locked --no-default-features --features tls12,logging,aws_lc_rs,fips,std
-cargo test --locked --no-default-features --features tls12,logging,ring,std
+cargo test -p rustls --locked --no-default-features --features tls12,logging,aws_lc_rs,fips,std
+cargo test -p rustls --locked --no-default-features --features tls12,logging,ring,std
 
 # ensure both zlib and brotli are tested, irrespective of their order
 cargo test --locked $(admin/all-features-except zlib rustls)


### PR DESCRIPTION
`from_crate_features()` and `get_default_or_install_from_crate_features()` became uncovered since 3249a5b39 due to unwanted workspace feature unification.