### PR TITLE
Introduce `TicketRotator`, a version of `TicketSwitcher` with improved thread scalability

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/ticketer.rs
+++ b/rustls/src/crypto/aws_lc_rs/ticketer.rs
@@ -33,7 +33,7 @@ impl Ticketer {
     /// [RFC 5077 §4]: https://www.rfc-editor.org/rfc/rfc5077#section-4
     #[cfg(feature = "std")]
     pub fn new() -> Result<Arc<dyn ProducesTickets>, Error> {
-        Ok(Arc::new(crate::ticketer::TicketSwitcher::new(
+        Ok(Arc::new(crate::ticketer::TicketRotator::new(
             6 * 60 * 60,
             make_ticket_generator,
         )?))
@@ -279,7 +279,68 @@ mod tests {
     }
 
     #[test]
+    fn ticketrotator_switching_test() {
+        let t = Arc::new(crate::ticketer::TicketRotator::new(1, make_ticket_generator).unwrap());
+        let now = UnixTime::now();
+        let cipher1 = t.encrypt(b"ticket 1").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        {
+            // Trigger new ticketer
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 10,
+            )));
+        }
+        let cipher2 = t.encrypt(b"ticket 2").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        {
+            // Trigger new ticketer
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 20,
+            )));
+        }
+        let cipher3 = t.encrypt(b"ticket 3").unwrap();
+        assert!(t.decrypt(&cipher1).is_none());
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
+    }
+
+    #[test]
+    fn ticketrotator_remains_usable_over_temporary_ticketer_creation_failure() {
+        let mut t = crate::ticketer::TicketRotator::new(1, make_ticket_generator).unwrap();
+        let now = UnixTime::now();
+        let cipher1 = t.encrypt(b"ticket 1").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        t.generator = fail_generator;
+        {
+            // Failed new ticketer; this means we still need to
+            // rotate.
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 10,
+            )));
+        }
+
+        // check post-failure encryption/decryption still works
+        let cipher2 = t.encrypt(b"ticket 2").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+
+        // do the rotation for real
+        t.generator = make_ticket_generator;
+        {
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 20,
+            )));
+        }
+        let cipher3 = t.encrypt(b"ticket 3").unwrap();
+        assert!(t.decrypt(&cipher1).is_some());
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
+    }
+
+    #[test]
     fn ticketswitcher_switching_test() {
+        #[expect(deprecated)]
         let t = Arc::new(crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap());
         let now = UnixTime::now();
         let cipher1 = t.encrypt(b"ticket 1").unwrap();
@@ -305,13 +366,9 @@ mod tests {
         assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
     }
 
-    #[cfg(test)]
-    fn fail_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> {
-        Err(GetRandomFailed)
-    }
-
     #[test]
     fn ticketswitcher_recover_test() {
+        #[expect(deprecated)]
         let mut t = crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap();
         let now = UnixTime::now();
         let cipher1 = t.encrypt(b"ticket 1").unwrap();
@@ -340,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    fn aeadticketer_is_debug_and_producestickets() {
+    fn rfc5077ticketer_is_debug_and_producestickets() {
         use alloc::format;
 
         use super::*;
@@ -350,5 +407,9 @@ mod tests {
         assert_eq!(format!("{:?}", t), "Rfc5077Ticketer { lifetime: 43200 }");
         assert!(t.enabled());
         assert_eq!(t.lifetime(), 43200);
+    }
+
+    fn fail_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> {
+        Err(GetRandomFailed)
     }
 }

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -26,7 +26,7 @@ impl Ticketer {
     /// The encryption mechanism used is Chacha20Poly1305.
     #[cfg(feature = "std")]
     pub fn new() -> Result<Arc<dyn ProducesTickets>, Error> {
-        Ok(Arc::new(crate::ticketer::TicketSwitcher::new(
+        Ok(Arc::new(crate::ticketer::TicketRotator::new(
             6 * 60 * 60,
             make_ticket_generator,
         )?))
@@ -244,7 +244,68 @@ mod tests {
     }
 
     #[test]
+    fn ticketrotator_switching_test() {
+        let t = Arc::new(crate::ticketer::TicketRotator::new(1, make_ticket_generator).unwrap());
+        let now = UnixTime::now();
+        let cipher1 = t.encrypt(b"ticket 1").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        {
+            // Trigger new ticketer
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 10,
+            )));
+        }
+        let cipher2 = t.encrypt(b"ticket 2").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        {
+            // Trigger new ticketer
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 20,
+            )));
+        }
+        let cipher3 = t.encrypt(b"ticket 3").unwrap();
+        assert!(t.decrypt(&cipher1).is_none());
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
+    }
+
+    #[test]
+    fn ticketrotator_remains_usable_over_temporary_ticketer_creation_failure() {
+        let mut t = crate::ticketer::TicketRotator::new(1, make_ticket_generator).unwrap();
+        let now = UnixTime::now();
+        let cipher1 = t.encrypt(b"ticket 1").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        t.generator = fail_generator;
+        {
+            // Failed new ticketer; this means we still need to
+            // rotate.
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 10,
+            )));
+        }
+
+        // check post-failure encryption/decryption still works
+        let cipher2 = t.encrypt(b"ticket 2").unwrap();
+        assert_eq!(t.decrypt(&cipher1).unwrap(), b"ticket 1");
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+
+        // do the rotation for real
+        t.generator = make_ticket_generator;
+        {
+            t.maybe_roll(UnixTime::since_unix_epoch(Duration::from_secs(
+                now.as_secs() + 20,
+            )));
+        }
+        let cipher3 = t.encrypt(b"ticket 3").unwrap();
+        assert!(t.decrypt(&cipher1).is_some());
+        assert_eq!(t.decrypt(&cipher2).unwrap(), b"ticket 2");
+        assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
+    }
+
+    #[test]
     fn ticketswitcher_switching_test() {
+        #[expect(deprecated)]
         let t = Arc::new(crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap());
         let now = UnixTime::now();
         let cipher1 = t.encrypt(b"ticket 1").unwrap();
@@ -270,13 +331,9 @@ mod tests {
         assert_eq!(t.decrypt(&cipher3).unwrap(), b"ticket 3");
     }
 
-    #[cfg(test)]
-    fn fail_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> {
-        Err(GetRandomFailed)
-    }
-
     #[test]
     fn ticketswitcher_recover_test() {
+        #[expect(deprecated)]
         let mut t = crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap();
         let now = UnixTime::now();
         let cipher1 = t.encrypt(b"ticket 1").unwrap();
@@ -316,5 +373,9 @@ mod tests {
         assert_eq!(format!("{:?}", t), expect);
         assert!(t.enabled());
         assert_eq!(t.lifetime(), 43200);
+    }
+
+    fn fail_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> {
+        Err(GetRandomFailed)
     }
 }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -536,7 +536,9 @@ pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     CipherSuiteCommon, ConnectionTrafficSecrets, ExtractedSecrets, SupportedCipherSuite,
 };
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(feature = "std")]
+pub use crate::ticketer::TicketRotator;
+#[cfg(any(feature = "std", feature = "hashbrown"))] // < XXX: incorrect feature gate
 pub use crate::ticketer::TicketSwitcher;
 #[cfg(feature = "tls12")]
 pub use crate::tls12::Tls12CipherSuite;
