### PR TITLE
Avoid inefficient aws-lc-rs `open_within()`

### DIFF
--- a/rustls/src/msgs/message/inbound.rs
+++ b/rustls/src/msgs/message/inbound.rs
@@ -1,4 +1,4 @@
-use core::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut, Range};
 
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{Error, PeerMisbehaved};
@@ -35,6 +35,21 @@ impl<'a> InboundOpaqueMessage<'a> {
             typ: self.typ,
             version: self.version,
             payload: self.payload.into_inner(),
+        }
+    }
+
+    /// Force conversion into a plaintext message.
+    ///
+    /// `range` restricts the resulting message: this function panics if it is out of range for
+    /// the underlying message payload.
+    ///
+    /// This should only be used for messages that are known to be in plaintext. Otherwise, the
+    /// `InboundOpaqueMessage` should be decrypted into a `PlainMessage` using a `MessageDecrypter`.
+    pub fn into_plain_message_range(self, range: Range<usize>) -> InboundPlainMessage<'a> {
+        InboundPlainMessage {
+            typ: self.typ,
+            version: self.version,
+            payload: &self.payload.into_inner()[range],
         }
     }
 


### PR DESCRIPTION
`open_within` is a specialised function useful for the case where we want the plaintext to end up at a different location to the ciphertext.  In TLS1.2 GCM decryption we have:

```
  0                       8
  nn nn nn nn nn nn nn nn cc cc cc ...
  `---------------------' `----------'
      explicit nonce       ciphertext
```

And we want to shift the ciphertext left during decryption. (This is, in fact, much less important now our message decryption functions return a borrow of the input buffer.)

In *ring*, this API is implemented by writing the plaintext to the desired location during decryption, making it entirely free.

In aws-lc-rs, this API is implemented by doing the decryption in-place, and then using `copy_within` to do the offsetting. This is not free.  `rustls-graviola` does the same thing.

Avoid it by adding a new `InboundOpaqueMessage::into_plain_message()` variant which accepts the subrange of the plaintext.

This only affects the receive direction of TLS1.2 GCM suites. But the improvement is very much worth having:

| test | vers | suite | frag | direction | before | after | unit | diff |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| bulk | TLSv1_2 | TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 | max_fragment_size:default | recv | 8828.1 | 9353.55 | MB/s | +6% |
| bulk-unbuffered | TLSv1_2 | TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 | max_fragment_size:default | recv | 10439.4 | 11354.4 | MB/s | +8.8% |
| bulk | TLSv1_2 | TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 | max_fragment_size:default | recv | 8003.23 | 8565.64 | MB/s | +7% |
| bulk-unbuffered | TLSv1_2 | TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 | max_fragment_size:default | recv | 9185.1 | 9917.08 | MB/s | +8% |

(measured on my laptop, not comparable to other numbers.)

This also should address the slightly mysterious closeness seen on this graph.

![image](https://github.com/user-attachments/assets/85997bb2-6fd8-4c9b-aa09-c7ce89408b7b)
