### PR TITLE
Markdown fixes in manual

### DIFF
--- a/rustls/src/manual/fips.rs
+++ b/rustls/src/manual/fips.rs
@@ -42,8 +42,8 @@ or health-check strategy better than panicking.
 
 # aws-lc-rs FIPS approval status
 
-This is covered by [FIPS 140-3 certificate #4816](cert-4816).
-See [the security policy](policy-4816) for precisely which
+This is covered by [FIPS 140-3 certificate #4816][cert-4816].
+See [the security policy][policy-4816] for precisely which
 environments and functions this certificate covers.
 
 Later releases of aws-lc-rs may be covered by later certificates,

--- a/rustls/src/manual/tlsvulns.rs
+++ b/rustls/src/manual/tlsvulns.rs
@@ -5,8 +5,8 @@
 Back in 2000 [Bellare and Namprempre](https://eprint.iacr.org/2000/025) discussed how to make authenticated
 encryption by composing separate encryption and authentication primitives.  That paper included this table:
 
-| Composition Method | Privacy || Integrity ||
-|--------------------|---------||-----------||
+| Composition Method | Privacy | | | Integrity | |
+|--------------------|---------|-|-|-----------|-|
 || IND-CPA | IND-CCA | NM-CPA | INT-PTXT | INT-CTXT |
 | Encrypt-and-MAC | insecure | insecure | insecure | secure | insecure |
 | MAC-then-encrypt | secure | insecure | insecure | secure | insecure |


### PR DESCRIPTION
The table in tlsvulns has not rendered for a while now, due to a downstream change. However the table wasn't correct anyway and was missing a column.

- https://docs.rs/rustls/0.23.10/rustls/manual/_02_tls_vulnerabilities/index.html
- https://docs.rs/rustls/0.23.11/rustls/manual/_02_tls_vulnerabilities/index.html

(The source didn't change between these points.)

The links I added in #2145 are broken in an embarrassing way.