### PR TITLE
Introducing Rustls Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 [![Documentation](https://docs.rs/rustls/badge.svg)](https://docs.rs/rustls/)
 [![Chat](https://img.shields.io/discord/976380008299917365?logo=discord)](https://discord.gg/MCSB76RU96)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9034/badge)](https://www.bestpractices.dev/projects/9034)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Rustls%20Guru-006BFF)](https://gurubase.io/g/rustls)
 
 ## Changelog
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Rustls Guru](https://gurubase.io/g/rustls) to Gurubase. Rustls Guru uses the data from this repo and data from the [docs](https://docs.rs/rustls/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Rustls Guru", which highlights that Rustls now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Rustls Guru in Gurubase, just let me know that's totally fine.
