### PR TITLE
Normalise syntax of `test_for_each_provider!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a82271f7bc033d84bbca59a3ce3e4159938cb08a9c3aebbe54d215131518a13"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dd856d451cc0da70e2ef2ce95a18e39a93b7558bedf10201ad28503f918568"
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2264,7 @@ dependencies = [
  "hashbrown",
  "hex",
  "log",
+ "macro_rules_attribute",
  "num-bigint",
  "once_cell",
  "rcgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ hpke-rs-crypto = "0.2"
 hpke-rs-rust-crypto = "0.2"
 itertools = "0.13"
 log = { version = "0.4.8" }
+macro_rules_attribute = "0.2"
 mio = { version = "1", features = ["net", "os-poll"] }
 num-bigint = "0.4.4"
 once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -52,6 +52,7 @@ bencher = { workspace = true }
 env_logger = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
+macro_rules_attribute = { workspace = true }
 num-bigint = { workspace = true }
 rcgen = { workspace = true }
 serde = { workspace = true }

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -276,13 +276,15 @@ impl client::ResolvesClientCert for AlwaysResolvesClientRawPublicKeys {
     }
 }
 
-test_for_each_provider! {
+#[cfg(test)]
+#[macro_rules_attribute::apply(test_for_each_provider)]
+mod tests {
     use alloc::sync::Arc;
     use std::prelude::v1::*;
 
     use pki_types::{ServerName, UnixTime};
-    use provider::cipher_suite;
 
+    use super::provider::cipher_suite;
     use super::NoClientSessionStorage;
     use crate::client::ClientSessionStore;
     use crate::msgs::base::PayloadU16;
@@ -328,7 +330,8 @@ test_for_each_provider! {
             c.remove_tls12_session(&name);
         }
 
-        let SupportedCipherSuite::Tls13(tls13_suite) = cipher_suite::TLS13_AES_256_GCM_SHA384 else {
+        let SupportedCipherSuite::Tls13(tls13_suite) = cipher_suite::TLS13_AES_256_GCM_SHA384
+        else {
             unreachable!();
         };
         c.insert_tls13_ticket(

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -212,13 +212,14 @@ impl quic::Algorithm for KeyBuilder {
     }
 }
 
-test_for_each_provider! {
+#[cfg(test)]
+#[macro_rules_attribute::apply(test_for_each_provider)]
+mod tests {
     use std::dbg;
 
-    use provider::tls13::{
+    use super::provider::tls13::{
         TLS13_AES_128_GCM_SHA256_INTERNAL, TLS13_CHACHA20_POLY1305_SHA256_INTERNAL,
     };
-
     use crate::common_state::Side;
     use crate::crypto::tls13::OkmBlock;
     use crate::quic::*;

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -183,9 +183,10 @@ impl Clone for HandshakeHash {
     }
 }
 
-test_for_each_provider! {
-    use provider::hash::SHA256;
-
+#[cfg(test)]
+#[macro_rules_attribute::apply(test_for_each_provider)]
+mod tests {
+    use super::provider::hash::SHA256;
     use super::*;
     use crate::crypto::hash::Hash;
     use crate::enums::{HandshakeType, ProtocolVersion};

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -391,6 +391,7 @@ mod log {
     pub(crate) use {_warn as warn, debug, error, trace};
 }
 
+#[cfg(test)]
 #[macro_use]
 mod test_macros;
 

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -240,14 +240,16 @@ pub enum ConnectionTrafficSecrets {
     },
 }
 
-test_for_each_provider! {
+#[cfg(test)]
+#[macro_rules_attribute::apply(test_for_each_provider)]
+mod tests {
     use std::println;
 
-    use provider::tls13::*;
+    use super::provider::tls13::*;
 
     #[test]
     fn test_scs_is_debug() {
-        println!("{:?}", provider::ALL_CIPHER_SUITES);
+        println!("{:?}", super::provider::ALL_CIPHER_SUITES);
     }
 
     #[test]

--- a/rustls/src/test_macros.rs
+++ b/rustls/src/test_macros.rs
@@ -5,17 +5,22 @@
 /// The selected provider module is bound as `provider`; you can rely on this
 /// having the union of the items common to the `crypto::ring` and
 /// `crypto::aws_lc_rs` modules.
+#[cfg(test)]
 macro_rules! test_for_each_provider {
     ($($tt:tt)+) => {
-        #[cfg(all(test, feature = "ring"))]
+        #[cfg(feature = "ring")]
         mod test_with_ring {
             use crate::crypto::ring as provider;
+            #[allow(unused_imports)]
+            use super::*;
             $($tt)+
         }
 
-        #[cfg(all(test, feature = "aws_lc_rs"))]
+        #[cfg(feature = "aws_lc_rs")]
         mod test_with_aws_lc_rs {
             use crate::crypto::aws_lc_rs as provider;
+            #[allow(unused_imports)]
+            use super::*;
             $($tt)+
         }
     };
@@ -26,32 +31,41 @@ macro_rules! test_for_each_provider {
 /// The selected provider module is bound as `provider`; you can rely on this
 /// having the union of the items common to the `crypto::ring` and
 /// `crypto::aws_lc_rs` modules.
+#[cfg(bench)]
 macro_rules! bench_for_each_provider {
     ($($tt:tt)+) => {
-        #[cfg(all(bench, feature = "ring"))]
+        #[cfg(feature = "ring")]
         mod bench_with_ring {
             use crate::crypto::ring as provider;
+            #[allow(unused_imports)]
+            use super::*;
             $($tt)+
         }
 
-        #[cfg(all(bench, feature = "aws_lc_rs"))]
+        #[cfg(feature = "aws_lc_rs")]
         mod bench_with_aws_lc_rs {
             use crate::crypto::aws_lc_rs as provider;
+            #[allow(unused_imports)]
+            use super::*;
             $($tt)+
         }
     };
 }
 
-test_for_each_provider! {
+#[cfg(test)]
+#[macro_rules_attribute::apply(test_for_each_provider)]
+mod tests {
     #[test]
     fn test_each_provider() {
-        std::println!("provider is {:?}", provider::default_provider());
+        std::println!("provider is {:?}", super::provider::default_provider());
     }
 }
 
-bench_for_each_provider! {
+#[cfg(all(test, bench))]
+#[macro_rules_attribute::apply(bench_for_each_provider)]
+mod benchmarks {
     #[bench]
     fn bench_each_provider(b: &mut test::Bencher) {
-        b.iter(|| provider::default_provider());
+        b.iter(|| super::provider::default_provider());
     }
 }

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -338,9 +338,10 @@ pub(crate) fn decode_kx_params<'a, T: KxDecode<'a>>(
 
 pub(crate) const DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01];
 
-test_for_each_provider! {
-    use provider::kx_group::X25519;
-
+#[cfg(test)]
+#[macro_rules_attribute::apply(test_for_each_provider)]
+mod tests {
+    use super::provider::kx_group::X25519;
     use super::*;
     use crate::common_state::{CommonState, Side};
     use crate::msgs::handshake::{ServerEcdhParams, ServerKeyExchangeParams};

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -898,16 +898,17 @@ where
     f(expander, info)
 }
 
-test_for_each_provider! {
+#[cfg(test)]
+#[macro_rules_attribute::apply(test_for_each_provider)]
+mod tests {
     use core::fmt::Debug;
     use std::prelude::v1::*;
     use std::vec;
 
-    use provider::ring_like::aead;
-    use provider::tls13::{
+    use super::provider::ring_like::aead;
+    use super::provider::tls13::{
         TLS13_AES_128_GCM_SHA256_INTERNAL, TLS13_CHACHA20_POLY1305_SHA256_INTERNAL,
     };
-
     use super::{derive_traffic_iv, derive_traffic_key, KeySchedule, SecretKind};
     use crate::KeyLog;
 
@@ -1085,13 +1086,15 @@ test_for_each_provider! {
     }
 }
 
-bench_for_each_provider! {
+#[cfg(all(test, bench))]
+#[macro_rules_attribute::apply(bench_for_each_provider)]
+mod benchmarks {
     #[bench]
     fn bench_sha256(b: &mut test::Bencher) {
         use core::fmt::Debug;
 
+        use super::provider::tls13::TLS13_CHACHA20_POLY1305_SHA256_INTERNAL;
         use super::{derive_traffic_iv, derive_traffic_key, KeySchedule, SecretKind};
-        use provider::tls13::TLS13_CHACHA20_POLY1305_SHA256_INTERNAL;
         use crate::KeyLog;
 
         fn extract_traffic_secret(ks: &KeySchedule, kind: SecretKind) {
@@ -1109,8 +1112,7 @@ bench_for_each_provider! {
                 .expander_for_okm(&traffic_secret);
             test::black_box(derive_traffic_key(
                 traffic_secret_expander.as_ref(),
-                TLS13_CHACHA20_POLY1305_SHA256_INTERNAL
-                    .aead_alg,
+                TLS13_CHACHA20_POLY1305_SHA256_INTERNAL.aead_alg,
             ));
             test::black_box(derive_traffic_iv(traffic_secret_expander.as_ref()));
         }

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -13,7 +13,9 @@ use crate::crypto::CryptoProvider;
 use crate::verify::ServerCertVerifier;
 use crate::webpki::{RootCertStore, WebPkiServerVerifier};
 
-bench_for_each_provider! {
+#[macro_rules_attribute::apply(bench_for_each_provider)]
+mod benchmarks {
+    use super::provider;
     use super::Context;
 
     #[bench]

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -428,7 +428,9 @@ pub(crate) enum AnonymousClientPolicy {
     Deny,
 }
 
-test_for_each_provider! {
+#[cfg(test)]
+#[macro_rules_attribute::apply(test_for_each_provider)]
+mod tests {
     use std::prelude::v1::*;
     use std::sync::Arc;
     use std::{format, println, vec};
@@ -436,7 +438,7 @@ test_for_each_provider! {
     use pki_types::pem::PemObject;
     use pki_types::{CertificateDer, CertificateRevocationListDer};
 
-    use super::WebPkiClientVerifier;
+    use super::{provider, WebPkiClientVerifier};
     use crate::server::VerifierBuilderError;
     use crate::RootCertStore;
 

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -300,7 +300,9 @@ impl ServerCertVerifier for WebPkiServerVerifier {
     }
 }
 
-test_for_each_provider! {
+#[cfg(test)]
+#[macro_rules_attribute::apply(test_for_each_provider)]
+mod tests {
     use std::prelude::v1::*;
     use std::sync::Arc;
     use std::{println, vec};
@@ -308,7 +310,7 @@ test_for_each_provider! {
     use pki_types::pem::PemObject;
     use pki_types::{CertificateDer, CertificateRevocationListDer};
 
-    use super::{VerifierBuilderError, WebPkiServerVerifier};
+    use super::{provider, VerifierBuilderError, WebPkiServerVerifier};
     use crate::RootCertStore;
 
     fn load_crls(crls_der: &[&[u8]]) -> Vec<CertificateRevocationListDer<'static>> {


### PR DESCRIPTION
This uses `macro_rules_attribute` (a new dev-dep) to apply a declarative macro as a proc macro.  That has the advantage that the use-site syntax is standard rust, which means rustfmt can format it.

(If we agree this is a good direction, I will later do something similar to the integration tests.)