### PR TITLE
unstable feature to support targets with no atomic pointers - DRAFT DO NOT MERGE YET

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,17 +76,32 @@ jobs:
       # nb. feature sets that include "fips" should be --release --
       # this is required for fips on windows.
       # nb. "--all-targets" does not include doctests
-      - name: cargo test (release; all features)
+      # unstable critical-section feature requires both `--cfg portable_atomic_unstable_coerce_unsized` & Rust nightly
+      - name: cargo test (release; all stable features)
+        if: ${{ !startsWith(matrix.rust, 'nightly') }}
+        run: cargo test --release --locked --lib $(admin/all-stable-features rustls) --all-targets
+        env:
+          RUST_BACKTRACE: 1
+      - name: cargo test (release; all features including unstable feature(s) - Rust nightly only - using unstable --cfg option)
+        if: startsWith(matrix.rust, 'nightly')
         run: cargo test --release --locked --all-features --all-targets
         env:
           RUST_BACKTRACE: 1
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
 
       # nb. this is separate since `--doc` option cannot be combined with other target option(s) ref:
       # - https://doc.rust-lang.org/cargo/commands/cargo-test.html
-      - name: cargo test --doc (release; all-features)
+      - name: cargo test --doc (release; all stable features)
+        if: ${{ !startsWith(matrix.rust, 'nightly') }}
+        run: cargo test --release --locked $(admin/all-stable-features rustls) --doc
+        env:
+          RUST_BACKTRACE: 1
+      - name: cargo test --doc (release; all features including unstable feature(s) - Rust nightly only - using unstable --cfg option)
+        if: startsWith(matrix.rust, 'nightly')
         run: cargo test --release --locked --all-features --doc
         env:
           RUST_BACKTRACE: 1
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
 
       - name: cargo test (debug; aws-lc-rs)
         run: cargo test --no-default-features --features aws_lc_rs,tls12,read_buf,logging,std --all-targets
@@ -104,17 +119,35 @@ jobs:
       - name: cargo build (debug; rustls-provider-example lib in no-std mode)
         run: cargo build --locked -p rustls-provider-example --no-default-features
 
-      - name: cargo test (debug; rustls-provider-example; all features)
+      - name: cargo build (debug; rustls-provider-example; all features including unstable feature(s) - Rust nightly only - using unstable --cfg option)
+        if: startsWith(matrix.rust, 'nightly')
+        run: cargo build --locked -p rustls-provider-example --all-features
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
+
+      - name: cargo test (debug; rustls-provider-example) # NOTE: only optional feature is critical-section (requires Rust nightly)
+        run: cargo test -p rustls-provider-example
+
+      - name: cargo test (debug; rustls-provider-example; all features [unstable critical-section feature] - Rust nightly only - using unstable --cfg option)
+        if: startsWith(matrix.rust, 'nightly')
         run: cargo test --all-features -p rustls-provider-example
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
 
       - name: cargo build (debug; rustls-provider-test)
         run: cargo build --locked -p rustls-provider-test
 
-      - name: cargo test (debug; rustls-provider-test; all features)
-        run: cargo test --all-features -p rustls-provider-test
+      - name: cargo test (debug; rustls-provider-test) # NOTE: only optional feature is critical-section (requires Rust nightly)
+        run: cargo test -p rustls-provider-test
 
-      - name: cargo package --all-features -p rustls
-        run: cargo package --all-features -p rustls
+      - name: cargo test (debug; rustls-provider-test; all features [unstable critical-section feature] - Rust nightly only - using unstable --cfg option)
+        if: startsWith(matrix.rust, 'nightly')
+        run: cargo test --all-features -p rustls-provider-test
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
+
+      - name: cargo package (all stable features)
+        run: cargo package $(admin/all-stable-features rustls) -p rustls
 
   msrv:
     name: MSRV
@@ -125,18 +158,21 @@ jobs:
         with:
           persist-credentials: false
 
+      # XXX TODO ADD CONSISTENT LABEL HERE - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.71"
 
-      # zlib-rs is optional and requires a later MSRV
-      - run: cargo check --locked --lib $(admin/all-features-except zlib rustls) -p rustls
+      # zlib-rs is optional and requires a later MSRV; unstable critical-section feature requires Rust nightly
+      - run: cargo check --locked --lib $(admin/all-features-except zlib,critical-section rustls) -p rustls
 
+      # XXX TODO ADD CONSISTENT LABEL HERE - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.75"
 
-      - run: cargo check --locked --lib --all-features -p rustls
+      # critical-section requires Rust nightly; check build of all stable features with MSRV
+      - run: cargo check --locked --lib $(admin/all-stable-features rustls) -p rustls
 
   features:
     name: Features
@@ -191,6 +227,44 @@ jobs:
       - name: cargo test (release; no run)
         run: cargo test --locked --release --no-run
         working-directory: rustls
+
+  features-unstable:
+    name: Features - unstable
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install rust-toolchain - nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          target: x86_64-unknown-none
+
+      - name: cargo build (debug; default features)
+        run: cargo build --locked
+        working-directory: rustls
+
+        # this target does _not_ include the libstd crate in its sysroot
+        # it will catch unwanted usage of libstd in _dependencies_
+      - name: cargo build (debug; no default features; no-std; unstable critical-section feature - using unstable --cfg option)
+        run: cargo build --locked --no-default-features --features critical-section --target x86_64-unknown-none
+        working-directory: rustls
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
+
+      - name: cargo test (debug; no default features; unstable critical-section feature - using unstable --cfg option)
+        run: cargo test --locked --no-default-features --features critical-section,std
+        working-directory: rustls
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
+
+      - name: cargo test (release; no run; all features including unstable feature(s) - using unstable --cfg option)
+        run: cargo test --locked --release --no-run --all-features
+        working-directory: rustls
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
 
   bogo:
     name: BoGo test suite
@@ -277,8 +351,8 @@ jobs:
       - name: Smoke-test benchmark program (fips)
         run: cargo run -p rustls-bench --profile=bench --locked --features fips -- --provider aws-lc-rs-fips --multiplier 0.1
 
-      - name: Run micro-benchmarks
-        run: cargo bench --locked --all-features
+      - name: Run micro-benchmarks (all stable features)
+        run: cargo bench --locked $(admin/all-stable-features rustls)
         env:
           RUSTFLAGS: --cfg=bench
 
@@ -291,17 +365,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install rust toolchain
+      # XXX TODO MORE CONSISTENT LABEL HERE - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
+      - name: Install rust toolchain - nightly
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: cargo doc (rustls; all features)
-        run: cargo doc --locked --all-features --no-deps --document-private-items --package rustls
+      - name: cargo doc (rustls; all stable features)
+        run: cargo doc --locked $(admin/all-stable-features rustls) --no-deps --document-private-items --package rustls
         env:
           RUSTDOCFLAGS: -Dwarnings
 
       - name: Check README.md
         run: |
-          cargo build --locked --all-features
+          cargo build --locked $(admin/all-stable-features rustls)
           ./admin/pull-readme
           git diff --exit-code
 
@@ -315,8 +390,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      # XXX TBD rust-toolchain - ??? ??? ???
+      # XXX TODO MORE CONSISTENT LABEL HERE - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
+      - name: Install rust-toolchain - nightly - with llvm-tools
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools
 
@@ -325,6 +402,9 @@ jobs:
 
       - name: Measure coverage
         run: ./admin/coverage --lcov --output-path final.info
+        # XXX TBD ??? - FEATURES ??? ??? ???
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
 
       - name: Report to codecov.io
         uses: codecov/codecov-action@v5
