### PR TITLE
bench: match default BoringSSL/OpenSSL ticket count

### DIFF
--- a/rustls/examples/internal/bench_impl.rs
+++ b/rustls/examples/internal/bench_impl.rs
@@ -611,6 +611,7 @@ fn make_server_config(
         cfg.session_storage = Arc::new(NoServerSessionStorage {});
     }
 
+    cfg.send_tls13_tickets = 2; // matches BoringSSL/OpenSSL default
     cfg.max_fragment_size = max_fragment_size;
     Arc::new(cfg)
 }


### PR DESCRIPTION
We send four tickets by default, which shows up in benchmarking of server-side resumption cost versus BoringSSL/OpenSSL (which default to two).