### PR TITLE
Eliminate an allocation in signature verification

### DIFF
--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1115,7 +1115,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
             .config
             .verifier
             .verify_tls13_signature(
-                &construct_server_verify_message(&handshake_hash),
+                construct_server_verify_message(&handshake_hash).as_ref(),
                 end_entity,
                 cert_verify,
             )
@@ -1204,7 +1204,7 @@ fn emit_certverify_tls13(
     let message = construct_client_verify_message(&flight.transcript.current_hash());
 
     let scheme = signer.scheme();
-    let sig = signer.sign(&message)?;
+    let sig = signer.sign(message.as_ref())?;
     let dss = DigitallySignedStruct::new(scheme, sig);
 
     flight.add(HandshakeMessagePayload {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -796,7 +796,7 @@ mod client_hello {
             })?;
 
         let scheme = signer.scheme();
-        let sig = signer.sign(&message)?;
+        let sig = signer.sign(message.as_ref())?;
 
         let cv = DigitallySignedStruct::new(scheme, sig);
 
@@ -1160,7 +1160,7 @@ impl State<ServerConnectionData> for ExpectCertificateVerify {
 
             self.config
                 .verifier
-                .verify_tls13_signature(&msg, &certs[0], sig)
+                .verify_tls13_signature(msg.as_ref(), &certs[0], sig)
         };
 
         if let Err(e) = rc {


### PR DESCRIPTION
The signed message has a pretty tight upper bound, so we can avoid a Vec allocation here.