### PR TITLE
remove Send + Sync not needed from client session storage field

### DIFF
--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -248,7 +248,7 @@ pub struct ServerConfig {
     pub max_fragment_size: Option<usize>,
 
     /// How to store client sessions.
-    pub session_storage: Arc<dyn StoresServerSessions + Send + Sync>,
+    pub session_storage: Arc<dyn StoresServerSessions>,
 
     /// How to produce tickets.
     pub ticketer: Arc<dyn ProducesTickets>,


### PR DESCRIPTION
While working on a proposal to support using `alloc::rc::Rc`, as discussed as a possible solution for #2068, I discovered a case of extra `Send + Sync` that I think is not needed & one more thing that would need to be updated. Of course I could remove this as part of my proposal for #2068, but would rather keep this kind of cleanup in a separate proposal & commit if possible.

FYI I did already get a green build of this proposal in my own fork.