@@ -342,7 +422,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install rust toolchain
+      # XXX TODO MORE CONSISTENT LABEL HERE - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
+      - name: Install rust toolchain - nightly
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-minimal-versions
@@ -383,14 +464,47 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install rust-toolchain - nightly # Rust nightly needed to test with unstable critical-section feature
+        uses: dtolnay/rust-toolchain@nightly
       - name: Install cross (cross-rs) from GitHub
         run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Install bindgen feature & CLI for aws-lc-sys (as needed for many cross targets)
         if: ${{ matrix.target != 'i686-unknown-linux-gnu' }}
         run: cargo add --dev --features bindgen 'aws-lc-sys@>0.20' --package rustls --verbose && cargo install bindgen-cli --verbose
       - run: cross test --package rustls --target ${{ matrix.target }}
+      - run: cross test --features critical-section --package rustls --target ${{ matrix.target }}
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
+
+  cross-build-with-critical-section-feature:
+    # NOTE: The purpose of this CI job is to test build support for CPU targets with no atomic ptr support
+    # (using unstable critical-section feature)
+    name: cross-target build with unstable critical-section feature
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          # FOR FUTURE CONSIDERATION: test with some more targets with & without atomic ptr support
+          # 32-bit targets with no atomic ptr:
+          # XXX TODO GET BUILD WORKING WITH THIS RISC 32-BIT TARGET - ALREADY WORKS IN THIS: https://github.com/brodycj/rustls-rustcrypto/pull/1
+          # - riscv32imc-unknown-none-elf
+          - thumbv6m-none-eabi
+          # 32-bit Android (Linux) target(s):
+          - armv7-linux-androideabi
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install rust-toolchain - nightly # Rust nightly needed to test with unstable critical-section feature
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cross (cross-rs) from GitHub
+        run: cargo install cross --git https://github.com/cross-rs/cross
+      # Omitting built-in aws-lc-rs & ring providers due to cross build issues encountered with target(s) with no atomic ptr
+      - run: cross build --no-default-features --features critical-section --package rustls --target ${{ matrix.target }}
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
 
   semver:
     name: Check semver compatibility
@@ -412,7 +526,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Install rust toolchain
+      # XXX TODO MORE CONSISTENT LABEL HERE WITH COMPONENT(S) LABEL - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
+      - name: Install rust toolchain - stable - with rustfmt
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -431,7 +546,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Install rust nightly toolchain
+      # XXX TODO MORE CONSISTENT LABEL HERE WITH COMPONENT(S) LABEL - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
+      - name: Install rust nightly toolchain - nightly-2024-02-21 - with rustfmt
         uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
@@ -447,7 +563,8 @@ jobs:
         continue-on-error: true
 
   clippy:
-    name: Clippy
+    # XXX TBD IMPROVE THIS JOB LABEL & REVIEW CONSISTENCY WITH LOOSER clippy-nightly JOB - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
+    name: Clippy (strict / deny warnings)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -459,7 +576,8 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y valgrind
 
-      - name: Install rust toolchain
+      # XXX TODO MORE CONSISTENT LABEL HERE WITH COMPONENT(S) LABEL - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
+      - name: Install rust toolchain - stable - with clippy
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -481,7 +599,8 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y valgrind
 
-      - name: Install rust toolchain
+      # XXX TODO MORE CONSISTENT LABEL HERE WITH COMPONENT(S) LABEL - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
+      - name: Install rust toolchain - nightly - with clippy
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
@@ -496,7 +615,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Install rust toolchain
+      # XXX TODO MORE CONSISTENT LABEL HERE WITH COMPONENT(S) LABEL - XXX TODO RAISE SEPARATE PR TO UPDATE THIS
+      - name: Install rust toolchain - nightly-2024-06-30
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2024-06-30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,6 +1826,10 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -2037,6 +2041,9 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+dependencies = [
+ "critical-section",
+]
 
 [[package]]
 name = "portable-atomic-util"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,6 +2033,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,6 +2314,7 @@ dependencies = [
  "bencher",
  "brotli",
  "brotli-decompressor",
+ "critical-section",
  "env_logger",
  "hashbrown",
  "hex",
@@ -2300,6 +2322,8 @@ dependencies = [
  "macro_rules_attribute",
  "num-bigint",
  "once_cell",
+ "portable-atomic",
+ "portable-atomic-util",
  "rcgen",
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ byteorder = "1.4.3"
 chacha20poly1305 = { version = "0.10", default-features = false, features = ["alloc"] }
 clap = { version = "4.3.21", features = ["derive", "env"] }
 crabgrind = "=0.1.9" # compatible with valgrind package on GHA ubuntu-latest
+critical-section = { version = "1.2.0", default-features = false } # feature(s) specified in workspace member(s) where critical-section is used
 der = "0.7"
 ecdsa = "0.16.8"
 env_logger = "0.11"
@@ -67,11 +68,14 @@ log = { version = "0.4.8" }
 macro_rules_attribute = "0.2"
 mio = { version = "1", features = ["net", "os-poll"] }
 num-bigint = "0.4.4"
+# XXX TODO USE OF UNDERSCORE FOR `once_cell` APPEARS INCONSISTENT WITH OTHER DEPENDENCIES - MAYBE FIX IN SEPARATE PR - XXX TODO CHECK FOR OTHER SIMILAR INCONSISTENCIES
 once_cell = { version = "1.20.2", default-features = false } # feature(s) specified in workspace member(s) where once_cell is used
 openssl = "0.10"
 p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecdsa", "pkcs8"] }
 pkcs8 = "0.10.2"
 pki-types = { package = "rustls-pki-types", version = "1.10", features = ["alloc"] }
+portable-atomic = { version = "1.10.0", default-features = false }
+portable-atomic-util = { version = "0.2.4", default-features = false } # feature(s) specified in member(s) where used
 rand_core = { version = "0.6", features = ["getrandom"] }
 rayon = "1.7"
 rcgen = { version = "0.13", features = ["pem", "aws_lc_rs"], default-features = false }
@@ -92,11 +96,6 @@ x25519-dalek = "2"
 x509-parser = "0.16"
 zeroize = "1.7"
 zlib-rs = "0.4"
-# XXX TODO MOVE & FIX ORDERING OF THESE ENTRIES
-# XXX TODO ADD NOTE THAT FEATURE(S) WOULD BE BE SPECIFIED IN WORKSPACE MEMBER(S) WHERE THESE ARE USED
-portable-atomic = { version = "1.10.0", default-features = false }
-portable-atomic-util = { version = "0.2.4", default-features = false }
-critical-section = { version = "1.2.0", default-features = false }
 
 [profile.bench]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ log = { version = "0.4.8" }
 macro_rules_attribute = "0.2"
 mio = { version = "1", features = ["net", "os-poll"] }
 num-bigint = "0.4.4"
-once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }
+once_cell = { version = "1.20.2", default-features = false } # feature(s) specified in workspace member(s) where once_cell is used
 openssl = "0.10"
 p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecdsa", "pkcs8"] }
 pkcs8 = "0.10.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,11 @@ x25519-dalek = "2"
 x509-parser = "0.16"
 zeroize = "1.7"
 zlib-rs = "0.4"
+# XXX TODO MOVE & FIX ORDERING OF THESE ENTRIES
+# XXX TODO ADD NOTE THAT FEATURE(S) WOULD BE BE SPECIFIED IN WORKSPACE MEMBER(S) WHERE THESE ARE USED
+portable-atomic = { version = "1.10.0", default-features = false }
+portable-atomic-util = { version = "0.2.4", default-features = false }
+critical-section = { version = "1.2.0", default-features = false }
 
 [profile.bench]
 codegen-units = 1

--- a/admin/all-stable-features
+++ b/admin/all-stable-features
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# XXX TODO DEFINE LIST OF UNSTABLE FEATURES IN ONE PLACE
+echo $(admin/all-features-except critical-section "$@")

--- a/admin/clippy
+++ b/admin/clippy
@@ -10,6 +10,9 @@
 rc=0
 script_args="$@"
 
+# XXX TODO: FIND A BETTER PLACE TO DEFINE STABLE VS UNSTABLE FEATURES IN A SINGLE PLACE
+UNSTABLE_FEATURES="critical-section"
+
 function run_clippy() {
   if ! ( set -x ; cargo clippy --locked "$@" $script_args ) ; then
     rc=$PIPESTATUS
@@ -29,10 +32,15 @@ for p in $(admin/all-workspace-members) ; do
       ;;
     rustls-bench)
       # rustls-bench with post-quantum cannot co-exist with aws-lc-rs+fips
-      ALL_FEATURES=$(admin/all-features-except post-quantum rustls-bench)
+      ALL_FEATURES=$(admin/all-features-except $UNSTABLE_FEATURES post-quantum rustls-bench)
+      ;;
+    rustls-provider-test)
+      # no features for `rustls-provider-test`, which only has unstable `critical-section` feature (besides default `std` feature)
+      ALL_FEATURES=$(admin/all-features-except $UNSTABLE_FEATURES post-quantum rustls-bench)
       ;;
     *)
