### PR TITLE
Update bogo

### DIFF
--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -56,6 +56,7 @@
 #else
     "*Kyber*": "",
 #endif
+    "*MLKEM*": "NYI",
     "ExtraClientEncryptedExtension-*": "we don't implement ALPS",
     "Server-JDK11*": "workarounds for oracle engineering quality",
     "Client-RejectJDK11DowngradeRandom": "",
@@ -85,14 +86,7 @@
 #ifdef RING
     "*-ECDSA_P521_SHA512-*": "no p521 signatures/verification",
 #endif
-    "CurveTest-Client-P-521-TLS12": "no p521 key exchange",
-    "CurveTest-Server-P-521-TLS12": "",
-    "CurveTest-Client-Compressed-P-521-TLS12": "",
-    "CurveTest-Server-Compressed-P-521-TLS12": "",
-    "CurveTest-Client-P-521-TLS13": "",
-    "CurveTest-Server-P-521-TLS13": "",
-    "CurveTest-Client-Compressed-P-521-TLS13": "",
-    "CurveTest-Server-Compressed-P-521-TLS13": "",
+    "CurveTest-*-P-521-*": "no p521 key exchange",
     "GREASE-*": "not implemented",
     "LargeMessage-Reject": "",
     "DelegatedCredentials-*": "not implemented",

--- a/bogo/fetch-and-build
+++ b/bogo/fetch-and-build
@@ -15,7 +15,7 @@ util/testresult
 EOF
 
 # fix on a tested point of rustls-testing branch
-COMMIT=6084f385927435f813d9bafa232bd985a26a7a3d
+COMMIT=018edfaaaeea43bf35a16e9f7ba24510c0c003bb
 git fetch --depth=1 https://github.com/rustls/boringssl.git $COMMIT
 git checkout $COMMIT
 (cd ssl/test/runner && go test -c)

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -956,6 +956,7 @@ fn handle_err(opts: &Options, err: Error) -> ! {
             quit(":UNEXPECTED_EXTENSION:")
         }
         Error::PeerMisbehaved(PeerMisbehaved::SelectedUnofferedKxGroup) => quit(":WRONG_CURVE:"),
+        Error::PeerMisbehaved(PeerMisbehaved::InvalidKeyShare) => quit(":BAD_ECPOINT:"),
         Error::PeerMisbehaved(_) => quit(":PEER_MISBEHAVIOUR:"),
         Error::NoCertificatesPresented => quit(":NO_CERTS:"),
         Error::AlertReceived(AlertDescription::UnexpectedMessage) => quit(":BAD_ALERT:"),
@@ -1660,6 +1661,7 @@ pub fn main() {
             "-ignore-tls13-downgrade" |
             "-allow-hint-mismatch" |
             "-wpa-202304" |
+            "-cnsa-202407" |
             "-srtp-profiles" |
             "-permute-extensions" |
             "-signed-cert-timestamps" |

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -938,7 +938,10 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
         let skxg = match maybe_skxg {
             Some(skxg) => skxg,
             None => {
-                return Err(PeerMisbehaved::SelectedUnofferedKxGroup.into());
+                return Err(cx.common.send_fatal_alert(
+                    AlertDescription::IllegalParameter,
+                    PeerMisbehaved::SelectedUnofferedKxGroup,
+                ));
             }
         };
         cx.common.kx_state = KxState::Start(skxg);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -149,7 +149,12 @@ pub(super) fn handle_server_hello(
     };
 
     cx.common.kx_state.complete();
-    let shared_secret = our_key_share.complete(&their_key_share.payload.0)?;
+    let shared_secret = our_key_share
+        .complete(&their_key_share.payload.0)
+        .map_err(|err| {
+            cx.common
+                .send_fatal_alert(AlertDescription::IllegalParameter, err)
+        })?;
 
     let mut key_schedule = key_schedule_pre_handshake.into_handshake(shared_secret);
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -583,7 +583,11 @@ impl State<ServerConnectionData> for ExpectClientKx<'_> {
             ems_seed,
             self.randoms,
             self.suite,
-        )?;
+        )
+        .map_err(|err| {
+            cx.common
+                .send_fatal_alert(AlertDescription::IllegalParameter, err)
+        })?;
         cx.common.kx_state.complete();
 
         self.config.key_log.log(

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -490,7 +490,12 @@ mod client_hello {
         // Prepare key exchange; the caller already found the matching SupportedKxGroup
         let (share, kxgroup) = share_and_kxgroup;
         debug_assert_eq!(kxgroup.name(), share.group);
-        let ckx = kxgroup.start_and_complete(&share.payload.0)?;
+        let ckx = kxgroup
+            .start_and_complete(&share.payload.0)
+            .map_err(|err| {
+                cx.common
+                    .send_fatal_alert(AlertDescription::IllegalParameter, err)
+            })?;
         cx.common.kx_state.complete();
 
         extensions.push(ServerExtension::KeyShare(KeyShareEntry::new(


### PR DESCRIPTION
This takes the current version of bogo, which adds testing of ML-KEM.

At the same time, there are some improved tests for alerts sent on key exchange failure.