### PR TITLE
Fix daily connect-tests

### DIFF
--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -9,7 +9,7 @@ mod ech_config {
 
     #[test]
     fn cloudflare() {
-        test_deserialize_ech_config_list("crypto.cloudflare.com");
+        test_deserialize_ech_config_list("research.cloudflare.com");
     }
 
     #[test]

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -1013,6 +1013,7 @@ impl<'a, const TLS13: bool> HandshakeFlight<'a, TLS13> {
     }
 }
 
+#[cfg(feature = "tls12")]
 pub(crate) type HandshakeFlightTls12<'a> = HandshakeFlight<'a, false>;
 pub(crate) type HandshakeFlightTls13<'a> = HandshakeFlight<'a, true>;
 


### PR DESCRIPTION
Our daily connect tests CI job [has been failing](https://github.com/rustls/rustls/actions/runs/10946737125). This branch lands two fixes to [restore it to green](https://github.com/cpu/rustls/actions/runs/10948986655):

1. A type alias added in https://github.com/rustls/rustls/pull/2120 needs a `cfg` gate to only include it when the `tls12` feature is active to avoid a dead code warning when that feature isn't enabled.

2. The `crypto.cloudflare.com` domain's HTTPS record seems to no longer include an `ech` parameter, breaking the deserialization test. The domain this redirects to in a browser, `research.cloudflare.com`, _does_ have an `ech` parameter in its HTTPS record, so let's use that.

```
❯ dig +short crypto.cloudflare.com HTTPS
1 . alpn="h2" ipv4hint=162.159.135.79,162.159.136.79 ipv6hint=2606:4700:7::a29f:874f,2606:4700:7::a29f:884f

❯ dig +short research.cloudflare.com HTTPS
1 . alpn="http/1.1,h2" ipv4hint=162.159.137.85,162.159.138.85 ech=AEX+DQBBlQAgACBDw7OiRdqE2AU6C2icJ25ynRmMzmp9V3c6ZXiXwVprdQAEAAEAAQASY2xvdWRmbGFyZS1lY2guY29tAAA= ipv6hint=2606:4700:7::a29f:8955,2606:4700:7::a29f:8a55
```