### PR TITLE
Faster TLS1.3 server resumption

### DIFF
--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -38,6 +38,7 @@ use crate::sign::{CertifiedKey, Signer};
 use crate::suites::PartiallyExtractedSecrets;
 use crate::tls13::key_schedule::{
     KeyScheduleEarly, KeyScheduleHandshake, KeySchedulePreHandshake, KeyScheduleTraffic,
+    ResumptionSecret,
 };
 use crate::tls13::{
     construct_client_verify_message, construct_server_verify_message, Tls13CipherSuite,
@@ -1426,9 +1427,8 @@ impl ExpectTraffic {
         }
 
         let handshake_hash = self.transcript.current_hash();
-        let secret = self
-            .key_schedule
-            .resumption_master_secret_and_derive_ticket_psk(&handshake_hash, &nst.nonce.0);
+        let secret = ResumptionSecret::new(&self.key_schedule, &handshake_hash)
+            .derive_ticket_psk(&nst.nonce.0);
 
         let now = self.config.current_time()?;
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4082,9 +4082,9 @@ fn vectored_write_for_server_handshake_with_half_rtt_data() {
     {
         let mut pipe = OtherSession::new(&mut client);
         let wrlen = server.write_tls(&mut pipe).unwrap();
-        // 4 tickets
-        assert_eq!(wrlen, 103 * 4);
-        assert_eq!(pipe.writevs, vec![vec![103, 103, 103, 103]]);
+        // 4 tickets (in one flight)
+        assert_eq!(wrlen, 346);
+        assert_eq!(pipe.writevs, vec![vec![346]]);
     }
 
     assert!(!server.is_handshaking());
@@ -4129,8 +4129,8 @@ fn check_half_rtt_does_not_work(server_config: ServerConfig) {
     {
         let mut pipe = OtherSession::new(&mut client);
         let wrlen = server.write_tls(&mut pipe).unwrap();
-        assert_eq!(wrlen, 486);
-        assert_eq!(pipe.writevs, vec![vec![103, 103, 103, 103, 42, 32]]);
+        assert_eq!(wrlen, 420);
+        assert_eq!(pipe.writevs, vec![vec![346, 42, 32]]);
     }
 
     assert!(!server.is_handshaking());

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -72,9 +72,6 @@ fn tls13_handshake() {
             "Ok(EncodeTlsData)",
             "Ok(TransmitTlsData)",
             "Ok(WriteTraffic)",
-            "Ok(WriteTraffic)",
-            "Ok(WriteTraffic)",
-            "Ok(WriteTraffic)",
             "Ok(WriteTraffic)"
         ],
         "client transcript mismatch"
@@ -88,9 +85,6 @@ fn tls13_handshake() {
             "Ok(EncodeTlsData)",
             "Ok(TransmitTlsData)",
             "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
             "Ok(EncodeTlsData)",
             "Ok(TransmitTlsData)",
             "Ok(WriteTraffic)"
@@ -219,9 +213,6 @@ fn early_data() {
             "Ok(EncodeTlsData)",
             "Ok(TransmitTlsData)",
             "Ok(WriteTraffic)",
-            "Ok(WriteTraffic)",
-            "Ok(WriteTraffic)",
-            "Ok(WriteTraffic)",
             "Ok(WriteTraffic)"
         ]
     );
@@ -235,9 +226,6 @@ fn early_data() {
             "Ok(ReadEarlyData)",
             "Ok(TransmitTlsData)",
             "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
             "Ok(EncodeTlsData)",
             "Ok(TransmitTlsData)",
             "Ok(WriteTraffic)"


### PR DESCRIPTION
First commit fixes a small bit of wastefulness. Its effect is somewhat tempered by #2167 , but worth having.
Second commit expands the scope of #2120.

Indicative performance results:

- 0.23.15: `8019.6 handshakes/sec`
- after this: `8499.08 handshakes/sec`
- after this and #2167: `9666.8 handshakes/sec`
