### PR TITLE
cancel-in-progress github action runs keyed on PR/ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ permissions:
 
 on:
   push:
+    branches-ignore:
+    - 'gh-readonly-queue/**'
+    tags:
+    - '**'
   pull_request:
   merge_group:
   schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '0 18 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build+test

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,10 @@
 name: CIFuzz
 on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This means multiple successive pushes to a ref or PR will only lead to one github action run being taken to completion -- the others will be started and then abandoned once they become obsolete.

See github docs: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-concurrency-groups
