### PR TITLE
Support multithreaded benchmarks

### DIFF
--- a/admin/bench-measure.mk
+++ b/admin/bench-measure.mk
@@ -53,6 +53,8 @@ threads: $(BENCH)
 	  $^ --threads $$thr handshake-ticket TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
 	  $^ --threads $$thr handshake TLS13_AES_256_GCM_SHA384 ; \
 	  $^ --threads $$thr handshake-ticket TLS13_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$thr bulk TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$thr bulk TLS13_AES_256_GCM_SHA384 ; \
 	done
 
 clean:

--- a/admin/bench-measure.mk
+++ b/admin/bench-measure.mk
@@ -46,6 +46,15 @@ memory: $(BENCH)
 	$(MEMUSAGE) $^ memory TLS13_AES_256_GCM_SHA384 1000
 	$(MEMUSAGE) $^ memory TLS13_AES_256_GCM_SHA384 5000
 
+threads: $(BENCH)
+	for thr in $(shell admin/threads-seq.rs) ; do \
+	  $^ --threads $$thr handshake TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$thr handshake-resume TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$thr handshake-ticket TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$thr handshake TLS13_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$thr handshake-ticket TLS13_AES_256_GCM_SHA384 ; \
+	done
+
 clean:
 	rm -f perf-*.svg
 	cargo clean

--- a/admin/threads-seq.rs
+++ b/admin/threads-seq.rs
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S cargo +nightly --quiet -Zscript
+
+//! # `admin/thread-seq N`
+//!
+//! This program prints a sequence of N integers for multithreaded
+//! performance testing.  The integers are numbers of threads to
+//! be sampled in a test.  The goal is to assist in graphing
+//! how per-thread throughput relates to concurrency.
+//!
+//! The sequence is (at most) length N, starts at 2, includes the
+//! number of CPU cores, and ends at 1.5 the number of CPU cores.
+//! It does not have repeated items.
+//!
+//! We exceed the number of cores specifically to see the
+//! "elbow" in the graph, when the number of threads tested
+//! exceeds the number of cores.  (This is good because otherwise
+//! -- assuming the software under test is perfectly scalable --
+//! the graph would be a straight line parallel with the x axis.)
+
+use std::{cmp, env, error, num::NonZeroUsize, str::FromStr, thread};
+
+fn main() -> Result<(), Box<dyn error::Error + Send + Sync + 'static>> {
+    let mut args = env::args();
+    args.next(); // skip argv[0]
+    let count = args
+        .next()
+        .map(|c| NonZeroUsize::from_str(&c))
+        .transpose()?
+        .unwrap_or(NonZeroUsize::new(16).unwrap())
+        .get();
+
+    let default_cpus = thread::available_parallelism()?;
+    let cpus = env::var("CPU_COUNT")
+        .map(|c| NonZeroUsize::from_str(&c))
+        .unwrap_or(Ok(default_cpus))?
+        .get();
+
+    let end = (cpus as f64 * 1.5).floor() as usize;
+
+    let before_count = (count as f64 * 0.75).floor() as usize;
+    let after_count = count - before_count;
+
+    let before = (2..cpus).step_by(cmp::max(1, cpus / before_count));
+    let after = (cpus..end).step_by(cmp::max(1, (end - cpus) / after_count));
+
+    for x in before.chain(after) {
+        print!("{} ", x);
+    }
+    println!();
+    Ok(())
+}

--- a/rustls/examples/internal/bench_impl.rs
+++ b/rustls/examples/internal/bench_impl.rs
@@ -4,10 +4,11 @@
 // etc. because it's unstable at the time of writing.
 
 use std::io::{self, Read, Write};
-use std::mem;
+use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::{mem, thread};
 
 use clap::{Parser, ValueEnum};
 use pki_types::pem::PemObject;
