### PR TITLE
ci: enable bindgen feature on correct aws-lc-sys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,7 +384,7 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Install bindgen feature & CLI for aws-lc-sys (as needed for many cross targets)
         if: ${{ matrix.target != 'i686-unknown-linux-gnu' }}
-        run: cargo add --dev --features bindgen aws-lc-sys --package rustls --verbose && cargo install bindgen-cli --verbose
+        run: cargo add --dev --features bindgen 'aws-lc-sys@>0.20' --package rustls --verbose && cargo install bindgen-cli --verbose
       - run: cross test --package rustls --target ${{ matrix.target }}
 
   semver:


### PR DESCRIPTION
`cargo add` adds the latest version of a package, meaning we end up with two aws-lc-sys versions if there is a newer version than the one in our Cargo.lock.

`cargo add aws-lc-sys@*` ought to work, but chooses the wrong version and then complains about the `bindgen` feature missing. (ref: https://github.com/rust-lang/cargo/issues/14832)

Instead, just splat the line into Cargo.toml with sed.