### PR TITLE
ci: restore defo.ie ECH daily test

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -120,11 +120,10 @@ jobs:
           cargo run --locked -p rustls-examples --bin ech-client -- research.cloudflare.com cloudflare.com --path /cdn-cgi/trace |
             grep 'sni=encrypted'
 
-      # TOOD(@cpu): Restore when defo.ie misconfiguration is addressed.
-      #- name: Check ech-client (defo.ie)
-      #  run: >
-      #    cargo run --locked -p rustls-examples --bin ech-client -- --host defo.ie defo.ie www.defo.ie |
-      #      grep 'SSL_ECH_STATUS: success'
+      - name: Check ech-client (defo.ie)
+        run: >
+          cargo run --locked -p rustls-examples --bin ech-client -- --host defo.ie defo.ie www.defo.ie |
+            grep 'SSL_ECH_STATUS: success'
 
       - name: Check provider-example client
         run: cargo run --locked -p rustls-provider-example --example client


### PR DESCRIPTION
The upstream misconfiguration has been resolved and we can restore this test coverage in the daily connect tests workflow that was removed in https://github.com/rustls/rustls/pull/2161.

Here's a [manual invocation](https://github.com/cpu/rustls/actions/runs/11386836128) of this branch that passed.