### PR TITLE
Expose UnknownExtensions fields & to use in projects.

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -441,7 +441,7 @@ pub mod internal {
         }
         pub mod enums {
             pub use crate::msgs::enums::{
-                AlertLevel, Compression, EchVersion, HpkeAead, HpkeKdf, HpkeKem, NamedGroup,
+                AlertLevel, Compression, EchVersion, HpkeAead, HpkeKdf, HpkeKem, NamedGroup, ExtensionType
             };
         }
         pub mod fragmenter {
@@ -452,7 +452,7 @@ pub mod internal {
                 CertificateChain, ClientExtension, ClientHelloPayload, DistinguishedName,
                 EchConfigContents, EchConfigPayload, HandshakeMessagePayload, HandshakePayload,
                 HpkeKeyConfig, HpkeSymmetricCipherSuite, KeyShareEntry, Random, ServerName,
-                SessionId,
+                SessionId, UnknownExtension
             };
         }
         pub mod message {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -441,7 +441,8 @@ pub mod internal {
         }
         pub mod enums {
             pub use crate::msgs::enums::{
-                AlertLevel, Compression, EchVersion, HpkeAead, HpkeKdf, HpkeKem, NamedGroup, ExtensionType
+                AlertLevel, Compression, EchVersion, ExtensionType, HpkeAead, HpkeKdf, HpkeKem,
+                NamedGroup,
             };
         }
         pub mod fragmenter {
@@ -452,7 +453,7 @@ pub mod internal {
                 CertificateChain, ClientExtension, ClientHelloPayload, DistinguishedName,
                 EchConfigContents, EchConfigPayload, HandshakeMessagePayload, HandshakePayload,
                 HpkeKeyConfig, HpkeSymmetricCipherSuite, KeyShareEntry, Random, ServerName,
-                SessionId, UnknownExtension
+                SessionId, UnknownExtension,
             };
         }
         pub mod message {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -187,8 +187,8 @@ impl SessionId {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct UnknownExtension {
-    pub(crate) typ: ExtensionType,
-    pub(crate) payload: Payload<'static>,
+    pub typ: ExtensionType,
+    pub payload: Payload<'static>,
 }
 
 impl UnknownExtension {


### PR DESCRIPTION
Hey. I am working on a Anti-Bot project and I need to access unknown extension fields to check if some extension is present. 

For example:
```
if let ClientExtension::Unknown(UnknownExtension {
    typ: ExtensionType::Unknown(28),
    ..
}) = ext
{
    Some(true)
} else {
    None
}
```

These fields & enums is private so I hope we can make them public 😃 
