### PR TITLE
Remove crossbuilds and coverage from merge_checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,6 +289,7 @@ jobs:
   coverage:
     name: Measure coverage
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -339,6 +340,7 @@ jobs:
   cross:
     name: cross-target testing
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group'
     strategy:
       matrix:
         target:


### PR DESCRIPTION
These are the more costly jobs, and it seems unlikely they uniquely will capture rebase failures in a way that other jobs cannot (?).

This should improve our merge queue time, which is currently around 16-24 minutes.