### PR TITLE
Prepare 0.23.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "env_logger",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "rustls-post-quantum",
 ]
@@ -1163,7 +1163,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
- "rustls 0.23.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.23.13",
  "rustls-pemfile",
  "thiserror",
  "time",
@@ -1190,7 +1190,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "resolv-conf",
- "rustls 0.23.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.23.13",
  "smallvec",
  "thiserror",
  "tokio",
@@ -2096,6 +2096,21 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.14"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2126,21 +2141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rustls-ci-bench"
 version = "0.0.1"
 dependencies = [
@@ -2152,7 +2152,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "rayon",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "tikv-jemallocator",
 ]
@@ -2164,7 +2164,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.13",
+ "rustls 0.23.14",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ dependencies = [
  "log",
  "mio 0.8.11",
  "rcgen",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "serde",
  "serde_derive",
@@ -2195,7 +2195,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
 ]
 
@@ -2221,7 +2221,7 @@ version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "webpki-roots",
 ]
 
@@ -2242,7 +2242,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "rustls-webpki",
  "sha2",
@@ -2256,7 +2256,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-provider-example",
  "serde",
  "serde_json",
@@ -2562,7 +2562,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.14"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.14"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
The main reason for this release is cutting a release that contains the minor perf improvements, for publishing benchmarks against aws-lc-rs 1.10. nb. this release does not require 1.10; there is not currently a need for that.

Draft release notes:

- **Breaking change for `no_std` users**: The return type of [`CryptoProvider::install_default()`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.install_default) would change depending on the `std` crate feature. This [was unintended](https://doc.rust-lang.org/cargo/reference/features.html#semver-compatibility) and is corrected in this release. But that does mean this semver-compatible release contains a breaking API change, albeit only for users who omit the `std` crate feature. Our apologies in advance.
- **Performance improvements** especially for servers doing a full TLS1.3 handshake, and clients doing a resumed TLS1.2 handshake.
- **Improvements to example code**: demonstrate usage of TLS1.3 early data (thanks to @tahmid-23) & using clap for CLI.
