### PR TITLE
Expose ConfigBuilder::crypto_provider()

### DIFF
--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -163,6 +163,8 @@ use crate::{ClientConfig, ServerConfig};
 #[derive(Clone)]
 pub struct ConfigBuilder<Side: ConfigSide, State> {
     pub(crate) state: State,
+    pub(crate) provider: Arc<CryptoProvider>,
+    pub(crate) time_provider: Arc<dyn TimeProvider>,
     pub(crate) side: PhantomData<Side>,
 }
 
@@ -184,10 +186,7 @@ impl<Side: ConfigSide, State: fmt::Debug> fmt::Debug for ConfigBuilder<Side, Sta
 ///
 /// For more information, see the [`ConfigBuilder`] documentation.
 #[derive(Clone, Debug)]
-pub struct WantsVersions {
-    pub(crate) provider: Arc<CryptoProvider>,
-    pub(crate) time_provider: Arc<dyn TimeProvider>,
-}
+pub struct WantsVersions {}
 
 impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
     /// Accept the default protocol versions: both TLS1.2 and TLS1.3 are enabled.
@@ -203,7 +202,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
         versions: &[&'static versions::SupportedProtocolVersion],
     ) -> Result<ConfigBuilder<S, WantsVerifier>, Error> {
         let mut any_usable_suite = false;
-        for suite in &self.state.provider.cipher_suites {
+        for suite in &self.provider.cipher_suites {
             if versions.contains(&suite.version()) {
                 any_usable_suite = true;
                 break;
@@ -214,13 +213,13 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
             return Err(Error::General("no usable cipher suites configured".into()));
         }
 
-        if self.state.provider.kx_groups.is_empty() {
+        if self.provider.kx_groups.is_empty() {
             return Err(Error::General("no kx groups configured".into()));
         }
 
         // verifying cipher suites have matching kx groups
         let mut supported_kx_algos = Vec::with_capacity(ALL_KEY_EXCHANGE_ALGORITHMS.len());
-        for group in self.state.provider.kx_groups.iter() {
+        for group in self.provider.kx_groups.iter() {
             let kx = group.name().key_exchange_algorithm();
             if !supported_kx_algos.contains(&kx) {
                 supported_kx_algos.push(kx);
@@ -232,7 +231,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
             }
         }
 
-        for cs in self.state.provider.cipher_suites.iter() {
+        for cs in self.provider.cipher_suites.iter() {
             let cs_kx = cs.key_exchange_algorithms();
             if cs_kx
                 .iter()
@@ -249,11 +248,11 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
 
         Ok(ConfigBuilder {
             state: WantsVerifier {
-                provider: self.state.provider,
                 versions: versions::EnabledVersions::new(versions),
-                time_provider: self.state.time_provider,
                 client_ech_mode: None,
             },
+            provider: self.provider,
+            time_provider: self.time_provider,
             side: self.side,
         })
     }
@@ -264,9 +263,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
 /// For more information, see the [`ConfigBuilder`] documentation.
 #[derive(Clone, Debug)]
 pub struct WantsVerifier {
-    pub(crate) provider: Arc<CryptoProvider>,
     pub(crate) versions: versions::EnabledVersions,
-    pub(crate) time_provider: Arc<dyn TimeProvider>,
     pub(crate) client_ech_mode: Option<EchMode>,
 }
 

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -168,6 +168,13 @@ pub struct ConfigBuilder<Side: ConfigSide, State> {
     pub(crate) side: PhantomData<Side>,
 }
 
+impl<Side: ConfigSide, State> ConfigBuilder<Side, State> {
+    /// Return the crypto provider used to construct this builder.
+    pub fn crypto_provider(&self) -> &Arc<CryptoProvider> {
+        &self.provider
+    }
+}
+
 impl<Side: ConfigSide, State: fmt::Debug> fmt::Debug for ConfigBuilder<Side, State> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let side_name = core::any::type_name::<Side>();

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -120,9 +120,9 @@ pub trait ResolvesClientCert: fmt::Debug + Send + Sync {
         sigschemes: &[SignatureScheme],
     ) -> Option<Arc<sign::CertifiedKey>>;
 
-    /// Return true if the client only supports raw public keys.  
-    ///  
-    /// See [RFC 7250](https://www.rfc-editor.org/rfc/rfc7250).  
+    /// Return true if the client only supports raw public keys.
+    ///
+    /// See [RFC 7250](https://www.rfc-editor.org/rfc/rfc7250).
     fn only_raw_public_keys(&self) -> bool {
         false
     }
@@ -316,10 +316,9 @@ impl ClientConfig {
         provider: Arc<CryptoProvider>,
     ) -> ConfigBuilder<Self, WantsVersions> {
         ConfigBuilder {
-            state: WantsVersions {
-                provider,
-                time_provider: Arc::new(DefaultTimeProvider),
-            },
+            state: WantsVersions {},
+            provider,
+            time_provider: Arc::new(DefaultTimeProvider),
             side: PhantomData,
         }
     }
@@ -342,10 +341,9 @@ impl ClientConfig {
         time_provider: Arc<dyn TimeProvider>,
     ) -> ConfigBuilder<Self, WantsVersions> {
         ConfigBuilder {
-            state: WantsVersions {
-                provider,
-                time_provider,
-            },
+            state: WantsVersions {},
+            provider,
+            time_provider,
             side: PhantomData,
         }
     }

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -5,11 +5,9 @@ use core::marker::PhantomData;
 use pki_types::{CertificateDer, PrivateKeyDer};
 
 use crate::builder::{ConfigBuilder, WantsVerifier};
-use crate::crypto::CryptoProvider;
 use crate::error::Error;
 use crate::server::{handy, ResolvesServerCert, ServerConfig};
 use crate::sign::CertifiedKey;
-use crate::time_provider::TimeProvider;
 use crate::verify::{ClientCertVerifier, NoClientAuth};
 use crate::{compress, versions, InconsistentKeys, NoKeyLog};
 
@@ -21,11 +19,11 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
     ) -> ConfigBuilder<ServerConfig, WantsServerCert> {
         ConfigBuilder {
             state: WantsServerCert {
-                provider: self.state.provider,
                 versions: self.state.versions,
                 verifier: client_cert_verifier,
-                time_provider: self.state.time_provider,
             },
+            provider: self.provider,
+            time_provider: self.time_provider,
             side: PhantomData,
         }
     }
@@ -42,10 +40,8 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
 /// For more information, see the [`ConfigBuilder`] documentation.
 #[derive(Clone, Debug)]
 pub struct WantsServerCert {
-    provider: Arc<CryptoProvider>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn ClientCertVerifier>,
-    time_provider: Arc<dyn TimeProvider>,
 }
 
 impl ConfigBuilder<ServerConfig, WantsServerCert> {
@@ -60,8 +56,8 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
     ///
     /// `cert_chain` is a vector of DER-encoded certificates.
     /// `key_der` is a DER-encoded private key as PKCS#1, PKCS#8, or SEC1. The
-    /// `aws-lc-rs` and `ring` [`CryptoProvider`]s support all three encodings,
-    /// but other `CryptoProviders` may not.
+    /// `aws-lc-rs` and `ring` [`CryptoProvider`][crate::CryptoProvider]s support
+    /// all three encodings, but other `CryptoProviders` may not.
     ///
     /// This function fails if `key_der` is invalid, or if the
     /// `SubjectPublicKeyInfo` from the private key does not match the public
@@ -72,7 +68,6 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
         key_der: PrivateKeyDer<'static>,
     ) -> Result<ServerConfig, Error> {
         let private_key = self
-            .state
             .provider
             .key_provider
             .load_private_key(key_der)?;
@@ -94,8 +89,8 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
     ///
     /// `cert_chain` is a vector of DER-encoded certificates.
     /// `key_der` is a DER-encoded private key as PKCS#1, PKCS#8, or SEC1. The
-    /// `aws-lc-rs` and `ring` [`CryptoProvider`]s support all three encodings,
-    /// but other `CryptoProviders` may not.
+    /// `aws-lc-rs` and `ring` [`CryptoProvider`][crate::CryptoProvider]s support
+    /// all three encodings, but other `CryptoProviders` may not.
     /// `ocsp` is a DER-encoded OCSP response.  Ignored if zero length.
     ///
     /// This function fails if `key_der` is invalid, or if the
@@ -108,7 +103,6 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
         ocsp: Vec<u8>,
     ) -> Result<ServerConfig, Error> {
         let private_key = self
-            .state
             .provider
             .key_provider
             .load_private_key(key_der)?;
@@ -127,7 +121,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
     /// Sets a custom [`ResolvesServerCert`].
     pub fn with_cert_resolver(self, cert_resolver: Arc<dyn ResolvesServerCert>) -> ServerConfig {
         ServerConfig {
-            provider: self.state.provider,
+            provider: self.provider,
             verifier: self.state.verifier,
             cert_resolver,
             ignore_client_order: false,
@@ -146,7 +140,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             send_tls13_tickets: 4,
             #[cfg(feature = "tls12")]
             require_ems: cfg!(feature = "fips"),
-            time_provider: self.state.time_provider,
+            time_provider: self.time_provider,
             cert_compressors: compress::default_cert_compressors().to_vec(),
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),
             cert_decompressors: compress::default_cert_decompressors().to_vec(),

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -450,10 +450,9 @@ impl ServerConfig {
         provider: Arc<CryptoProvider>,
     ) -> ConfigBuilder<Self, WantsVersions> {
         ConfigBuilder {
-            state: WantsVersions {
-                provider,
-                time_provider: Arc::new(DefaultTimeProvider),
-            },
+            state: WantsVersions {},
+            provider,
+            time_provider: Arc::new(DefaultTimeProvider),
             side: PhantomData,
         }
     }
@@ -477,10 +476,9 @@ impl ServerConfig {
         time_provider: Arc<dyn TimeProvider>,
     ) -> ConfigBuilder<Self, WantsVersions> {
         ConfigBuilder {
-            state: WantsVersions {
-                provider,
-                time_provider,
-            },
+            state: WantsVersions {},
+            provider,
+            time_provider,
             side: PhantomData,
         }
     }

--- a/rustls/tests/process_provider.rs
+++ b/rustls/tests/process_provider.rs
@@ -50,11 +50,12 @@ fn test_ring_used_as_implicit_provider() {
     // implicitly installs ring provider
     finish_client_config(KeyType::Rsa2048, ClientConfig::builder());
 
-    assert!(format!(
-        "{:?}",
-        CryptoProvider::get_default().expect("provider missing")
-    )
-    .contains("secure_random: Ring"));
+    let default = CryptoProvider::get_default().expect("provider missing");
+    let debug = format!("{default:?}");
+    assert!(debug.contains("secure_random: Ring"));
+
+    let builder = ClientConfig::builder();
+    assert_eq!(format!("{:?}", builder.crypto_provider()), debug);
 }
 
 fn test_aws_lc_rs_used_as_implicit_provider() {
@@ -63,9 +64,10 @@ fn test_aws_lc_rs_used_as_implicit_provider() {
     // implicitly installs aws-lc-rs provider
     finish_client_config(KeyType::Rsa2048, ClientConfig::builder());
 
-    assert!(format!(
-        "{:?}",
-        CryptoProvider::get_default().expect("provider missing")
-    )
-    .contains("secure_random: AwsLcRs"));
+    let default = CryptoProvider::get_default().expect("provider missing");
+    let debug = format!("{default:?}");
+    assert!(debug.contains("secure_random: AwsLcRs"));
+
+    let builder = ClientConfig::builder();
+    assert_eq!(format!("{:?}", builder.crypto_provider()), debug);
 }


### PR DESCRIPTION
This enables downstream projects (such as rustls-platform-verifier -- see https://github.com/rustls/rustls-platform-verifier/pull/150) to get the `CryptoProvider` from the `ConfigBuilder`, instead of having to pick one in parallel.