### PR TITLE
doc(no_inline) rustls::pki_types re-export

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -637,6 +637,7 @@ pub mod version {
 
 /// Re-exports the contents of the [rustls-pki-types](https://docs.rs/rustls-pki-types) crate for easy access
 pub mod pki_types {
+    #[doc(no_inline)]
     pub use pki_types::*;
 }
 


### PR DESCRIPTION
This prevents the slightly odd case where the docs for pki_types crate appears under `rustls::pki_types`, which becomes confusing:

- items mention an `alloc` feature which the rustls crate doesn't have.
- documentation says things like "refer to the crate documentation" but it this refers to the `pki-types` crate, not the crate the containing the documentation.
- the front page of the pki-types crate documentation is absent, meaning people will miss the introductory text and advice we put there.
- links from rustls to a pki-types type goes to this bizarro version, rather than the original crate docs.

doc(no_inline) disables this, and leaves just a hyperlink to the docs of the other crate.

fixes #1662 