### PR TITLE
rustls-bench: fix warnings with no features

### DIFF
--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -867,6 +867,8 @@ enum Provider {
     AwsLcRsFips,
     #[cfg(feature = "ring")]
     Ring,
+    #[value(skip)]
+    _None, // prevents this enum being uninhabited when built with no features
 }
 
 impl Provider {
@@ -878,6 +880,7 @@ impl Provider {
             Self::AwsLcRsFips => rustls::crypto::default_fips_provider(),
             #[cfg(feature = "ring")]
             Self::Ring => rustls::crypto::ring::default_provider(),
+            Self::_None => unreachable!(),
         }
     }
 
@@ -889,6 +892,7 @@ impl Provider {
             Self::AwsLcRsFips => rustls::crypto::aws_lc_rs::Ticketer::new(),
             #[cfg(feature = "ring")]
             Self::Ring => rustls::crypto::ring::Ticketer::new(),
+            Self::_None => unreachable!(),
         }
     }
 


### PR DESCRIPTION
This is a kind of degenerate case, and the program will panic with "no providers available in this build".