### PR TITLE
ci: update ECH daily-test configuration

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -115,10 +115,16 @@ jobs:
       - name: Check server acceptor
         run: cargo run --locked -p rustls-examples --bin server_acceptor -- --help
 
-      - name: Check ech-client
+      - name: Check ech-client (research.cloudflare.com)
         run: >
-          cargo run --locked -p rustls-examples --bin ech-client -- --host defo.ie defo.ie www.defo.ie |
-            grep 'SSL_ECH_STATUS: success'
+          cargo run --locked -p rustls-examples --bin ech-client -- research.cloudflare.com cloudflare.com --path /cdn-cgi/trace |
+            grep 'sni=encrypted'
+
+      # TOOD(@cpu): Restore when defo.ie misconfiguration is addressed.
+      #- name: Check ech-client (defo.ie)
+      #  run: >
+      #    cargo run --locked -p rustls-examples --bin ech-client -- --host defo.ie defo.ie www.defo.ie |
+      #      grep 'SSL_ECH_STATUS: success'
 
       - name: Check provider-example client
         run: cargo run --locked -p rustls-provider-example --example client


### PR DESCRIPTION
Temporarily comments out the `defo.ie` test. The server is misconfigured at the moment and [rejecting ECH](https://github.com/rustls/rustls/actions/runs/11365528281/job/31613908939). The operator is aware & fixing. For the meantime let's comment it out to unbreak daily tests.

To maintain coverage a new test case is added that checks ECH is successfully negotiated with Cloudflare using the `/cdn-cgi/trace` output to verify SNI is encrypted.

We might as well leave this in place after `defo.ie` is fixed so we can have two separate server implementations being tested (OpenSSL and whatever CF uses (forked Go? boringssl?)).

Edit: Here's a [manually invoked run](https://github.com/cpu/rustls/actions/runs/11367592338/) completing successfully.