-      ALL_FEATURES="--all-features"
+      # XXX TODO RENAME ALL_FEATURES TO SOMETHING MORE CONSISTENT
+      ALL_FEATURES=$(admin/all-features-except $UNSTABLE_FEATURES $p)
       ;;
   esac
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,3 +18,7 @@ rustls = { path = "../rustls", features = [ "logging" ]}
 serde = { workspace = true }
 tokio = { workspace = true }
 webpki-roots = { workspace = true }
+
+[features]
+# XXX TODO ADD NOTE REGARDING UNSTABLE FEATURE(S) HERE
+critical-section = ["rustls/critical-section"]

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -32,7 +32,8 @@ use std::error::Error;
 use std::fs;
 use std::io::{stdout, BufReader, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 use clap::Parser;
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
@@ -40,6 +41,7 @@ use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::{ResolveError, Resolver, TokioResolver};
 use log::trace;
+
 use rustls::client::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -4,9 +4,11 @@
 
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
+use rustls::ClientConnection;
 
 fn main() {
     let root_store = rustls::RootCertStore::from_iter(
@@ -29,7 +31,7 @@ fn main() {
     .with_no_client_auth();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
-    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    let mut conn = ClientConnection::new(Arc::new(config), server_name).unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write_all(

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -8,12 +8,14 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::ops::Add;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
 use std::{fs, thread};
 
+use rustls::util::alias::Arc;
+
 use clap::Parser;
 use rcgen::KeyPair;
+
 use rustls::pki_types::{CertificateRevocationListDer, PrivatePkcs8KeyDer};
 use rustls::server::{Acceptor, ClientHello, ServerConfig, WebPkiClientVerifier};
 use rustls::RootCertStore;

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -17,7 +17,8 @@ use std::env;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::str::FromStr;
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, ServerName};

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -15,8 +15,9 @@
 use std::error::Error as StdError;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::Arc;
 use std::{env, io};
+
+use rustls::util::alias::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -10,7 +10,8 @@
 
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 use rustls::RootCertStore;
 

--- a/examples/src/bin/simpleserver.rs
+++ b/examples/src/bin/simpleserver.rs
@@ -11,7 +11,8 @@ use std::env;
 use std::error::Error as StdError;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -21,11 +21,13 @@
 
 use std::io::{self, Read, Write};
 use std::net::ToSocketAddrs;
-use std::sync::Arc;
 use std::{process, str};
+
+use rustls::util::alias::Arc;
 
 use clap::Parser;
 use mio::net::TcpStream;
+
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -22,12 +22,14 @@
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::{fs, net};
+
+use rustls::util::alias::Arc;
 
 use clap::{Parser, Subcommand};
 use log::{debug, error};
 use mio::net::{TcpListener, TcpStream};
+
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};

--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -3,12 +3,14 @@
 //! using asynchronous I/O using either async-std or tokio.
 
 use std::error::Error;
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 #[cfg(feature = "async-std")]
 use async_std::io::{ReadExt, WriteExt};
 #[cfg(feature = "async-std")]
 use async_std::net::TcpStream;
+
 use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
 use rustls::unbuffered::{
     AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -4,7 +4,8 @@
 use std::error::Error;
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 use rustls::client::{ClientConnectionData, EarlyDataError, UnbufferedClientConnection};
 use rustls::unbuffered::{

--- a/examples/src/bin/unbuffered-server.rs
+++ b/examples/src/bin/unbuffered-server.rs
@@ -6,7 +6,8 @@ use std::error::Error;
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -32,3 +32,5 @@ webpki-roots = { workspace = true }
 [features]
 default = ["std"]
 std = ["hpke-rs/std", "hpke-rs-crypto/std", "pkcs8/std", "rustls/std"]
+# XXX TODO ADD NOTE REGARDING STABLE VS UNSTABLE FEATURE(S) HERE
+critical-section = ["rustls/critical-section"]

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -1,6 +1,7 @@
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 fn main() {
     env_logger::init();

--- a/provider-example/examples/server.rs
+++ b/provider-example/examples/server.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
-use std::sync::Arc;
 
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::Acceptor;
+use rustls::util::alias::Arc;
 use rustls::ServerConfig;
 
 fn main() {

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -213,7 +213,7 @@ impl HpkeOpener for HpkeRsReceiver {
 
 #[cfg(feature = "std")]
 fn other_err(err: impl std::error::Error + Send + Sync + 'static) -> Error {
-    Error::Other(OtherError(alloc::sync::Arc::new(err)))
+    Error::Other(OtherError(rustls::util::alias::Arc::new(err)))
 }
 
 #[cfg(not(feature = "std"))]

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -4,10 +4,9 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-use alloc::sync::Arc;
-
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::PrivateKeyDer;
+use rustls::util::alias::Arc;
 
 mod aead;
 mod hash;

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -7,11 +7,11 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{mem, thread};
 
 use clap::{Parser, ValueEnum};
+
 use rustls::client::{Resumption, UnbufferedClientConnection};
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::pem::PemObject;
@@ -21,6 +21,7 @@ use rustls::server::{
     WebPkiClientVerifier,
 };
 use rustls::unbuffered::{ConnectionState, EncryptError, InsufficientSizeError, UnbufferedStatus};
+use rustls::util::alias::Arc;
 use rustls::{
     CipherSuite, ClientConfig, ClientConnection, ConnectionCommon, Error, HandshakeKind,
     RootCertStore, ServerConfig, ServerConnection, SideData,

--- a/rustls-provider-test/Cargo.toml
+++ b/rustls-provider-test/Cargo.toml
@@ -12,3 +12,7 @@ provider-example = { package = "rustls-provider-example", version = "0.0.1", pat
 rustls = { version = "0.23.8", features = ["aws_lc_rs", "logging"], path = "../rustls" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[features]
+# XXX TODO ADD NOTE REGARDING UNSTABLE FEATURE(S) HERE
+critical-section = ["provider-example/critical-section"]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -23,17 +23,23 @@ brotli = { workspace = true, optional = true }
 brotli-decompressor = { workspace = true, optional = true }
 hashbrown = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
-# only required for no-std
-once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }
+# XXX TODO UPDATE `once_cell` ENTRY IN SEPARATE PR (IF NEEDED)
+# once_cell is only required for no-std feature (this is also used with critical-section feature)
+# XXX TODO CONFIRM OR REMOVE THIS STATEMENT: once_cell `alloc` feature is specified as ONLY required with `critical-section` feature;
+# alloc & race features are only required in case of both no-std & critical-section NOT enabled
+# XXX TBD ADD STATEMENT: looks like alloc implies race but need to reserach this further (seems to be not documented, potentially may not be true in the future)
+once_cell = { workspace = true, default-features = false, features = ["alloc", "race"] }
+portable-atomic = { workspace = true, default-features = false, optional = true }
+portable-atomic-util = { workspace = true, default-features = false, optional = true }
 ring = { workspace = true, optional = true }
 subtle = { workspace = true }
 webpki = { workspace = true }
 pki-types = { workspace = true }
 zeroize = { workspace = true }
 zlib-rs = { workspace = true, optional = true }
-# XXX TODO MOVE & FIX ORDERING OF THESE ENTRIES
-portable-atomic = { workspace = true, default-features = false, optional = true }
-portable-atomic-util = { workspace = true, default-features = false, optional = true }
+# XXX TBD KEEPING TO MAKE IT EASIER TO UPGRADE USING `cargo upgrade` (available in third-party `cargo-edit` crate)
+# XXX TBD MAY BE REMOVED FROM HERE & WORKSPACE CARGO TOML IF THIS PR IS READY FOR REVIEW (SOMEDAY)
+# XXX TBD MAY MOVE THIS ENTRY UP IF THIS STAYS IN PR READY FOR REVIEW
 critical-section = { workspace = true, default-features = false, optional = true }
 
 [features]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -49,8 +49,15 @@ tls12 = []
 read_buf = ["rustversion", "std"]
 fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
 zlib = ["dep:zlib-rs"]
-# XXX TBD NEW / UNSTABLE FEATURE(S):
-critical-section = ["dep:critical-section", "dep:portable-atomic", "dep:portable-atomic-util", "once_cell/critical-section", "portable-atomic/critical-section"]
+# XXX TODO ADD COMMENT(S) FOR STABLE VS UNSTABLE FEATURES
+# XXX TODO ADD CI TESTING FOR NEW `critical-section` FEATURE
+critical-section = [
+    "dep:critical-section",
+    "dep:portable-atomic",
+    "dep:portable-atomic-util",
+    "once_cell/critical-section",
+    "portable-atomic/critical-section",
+]
 
 [dev-dependencies]
 base64 = { workspace = true }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -50,11 +50,8 @@ tls12 = []
 read_buf = ["rustversion", "std"]
 fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
 zlib = ["dep:zlib-rs"]
-# XXX TODO COMBINE THESE TWO INTO NEW `critical-section` feature
-portable-atomic = ["dep:portable-atomic"]
-portable-atomic-util = ["dep:portable-atomic-util"]
-# XXX TODO UPDATE TO INCLUDE ALL DEPENDENCIES & DEPENDENCY FEATURES REQUIRED FOR THIS FUNCTIONALITY
-critical-section = ["dep:critical-section"]
+# XXX TBD NEW / UNSTABLE FEATURE(S):
+critical-section = ["dep:critical-section", "dep:portable-atomic", "dep:portable-atomic-util", "once_cell/critical-section", "portable-atomic/critical-section"]
 
 [dev-dependencies]
 base64 = { workspace = true }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -57,6 +57,7 @@ critical-section = [
     "dep:portable-atomic-util",
     "once_cell/critical-section",
     "portable-atomic/critical-section",
+    "portable-atomic-util/alloc",
 ]
 
 [dev-dependencies]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -31,6 +31,11 @@ webpki = { workspace = true }
 pki-types = { workspace = true }
 zeroize = { workspace = true }
 zlib-rs = { workspace = true, optional = true }
+# XXX TODO MOVE & FIX ORDERING OF THESE ENTRIES
+# XXX TODO SPECIFY DEPENDENCY VERSIONS IN TOP-LEVEL CARGO TOML
+portable-atomic = { version = "1.10.0", default-features = false, optional = true }
+portable-atomic-util = { version = "0.2.4", default-features = false, optional = true }
+critical-section = { version = "1.2.0", default-features = false, optional = true }
 
 [features]
 default = ["aws_lc_rs", "logging", "std", "tls12"]
@@ -45,6 +50,11 @@ tls12 = []
 read_buf = ["rustversion", "std"]
 fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
 zlib = ["dep:zlib-rs"]
+# XXX TODO COMBINE THESE TWO INTO NEW `critical-section` feature
+portable-atomic = ["dep:portable-atomic"]
+portable-atomic-util = ["dep:portable-atomic-util"]
+# XXX TODO UPDATE TO INCLUDE ALL DEPENDENCIES & DEPENDENCY FEATURES REQUIRED FOR THIS FUNCTIONALITY
+critical-section = ["dep:critical-section"]
 
 [dev-dependencies]
 base64 = { workspace = true }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -50,7 +50,6 @@ read_buf = ["rustversion", "std"]
 fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
 zlib = ["dep:zlib-rs"]
 # XXX TODO ADD COMMENT(S) FOR STABLE VS UNSTABLE FEATURES
-# XXX TODO ADD CI TESTING FOR NEW `critical-section` FEATURE
 critical-section = [
     "dep:critical-section",
     "dep:portable-atomic",
@@ -123,7 +122,7 @@ name = "unbuffered"
 path = "tests/runners/unbuffered.rs"
 
 [package.metadata.docs.rs]
-# all non-default features except fips (cannot build on docs.rs environment)
+# all non-default features except critical-section (uses portable-atomic-util) & fips (cannot build on docs.rs environment)
 features = ["read_buf", "ring"]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -32,10 +32,9 @@ pki-types = { workspace = true }
 zeroize = { workspace = true }
 zlib-rs = { workspace = true, optional = true }
 # XXX TODO MOVE & FIX ORDERING OF THESE ENTRIES
-# XXX TODO SPECIFY DEPENDENCY VERSIONS IN TOP-LEVEL CARGO TOML
-portable-atomic = { version = "1.10.0", default-features = false, optional = true }
-portable-atomic-util = { version = "0.2.4", default-features = false, optional = true }
-critical-section = { version = "1.2.0", default-features = false, optional = true }
+portable-atomic = { workspace = true, default-features = false, optional = true }
+portable-atomic-util = { workspace = true, default-features = false, optional = true }
+critical-section = { workspace = true, default-features = false, optional = true }
 
 [features]
 default = ["aws_lc_rs", "logging", "std", "tls12"]

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -5,10 +5,13 @@ use rustls::crypto::ring as provider;
 
 #[path = "../tests/common/mod.rs"]
 mod test_utils;
+
 use std::io;
-use std::sync::Arc;
+
+use rustls::util::alias::Arc;
 
 use rustls::ServerConnection;
+
 use test_utils::*;
 
 fn bench_ewouldblock(c: &mut Bencher) {

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -1,9 +1,9 @@
 use alloc::format;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 
+use crate::alias::Arc;
 use crate::client::EchMode;
 use crate::crypto::CryptoProvider;
 use crate::error::Error;

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -1,10 +1,10 @@
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use pki_types::{CertificateDer, PrivateKeyDer};
 
 use super::client_conn::Resumption;
+use crate::alias::Arc;
 use crate::builder::{ConfigBuilder, WantsVerifier};
 use crate::client::{handy, ClientConfig, EchMode, ResolvesClientCert};
 use crate::error::Error;
@@ -89,9 +89,9 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
 
 /// Container for unsafe APIs
 pub(super) mod danger {
-    use alloc::sync::Arc;
     use core::marker::PhantomData;
 
+    use crate::alias::Arc;
     use crate::client::WantsClientCert;
     use crate::{verify, ClientConfig, ConfigBuilder, WantsVerifier};
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
@@ -8,6 +7,7 @@ use pki_types::{ServerName, UnixTime};
 
 use super::handy::NoClientSessionStorage;
 use super::hs;
+use crate::alias::Arc;
 use crate::builder::ConfigBuilder;
 use crate::client::{EchMode, EchStatus};
 use crate::common_state::{CommonState, Protocol, Side};
@@ -511,10 +511,9 @@ pub enum Tls12Resumption {
 
 /// Container for unsafe APIs
 pub(super) mod danger {
-    use alloc::sync::Arc;
-
     use super::verify::ServerCertVerifier;
     use super::ClientConfig;
+    use crate::alias::Arc;
 
     /// Accessor for dangerous configuration options.
     #[derive(Debug)]
@@ -611,7 +610,6 @@ impl EarlyData {
 
 #[cfg(feature = "std")]
 mod connection {
-    use alloc::sync::Arc;
     use alloc::vec::Vec;
     use core::fmt;
     use core::ops::{Deref, DerefMut};
@@ -620,6 +618,7 @@ mod connection {
     use pki_types::ServerName;
 
     use super::ClientConnectionData;
+    use crate::alias::Arc;
     use crate::client::EchStatus;
     use crate::common_state::Protocol;
     use crate::conn::{ConnectionCommon, ConnectionCore};

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -1,8 +1,8 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use super::ResolvesClientCert;
+use crate::alias::Arc;
 use crate::log::{debug, trace};
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::handshake::{CertificateChain, DistinguishedName, ServerExtension};

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -1,7 +1,6 @@
-use alloc::sync::Arc;
-
 use pki_types::ServerName;
 
+use crate::alias::Arc;
 use crate::enums::SignatureScheme;
 use crate::error::Error;
 use crate::msgs::handshake::CertificateChain;
@@ -279,13 +278,13 @@ impl client::ResolvesClientCert for AlwaysResolvesClientRawPublicKeys {
 #[cfg(test)]
 #[macro_rules_attribute::apply(test_for_each_provider)]
 mod tests {
-    use alloc::sync::Arc;
     use std::prelude::v1::*;
 
     use pki_types::{ServerName, UnixTime};
 
     use super::provider::cipher_suite;
     use super::NoClientSessionStorage;
+    use crate::alias::Arc;
     use crate::client::ClientSessionStore;
     use crate::msgs::base::PayloadU16;
     use crate::msgs::enums::NamedGroup;

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -1,6 +1,5 @@
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Deref;
@@ -10,6 +9,7 @@ use pki_types::ServerName;
 #[cfg(feature = "tls12")]
 use super::tls12;
 use super::Tls12Resumption;
+use crate::alias::Arc;
 #[cfg(feature = "logging")]
 use crate::bs_debug;
 use crate::check::inappropriate_handshake_message;

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,6 +1,5 @@
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -10,6 +9,7 @@ use subtle::ConstantTimeEq;
 
 use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;
+use crate::alias::Arc;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::client::common::{ClientAuthDetails, ServerCertDetails};
 use crate::client::{hs, ClientConfig};

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1,5 +1,4 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -8,6 +7,7 @@ use subtle::ConstantTimeEq;
 
 use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;
+use crate::alias::Arc;
 use crate::check::inappropriate_handshake_message;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails, ServerCertDetails};
 use crate::client::ech::{self, EchState, EchStatus};

--- a/rustls/src/compress.rs
+++ b/rustls/src/compress.rs
@@ -34,12 +34,12 @@
 
 #[cfg(feature = "std")]
 use alloc::collections::VecDeque;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 #[cfg(feature = "std")]
 use std::sync::Mutex;
 
+use crate::alias::Arc;
 use crate::enums::CertificateCompressionAlgorithm;
 use crate::msgs::base::{Payload, PayloadU24};
 use crate::msgs::codec::Codec;

--- a/rustls/src/crypto/aws_lc_rs/hpke.rs
+++ b/rustls/src/crypto/aws_lc_rs/hpke.rs
@@ -1,6 +1,4 @@
 use alloc::boxed::Box;
-#[cfg(feature = "std")]
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug, Formatter};
 
@@ -13,6 +11,8 @@ use aws_lc_rs::digest::{SHA256_OUTPUT_LEN, SHA384_OUTPUT_LEN, SHA512_OUTPUT_LEN}
 use aws_lc_rs::encoding::{AsBigEndian, Curve25519SeedBin, EcPrivateKeyBin};
 use zeroize::Zeroize;
 
+#[cfg(feature = "std")]
+use crate::alias::Arc;
 use crate::crypto::aws_lc_rs::hmac::{HMAC_SHA256, HMAC_SHA384, HMAC_SHA512};
 use crate::crypto::aws_lc_rs::unspecified_err;
 use crate::crypto::hpke::{

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 // aws-lc-rs has a -- roughly -- ring-compatible API, so we just reuse all that
@@ -9,6 +8,7 @@ pub(crate) use aws_lc_rs as ring_like;
 use pki_types::PrivateKeyDer;
 use webpki::aws_lc_rs as webpki_algs;
 
+use crate::alias::Arc;
 use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;

--- a/rustls/src/crypto/aws_lc_rs/sign.rs
+++ b/rustls/src/crypto/aws_lc_rs/sign.rs
@@ -2,7 +2,6 @@
 
 use alloc::boxed::Box;
 use alloc::string::ToString;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::fmt::{self, Debug, Formatter};
@@ -12,6 +11,7 @@ use webpki::alg_id;
 
 use super::ring_like::rand::SystemRandom;
 use super::ring_like::signature::{self, EcdsaKeyPair, Ed25519KeyPair, KeyPair, RsaKeyPair};
+use crate::alias::Arc;
 use crate::crypto::signer::{public_key_to_spki, Signer, SigningKey};
 use crate::enums::{SignatureAlgorithm, SignatureScheme};
 use crate::error::Error;

--- a/rustls/src/crypto/aws_lc_rs/ticketer.rs
+++ b/rustls/src/crypto/aws_lc_rs/ticketer.rs
@@ -1,5 +1,4 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 use core::fmt::{Debug, Formatter};
@@ -13,6 +12,7 @@ use aws_lc_rs::{hmac, iv};
 
 use super::ring_like::rand::{SecureRandom, SystemRandom};
 use super::unspecified_err;
+use crate::alias::Arc;
 use crate::error::Error;
 #[cfg(debug_assertions)]
 use crate::log::debug;

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -158,6 +158,15 @@ pub use crate::suites::CipherSuiteCommon;
 /// - **Authentication key loading** - see [`crypto::KeyProvider::load_private_key()`] and
 ///   [`sign::SigningKey`].
 ///
+/// XXX TODO ADD SOME INFO FOR CARGO PACKAGING AND IMPROVE TITLE FOR PROVIDER EXAMPLE BELOW - POSSIBLY IN A SEPARATE PR
+///
+/// # Cargo packaging with optional crate features
+///
+/// XXX TODO ADD DESCRIPTION & ADD REFERENCE TO PROVIDER EXAMPLE
+///
+/// - `std` (generally enabled by default) - enable functionality that is not available with `no-std` build - XXX TODO ADD SOME MORE DETAIL (???)
+/// - `critical-section` - XXX TODO XXX
+///
 /// # Example code
 ///
 /// See [provider-example/] for a full client and server example that uses

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -1,11 +1,11 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use pki_types::PrivateKeyDer;
 use zeroize::Zeroize;
 
+use crate::alias::Arc;
 use crate::msgs::ffdhe_groups::FfdheGroup;
 use crate::sign::SigningKey;
 pub use crate::webpki::{
@@ -124,7 +124,7 @@ pub use crate::suites::CipherSuiteCommon;
 ///
 /// ```
 /// # #[cfg(feature = "aws_lc_rs")] {
-/// # use std::sync::Arc;
+/// # use rustls::util::alias::Arc;
 /// # mod fictious_hsm_api { pub fn load_private_key(key_der: pki_types::PrivateKeyDer<'static>) -> ! { unreachable!(); } }
 /// use rustls::crypto::aws_lc_rs;
 ///
@@ -705,7 +705,6 @@ mod static_default {
     // XXX TODO ADD CLEAR EXPLANATION OF SELECTION BETWEEN std::sync::OnceLock / once_cell::sync::OnceCell / once_cell::race::OnceBox
     #[cfg(not(any(feature = "critical-section", feature = "std")))]
     use alloc::boxed::Box;
-    use alloc::sync::Arc;
     #[cfg(all(not(feature = "critical-section"), feature = "std"))]
     use std::sync::OnceLock;
 
@@ -715,6 +714,7 @@ mod static_default {
     use once_cell::sync::OnceCell;
 
     use super::CryptoProvider;
+    use crate::alias::Arc;
 
     #[cfg(any(feature = "critical-section", feature = "std"))]
     pub(crate) fn install_default(

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -1,9 +1,8 @@
-use alloc::sync::Arc;
-
 use pki_types::PrivateKeyDer;
 pub(crate) use ring as ring_like;
 use webpki::ring as webpki_algs;
 
+use crate::alias::Arc;
 use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -2,7 +2,6 @@
 
 use alloc::boxed::Box;
 use alloc::string::ToString;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::fmt::{self, Debug, Formatter};
@@ -12,6 +11,7 @@ use webpki::alg_id;
 
 use super::ring_like::rand::{SecureRandom, SystemRandom};
 use super::ring_like::signature::{self, EcdsaKeyPair, Ed25519KeyPair, KeyPair, RsaKeyPair};
+use crate::alias::Arc;
 use crate::crypto::signer::{public_key_to_spki, Signer, SigningKey};
 use crate::enums::{SignatureAlgorithm, SignatureScheme};
 use crate::error::Error;

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -1,5 +1,4 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 use core::fmt::{Debug, Formatter};
@@ -9,6 +8,7 @@ use subtle::ConstantTimeEq;
 
 use super::ring_like::aead;
 use super::ring_like::rand::{SecureRandom, SystemRandom};
+use crate::alias::Arc;
 use crate::error::Error;
 #[cfg(debug_assertions)]
 use crate::log::debug;

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -1,10 +1,11 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
+
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use pki_types::{AlgorithmIdentifier, CertificateDer, SubjectPublicKeyInfoDer};
 
+use crate::alias::Arc;
 use crate::enums::{SignatureAlgorithm, SignatureScheme};
 use crate::error::{Error, InconsistentKeys};
 use crate::server::ParsedCertificate;

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -621,13 +621,13 @@ impl From<rand::GetRandomFailed> for Error {
 }
 
 mod other_error {
-    #[cfg(feature = "std")]
-    use alloc::sync::Arc;
     use core::fmt;
     #[cfg(feature = "std")]
     use std::error::Error as StdError;
 
     use super::Error;
+    #[cfg(feature = "std")]
+    use crate::alias::Arc;
 
     /// Any other error that cannot be expressed by a more specific [`Error`] variant.
     ///
@@ -679,6 +679,8 @@ mod tests {
     use std::{println, vec};
 
     use super::{CertRevocationListError, Error, InconsistentKeys, InvalidMessage, OtherError};
+    #[cfg(feature = "std")]
+    use crate::alias::Arc;
 
     #[test]
     fn certificate_error_equality() {
@@ -698,7 +700,7 @@ mod tests {
         );
         let other = Other(OtherError(
             #[cfg(feature = "std")]
-            alloc::sync::Arc::from(Box::from("")),
+            Arc::from(Box::from("")),
         ));
         assert_ne!(other, other);
         assert_ne!(BadEncoding, Expired);
@@ -722,7 +724,7 @@ mod tests {
         assert_eq!(UnsupportedRevocationReason, UnsupportedRevocationReason);
         let other = Other(OtherError(
             #[cfg(feature = "std")]
-            alloc::sync::Arc::from(Box::from("")),
+            Arc::from(Box::from("")),
         ));
         assert_ne!(other, other);
         assert_ne!(BadSignature, InvalidCrlNumber);
@@ -731,7 +733,7 @@ mod tests {
     #[test]
     #[cfg(feature = "std")]
     fn other_error_equality() {
-        let other_error = OtherError(alloc::sync::Arc::from(Box::from("")));
+        let other_error = OtherError(Arc::from(Box::from("")));
         assert_ne!(other_error, other_error);
         let other: Error = other_error.into();
         assert_ne!(other, other);
@@ -769,7 +771,7 @@ mod tests {
             Error::InvalidCertRevocationList(CertRevocationListError::BadSignature),
             Error::Other(OtherError(
                 #[cfg(feature = "std")]
-                alloc::sync::Arc::from(Box::from("")),
+                Arc::from(Box::from("")),
             )),
         ];
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -273,6 +273,10 @@
 //! Here's a list of what features are exposed by the rustls crate and what
 //! they mean.
 //!
+//! - `std` (enabled by default): XXX TODO ADD THIS - XXX TODO SHOULD ADD THIS IN SEPARATE PR
+//!
+//! XXX TODO CHECK FOR ANY OTHER FEATURES MISSING FROM THIS CRATE FEATURES DOCUMENTATION
+//!
 //! - `aws_lc_rs` (enabled by default): makes the rustls crate depend on the [`aws-lc-rs`] crate.
 //!   Use `rustls::crypto::aws_lc_rs::default_provider().install_default()` to
 //!   use it as the default `CryptoProvider`, or provide it explicitly
@@ -315,6 +319,7 @@
 //!
 //! - `zlib`: uses the `zlib-rs` crate for RFC8879 certificate compression support.
 //!
+//! - `critical-section`: XXX TODO DOCUMENT INTERACTION WITH once_cell; XXX TBD DOCUMENT AS UNSTABLE OPTION
 
 // Require docs for public APIs, deny unsafe code, etc.
 #![forbid(unsafe_code, unused_must_use)]

--- a/rustls/src/lock.rs
+++ b/rustls/src/lock.rs
@@ -35,9 +35,10 @@ mod std_lock {
 #[cfg(not(feature = "std"))]
 mod no_std_lock {
     use alloc::boxed::Box;
-    use alloc::sync::Arc;
     use core::fmt::Debug;
     use core::ops::DerefMut;
+
+    use crate::alias::Arc;
 
     /// A no-std compatible wrapper around [`Lock`].
     #[derive(Debug)]

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1,7 +1,6 @@
 use alloc::collections::BTreeSet;
 #[cfg(feature = "logging")]
 use alloc::string::String;
-use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Deref;
@@ -9,6 +8,7 @@ use core::{fmt, iter};
 
 use pki_types::{CertificateDer, DnsName};
 
+use crate::alias::Arc;
 #[cfg(feature = "tls12")]
 use crate::crypto::ActiveKeyExchange;
 use crate::crypto::SecureRandom;

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use std::prelude::v1::*;
 use std::{format, println, vec};
 
@@ -22,6 +21,7 @@ use super::handshake::{
     ServerDhParams, ServerEcdhParams, ServerExtension, ServerHelloPayload, ServerKeyExchange,
     ServerKeyExchangeParams, ServerKeyExchangePayload, SessionId, UnknownExtension,
 };
+use crate::alias::Arc;
 use crate::enums::{
     CertificateCompressionAlgorithm, CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme,
 };

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -1,10 +1,10 @@
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cmp;
 
 use pki_types::{DnsName, UnixTime};
 use zeroize::Zeroizing;
 
+use crate::alias::Arc;
 use crate::enums::{CipherSuite, ProtocolVersion};
 use crate::error::InvalidMessage;
 use crate::msgs::base::{PayloadU16, PayloadU8};

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -17,7 +17,6 @@ use crate::tls13::Tls13CipherSuite;
 
 #[cfg(feature = "std")]
 mod connection {
-    use alloc::sync::Arc;
     use alloc::vec;
     use alloc::vec::Vec;
     use core::fmt::{self, Debug};
@@ -26,6 +25,7 @@ mod connection {
     use pki_types::ServerName;
 
     use super::{DirectionalKeys, KeyChange, Version};
+    use crate::alias::Arc;
     use crate::client::{ClientConfig, ClientConnectionData};
     use crate::common_state::{CommonState, Protocol, DEFAULT_BUFFER_LIMIT};
     use crate::conn::{ConnectionCore, SideData};

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -1,9 +1,9 @@
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use pki_types::{CertificateDer, PrivateKeyDer};
 
+use crate::alias::Arc;
 use crate::builder::{ConfigBuilder, WantsVerifier};
 use crate::error::Error;
 use crate::server::{handy, ResolvesServerCert, ServerConfig};

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -1,7 +1,7 @@
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
+use crate::alias::Arc;
 use crate::server::ClientHello;
 use crate::{server, sign};
 
@@ -26,10 +26,10 @@ impl server::StoresServerSessions for NoServerSessionStorage {
 
 #[cfg(any(feature = "std", feature = "hashbrown"))]
 mod cache {
-    use alloc::sync::Arc;
     use alloc::vec::Vec;
     use core::fmt::{Debug, Formatter};
 
+    use crate::alias::Arc;
     use crate::lock::Mutex;
     use crate::{limited_cache, server};
 
@@ -226,11 +226,11 @@ impl server::ResolvesServerCert for AlwaysResolvesServerRawPublicKeys {
 #[cfg(any(feature = "std", feature = "hashbrown"))]
 mod sni_resolver {
     use alloc::string::{String, ToString};
-    use alloc::sync::Arc;
     use core::fmt::Debug;
 
     use pki_types::{DnsName, ServerName};
 
+    use crate::alias::Arc;
     use crate::error::Error;
     use crate::hash_map::HashMap;
     use crate::server::ClientHello;

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -1,6 +1,5 @@
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use pki_types::DnsName;
@@ -8,6 +7,7 @@ use pki_types::DnsName;
 use super::server_conn::ServerConnectionData;
 #[cfg(feature = "tls12")]
 use super::tls12;
+use crate::alias::Arc;
 use crate::common_state::{
     KxState, Protocol, RawKeyNegotationResult, RawKeyNegotiationParams, State,
 };

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1,5 +1,4 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 use core::fmt::{Debug, Formatter};
@@ -11,6 +10,7 @@ use std::io;
 use pki_types::{DnsName, UnixTime};
 
 use super::hs;
+use crate::alias::Arc;
 use crate::builder::ConfigBuilder;
 use crate::common_state::{CommonState, Side};
 #[cfg(feature = "std")]
@@ -528,7 +528,6 @@ impl ServerConfig {
 #[cfg(feature = "std")]
 mod connection {
     use alloc::boxed::Box;
-    use alloc::sync::Arc;
     use alloc::vec::Vec;
     use core::fmt;
     use core::fmt::{Debug, Formatter};
@@ -536,6 +535,7 @@ mod connection {
     use std::io;
 
     use super::{Accepted, Accepting, EarlyDataState, ServerConfig, ServerConnectionData};
+    use crate::alias::Arc;
     use crate::common_state::{CommonState, Context, Side};
     use crate::conn::{ConnectionCommon, ConnectionCore};
     use crate::error::Error;
@@ -719,9 +719,10 @@ mod connection {
     ///
     /// ```no_run
     /// # #[cfg(feature = "aws_lc_rs")] {
+    /// # use rustls::util::alias::Arc;
     /// # fn choose_server_config(
     /// #     _: rustls::server::ClientHello,
-    /// # ) -> std::sync::Arc<rustls::ServerConfig> {
+    /// # ) -> Arc<rustls::ServerConfig> {
     /// #     unimplemented!();
     /// # }
     /// # #[allow(unused_variables)]

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,6 +1,5 @@
 use alloc::boxed::Box;
 use alloc::string::ToString;
-use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -11,6 +10,7 @@ use subtle::ConstantTimeEq;
 use super::common::ActiveCertifiedKey;
 use super::hs::{self, ServerContext};
 use super::server_conn::{ProducesTickets, ServerConfig, ServerConnectionData};
+use crate::alias::Arc;
 use crate::check::inappropriate_message;
 use crate::common_state::{CommonState, HandshakeFlightTls12, HandshakeKind, Side, State};
 use crate::conn::ConnectionRandoms;

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1,5 +1,4 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -9,6 +8,7 @@ use subtle::ConstantTimeEq;
 
 use super::hs::{self, HandshakeHashOrBuffer, ServerContext};
 use super::server_conn::ServerConnectionData;
+use crate::alias::Arc;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::common_state::{
     CommonState, HandshakeFlightTls13, HandshakeKind, Protocol, Side, State,

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -1,10 +1,10 @@
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use pki_types::{CertificateDer, CertificateRevocationListDer, UnixTime};
 use webpki::{CertRevocationList, ExpirationPolicy, RevocationCheckDepth, UnknownStatusPolicy};
 
 use super::{pki_error, VerifierBuilderError};
+use crate::alias::Arc;
 #[cfg(doc)]
 use crate::crypto;
 use crate::crypto::{CryptoProvider, WebPkiSupportedAlgorithms};
@@ -432,13 +432,13 @@ pub(crate) enum AnonymousClientPolicy {
 #[macro_rules_attribute::apply(test_for_each_provider)]
 mod tests {
     use std::prelude::v1::*;
-    use std::sync::Arc;
     use std::{format, println, vec};
 
     use pki_types::pem::PemObject;
     use pki_types::{CertificateDer, CertificateRevocationListDer};
 
     use super::{provider, WebPkiClientVerifier};
+    use crate::alias::Arc;
     use crate::server::VerifierBuilderError;
     use crate::RootCertStore;
 

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -1,11 +1,11 @@
-#[cfg(feature = "std")]
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 
 use pki_types::CertificateRevocationListDer;
 use webpki::{CertRevocationList, OwnedCertRevocationList};
 
+#[cfg(feature = "std")]
+use crate::alias::Arc;
 use crate::error::{CertRevocationListError, CertificateError, Error, OtherError};
 
 mod anchors;

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -1,9 +1,9 @@
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use pki_types::{CertificateDer, CertificateRevocationListDer, ServerName, UnixTime};
 use webpki::{CertRevocationList, ExpirationPolicy, RevocationCheckDepth, UnknownStatusPolicy};
 
+use crate::alias::Arc;
 use crate::crypto::{CryptoProvider, WebPkiSupportedAlgorithms};
 use crate::log::trace;
 use crate::verify::{
@@ -304,13 +304,13 @@ impl ServerCertVerifier for WebPkiServerVerifier {
 #[macro_rules_attribute::apply(test_for_each_provider)]
 mod tests {
     use std::prelude::v1::*;
-    use std::sync::Arc;
     use std::{println, vec};
 
     use pki_types::pem::PemObject;
     use pki_types::{CertificateDer, CertificateRevocationListDer};
 
     use super::{provider, VerifierBuilderError, WebPkiServerVerifier};
+    use crate::alias::Arc;
     use crate::RootCertStore;
 
     fn load_crls(crls_der: &[&[u8]]) -> Vec<CertificateRevocationListDer<'static>> {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6,10 +6,11 @@ use std::fmt::Debug;
 use std::io::{self, IoSlice, Read, Write};
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::{fmt, mem};
 
 use pki_types::{CertificateDer, IpAddr, ServerName, UnixTime};
+
 use rustls::client::{verify_server_cert_signed_by_trust_anchor, ResolvesClientCert, Resumption};
 use rustls::crypto::{ActiveKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup};
 use rustls::internal::msgs::base::Payload;
@@ -21,6 +22,7 @@ use rustls::internal::msgs::handshake::{
 };
 use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
+use rustls::util::alias::Arc;
 #[cfg(feature = "aws_lc_rs")]
 use rustls::{
     client::{EchConfig, EchGreaseConfig, EchMode},

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -5,14 +5,15 @@
 use super::*;
 
 mod common;
-use std::sync::Arc;
 
 use common::{
     do_handshake_until_both_error, do_handshake_until_error, make_client_config_with_versions,
     make_client_config_with_versions_with_auth, make_pair_for_arc_configs, server_config_builder,
     server_name, ErrorFromPeer, KeyType, MockClientVerifier, ALL_KEY_TYPES,
 };
+
 use rustls::server::danger::ClientCertVerified;
+use rustls::util::alias::Arc;
 use rustls::{
     AlertDescription, ClientConnection, Error, InvalidMessage, ServerConfig, ServerConnection,
 };

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -3,7 +3,7 @@
 
 use std::io;
 use std::ops::DerefMut;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use pki_types::pem::PemObject;
 use pki_types::{
@@ -23,6 +23,7 @@ use rustls::server::{
     AlwaysResolvesServerRawPublicKeys, ClientCertVerifierBuilder, WebPkiClientVerifier,
 };
 use rustls::sign::CertifiedKey;
+use rustls::util::alias::Arc;
 use rustls::{
     ClientConfig, ClientConnection, Connection, ConnectionCommon, ContentType,
     DigitallySignedStruct, DistinguishedName, Error, InconsistentKeys, NamedGroup, ProtocolVersion,

--- a/rustls/tests/key_log_file_env.rs
+++ b/rustls/tests/key_log_file_env.rs
@@ -25,7 +25,6 @@
 
 use std::env;
 use std::io::Write;
-use std::sync::Arc;
 
 use super::*;
 
@@ -34,6 +33,8 @@ use common::{
     do_handshake, make_client_config_with_versions, make_pair_for_arc_configs, make_server_config,
     transfer, KeyType,
 };
+
+use rustls::util::alias::Arc;
 
 #[test]
 fn exercise_key_log_file_for_client() {

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -5,7 +5,6 @@
 use super::*;
 
 mod common;
-use std::sync::Arc;
 
 use common::{
     client_config_builder, client_config_builder_with_versions, do_handshake,
@@ -20,6 +19,7 @@ use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
 use rustls::internal::msgs::message::{Message, MessagePayload};
 use rustls::server::{ClientHello, ResolvesServerCert};
 use rustls::sign::CertifiedKey;
+use rustls::util::alias::Arc;
 use rustls::version::{TLS12, TLS13};
 use rustls::{
     AlertDescription, CertificateError, DigitallySignedStruct, DistinguishedName, Error,

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::duplicate_mod)]
 
 use std::num::NonZeroUsize;
-use std::sync::Arc;
 
 use rustls::client::{ClientConnectionData, EarlyDataError, UnbufferedClientConnection};
 use rustls::server::{ServerConnectionData, UnbufferedServerConnection};
@@ -9,6 +8,7 @@ use rustls::unbuffered::{
     ConnectionState, EncodeError, EncryptError, InsufficientSizeError, UnbufferedConnectionCommon,
     UnbufferedStatus, WriteTraffic,
 };
+use rustls::util::alias::Arc;
 use rustls::version::TLS13;
 use rustls::{
     AlertDescription, CertificateError, ClientConfig, Error, InvalidMessage, ServerConfig, SideData,


### PR DESCRIPTION
__STATUS:__ _see TODO items below_

Proposal to resolve issue: #2068

This is a proposal to support targets w/o atomic ptr by using portable-atomic `Arc` & `critical-section`, as optional features, _with help from a recently published contribution: <https://github.com/taiki-e/portable-atomic/pull/195>_

This solution requires use of Rust nightly in order for the required coercion to work with the _recent update from_ https://github.com/taiki-e/portable-atomic/pull/195 ... looks like the stabilization is blocked pending this: https://github.com/rust-lang/rust/issues/18598

Optional features added to `rustls/Cargo.toml`:

- `portable-atomic-arc` - enable use of `Arc` from portable-atomic-util
- `critical-section` - enable `critical-section` feature on once-cell & portable-atomic-util crates & include `portable-atomic-arc` feature - this is needed to support build on targets w/o atomic ptr

CI TESTING:

- this adds a new job to try `cross build` with `critical-section` on multiple targets including non-atomic ptr target
- Some additional CI testing with nightly Rust

COMPARISON TO ALTERNATIVE SOLUTIONS:

- use alias to `Rc` for target(s) with no atomic ptr - already proposed in PR #2088 - seems to imply some API mangling & use of an ugly macro to enable or disable use of `Send` & `Sync` traits; possibly harder to document & understand the updated API
- add & use casting macros to get this working with Rust stable - I have already done this in my work area, seems to imply some worse-looking API mangling, with more documentation burden & possibly harder to understand the updated API

---

__STATEMENT OF IMPACT__

This unstable `critical-section` feature would require using Rust nightly along with the unstable `--cfg portable_atomic_unstable_coerce_unsized` build option in order for the build to succeed with this feature.

The one form of impact I can think of is on users building rustls library with `--all-features` flag. I do NOT think this should affect anyone using rustls as a dependency for a higher-level library or application.

Alternative could be to use an unstable cfg option, like I had to do in <https://github.com/taiki-e/portable-atomic/pull/195>, but this seems to be inconsistent with the other rustls build options.

---

__XXX / TODO ITEMS:__

- [ ] resolve remaining XXX / TODO item(s) in `.github/workflows/build.yml`
- [ ] resolve remaining documentation TODO item(s) doc items in `rustls/src` (`rustls/src/lib.rs` & `rustls/src/crypto/mod.rs`)
- [ ] I noticed that https://docs.rs/rustls has references into documentation for Rust nightly, thinking these should point into documentation for Rust stable instead (moving this item out of PR #2285)
- [ ] check for any other remaining remaining XXX / TODO item(s) in this PR

/cc @bjoernQ @taiki-e