### PR TITLE
ML-KEM-only key agreement

### DIFF
--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "cryptography"]
 
 [dependencies]
 rustls = { version = "0.23.2", features = ["aws_lc_rs"], path = "../rustls" }
-aws-lc-rs = { version = "1.9", features = ["non-fips", "unstable"], default-features = false }
+aws-lc-rs = { version = "1.10", features = ["non-fips", "unstable"], default-features = false }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/rustls-post-quantum/src/lib.rs
+++ b/rustls-post-quantum/src/lib.rs
@@ -63,7 +63,7 @@ use rustls::{Error, NamedGroup, PeerMisbehaved, ProtocolVersion};
 
 mod mlkem;
 
-use crate::mlkem::MLKEM768;
+pub use mlkem::MLKEM768;
 
 /// A `CryptoProvider` which includes `X25519MLKEM768`, `MLKEM512`,
 /// `MLKEM768`, and `MLKEM1024` key exchanges.
@@ -74,7 +74,9 @@ pub fn provider() -> CryptoProvider {
         .kx_groups
         .insert(0, &X25519MLKEM768);
 
-    parent.kx_groups.insert(1, &MLKEM768);
+    parent
+        .kx_groups
+        .insert(1, &crate::mlkem::MLKEM768);
 
     parent
 }

--- a/rustls-post-quantum/src/mlkem.rs
+++ b/rustls-post-quantum/src/mlkem.rs
@@ -8,8 +8,6 @@ use rustls::crypto::{ActiveKeyExchange, CompletedKeyExchange, SharedSecret, Supp
 use rustls::ffdhe_groups::FfdheGroup;
 use rustls::{Error, NamedGroup, PeerMisbehaved, ProtocolVersion};
 
-use crate::MLKEM768_ENCAP_LEN;
-
 /// This is the [MLKEM] key exchange.
 ///
 /// [MLKEM]: https://datatracker.ietf.org/doc/draft-connolly-tls-mlkem-key-agreement

--- a/rustls-post-quantum/src/mlkem.rs
+++ b/rustls-post-quantum/src/mlkem.rs
@@ -1,0 +1,105 @@
+use aws_lc_rs::kem;
+use aws_lc_rs::unstable::kem::{
+    // ML_KEM_1024, ML_KEM_512,
+    ML_KEM_768,
+};
+use rustls::crypto::aws_lc_rs::{default_provider, kx_group};
+use rustls::crypto::{ActiveKeyExchange, CompletedKeyExchange, SharedSecret, SupportedKxGroup};
+use rustls::ffdhe_groups::FfdheGroup;
+use rustls::{Error, NamedGroup, PeerMisbehaved, ProtocolVersion};
+
+use crate::MLKEM768_ENCAP_LEN;
+
+/// This is the [MLKEM] key exchange.
+///
+/// [MLKEM]: https://datatracker.ietf.org/doc/draft-connolly-tls-mlkem-key-agreement
+#[derive(Debug)]
+pub struct MLKEM768;
+
+impl SupportedKxGroup for MLKEM768 {
+    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
+        let decaps_key = kem::DecapsulationKey::generate(&ML_KEM_768)
+            .map_err(|_| Error::FailedToGetRandomBytes)?;
+
+        let encaps_key = decaps_key
+            .encapsulation_key()
+            .map_err(|_| Error::FailedToGetRandomBytes)?;
+
+        let pub_key_bytes = encaps_key.key_bytes().unwrap();
+
+        Ok(Box::new(Active {
+            decaps_key: Box::new(decaps_key),
+            encaps_key_bytes: Vec::from(pub_key_bytes.as_ref()),
+        }))
+    }
+
+    fn start_and_complete(&self, client_share: &[u8]) -> Result<CompletedKeyExchange, Error> {
+        let (ciphertext, shared_secret) = kem::EncapsulationKey::new(&ML_KEM_768, client_share)
+            .map_err(|_| INVALID_KEY_SHARE)
+            .and_then(|encaps_key| {
+                encaps_key
+                    .encapsulate()
+                    .map_err(|_| INVALID_KEY_SHARE)
+            })?;
+
+        Ok(CompletedKeyExchange {
+            group: self.name(),
+            pub_key: Vec::from(ciphertext.as_ref()),
+            secret: SharedSecret::from(shared_secret.as_ref()),
+        })
+    }
+
+    fn ffdhe_group(&self) -> Option<FfdheGroup<'static>> {
+        None
+    }
+
+    fn name(&self) -> NamedGroup {
+        NAMED_GROUP
+    }
+
+    fn usable_for_version(&self, version: ProtocolVersion) -> bool {
+        version == ProtocolVersion::TLSv1_3
+    }
+}
+
+struct Active {
+    decaps_key: Box<kem::DecapsulationKey<kem::AlgorithmId>>,
+    encaps_key_bytes: Vec<u8>,
+}
+
+impl ActiveKeyExchange for Active {
+    // The received 'peer_pub_key' is actually the ML-KEM ciphertext,
+    // which when decapsulated with our `decaps_key` produces the shared
+    // secret.
+    fn complete(self: Box<Self>, peer_pub_key: &[u8]) -> Result<SharedSecret, Error> {
+        let shared_secret = self
+            .decaps_key
+            .decapsulate(peer_pub_key.into())
+            .map_err(|_| INVALID_KEY_SHARE)?;
+
+        Ok(SharedSecret::from(shared_secret.as_ref()))
+    }
+
+    fn pub_key(&self) -> &[u8] {
+        &self.encaps_key_bytes
+    }
+
+    fn ffdhe_group(&self) -> Option<FfdheGroup<'static>> {
+        None
+    }
+
+    fn group(&self) -> NamedGroup {
+        NAMED_GROUP
+    }
+}
+
+// IANA TLS Supported Group value 262, 0x106
+//
+// https://www.iana.org/assignments/tls-para≈1meters/tls-parameters.xhtml#tls-parameters-8
+const NAMED_GROUP: NamedGroup = NamedGroup::Unknown(0x106);
+
+const INVALID_KEY_SHARE: Error = Error::PeerMisbehaved(PeerMisbehaved::InvalidKeyShare);
+
+const MLKEM768_CIPHERTEXT_LEN: usize = 1088;
+const MLKEM768_ENCAPS_KEY_LEN: usize = 1184;
+const MLKEM768_SHARED_SECRET_LEN: usize = 32;

--- a/rustls-post-quantum/src/mlkem.rs
+++ b/rustls-post-quantum/src/mlkem.rs
@@ -91,10 +91,10 @@ impl ActiveKeyExchange for Active {
     }
 }
 
-// IANA TLS Supported Group value 262, 0x106
+// IANA TLS Supported Group value 513, 0x0201
 //
 // https://www.iana.org/assignments/tls-para≈1meters/tls-parameters.xhtml#tls-parameters-8
-const NAMED_GROUP: NamedGroup = NamedGroup::Unknown(0x106);
+const NAMED_GROUP: NamedGroup = NamedGroup::Unknown(0x0201);
 
 const INVALID_KEY_SHARE: Error = Error::PeerMisbehaved(PeerMisbehaved::InvalidKeyShare);
 


### PR DESCRIPTION
This may be relevant to https://github.com/rustls/rustls/issues/2056

TLSWG has [approved ML-KEM-only codepoints](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8) for key agreement in TLS 1.3, this is a first stab at supporting that. Restructuring feedback welcome.

This is ML-KEM-768 to start, 512 and 1024 are planned but wanted to get eyes on the approach first.