@@ -649,7 +651,7 @@ pub mod sign {
 /// APIs for implementing QUIC TLS
 pub mod quic;
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", feature = "hashbrown"))] // < XXX: incorrect feature gate
 /// APIs for implementing TLS tickets
 pub mod ticketer;
 

--- a/rustls/src/lock.rs
+++ b/rustls/src/lock.rs
@@ -11,7 +11,7 @@ mod std_lock {
     /// A wrapper around [`std::sync::Mutex`].
     #[derive(Debug)]
     pub struct Mutex<T> {
-        inner: std::sync::Mutex<T>,
+        inner: StdMutex<T>,
     }
 
     impl<T> Mutex<T> {
@@ -39,8 +39,8 @@ mod no_std_lock {
     use core::fmt::Debug;
     use core::ops::DerefMut;
 
-    #[derive(Debug)]
     /// A no-std compatible wrapper around [`Lock`].
+    #[derive(Debug)]
     pub struct Mutex<T> {
         inner: Arc<dyn Lock<T>>,
     }

--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -1,6 +1,8 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::mem;
+#[cfg(feature = "std")]
+use std::sync::{RwLock, RwLockReadGuard};
 
 use pki_types::UnixTime;
 
@@ -39,6 +41,7 @@ impl TicketSwitcher {
     /// longer than twice this duration.  `generator` produces a new
     /// `ProducesTickets` implementation.
     #[cfg(feature = "std")]
+    #[deprecated(note = "use TicketRotator instead")]
     pub fn new(
         lifetime: u32,
         generator: fn() -> Result<Box<dyn ProducesTickets>, rand::GetRandomFailed>,
@@ -223,5 +226,139 @@ impl core::fmt::Debug for TicketSwitcher {
             .field("lifetime", &self.lifetime)
             .field("state", &**self.state.lock().unwrap())
             .finish()
+    }
+}
+
+#[cfg(feature = "std")]
+#[derive(Debug)]
+pub(crate) struct TicketRotatorState {
+    current: Box<dyn ProducesTickets>,
+    previous: Option<Box<dyn ProducesTickets>>,
+    next_switch_time: u64,
+}
+
+/// A ticketer that has a 'current' sub-ticketer and a single
+/// 'previous' ticketer.  It creates a new ticketer every so
+/// often, demoting the current ticketer.
+#[cfg(feature = "std")]
+pub struct TicketRotator {
+    pub(crate) generator: fn() -> Result<Box<dyn ProducesTickets>, rand::GetRandomFailed>,
+    lifetime: u32,
+    state: RwLock<TicketRotatorState>,
+}
+
+#[cfg(feature = "std")]
+impl TicketRotator {
+    /// Creates a new `TicketRotator`, which rotates through sub-ticketers
+    /// based on the passage of time.
+    ///
+    /// `lifetime` is in seconds, and is how long the current ticketer
+    /// is used to generate new tickets.  Tickets are accepted for no
+    /// longer than twice this duration.  `generator` produces a new
+    /// `ProducesTickets` implementation.
+    pub fn new(
+        lifetime: u32,
+        generator: fn() -> Result<Box<dyn ProducesTickets>, rand::GetRandomFailed>,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            generator,
+            lifetime,
+            state: RwLock::new(TicketRotatorState {
+                current: generator()?,
+                previous: None,
+                next_switch_time: UnixTime::now()
+                    .as_secs()
+                    .saturating_add(u64::from(lifetime)),
+            }),
+        })
+    }
+
+    /// If it's time, demote the `current` ticketer to `previous` (so it
+    /// does no new encryptions but can do decryption) and replace it
+    /// with a new one.
+    ///
+    /// Calling this regularly will ensure timely key erasure.  Otherwise,
+    /// key erasure will be delayed until the next encrypt/decrypt call.
+    ///
+    /// For efficiency, this is also responsible for locking the state rwlock
+    /// and returning it for read.
+    pub(crate) fn maybe_roll(
+        &self,
+        now: UnixTime,
+    ) -> Option<RwLockReadGuard<'_, TicketRotatorState>> {
+        let now = now.as_secs();
+
+        // Fast, common, & read-only path in case we do not need to switch
+        // to the next ticketer yet
+        {
+            let read = self.state.read().ok()?;
+
+            if now <= read.next_switch_time {
+                return Some(read);
+            }
+        }
+
+        // We need to switch ticketers, and make a new one.
+        // Generate a potential "next" ticketer outside the lock.
+        let next = (self.generator)().ok()?;
+
+        let mut write = self.state.write().ok()?;
+
+        if now <= write.next_switch_time {
+            // Another thread beat us to it.  Nothing to do.
+            drop(write);
+
+            return self.state.read().ok();
+        }
+
+        // Now we have:
+        // - confirmed we need rotation
+        // - confirmed we are the thread that will do it
+        // - successfully made the replacement ticketer
+        write.previous = Some(mem::replace(&mut write.current, next));
+        write.next_switch_time = now.saturating_add(u64::from(self.lifetime));
+        drop(write);
+
+        self.state.read().ok()
+    }
+}
+
+#[cfg(feature = "std")]
+impl ProducesTickets for TicketRotator {
+    fn lifetime(&self) -> u32 {
+        self.lifetime * 2
+    }
+
+    fn enabled(&self) -> bool {
+        true
+    }
+
+    fn encrypt(&self, message: &[u8]) -> Option<Vec<u8>> {
+        self.maybe_roll(UnixTime::now())?
+            .current
+            .encrypt(message)
+    }
+
+    fn decrypt(&self, ciphertext: &[u8]) -> Option<Vec<u8>> {
+        let state = self.maybe_roll(UnixTime::now())?;
+
+        // Decrypt with the current key; if that fails, try with the previous.
+        state
+            .current
+            .decrypt(ciphertext)
+            .or_else(|| {
+                state
+                    .previous
+                    .as_ref()
+                    .and_then(|previous| previous.decrypt(ciphertext))
+            })
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Debug for TicketRotator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TicketRotator")
+            .finish_non_exhaustive()
     }
 }


### PR DESCRIPTION
The vastly overwhelming majority of ticket operations are "reads", as this covers encrypting a new ticket, decrypting an existing one, and checking if the ticketer needs rotating.

Since `TicketSwitcher` is used by default for every default ticketer, it is a bottleneck for multi-threaded servers as it serialised every single ticket creation and resumption attempt.

Here's what this PR looks like using the benchmark changes introduced in #2192 :

![image](https://github.com/user-attachments/assets/8006e2fc-aa2b-467e-99cb-acf79d585a70)

The Y axis here is handshakes per second _per thread_ --- the ideal shape of this graph is straight, flat lines -- that would mean perfect linear scalability with the number of threads. As you can see, where the ticketer is in play -- blue and yellow -- are improved in this PR.