### PR TITLE
chore: remove trailing spaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Use one of the examples to connect to `....` 
+1. Use one of the examples to connect to `....`
 2. ...
 3. See error
 

--- a/.github/ISSUE_TEMPLATE/dependency-update.md
+++ b/.github/ISSUE_TEMPLATE/dependency-update.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-Please note that we are only interested in **semver-incompatible** update requests. Updates to dependencies that are 
+Please note that we are only interested in **semver-incompatible** update requests. Updates to dependencies that are
 semver-compatible can be done in dependent projects without needing changes in this repository.
 
 For example, if you are here because you believe Rustls is bringing in dependency `foo` at version `0.2.1` and

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -101,13 +101,13 @@ jobs:
       - name: Check simple 0rtt client
         run: cargo run --locked -p rustls-examples --bin simple_0rtt_client
 
-      - name: Check unbuffered client 
+      - name: Check unbuffered client
         run: cargo run --locked -p rustls-examples --bin unbuffered-client
 
-      - name: Check unbuffered tokio client 
+      - name: Check unbuffered tokio client
         run: cargo run --locked -p rustls-examples --bin unbuffered-async-client
 
-      - name: Check unbuffered async-std client 
+      - name: Check unbuffered async-std client
         run: cargo run --locked -p rustls-examples --bin unbuffered-async-client --features=async-std
 
       # Test the server_acceptor binary builds - we invoke with --help since it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,7 +306,7 @@ We use 3 blocks of imports in our Rust files:
 
 We believe that this makes it easier to see where a particular import comes from.
 
-Within the import blocks we prefer to separate imports that don't share a parent 
+Within the import blocks we prefer to separate imports that don't share a parent
 module. For example,
 
 ```rust
@@ -330,9 +330,9 @@ prefer to `import std::error::Error as StdError`.
 
 We prefer to export types under a single name, avoiding re-exporting types from
 the top-level `lib.rs`. The exception to this are "paved path" exports that we
-expect every user will need. The canonical example of such types are 
+expect every user will need. The canonical example of such types are
 `client::ClientConfig` and `server::ServerConfig`. In general this sort of type
-is rare and most new types should be exported only from the module in which they 
+is rare and most new types should be exported only from the module in which they
 are defined.
 
 ### Misc

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,7 +47,7 @@
 
 ## Maintenance point releases
 
-When point releases for bug fixes and small backwards compatible changes, but `main` contains unreleased breaking 
+When point releases for bug fixes and small backwards compatible changes, but `main` contains unreleased breaking
 changes we follow a modified release process using a longer-lived maintenance branch.
 
 1. Check if there is an existing release branch, e.g. `rel-0.21` for point releases in the `0.21.x` series.

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -155,7 +155,7 @@ fn main() {
 
 const USAGE: &str = "
 Connects to the TLS server at hostname:PORT.  The default PORT
-is 443. If an ECH config can be fetched for hostname using 
+is 443. If an ECH config can be fetched for hostname using
 DNS-over-HTTPS, ECH is enabled. Otherwise, a placeholder ECH
 extension is sent for anti-ossification testing.
 

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -382,7 +382,7 @@ impl CommonState {
 
     /// Mark the connection as ready to send application data.
     ///
-    /// Also flush `sendable_plaintext` if it is `Some`.  
+    /// Also flush `sendable_plaintext` if it is `Some`.
     pub(crate) fn start_outgoing_traffic(
         &mut self,
         sendable_plaintext: &mut Option<&mut ChunkVecBuffer>,
@@ -395,7 +395,7 @@ impl CommonState {
 
     /// Mark the connection as ready to send and receive application data.
     ///
-    /// Also flush `sendable_plaintext` if it is `Some`.  
+    /// Also flush `sendable_plaintext` if it is `Some`.
     pub(crate) fn start_traffic(&mut self, sendable_plaintext: &mut Option<&mut ChunkVecBuffer>) {
         self.may_receive_application_data = true;
         self.start_outgoing_traffic(sendable_plaintext);

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -270,7 +270,7 @@ impl CryptoProvider {
     /// Returns a provider named unambiguously by rustls crate features.
     ///
     /// This function returns `None` if the crate features are ambiguous (ie, specify two
-    /// providers), or specify no providers, or the feature `custom-provider` is activated.  
+    /// providers), or specify no providers, or the feature `custom-provider` is activated.
     /// In all cases the application should explicitly specify the provider to use
     /// with [`CryptoProvider::install_default`].
     fn from_crate_features() -> Option<Self> {

--- a/rustls/src/lock.rs
+++ b/rustls/src/lock.rs
@@ -72,9 +72,9 @@ mod no_std_lock {
         fn lock(&self) -> Result<MutexGuard<'_, T>, Poisoned>;
     }
 
-    /// A lock builder.                                                                                     
+    /// A lock builder.
     pub trait MakeMutex {
-        /// Create a new mutex.                                                                             
+        /// Create a new mutex.
         fn make_mutex<T>(value: T) -> Arc<dyn Lock<T>>
         where
             T: Send + 'static;


### PR DESCRIPTION
Discovered the trailing spaces while working on doc fixes for PR #2088 - looks like this should be very, very limited in scope