### PR TITLE
automate dead link checking of documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ permissions:
   id-token: write
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,6 +47,24 @@ jobs:
           # make resulting url be more sensible
           mv target/doc/rustls target/doc/prerelease
 
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2.0.0
+        with:
+          args: >
+            --verbose
+            --cache
+            --max-cache-age 1d
+            '**.md'
+            'target/doc/**'
+          fail: true
+
       - name: Package and upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,3 @@
+^file\:\/\/\/.*\/target\/doc\/index\.html$
+^http:\/\/www\.isg\.rhul\.ac\.uk\/tls\/Lucky13.html$
+^http:\/\/www\.adobe\.com/$

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -500,8 +500,8 @@ pub mod internal {
 /// [`unbuffered-client`] and [`unbuffered-server`] are examples that fully exercise the API in
 /// std, non-async context.
 ///
-/// [`unbuffered-client`]: https://github.com/rustls/rustls/blob/main/examples/src/bin/unbuffererd-client.rs
-/// [`unbuffered-server`]: https://github.com/rustls/rustls/blob/main/examples/src/bin/unbuffererd-server.rs
+/// [`unbuffered-client`]: https://github.com/rustls/rustls/blob/main/examples/src/bin/unbuffered-client.rs
+/// [`unbuffered-server`]: https://github.com/rustls/rustls/blob/main/examples/src/bin/unbuffered-server.rs
 pub mod unbuffered {
     pub use crate::conn::unbuffered::{
         AppDataRecord, ConnectionState, EncodeError, EncodeTlsData, EncryptError,

--- a/rustls/src/manual/tlsvulns.rs
+++ b/rustls/src/manual/tlsvulns.rs
@@ -71,7 +71,7 @@ as applied to compression of combined secret and attacker-chosen strings.
 
 Compression continued to be an option in TLSv1.1 (2006) and in TLSv1.2 (2008).  Support in libraries was widespread.
 
-[CRIME](http://netifera.com/research/crime/CRIME_ekoparty2012.pdf) ([CVE-2012-4929](https://nvd.nist.gov/vuln/detail/CVE-2012-4929))
+[CRIME](https://en.wikipedia.org/wiki/CRIME) ([CVE-2012-4929](https://nvd.nist.gov/vuln/detail/CVE-2012-4929))
 was demonstrated in 2012, again by Thai Duong and Juliano Rizzo.  It attacked several protocols offering transparent
 compression of application data, allowing quick adaptive chosen-plaintext attacks against secret values like cookies.
 
@@ -115,7 +115,7 @@ rustls naturally does not support SSLv2, but most importantly does not support R
 
 ## Poodle
 
-[POODLE](https://www.openssl.org/~bodo/ssl-poodle.pdf) ([CVE-2014-3566](https://nvd.nist.gov/vuln/detail/CVE-2014-3566))
+[POODLE](https://cdn1.vox-cdn.com/uploads/chorus_asset/file/2354994/ssl-poodle.0.pdf) ([CVE-2014-3566](https://nvd.nist.gov/vuln/detail/CVE-2014-3566))
 is an attack against CBC mode ciphersuites in SSLv3.  This was possible in most cases because some clients willingly
 downgraded to SSLv3 after failed handshakes for later versions.
 


### PR DESCRIPTION
This branch adds [lychee](https://github.com/lycheeverse/lychee) via [lychee-action](https://github.com/lycheeverse/lychee-actio) to do fast link checking of the markdown files & generated rustdoc documentation. I've been using this successfully with some side projects and find it to be a high-quality tool. 

The link checking happens during the scheduled nightly docs build/deploy workflow in `docs.yml` so as to not block normal development if there are new broken links or flaky bad internet weather. There's a nice pattern to have Lychee automatically open issues for broken links, but it uses `peter-evans/create-issue-from-file` and seems to require write permission on the repo. I've skipped that for now and we'll just have to try and keep an eye on this workflow failing.

A few ignore regexps are added up front:

* One ignoring a file that's referenced by some generated rustdoc boilerplate but that doesn't seem to exist on-disk.

* Two ignoring specific URLs. These were failing for me locally with lychee but work in browser. I suspect due to WAF-like stuff in front of the servers swatting away automated traffic.