@@ -38,6 +39,7 @@ pub fn main() {
     let options = Options {
         work_multiplier: args.multiplier,
         api: args.api,
+        threads: args.threads,
     };
 
     match args.command() {
@@ -92,6 +94,9 @@ struct Args {
         help = "Multiplies the length of every test by the given float value"
     )]
     multiplier: f64,
+
+    #[arg(long, default_value = "1", help = "Number of threads to use")]
+    threads: NonZeroUsize,
 
     #[arg(long, value_enum, default_value_t = Api::Both, help = "Choose buffered or unbuffered API")]
     api: Api,
@@ -220,24 +225,35 @@ fn bench_handshake(
     );
 
     if options.api.use_buffered() {
-        report_handshake_result(
-            "handshakes",
-            params,
-            clientauth,
-            resume,
-            rounds,
-            bench_handshake_buffered(rounds, resume, client_config.clone(), server_config.clone()),
+        let results = multithreaded(
+            options.threads,
+            &client_config,
+            &server_config,
+            move |client_config, server_config| {
+                bench_handshake_buffered(rounds, resume, client_config, server_config)
+            },
         );
+
+        report_handshake_result("handshakes", params, clientauth, resume, rounds, results);
     }
 
     if options.api.use_unbuffered() {
+        let results = multithreaded(
+            options.threads,
+            &client_config,
+            &server_config,
+            move |client_config, server_config| {
+                bench_handshake_unbuffered(rounds, resume, client_config, server_config)
+            },
+        );
+
         report_handshake_result(
             "handshakes-unbuffered",
             params,
             clientauth,
             resume,
             rounds,
-            bench_handshake_unbuffered(rounds, resume, client_config, server_config),
+            results,
         );
     }
 }
@@ -340,16 +356,42 @@ fn bench_handshake_unbuffered(
     timings
 }
 
+/// Run `f` on `count` threads, and then return the timings produced
+/// by each thread.
+///
+/// `client_config` and `server_config` are cloned into each thread fn.
+fn multithreaded(
+    count: NonZeroUsize,
+    client_config: &Arc<ClientConfig>,
+    server_config: &Arc<ServerConfig>,
+    f: impl Fn(Arc<ClientConfig>, Arc<ServerConfig>) -> Timings + Send + Sync,
+) -> Vec<Timings> {
+    thread::scope(|s| {
+        let threads = (0..count.into())
+            .map(|_| {
+                let client_config = client_config.clone();
+                let server_config = server_config.clone();
+                s.spawn(|| f(client_config, server_config))
+            })
+            .collect::<Vec<_>>();
+
+        threads
+            .into_iter()
+            .map(|thr| thr.join().unwrap())
+            .collect::<Vec<Timings>>()
+    })
+}
+
 fn report_handshake_result(
     variant: &str,
     params: &BenchmarkParam,
     clientauth: ClientAuth,
     resume: ResumptionParam,
     rounds: u64,
-    timings: Timings,
+    timings: Vec<Timings>,
 ) {
-    println!(
-        "{}\t{:?}\t{:?}\t{:?}\tclient\t{}\t{}\t{:.2}\thandshake/s",
+    print!(
+        "{}\t{:?}\t{:?}\t{:?}\tclient\t{}\t{}\t",
         variant,
         params.version,
         params.key_type,
@@ -360,10 +402,11 @@ fn report_handshake_result(
             "server-auth"
         },
         resume.label(),
-        (rounds as f64) / timings.client
     );
-    println!(
-        "{}\t{:?}\t{:?}\t{:?}\tserver\t{}\t{}\t{:.2}\thandshake/s",
+
+    report_timings("handshakes/s", &timings, rounds as f64, |t| t.client);
+    print!(
+        "{}\t{:?}\t{:?}\t{:?}\tserver\t{}\t{}\t",
         variant,
         params.version,
         params.key_type,
@@ -374,11 +417,41 @@ fn report_handshake_result(
             "server-auth"
         },
         resume.label(),
-        (rounds as f64) / timings.server
+    );
+
+    report_timings("handshakes/s", &timings, rounds as f64, |t| t.server);
+}
+
+fn report_timings(
+    units: &str,
+    thread_timings: &[Timings],
+    work_per_thread: f64,
+    which: impl Fn(&Timings) -> f64,
+) {
+    // maintain old output for --threads=1
+    if let &[timing] = thread_timings {
+        println!("{:.2}\t{}", work_per_thread / which(&timing), units);
+        return;
+    }
+
+    let mut total_rate = 0.;
+    print!("threads\t{}\t", thread_timings.len());
+
+    for t in thread_timings.iter() {
+        let rate = work_per_thread / which(t);
+        total_rate += rate;
+        print!("{:.2}\t", rate);
+    }
+
+    println!(
+        "total\t{:.2}\tper-thread\t{:.2}\t{}",
+        total_rate,
+        total_rate / (thread_timings.len() as f64),
+        units,
     );
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 struct Timings {
     client: f64,
     server: f64,
@@ -715,6 +788,7 @@ impl ResumptionParam {
 struct Options {
     work_multiplier: f64,
     api: Api,
+    threads: NonZeroUsize,
 }
 
 impl Options {


### PR DESCRIPTION
This produces output like:

```
$ cargo run --release --example bench -- --threads 8 handshake TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
handshakes	TLSv1_2	Rsa2048	TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256	client	server-auth	no-resume	threads	8	10155.44	10166.96	10092.23	10234.48	9095.63	10098.87	10075.14	9104.87	total	79023.63	per-thread	9877.95	handshakes/s
```

This means:

```
handshakes	TLSv1_2	Rsa2048	TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256	client	server-auth	no-resume
```

old output

```
threads	8
```

number of threads used

```
10155.44	10166.96	10092.23	10234.48	9095.63	10098.87	10075.14	9104.87
```

individual thread measurements

```
total	79023.63	per-thread	9877.95	handshakes/s
```

sum and average of thread measurements