### PR TITLE
Fix excessively long first rustdoc paragraphs

### DIFF
--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -251,7 +251,9 @@ pub trait ClientCertVerifier: Debug + Send + Sync {
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme>;
 }
 
-/// Turns off client authentication. In contrast to using
+/// Turns off client authentication.
+///
+/// In contrast to using
 /// `WebPkiClientVerifier::builder(roots).allow_unauthenticated().build()`, the `NoClientAuth`
 /// `ClientCertVerifier` will not offer client authentication at all, vs offering but not
 /// requiring it.

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -188,7 +188,9 @@ impl ClientCertVerifierBuilder {
 }
 
 /// A client certificate verifier that uses the `webpki` crate[^1] to perform client certificate
-/// validation. It must be created via the [`WebPkiClientVerifier::builder()`] or
+/// validation.
+///
+/// It must be created via the [`WebPkiClientVerifier::builder()`] or
 /// [`WebPkiClientVerifier::builder_with_provider()`] functions.
 ///
 /// Once built, the provided `Arc<dyn ClientCertVerifier>` can be used with a Rustls [`ServerConfig`]

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -40,8 +40,9 @@ pub fn verify_server_cert_signed_by_trust_anchor(
     )
 }
 
-/// Verify that the `end_entity` has an alternative name matching the `server_name`
-/// note: this only verifies the name and should be used in conjunction with more verification
+/// Verify that the `end_entity` has an alternative name matching the `server_name`.
+///
+/// Note: this only verifies the name and should be used in conjunction with more verification
 /// like [verify_server_cert_signed_by_trust_anchor]
 pub fn verify_server_name(
     cert: &ParsedCertificate<'_>,


### PR DESCRIPTION
This fixes `clippy::too_long_first_doc_paragraph` instances, a new lint just introduced on nightly:

```
warning: first doc comment paragraph is too long
   --> rustls/src/verify.rs:254:1
    |
254 | / /// Turns off client authentication. In contrast to using
255 | | /// `WebPkiClientVerifier::builder(roots).allow_unauthenticated().build()`, the `NoClientAuth`
256 | | /// `ClientCertVerifier` will not offer client authentication at all, vs offering but not
257 | | /// requiring it.
    | |_
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
    = note: `#[warn(clippy::too_long_first_doc_paragraph)]` on by default

warning: first doc comment paragraph is too long
   --> rustls/src/webpki/client_verifier.rs:190:1
    |
190 | / /// A client certificate verifier that uses the `webpki` crate[^1] to perform client certificate
191 | | /// validation. It must be created via the [`WebPkiClientVerifier::builder()`] or
192 | | /// [`WebPkiClientVerifier::builder_with_provider()`] functions.
193 | | ///
194 | | /// Once built, the provided `Arc<dyn ClientCertVerifier>` can be used with a Rustls [`ServerConfig`]
    | |_
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph

warning: first doc comment paragraph is too long
  --> rustls/src/webpki/verify.rs:43:1
   |
43 | / /// Verify that the `end_entity` has an alternative name matching the `server_name`
44 | | /// note: this only verifies the name and should be used in conjunction with more verification
45 | | /// like [verify_server_cert_signed_by_trust_anchor]
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph

```