### PR TITLE
Fix tls13_packed_handshake test bitrot

### DIFF
--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -7657,12 +7657,14 @@ fn tls13_packed_handshake() {
 
     // regression test for https://github.com/rustls/rustls/issues/2040
     // (did not affect the buffered api)
-    let client_config = finish_client_config(
-        KeyType::Rsa2048,
-        ClientConfig::builder_with_provider(unsafe_plaintext_crypto_provider())
-            .with_safe_default_protocol_versions()
-            .unwrap(),
-    );
+    let client_config = ClientConfig::builder_with_provider(unsafe_plaintext_crypto_provider())
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(MockServerVerifier::rejects_certificate(
+            CertificateError::UnknownIssuer.into(),
+        )))
+        .with_no_client_auth();
 
     let mut client =
         ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -792,12 +792,14 @@ fn tls13_packed_handshake() {
     }
 
     // regression test for https://github.com/rustls/rustls/issues/2040
-    let client_config = finish_client_config(
-        KeyType::Rsa2048,
-        ClientConfig::builder_with_provider(unsafe_plaintext_crypto_provider())
-            .with_safe_default_protocol_versions()
-            .unwrap(),
-    );
+    let client_config = ClientConfig::builder_with_provider(unsafe_plaintext_crypto_provider())
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(MockServerVerifier::rejects_certificate(
+            CertificateError::UnknownIssuer.into(),
+        )))
+        .with_no_client_auth();
 
     let mut client =
         UnbufferedClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();


### PR DESCRIPTION
These tests started failing at 0955UTC today, since the cert embedded in the captured handshake expired.  Verifying that cert is not fundamental to the test, so don't.