### PR TITLE
add DerefMut to common state for UnbufferedConnectionCommon

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -792,6 +792,13 @@ impl<T> Deref for UnbufferedConnectionCommon<T> {
     }
 }
 
+impl<T> DerefMut for UnbufferedConnectionCommon<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.core.common_state
+    }
+}
+
+
 pub(crate) struct ConnectionCore<Data> {
     pub(crate) state: Result<Box<dyn State<Data>>, Error>,
     pub(crate) data: Data,

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -798,7 +798,6 @@ impl<T> DerefMut for UnbufferedConnectionCommon<T> {
     }
 }
 
-
 pub(crate) struct ConnectionCore<Data> {
     pub(crate) state: Result<Box<dyn State<Data>>, Error>,
     pub(crate) data: Data,


### PR DESCRIPTION
This is needed because `CommonState::send_close_notify()` is needed to be called when you need to do `send_close_notify` for fatal case.