### PR TITLE
consistent APIs for connection FIPS indicator

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -752,7 +752,7 @@ mod connection {
         /// it is concerned only with cryptography, whereas this _also_ covers TLS-level
         /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
         pub fn fips(&self) -> bool {
-            self.inner.core.data.fips
+            self.inner.core.common_state.fips
         }
 
         fn write_early_data(&mut self, data: &[u8]) -> io::Result<usize> {
@@ -815,8 +815,8 @@ impl ConnectionCore<ClientConnectionData> {
         common_state.set_max_fragment_size(config.max_fragment_size)?;
         common_state.protocol = proto;
         common_state.enable_secret_extraction = config.enable_secret_extraction;
+        common_state.fips = config.fips();
         let mut data = ClientConnectionData::new();
-        data.fips = config.fips();
 
         let mut cx = hs::ClientContext {
             common: &mut common_state,
@@ -953,7 +953,6 @@ pub struct ClientConnectionData {
     pub(super) early_data: EarlyData,
     pub(super) resumption_ciphersuite: Option<SupportedCipherSuite>,
     pub(super) ech_status: EchStatus,
-    pub(super) fips: bool,
 }
 
 impl ClientConnectionData {
@@ -962,7 +961,6 @@ impl ClientConnectionData {
             early_data: EarlyData::new(),
             resumption_ciphersuite: None,
             ech_status: EchStatus::NotOffered,
-            fips: false,
         }
     }
 }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -56,6 +56,7 @@ pub struct CommonState {
     pub(crate) enable_secret_extraction: bool,
     temper_counters: TemperCounters,
     pub(crate) refresh_traffic_keys_pending: bool,
+    pub(crate) fips: bool,
 }
 
 impl CommonState {
@@ -86,6 +87,7 @@ impl CommonState {
             enable_secret_extraction: false,
             temper_counters: TemperCounters::default(),
             refresh_traffic_keys_pending: false,
+            fips: false,
         }
     }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -670,6 +670,15 @@ mod connection {
             }
         }
 
+        /// Return true if the connection was made with a `ServerConfig` that is FIPS compatible.
+        ///
+        /// This is different from [`crate::crypto::CryptoProvider::fips()`]:
+        /// it is concerned only with cryptography, whereas this _also_ covers TLS-level
+        /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
+        pub fn fips(&self) -> bool {
+            self.inner.core.common_state.fips
+        }
+
         /// Extract secrets, so they can be used when configuring kTLS, for example.
         /// Should be used with care as it exposes secret key material.
         pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
@@ -1119,6 +1128,7 @@ impl ConnectionCore<ServerConnectionData> {
         let mut common = CommonState::new(Side::Server);
         common.set_max_fragment_size(config.max_fragment_size)?;
         common.enable_secret_extraction = config.enable_secret_extraction;
+        common.fips = config.fips();
         Ok(Self::new(
             Box::new(hs::ExpectClientHello::new(config, extra_exts)),
             ServerConnectionData::default(),

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -7116,6 +7116,17 @@ fn test_server_fips_service_indicator() {
 }
 
 #[test]
+fn test_connection_fips_service_indicator() {
+    let client_config = Arc::new(make_client_config(KeyType::Rsa2048));
+    let server_config = Arc::new(make_server_config(KeyType::Rsa2048));
+    let conn_pair = make_pair_for_arc_configs(&client_config, &server_config);
+    // Each connection's FIPS status should reflect the FIPS status of the config it was created
+    // from.
+    assert_eq!(client_config.fips(), conn_pair.0.fips());
+    assert_eq!(server_config.fips(), conn_pair.1.fips());
+}
+
+#[test]
 fn test_client_fips_service_indicator_includes_require_ems() {
     if !provider_is_fips() {
         return;


### PR DESCRIPTION
Previously `ClientConnection::fips()` could be used to determine if a `ClientConnection` was created from a FIPS-enabled `ClientConfig`, but there was no similar support for a `ServerConnection` - just `ServerConfig::fips()`.

This commit adds an equivalent `ServerConnection::fips()` fn and tidies up the internal code for where the fips status is shared to be in `CommonState` instead of `ClientConnectionData`.