### PR TITLE
ci: cross-target build & test updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,8 +338,25 @@ jobs:
         working-directory: rustls/
 
   cross:
-    name: Check cross compilation targets
+    name: cross-target testing
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          # 32-bit Android (Linux) targets:
+          - armv7-linux-androideabi
+          - i686-linux-android
+          - thumbv7neon-linux-androideabi
+          # Other standard 32-bit (Linux) targets (SKIP bindgen for i686 only)
+          - i586-unknown-linux-gnu
+          - i686-unknown-linux-gnu
+          # exotic Linux targets:
+          - riscv64gc-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
+          # additional target(s):
+          # NOTE: This could have some overlap with 64-bit ARM-style CPU on macOS CI host;
+          # may have similar ARM-style CPU overlap with standard Windows & possibly Linux in the future
+          - aarch64-linux-android
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -348,9 +365,12 @@ jobs:
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Install cross
-        uses: taiki-e/install-action@cross
-      - run: cross build -p rustls --locked --target i686-unknown-linux-gnu
+      - name: Install cross (cross-rs) from GitHub
+        run: cargo install cross --git https://github.com/cross-rs/cross
+      - name: Install bindgen feature & CLI for aws-lc-sys (as needed for many cross targets)
+        if: ${{ matrix.target != 'i686-unknown-linux-gnu' }}
+        run: cargo add --dev --features bindgen aws-lc-sys --package rustls --verbose && cargo install bindgen-cli --verbose
+      - run: cross test --package rustls --target ${{ matrix.target }}
 
   semver:
     name: Check semver compatibility


### PR DESCRIPTION
__UPDATED:__ _update to do `cross test` over multiple targets_

Leaving out the following targets, need to use `portable-atomic` to get CA test working for these (already got these working in my personal branch):

- arm-linux-androideabi
- armv5te-unknown-linux-gnueabi

Another nice target for `no-std`, if we can work around issue with no atomic refs for issue #2068: `thumbv6m-none-eabi`

will likely defer these missing targets for issue #2100 (time permitting, of course)

---

NOTES - UPDATED:

I think this should only be seen as a very small, slightly-incremental step towards testing on more and more embedded, "no-std" target environments.

Building & testing with `cross-rs` for many embedded targets seems to be limited by the following issues:

- supported Rust toolchain has a very limited number of Tier 2 / Tier 3 targets (I am not sure if it has any tier 3 targets builit-in)
- limited number of targets supported by `cross` docker images (there may be some others out there in the wild)
- It looks like `aws-lc-rs` / `aws-lc-sys` requires some bindgen setup to build for most of the targets other than the normal Windows / /macOS / normal headless Linux targets. And it looks to me like even if we would not enable the `aws_lc_rs` feature, `cross test` would still include `aws-lc-rs` / `aws-lc-sys` due to this `dev-depenencies` entry needed for `rustls/examples/internal/test_ca.rs`:
  - `rcgen = { version = "0.13", default-features = false, features = ["aws_lc_rs", "pem"] }`

---

SOME HELPFUL RESOURCES:

- https://hongchai.medium.com/cross-compiling-armv7-linux-androideabi-using-rust-5b59c857353c
- https://doc.rust-lang.org/nightly/rustc/platform-support.html
- https://github.com/aws/aws-lc-rs/blob/main/.github/workflows/cross.yml
- https://doc.rust-lang.org/stable/rustc/platform-support.html