### PR TITLE
StoresServerSessions: guarantee keys are high entropy

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -145,7 +145,7 @@ impl Codec<'_> for SessionId {
     fn encode(&self, bytes: &mut Vec<u8>) {
         debug_assert!(self.len <= 32);
         bytes.push(self.len as u8);
-        bytes.extend_from_slice(&self.data[..self.len]);
+        bytes.extend_from_slice(self.as_ref());
     }
 
     fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
@@ -182,6 +182,12 @@ impl SessionId {
     #[cfg(feature = "tls12")]
     pub(crate) fn is_empty(&self) -> bool {
         self.len == 0
+    }
+}
+
+impl AsRef<[u8]> for SessionId {
+    fn as_ref(&self) -> &[u8] {
+        &self.data[..self.len]
     }
 }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -38,6 +38,10 @@ use crate::{compress, sign, verify, versions, KeyLog, WantsVersions};
 ///
 /// The keys and values are opaque.
 ///
+/// Inserted keys are randomly chosen by the library and have
+/// no internal structure (in other words, you may rely on all
+/// bits being uniformly random).  Queried keys are untrusted data.
+///
 /// Both the keys and values should be treated as
 /// **highly sensitive data**, containing enough key material
 /// to break all security of the corresponding sessions.

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -146,7 +146,7 @@ mod client_hello {
 
                     self.config
                         .session_storage
-                        .get(&client_hello.session_id.get_encoding())
+                        .get(client_hello.session_id.as_ref())
                 })
                 .and_then(|x| persist::ServerSessionValue::read_bytes(&x).ok())
                 .filter(|resumedata| {
@@ -910,7 +910,7 @@ impl State<ServerConnectionData> for ExpectFinished {
             let worked = self
                 .config
                 .session_storage
-                .put(self.session_id.get_encoding(), value.get_encoding());
+                .put(self.session_id.as_ref().to_vec(), value.get_encoding());
             if worked {
                 debug!("Session saved");
             } else {


### PR DESCRIPTION
In TLS1.2, these were wire encoding of a SessionID (which is a 0..32 byte string with a one-byte length prefix). Fix that, which we can do because `Vec<u8>` knows its length.

In TLS1.3 this was already 32 random bytes.

This opens the way to allow implementations to shard the storage by key.

In the future we could change the key type to be `[u8; 32]`.

---

I experimented a bit with sharding the server session cache like this, but it didn't seem to improve scalability in a measurable way: probably because the critical section is already very very small? But I think this commit is worth having anyway.