### PR TITLE
Change link to the NSS Key Log Format

### DIFF
--- a/rustls/src/key_log.rs
+++ b/rustls/src/key_log.rs
@@ -35,7 +35,7 @@ pub trait KeyLog: Debug + Send + Sync {
     ///   in a TLSv1.3 session.
     ///
     /// These strings are selected to match the NSS key log format:
-    /// <https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format>
+    /// <https://nss-crypto.org/reference/security/nss/legacy/key_log_format/index.html>
     fn log(&self, label: &str, client_random: &[u8], secret: &[u8]);
 
     /// Indicates whether the secret with label `label` will be logged.


### PR DESCRIPTION
The current link is 404.
I'm not sure that this is the official website, but this contains the correct information in any case.