### PR TITLE
Allow `SupportedKxGroup` to be version-specific

### DIFF
--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -53,8 +53,6 @@
     "NotJustKyberKeyShare": "we only offer the first kxg in a clienthello",
     "KyberKeyShareIncludedSecond": "^",
     "KyberKeyShareIncludedThird": "^",
-    "KyberNotInTLS12": "our bug: https://github.com/rustls/rustls/issues/2056",
-    "KyberNotAcceptedByTLS12Client": "^",
 #else
     "*Kyber*": "",
 #endif
@@ -193,7 +191,6 @@
     "MissingKeyShare-Server-TLS13": ":INCOMPATIBLE:",
     "EmptyEncryptedExtensions-TLS13": ":BAD_HANDSHAKE_MSG:",
     "NoSupportedCurves": ":INCOMPATIBLE:",
-    "BadECDHECurve": ":PEER_MISBEHAVIOUR:",
     "VersionTooLow": ":INCOMPATIBLE:",
     "ALPNClient-RejectUnknown-TLS-TLS12": ":PEER_MISBEHAVIOUR:",
     "ALPNClient-RejectUnknown-TLS-TLS13": ":PEER_MISBEHAVIOUR:",
@@ -368,7 +365,6 @@
     "Downgrade-TLS12-Client": ":PEER_MISBEHAVIOUR:",
     "Downgrade-TLS10-Client": ":HANDSHAKE_FAILURE:",
     "Downgrade-TLS10-Server": ":INCOMPATIBLE:",
-    "UnsupportedCurve": ":PEER_MISBEHAVIOUR:",
     "ECDSACurveMismatch-Verify-TLS13": ":BAD_SIGNATURE:",
     "SecondServerHelloNoVersion-TLS13": ":PEER_MISBEHAVIOUR:",
     "SecondServerHelloWrongVersion-TLS13": ":INCOMPATIBLE:",

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -962,6 +962,7 @@ fn handle_err(opts: &Options, err: Error) -> ! {
         {
             quit(":UNEXPECTED_EXTENSION:")
         }
+        Error::PeerMisbehaved(PeerMisbehaved::SelectedUnofferedKxGroup) => quit(":WRONG_CURVE:"),
         Error::PeerMisbehaved(_) => quit(":PEER_MISBEHAVIOUR:"),
         Error::NoCertificatesPresented => quit(":NO_CERTS:"),
         Error::AlertReceived(AlertDescription::UnexpectedMessage) => quit(":BAD_ALERT:"),

--- a/rustls-post-quantum/src/lib.rs
+++ b/rustls-post-quantum/src/lib.rs
@@ -56,7 +56,7 @@ use rustls::crypto::{
     ActiveKeyExchange, CompletedKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup,
 };
 use rustls::ffdhe_groups::FfdheGroup;
-use rustls::{Error, NamedGroup, PeerMisbehaved};
+use rustls::{Error, NamedGroup, PeerMisbehaved, ProtocolVersion};
 
 /// A `CryptoProvider` which includes `X25519Kyber768Draft00` key exchange.
 pub fn provider() -> CryptoProvider {
@@ -126,6 +126,10 @@ impl SupportedKxGroup for X25519Kyber768Draft00 {
 
     fn name(&self) -> NamedGroup {
         NAMED_GROUP
+    }
+
+    fn usable_for_version(&self, version: ProtocolVersion) -> bool {
+        version == ProtocolVersion::TLSv1_3
     }
 }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -403,12 +403,16 @@ impl ClientConfig {
             .find(|&scs| scs.suite() == suite)
     }
 
-    pub(super) fn find_kx_group(&self, group: NamedGroup) -> Option<&'static dyn SupportedKxGroup> {
+    pub(super) fn find_kx_group(
+        &self,
+        group: NamedGroup,
+        version: ProtocolVersion,
+    ) -> Option<&'static dyn SupportedKxGroup> {
         self.provider
             .kx_groups
             .iter()
             .copied()
-            .find(|skxg| skxg.name() == group)
+            .find(|skxg| skxg.usable_for_version(version) && skxg.name() == group)
     }
 
     pub(super) fn current_time(&self) -> Result<UnixTime, Error> {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -922,7 +922,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
         let maybe_skxg = match &kx_params {
             ServerKeyExchangeParams::Ecdh(ecdh) => st
                 .config
-                .find_kx_group(ecdh.curve_params.named_group),
+                .find_kx_group(ecdh.curve_params.named_group, ProtocolVersion::TLSv1_2),
             ServerKeyExchangeParams::Dh(dh) => {
                 let ffdhe_group = dh.as_ffdhe_group();
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -234,7 +234,7 @@ pub(super) fn initial_key_share(
         .resumption
         .store
         .kx_hint(server_name)
-        .and_then(|group_name| config.find_kx_group(group_name))
+        .and_then(|group_name| config.find_kx_group(group_name, ProtocolVersion::TLSv1_3))
         .unwrap_or_else(|| {
             config
                 .provider

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -437,6 +437,13 @@ pub trait SupportedKxGroup: Send + Sync + Debug {
     fn fips(&self) -> bool {
         false
     }
+
+    /// Return `true` if this should be offered/selected with the given version.
+    ///
+    /// The default implementation returns true for all versions.
+    fn usable_for_version(&self, _version: ProtocolVersion) -> bool {
+        true
+    }
 }
 
 /// An in-progress key exchange originating from a [`SupportedKxGroup`].

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -430,7 +430,9 @@ impl ExpectClientHello {
                 .provider
                 .kx_groups
                 .iter()
-                .find(|skxg| skxg.name() == *offered_group);
+                .find(|skxg| {
+                    skxg.usable_for_version(selected_version) && skxg.name() == *offered_group
+                });
 
             match offered_group.key_exchange_algorithm() {
                 KeyExchangeAlgorithm::DHE => {


### PR DESCRIPTION
X25519Kyber768Draft00 and the forthcoming equivalent with ML-KEM are only defined for TLS1.3.

Therefore, a TLS1.2 client should not offer it, and server that decides on TLS1.2 should not select it.

This is one small step towards #2056.