### PR TITLE
Tidy logging macros

### DIFF
--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -1,6 +1,5 @@
 use crate::enums::{ContentType, HandshakeType};
 use crate::error::Error;
-#[cfg(feature = "logging")]
 use crate::log::warn;
 use crate::msgs::message::MessagePayload;
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -15,7 +15,6 @@ use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
-#[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::msgs::enums::NamedGroup;
 use crate::msgs::handshake::ClientExtension;

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -3,7 +3,6 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use super::ResolvesClientCert;
-#[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::handshake::{CertificateChain, DistinguishedName, ServerExtension};

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -10,7 +10,6 @@ use crate::crypto::hash::Hash;
 use crate::crypto::hpke::{EncapsulatedSecret, Hpke, HpkePublicKey, HpkeSealer, HpkeSuite};
 use crate::crypto::SecureRandom;
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
-#[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
 use crate::msgs::base::{Payload, PayloadU16};
 use crate::msgs::codec::{Codec, Reader};

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -23,7 +23,6 @@ use crate::crypto::{ActiveKeyExchange, KeyExchangeAlgorithm};
 use crate::enums::{AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHashBuffer;
-#[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::enums::{Compression, ECPointFormat, ExtensionType, PSKKeyExchangeMode};

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -19,7 +19,6 @@ use crate::crypto::KeyExchangeAlgorithm;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
-#[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
 use crate::msgs::base::{Payload, PayloadU16, PayloadU8};
 use crate::msgs::ccs::ChangeCipherSpecPayload;

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -20,7 +20,6 @@ use crate::enums::{
 };
 use crate::error::{Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
-#[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
 use crate::msgs::base::{Payload, PayloadU8};
 use crate::msgs::ccs::ChangeCipherSpecPayload;

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -6,7 +6,6 @@ use pki_types::CertificateDer;
 use crate::crypto::SupportedKxGroup;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
-#[cfg(feature = "logging")]
 use crate::log::{debug, error, warn};
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -8,7 +8,6 @@ use std::io;
 use crate::common_state::{CommonState, Context, IoState, State, DEFAULT_BUFFER_LIMIT};
 use crate::enums::{AlertDescription, ContentType, ProtocolVersion};
 use crate::error::{Error, PeerMisbehaved};
-#[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::msgs::deframer::buffers::{BufferProgress, DeframerVecBuffer, Delocator, Locator};
 use crate::msgs::deframer::handshake::HandshakeDeframer;

--- a/rustls/src/crypto/aws_lc_rs/ticketer.rs
+++ b/rustls/src/crypto/aws_lc_rs/ticketer.rs
@@ -14,7 +14,6 @@ use aws_lc_rs::{hmac, iv};
 use super::ring_like::rand::{SecureRandom, SystemRandom};
 use super::unspecified_err;
 use crate::error::Error;
-#[cfg(feature = "logging")]
 use crate::log::debug;
 use crate::polyfill::try_split_at;
 use crate::rand::GetRandomFailed;

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -10,7 +10,6 @@ use subtle::ConstantTimeEq;
 use super::ring_like::aead;
 use super::ring_like::rand::{SecureRandom, SystemRandom};
 use crate::error::Error;
-#[cfg(feature = "logging")]
 use crate::log::debug;
 use crate::polyfill::try_split_at;
 use crate::rand::GetRandomFailed;

--- a/rustls/src/key_log_file.rs
+++ b/rustls/src/key_log_file.rs
@@ -7,7 +7,6 @@ use std::io;
 use std::io::Write;
 use std::sync::Mutex;
 
-#[cfg(feature = "logging")]
 use crate::log::warn;
 use crate::KeyLog;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -379,12 +379,12 @@ use log;
 use crate::crypto::CryptoProvider;
 
 #[cfg(not(feature = "logging"))]
-#[macro_use]
 mod log {
     macro_rules! trace    ( ($($tt:tt)*) => {{}} );
     macro_rules! debug    ( ($($tt:tt)*) => {{}} );
-    macro_rules! warn     ( ($($tt:tt)*) => {{}} );
     macro_rules! error    ( ($($tt:tt)*) => {{}} );
+    macro_rules! _warn    ( ($($tt:tt)*) => {{}} );
+    pub(crate) use {_warn as warn, debug, error, trace};
 }
 
 #[macro_use]

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -18,7 +18,6 @@ use crate::enums::{
 use crate::error::InvalidMessage;
 #[cfg(feature = "tls12")]
 use crate::ffdhe_groups::FfdheGroup;
-#[cfg(feature = "logging")]
 use crate::log::warn;
 use crate::msgs::base::{Payload, PayloadU16, PayloadU24, PayloadU8};
 use crate::msgs::codec::{self, Codec, LengthPrefixedBuffer, ListLength, Reader, TlsListElement};

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -3,7 +3,6 @@ use core::cmp::min;
 
 use crate::crypto::cipher::{InboundOpaqueMessage, MessageDecrypter, MessageEncrypter};
 use crate::error::Error;
-#[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::msgs::message::{InboundPlainMessage, OutboundOpaqueMessage, OutboundPlainMessage};
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -17,7 +17,6 @@ use crate::enums::{
 };
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
-#[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::enums::{Compression, ExtensionType, NamedGroup};
 #[cfg(feature = "tls12")]

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -21,7 +21,6 @@ use crate::crypto;
 use crate::crypto::CryptoProvider;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
-#[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::msgs::base::Payload;
 use crate::msgs::handshake::{ClientHelloPayload, ProtocolName, ServerExtension};

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -18,7 +18,6 @@ use crate::crypto::ActiveKeyExchange;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
-#[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -15,7 +15,6 @@ use crate::conn::ConnectionRandoms;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
-#[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::KeyUpdateRequest;

--- a/rustls/src/webpki/anchors.rs
+++ b/rustls/src/webpki/anchors.rs
@@ -5,7 +5,6 @@ use pki_types::{CertificateDer, TrustAnchor};
 use webpki::anchor_from_trusted_cert;
 
 use super::pki_error;
-#[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::{DistinguishedName, Error};
 

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -5,7 +5,6 @@ use pki_types::{CertificateDer, CertificateRevocationListDer, ServerName, UnixTi
 use webpki::{CertRevocationList, ExpirationPolicy, RevocationCheckDepth, UnknownStatusPolicy};
 
 use crate::crypto::{CryptoProvider, WebPkiSupportedAlgorithms};
-#[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::verify::{
     DigitallySignedStruct, HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,


### PR DESCRIPTION
Normalise the fact that logging macros live in `crate::log`, rather than a difference place depending on the `logging` feature.

ref https://github.com/rustls/hyper-rustls/pull/285#issuecomment-2324605158