### PR TITLE
Migrate to pki-types PEM decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,7 +2111,6 @@ dependencies = [
  "once_cell",
  "rcgen",
  "ring",
- "rustls-pemfile",
  "rustls-pki-types",
  "rustls-post-quantum",
  "rustls-webpki",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,7 +2197,6 @@ dependencies = [
  "once_cell",
  "openssl",
  "rustls 0.23.13",
- "rustls-pemfile",
  "rustls-pki-types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,6 @@ dependencies = [
  "base64",
  "env_logger",
  "rustls 0.23.13",
- "rustls-pemfile",
  "rustls-pki-types",
  "rustls-post-quantum",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,7 +2153,6 @@ dependencies = [
  "itertools 0.13.0",
  "rayon",
  "rustls 0.23.13",
- "rustls-pemfile",
  "rustls-pki-types",
  "tikv-jemallocator",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,6 @@ dependencies = [
  "mio 0.8.11",
  "rcgen",
  "rustls 0.23.13",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_derive",

--- a/bogo/Cargo.toml
+++ b/bogo/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 base64 = "0.22"
 env_logger = "0.10" # 0.11 requires 1.71 MSRV even as a dev-dep (due to manifest features)
-pki-types = { package = "rustls-pki-types", version = "1.7" }
+pki-types = { package = "rustls-pki-types", version = "1.9", features = ["std"] }
 rustls = { path = "../rustls", features = ["aws_lc_rs", "fips", "ring", "tls12"] }
-rustls-pemfile = "2"
 rustls-post-quantum = { path = "../rustls-post-quantum" }

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -13,10 +13,9 @@ byteorder = "1.4.3"
 clap = { version = "4.3.21", features = ["derive"] }
 fxhash = "0.2.1"
 itertools = "0.13"
-pki-types = { package = "rustls-pki-types", version = "1.4.1" }
+pki-types = { package = "rustls-pki-types", version = "1.9" }
 rayon = "1.7.0"
 rustls = { path = "../rustls", features = ["ring", "aws_lc_rs"] }
-rustls-pemfile = "2"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -1,5 +1,4 @@
-use std::{fs, io};
-
+use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 
 #[derive(PartialEq, Clone, Copy, Debug)]
@@ -19,19 +18,14 @@ impl KeyType {
     }
 
     pub(crate) fn get_chain(&self) -> Vec<CertificateDer<'static>> {
-        rustls_pemfile::certs(&mut io::BufReader::new(
-            fs::File::open(self.path_for("end.fullchain")).unwrap(),
-        ))
-        .map(|result| result.unwrap())
-        .collect()
+        CertificateDer::pem_file_iter(self.path_for("end.fullchain"))
+            .unwrap()
+            .map(|result| result.unwrap())
+            .collect()
     }
 
     pub(crate) fn get_key(&self) -> PrivateKeyDer<'static> {
-        rustls_pemfile::private_key(&mut io::BufReader::new(
-            fs::File::open(self.path_for("end.key")).unwrap(),
-        ))
-        .unwrap()
-        .unwrap()
+        PrivateKeyDer::from_pem_file(self.path_for("end.key")).unwrap()
     }
 }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,10 +13,9 @@ env_logger = "0.10" # 0.11 requires 1.71 MSRV even as a dev-dep (due to manifest
 hickory-resolver = { version = "0.25.0-alpha.1", features = ["dns-over-https-rustls", "webpki-roots"] }
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
-pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }
+pki-types = { package = "rustls-pki-types", version = "1.9", features = ["std"] }
 rcgen = { version = "0.13", features = ["pem", "aws_lc_rs"], default-features = false }
 rustls = { path = "../rustls", features = [ "logging" ]}
