### PR TITLE
polyfill: allow dead code w/o built-in providers, no-std

### DIFF
--- a/rustls/src/polyfill.rs
+++ b/rustls/src/polyfill.rs
@@ -1,5 +1,6 @@
 /// Non-panicking `let (nonce, ciphertext) = ciphertext.split_at(...)`.
 // TODO(XXX): remove once stabilized in https://github.com/rust-lang/rust/issues/119128
+#[allow(dead_code)] // Complicated conditional compilation guards elided
 pub(crate) fn try_split_at(slice: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
     match mid > slice.len() {
         true => None,


### PR DESCRIPTION
The dead code warning from `clippy` for `--no-default-features` builds has been breaking the daily powerset job ([exemplar](https://github.com/rustls/rustls/actions/runs/10565112794/job/29268946096)) since https://github.com/rustls/rustls/commit/1c33f4b78155b624a9fc6218ef48fae10edf10d9 landed.

Since it's a small polyfill function we allow it to be dead code and avoid more complicated `cfg_attr` expressions. Here's a [passing run](https://github.com/cpu/rustls/actions/runs/10567141405) with the change applied.

