### PR TITLE
Eliminate large copies in resumption code paths

### DIFF
--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -243,6 +243,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
 
 test_for_each_provider! {
     use std::prelude::v1::*;
+    use alloc::sync::Arc;
     use super::NoClientSessionStorage;
     use crate::client::ClientSessionStore;
     use crate::msgs::enums::NamedGroup;
@@ -251,6 +252,7 @@ test_for_each_provider! {
     use crate::msgs::handshake::SessionId;
     use crate::msgs::persist::Tls13ClientSessionValue;
     use crate::suites::SupportedCipherSuite;
+    use crate::msgs::base::PayloadU16;
     use provider::cipher_suite;
 
     use pki_types::{ServerName, UnixTime};
@@ -278,7 +280,7 @@ test_for_each_provider! {
                 Tls12ClientSessionValue::new(
                     tls12_suite,
                     SessionId::empty(),
-                    Vec::new(),
+                    Arc::new(PayloadU16::empty()),
                     &[],
                     CertificateChain::default(),
                     now,
@@ -300,7 +302,7 @@ test_for_each_provider! {
             name.clone(),
             Tls13ClientSessionValue::new(
                 tls13_suite,
-                Vec::new(),
+                Arc::new(PayloadU16::empty()),
                 &[],
                 CertificateChain::default(),
                 now,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -126,7 +126,7 @@ pub(super) fn start_handshake(
                 // If we have a ticket, we use the sessionid as a signal that
                 // we're  doing an abbreviated handshake.  See section 3.4 in
                 // RFC5077.
-                if !inner.ticket().is_empty() {
+                if !inner.ticket().0.is_empty() {
                     inner.session_id = SessionId::random(config.provider.secure_random)?;
                 }
                 Some(inner.session_id)

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1163,17 +1163,17 @@ impl ExpectFinished {
         // Save a ticket.  If we got a new ticket, save that.  Otherwise, save the
         // original ticket again.
         let (mut ticket, lifetime) = match self.ticket.take() {
-            Some(nst) => (nst.ticket.0, nst.lifetime_hint),
-            None => (Vec::new(), 0),
+            Some(nst) => (nst.ticket, nst.lifetime_hint),
+            None => (Arc::new(PayloadU16::empty()), 0),
         };
 
-        if ticket.is_empty() {
+        if ticket.0.is_empty() {
             if let Some(resuming_session) = &mut self.resuming_session {
-                ticket = resuming_session.take_ticket();
+                ticket = resuming_session.ticket();
             }
         }
 
-        if self.session_id.is_empty() && ticket.is_empty() {
+        if self.session_id.is_empty() && ticket.0.is_empty() {
             debug!("Session not saved: server didn't allocate id or ticket");
             return;
         }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1428,7 +1428,7 @@ impl ExpectTraffic {
         #[allow(unused_mut)]
         let mut value = persist::Tls13ClientSessionValue::new(
             self.suite,
-            nst.ticket.0.clone(),
+            Arc::clone(&nst.ticket),
             secret.as_ref(),
             cx.common
                 .peer_certificates

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -1,3 +1,4 @@
+use alloc::sync::Arc;
 use std::prelude::v1::*;
 use std::{format, println, vec};
 
@@ -1248,7 +1249,7 @@ fn sample_certificate_request_payload_tls13() -> CertificateRequestPayloadTls13 
 fn sample_new_session_ticket_payload() -> NewSessionTicketPayload {
     NewSessionTicketPayload {
         lifetime_hint: 1234,
-        ticket: PayloadU16(vec![1, 2, 3]),
+        ticket: Arc::new(PayloadU16(vec![1, 2, 3])),
     }
 }
 
@@ -1257,7 +1258,7 @@ fn sample_new_session_ticket_payload_tls13() -> NewSessionTicketPayloadTls13 {
         lifetime: 123,
         age_add: 1234,
         nonce: PayloadU8(vec![1, 2, 3]),
-        ticket: PayloadU16(vec![4, 5, 6]),
+        ticket: Arc::new(PayloadU16(vec![4, 5, 6])),
         exts: vec![NewSessionTicketExtension::Unknown(UnknownExtension {
             typ: ExtensionType::Unknown(12345),
             payload: Payload::Borrowed(&[1, 2, 3]),

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -1,8 +1,6 @@
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cmp;
-#[cfg(feature = "tls12")]
-use core::mem;
 
 use pki_types::{DnsName, UnixTime};
 use zeroize::Zeroizing;
@@ -81,7 +79,7 @@ pub struct Tls13ClientSessionValue {
 impl Tls13ClientSessionValue {
     pub(crate) fn new(
         suite: &'static Tls13CipherSuite,
-        ticket: Vec<u8>,
+        ticket: Arc<PayloadU16>,
         secret: &[u8],
         server_cert_chain: CertificateChain<'static>,
         time_now: UnixTime,
@@ -159,7 +157,7 @@ impl Tls12ClientSessionValue {
     pub(crate) fn new(
         suite: &'static Tls12CipherSuite,
         session_id: SessionId,
-        ticket: Vec<u8>,
+        ticket: Arc<PayloadU16>,
         master_secret: &[u8],
         server_cert_chain: CertificateChain<'static>,
         time_now: UnixTime,
@@ -180,8 +178,8 @@ impl Tls12ClientSessionValue {
         }
     }
 
-    pub(crate) fn take_ticket(&mut self) -> Vec<u8> {
-        mem::take(&mut self.common.ticket.0)
+    pub(crate) fn ticket(&mut self) -> Arc<PayloadU16> {
+        Arc::clone(&self.common.ticket)
     }
 
     pub(crate) fn extended_ms(&self) -> bool {
@@ -210,7 +208,7 @@ impl core::ops::Deref for Tls12ClientSessionValue {
 
 #[derive(Debug, Clone)]
 pub struct ClientSessionCommon {
-    ticket: PayloadU16,
+    ticket: Arc<PayloadU16>,
     secret: Zeroizing<PayloadU8>,
     epoch: u64,
     lifetime_secs: u32,
@@ -219,14 +217,14 @@ pub struct ClientSessionCommon {
 
 impl ClientSessionCommon {
     fn new(
-        ticket: Vec<u8>,
+        ticket: Arc<PayloadU16>,
         secret: &[u8],
         time_now: UnixTime,
         lifetime_secs: u32,
         server_cert_chain: CertificateChain<'static>,
     ) -> Self {
         Self {
-            ticket: PayloadU16(ticket),
+            ticket,
             secret: Zeroizing::new(PayloadU8(secret.to_vec())),
             epoch: time_now.as_secs(),
             lifetime_secs: cmp::min(lifetime_secs, MAX_TICKET_LIFETIME),

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -1,3 +1,4 @@
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cmp;
 #[cfg(feature = "tls12")]
@@ -213,7 +214,7 @@ pub struct ClientSessionCommon {
     secret: Zeroizing<PayloadU8>,
     epoch: u64,
     lifetime_secs: u32,
-    server_cert_chain: CertificateChain<'static>,
+    server_cert_chain: Arc<CertificateChain<'static>>,
 }
 
 impl ClientSessionCommon {
@@ -229,7 +230,7 @@ impl ClientSessionCommon {
             secret: Zeroizing::new(PayloadU8(secret.to_vec())),
             epoch: time_now.as_secs(),
             lifetime_secs: cmp::min(lifetime_secs, MAX_TICKET_LIFETIME),
-            server_cert_chain,
+            server_cert_chain: Arc::new(server_cert_chain),
         }
     }
 


### PR DESCRIPTION
This fixes two large-ish copies in client resumption paths.

These were identified by:

- expanding quite a lot of `derive(Clone)` into manual implementations, 
- making those log how much data they were cloning,
- chasing down the instances which indicated large clones