### PR TITLE
ci: loosen lychee-action version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: cache-lychee-
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2.0.0
+        uses: lycheeverse/lychee-action@v2
         with:
           args: >
             --cache


### PR DESCRIPTION
We generally only specify the major version.

Replaces https://github.com/rustls/rustls/pull/2177