-rustls-pemfile = "2"
 serde = "1.0"
 serde_derive = "1.0"
 tokio = { version = "1.34.0", features = ["io-util", "macros", "net", "rt"]}

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -35,7 +35,8 @@ use rustls::client::{EchConfig, EchGreaseConfig, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
 use rustls::crypto::hpke::Hpke;
-use rustls::pki_types::ServerName;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, ServerName};
 use rustls::RootCertStore;
 
 fn main() {
@@ -78,10 +79,10 @@ fn main() {
     let root_store = match args.cafile {
         Some(file) => {
             let mut root_store = RootCertStore::empty();
-            let certfile = fs::File::open(file).expect("Cannot open CA file");
-            let mut reader = BufReader::new(certfile);
             root_store.add_parsable_certificates(
-                rustls_pemfile::certs(&mut reader).map(|result| result.unwrap()),
+                CertificateDer::pem_file_iter(file)
+                    .expect("Cannot open CA file")
+                    .map(|result| result.unwrap()),
             );
             root_store
         }

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -9,13 +9,14 @@
 //! Note that `unwrap()` is used to deal with networking errors; this is not something
 //! that is sensible outside of example code.
 
+use std::env;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::{env, fs};
 
-use rustls::pki_types::ServerName;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, ServerName};
 use rustls::RootCertStore;
 
 fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str, port: u16) {
@@ -82,10 +83,10 @@ fn main() {
 
     let mut root_store = RootCertStore::empty();
     if let Some(cafile) = args.next() {
-        let certfile = fs::File::open(cafile).expect("Cannot open CA file");
-        let mut reader = BufReader::new(certfile);
         root_store.add_parsable_certificates(
-            rustls_pemfile::certs(&mut reader).map(|result| result.unwrap()),
+            CertificateDer::pem_file_iter(cafile)
+                .expect("Cannot open CA file")
+                .map(|result| result.unwrap()),
         );
     } else {
         root_store.extend(

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -19,14 +19,15 @@
 //!
 //! [mio]: https://docs.rs/mio/latest/mio/
 
-use std::io::{self, BufReader, Read, Write};
+use std::io::{self, Read, Write};
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
-use std::{fs, process, str};
+use std::{process, str};
 
 use clap::Parser;
 use mio::net::TcpStream;
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
+use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 use rustls::RootCertStore;
 
@@ -317,31 +318,14 @@ fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtoco
 }
 
 fn load_certs(filename: &str) -> Vec<CertificateDer<'static>> {
-    let certfile = fs::File::open(filename).expect("cannot open certificate file");
-    let mut reader = BufReader::new(certfile);
-    rustls_pemfile::certs(&mut reader)
+    CertificateDer::pem_file_iter(filename)
+        .expect("cannot open certificate file")
         .map(|result| result.unwrap())
         .collect()
 }
 
 fn load_private_key(filename: &str) -> PrivateKeyDer<'static> {
-    let keyfile = fs::File::open(filename).expect("cannot open private key file");
-    let mut reader = BufReader::new(keyfile);
-
-    loop {
-        match rustls_pemfile::read_one(&mut reader).expect("cannot parse private key .pem file") {
-            Some(rustls_pemfile::Item::Pkcs1Key(key)) => return key.into(),
-            Some(rustls_pemfile::Item::Pkcs8Key(key)) => return key.into(),
-            Some(rustls_pemfile::Item::Sec1Key(key)) => return key.into(),
-            None => break,
-            _ => {}
-        }
-    }
-
-    panic!(
-        "no keys found in {:?} (encrypted keys not supported)",
-        filename
-    );
+    PrivateKeyDer::from_pem_file(filename).expect("cannot read private key file")
 }
 
 mod danger {
@@ -412,10 +396,10 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     let mut root_store = RootCertStore::empty();
 
     if let Some(cafile) = args.cafile.as_ref() {
-        let certfile = fs::File::open(cafile).expect("Cannot open CA file");
-        let mut reader = BufReader::new(certfile);
         root_store.add_parsable_certificates(
-            rustls_pemfile::certs(&mut reader).map(|result| result.unwrap()),
+            CertificateDer::pem_file_iter(cafile)
+                .expect("Cannot open CA file")
+                .map(|result| result.unwrap()),
         );
     } else {
         root_store.extend(

--- a/examples/src/bin/unbuffered-server.rs
+++ b/examples/src/bin/unbuffered-server.rs
@@ -3,12 +3,12 @@
 
 use std::env;
 use std::error::Error;
-use std::fs::File;
-use std::io::{self, BufReader, Read, Write};
+use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::sync::Arc;
 
+use pki_types::pem::PemObject;
 use pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::UnbufferedServerConnection;
 use rustls::unbuffered::{
@@ -16,7 +16,6 @@ use rustls::unbuffered::{
     UnbufferedStatus,
 };
 use rustls::ServerConfig;
-use rustls_pemfile::Item;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut args = env::args();
@@ -248,24 +247,14 @@ fn send_tls(
 }
 
 fn load_certs(path: impl AsRef<Path>) -> Result<Vec<CertificateDer<'static>>, io::Error> {
-    let mut reader = BufReader::new(File::open(path)?);
-    rustls_pemfile::certs(&mut reader).collect()
+    Ok(CertificateDer::pem_file_iter(path)
+        .expect("cannot open certificate file")
+        .map(|cert| cert.unwrap())
+        .collect())
 }
 
 fn load_private_key(path: impl AsRef<Path>) -> Result<PrivateKeyDer<'static>, io::Error> {
-    let mut reader = BufReader::new(File::open(&path)?);
-
-    loop {
-        match rustls_pemfile::read_one(&mut reader)? {
-            Some(Item::Pkcs1Key(key)) => return Ok(key.into()),
-            Some(Item::Pkcs8Key(key)) => return Ok(key.into()),
-            Some(Item::Sec1Key(key)) => return Ok(key.into()),
-            None => break,
-            _ => continue,
-        }
-    }
-
-    panic!("no keys found in {}", path.as_ref().display())
+    Ok(PrivateKeyDer::from_pem_file(path).expect("cannot open private key file"))
 }
 
 const KB: usize = 1024;

--- a/openssl-tests/Cargo.toml
+++ b/openssl-tests/Cargo.toml
@@ -12,6 +12,5 @@ base64 = "0.22"
 num-bigint = "0.4.4"
 once_cell = "1.19"
 rustls = {path = "../rustls"}
-rustls-pemfile = "2"
-rustls-pki-types = "1.0"
+rustls-pki-types = "1.9"
 openssl = "0.10"

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -1,14 +1,13 @@
-use std::fs::{self, File};
-use std::io::{BufReader, Read, Write};
+use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
-use std::{str, thread};
+use std::{fs, str, thread};
 
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::version::{TLS12, TLS13};
 use rustls::{ClientConfig, RootCertStore, ServerConfig, SupportedProtocolVersion};
-use rustls_pemfile::Item;
+use rustls_pki_types::pem::PemObject;
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 
 use crate::ffdhe::{self, FfdheKxGroup};
@@ -185,24 +184,14 @@ fn root_ca() -> RootCertStore {
 }
 
 fn load_certs() -> Vec<CertificateDer<'static>> {
-    let mut reader = BufReader::new(File::open(CERT_CHAIN_FILE).unwrap());
-    rustls_pemfile::certs(&mut reader)
+    CertificateDer::pem_file_iter(CERT_CHAIN_FILE)
+        .unwrap()
         .map(|c| c.unwrap())
         .collect()
 }
 
 fn load_private_key() -> PrivateKeyDer<'static> {
-    let mut reader = BufReader::new(File::open(PRIV_KEY_FILE).unwrap());
-
-    match rustls_pemfile::read_one(&mut reader)
-        .unwrap()
-        .unwrap()
-    {
-        Item::Pkcs1Key(key) => key.into(),
-        Item::Pkcs8Key(key) => key.into(),
-        Item::Sec1Key(key) => key.into(),
-        _ => panic!("no key in key file {PRIV_KEY_FILE}"),
-    }
+    PrivateKeyDer::from_pem_file(PRIV_KEY_FILE).unwrap()
 }
 
 fn ffdhe_provider() -> CryptoProvider {

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = { version = "1.16", default-features = false, features = ["alloc", "
 ring = { version = "0.17", optional = true }
 subtle = { version = "2.5.0", default-features = false }
 webpki = { package = "rustls-webpki", version = "0.102.8", features = ["alloc"], default-features = false }
-pki-types = { package = "rustls-pki-types", version = "1.7", features = ["alloc"] }
+pki-types = { package = "rustls-pki-types", version = "1.9", features = ["alloc"] }
 zeroize = "1.7"
 zlib-rs = { version = "0.3", optional = true }
 
@@ -55,7 +55,6 @@ hex = "0.4"
 log = "0.4.8"
 num-bigint = "0.4.4"
 rcgen = { version = "0.13", default-features = false, features = ["aws_lc_rs", "pem"] }
-rustls-pemfile = "2"
 rustls-post-quantum = { path = "../rustls-post-quantum" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -433,6 +433,7 @@ test_for_each_provider! {
     use crate::server::VerifierBuilderError;
     use crate::RootCertStore;
 
+    use pki_types::pem::PemObject;
     use pki_types::{CertificateDer, CertificateRevocationListDer};
 
     use std::prelude::v1::*;
@@ -442,12 +443,7 @@ test_for_each_provider! {
     fn load_crls(crls_der: &[&[u8]]) -> Vec<CertificateRevocationListDer<'static>> {
         crls_der
             .iter()
-            .map(|pem_bytes| {
-                rustls_pemfile::crls(&mut &pem_bytes[..])
-                    .next()
-                    .unwrap()
-                    .unwrap()
-            })
+            .map(|pem_bytes| CertificateRevocationListDer::from_pem_slice(pem_bytes).unwrap())
             .collect()
     }
 

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -305,6 +305,7 @@ test_for_each_provider! {
     use std::{vec, println};
     use std::prelude::v1::*;
 
+    use pki_types::pem::PemObject;
     use pki_types::{CertificateDer, CertificateRevocationListDer};
 
     use super::{VerifierBuilderError, WebPkiServerVerifier};
@@ -313,12 +314,7 @@ test_for_each_provider! {
     fn load_crls(crls_der: &[&[u8]]) -> Vec<CertificateRevocationListDer<'static>> {
         crls_der
             .iter()
-            .map(|pem_bytes| {
-                rustls_pemfile::crls(&mut &pem_bytes[..])
-                    .next()
-                    .unwrap()
-                    .unwrap()
-            })
+            .map(|pem_bytes| CertificateRevocationListDer::from_pem_slice(pem_bytes).unwrap())
             .collect()
     }
 


### PR DESCRIPTION
This reworks all the test and example code we have to use the new pki-types PEM decoding.

Generally this went smoothly, and I'm very pleased that quite a lot of boilerplate fell away. We might want to `impl std::error::Error` on `pem::Error`?