### PR TITLE
Prepare 0.23.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "env_logger",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-post-quantum",
 ]
 
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.17"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2136,7 +2136,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "rayon",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "tikv-jemallocator",
 ]
 
@@ -2147,7 +2147,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.16",
+ "rustls 0.23.17",
 ]
 
 [[package]]
@@ -2161,7 +2161,7 @@ dependencies = [
  "log",
  "mio 0.8.11",
  "rcgen",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "serde",
  "serde_derive",
  "tokio",
@@ -2177,7 +2177,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-pki-types",
 ]
 
@@ -2201,7 +2201,7 @@ name = "rustls-post-quantum"
 version = "0.2.0"
 dependencies = [
  "aws-lc-rs",
- "rustls 0.23.16",
+ "rustls 0.23.17",
 ]
 
 [[package]]
@@ -2221,7 +2221,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-webpki",
  "sha2",
  "signature",
@@ -2234,7 +2234,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.23.16",
+ "rustls 0.23.17",
  "rustls-provider-example",
  "serde",
  "serde_json",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.17"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls-post-quantum/Cargo.lock
+++ b/rustls-post-quantum/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.17"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.17"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Headlines:

- Performance improvement: by default rustls servers now send fewer TLS1.3 tickets to a client. The old default was 4 tickets, now it is 2. The number can be tuned if needed by setting [`ServerConfig::send_tls13_tickets`](https://docs.rs/rustls/latest/rustls/server/struct.ServerConfig.html#structfield.send_tls13_tickets).
- Performance improvement: the default ticket rotator now has improved multithreaded performance. 