### PR TITLE
ci: trim daily-tests powerset

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -143,6 +143,15 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
 
       - name: Check feature powerset
-        run: cargo hack check --feature-powerset --no-dev-deps
+        run: >
+            cargo hack check
+            --package rustls
+            --feature-powerset 
+            --no-dev-deps
+            --group-features aws_lc_rs,aws-lc-rs
+            --group-features fips,aws_lc_rs
+            --mutually-exclusive-features fips,ring
+            --mutually-exclusive-features custom_provider,aws_lc_rs
+            --mutually-exclusive-features custom_provider,ring
         env:
           RUSTFLAGS: --deny warnings


### PR DESCRIPTION
Reduces the runtime of the `cargo hack check` step of the `daily-tests.yml` workflow by grouping/excluding certain feature combos. Follow-up from https://github.com/rustls/rustls/pull/2091

Since the number of features in Rustls has grown the powerset check task has been getting very long, requiring ~940 builds without further configuration. In some cases we know certain features imply another, or are somewhat mutually exclusive in intent.

This commit adds `--group-features` and `--mutually-exclusive-features` configuration to the `cargo hack check` invocation, reducing the runtime greatly. Here's a [completed run](https://github.com/cpu/rustls/actions/runs/10598891676/job/29372553113) with the updated configuration (_4m duration_).