### PR TITLE
Improve early data examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,5 +18,6 @@ We recommend new users start by looking at `simpleclient.rs` and `simpleserver.r
 
 * `simpleserver.rs` - shows a very minimal server example that accepts a single TLS connection. See `tlsserver-mio.rs` or `server_acceptor.rs` for a more realistic example.
 * `tlsserver-mio.rs` - shows a more complete server example that handles command line flags for customizing TLS options, and uses MIO to handle asynchronous I/O.
+* `simple_0rtt_server.rs` - shows how to make a TLS1.3 that accepts multiple connections and prints early 0RTT data.
 * `server_acceptor.rs` - shows how to use the `Acceptor` API to create a server that generates a unique `ServerConfig` for each client. This example also shows how to use client authentication, CRL revocation checking, and uses `rcgen` to generate its own certificates.
 * `unbuffered-server.rs` - shows an advanced example of using Rustls lower-level APIs to implement a server that does not buffer any data inside Rustls.

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -1,5 +1,7 @@
 //! This is an example client that uses rustls for TLS, and sends early 0-RTT data.
 //!
+//! Usage: cargo r --bin simple_0rtt_client --package rustls-examples [domain name] [port] [path/to/ca.cert]
+//!
 //! You may set the `SSLKEYLOGFILE` env var when using this example to write a
 //! log file with key material (insecure) for debugging purposes. See [`rustls::KeyLog`]
 //! for more information.
@@ -9,17 +11,19 @@
 
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
+use std::str::FromStr;
 use std::sync::Arc;
+use std::{env, fs};
 
 use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
 
-fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
+fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str, port: u16) {
     let server_name = ServerName::try_from(domain_name)
         .expect("invalid DNS name")
         .to_owned();
     let mut conn = rustls::ClientConnection::new(Arc::clone(config), server_name).unwrap();
-    let mut sock = TcpStream::connect(format!("{}:443", domain_name)).unwrap();
+    let mut sock = TcpStream::connect(format!("{}:{}", domain_name, port)).unwrap();
     sock.set_nodelay(true).unwrap();
     let request = format!(
         "GET / HTTP/1.1\r\n\
@@ -66,11 +70,30 @@ fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
 fn main() {
     env_logger::init();
 
-    let root_store = RootCertStore::from_iter(
-        webpki_roots::TLS_SERVER_ROOTS
-            .iter()
-            .cloned(),
-    );
+    let mut args = env::args();
+    args.next();
+    let domain_name = args
+        .next()
+        .unwrap_or("jbp.io".to_owned());
+    let port = args
+        .next()
+        .map(|port| u16::from_str(&port).expect("invalid port"))
+        .unwrap_or(443);
+
+    let mut root_store = RootCertStore::empty();
+    if let Some(cafile) = args.next() {
+        let certfile = fs::File::open(cafile).expect("Cannot open CA file");
+        let mut reader = BufReader::new(certfile);
+        root_store.add_parsable_certificates(
+            rustls_pemfile::certs(&mut reader).map(|result| result.unwrap()),
+        );
+    } else {
+        root_store.extend(
+            webpki_roots::TLS_SERVER_ROOTS
+                .iter()
+                .cloned(),
+        )
+    }
 
     let mut config = rustls::ClientConfig::builder()
         .with_root_certificates(root_store)
@@ -87,7 +110,7 @@ fn main() {
     // second will use early data if the server supports it.
 
     println!("* Sending first request:");
-    start_connection(&config, "jbp.io");
+    start_connection(&config, &domain_name, port);
     println!("* Sending second request:");
-    start_connection(&config, "jbp.io");
+    start_connection(&config, &domain_name, port);
 }

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -1,0 +1,107 @@
+//! This is an example server that streams 0-RTT early data from the client.
+//!
+//! Usage: cargo r --bin simple_0rtt_server --package rustls-examples <path/to/cert.pem> <path/to/privatekey.pem>
+//!
+//! You can test interaction either with simple_0rtt_client or with OpenSSL:
+//!
+//! `openssl s_client -connect localhost:4443 -sess_out sess.pem`
+//!
+//! `openssl s_client -connect localhost:4443 -sess_in sess.pem -early_data early.txt`
+//!
+//!
+//! Note that `unwrap()` is used to deal with networking errors; this is not something
+//! that is sensible outside of example code.
+
+use std::error::Error as StdError;
+use std::fs::File;
+use std::io::{BufReader, Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::{env, io};
+
+fn main() -> Result<(), Box<dyn StdError>> {
+    let mut args = env::args();
+    args.next();
+    let cert_file = args
+        .next()
+        .expect("missing certificate file argument");
+    let private_key_file = args
+        .next()
+        .expect("missing private key file argument");
+
+    let certs = rustls_pemfile::certs(&mut BufReader::new(&mut File::open(cert_file)?))
+        .collect::<Result<Vec<_>, _>>()?;
+    let private_key =
+        rustls_pemfile::private_key(&mut BufReader::new(&mut File::open(private_key_file)?))?
+            .unwrap();
+
+    let mut config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, private_key)?;
+    config.max_early_data_size = 1000;
+
+    let listener = TcpListener::bind(format!("[::]:{}", 4443)).unwrap();
+
+    loop {
+        let (mut stream, _) = listener.accept()?;
+
+        println!("Accepting connection");
+
+        let mut conn = rustls::ServerConnection::new(Arc::new(config.clone()))?;
+
+        let mut buf = Vec::new();
+        let mut did_early_data = false;
+        'handshake: while conn.is_handshaking() {
+            while conn.wants_write() {
+                if conn.write_tls(&mut stream)? == 0 {
+                    // EOF
+                    stream.flush()?;
+                    break 'handshake;
+                }
+            }
+            stream.flush()?;
+
+            while conn.wants_read() {
+                match conn.read_tls(&mut stream) {
+                    Ok(0) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into()),
+                    Ok(_) => break,
+                    Err(ref err) if err.kind() == io::ErrorKind::Interrupted => {}
+                    Err(err) => return Err(err.into()),
+                };
+            }
+
+            if let Err(e) = conn.process_new_packets() {
+                let _ignored = conn.write_tls(&mut stream);
+                stream.flush()?;
+
+                return Err(io::Error::new(io::ErrorKind::InvalidData, e).into());
+            };
+
+            if let Some(mut early_data) = conn.early_data() {
+                if !did_early_data {
+                    println!("Receiving early data from client");
+                    did_early_data = true;
+                }
+
+                let bytes_read = early_data
+                    .read_to_end(&mut buf)
+                    .unwrap();
+
+                if bytes_read != 0 {
+                    println!("Early data from client: {:?}", buf);
+                }
+            }
+        }
+
+        if !did_early_data {
+            println!("Did not receive early data from client");
+        }
+
+        println!("Handshake complete\n");
+
+        conn.writer()
+            .write_all(b"Hello from the server")?;
+        conn.send_close_notify();
+        conn.complete_io(&mut stream)?;
+    }
+}


### PR DESCRIPTION
Adds simple_0rtt_server, lets simple_0rtt_client connect to arbitrary servers (so it can work with simple_0rtt_server), makes tlsserver-mio read early data

questions
1. I need to add `--package rustls-examples` or else I get an error about no crypto provider being installed for both the existing 0rtt client and the new 0rtt server. might I be doing something wrong?
2. should I use an actual named args struct like in tlsclient-mio for the new options, or are the positional arguments fine?
3. if not, do I have the correct "syntax" for the arguments in the usage comment?
4. the handshaking code is a bit obtuse and mostly inspired by complete_io(). ideally I want to be able to progress the handshake without completion (since the point of early data is to not have to wait for the handshake completion). should some of this code be extracted to a new method? or maybe we can have a new function to handshake until early data can be read?
5. afaik early data is terminated by the EndOfEarlyData message, not by handshake completion, but usually these happen at the same time. should there be a new method to determine this, or is it not really worth it?
6. tlsserver-mio early data does not "work" with `openssl s_client -connect localhost:8443 -tls1_3 -sess_in sess.pem -early_data early.txt` if I don't specify --package rustls-examples (at least on my machine). something to do with fips feature being enabled causing a HRR to be sent due to mismatched kx groups, meaning that the early data gets dropped (I barely know what any of that means but this is what I think is happening). is this anything to worry about?