### PR TITLE
fix codecov.io upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Report to codecov.io
         uses: codecov/codecov-action@v5
         with:
-          file: final.info
+          files: final.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 


### PR DESCRIPTION
This hasn't worked since taking the v5 uploader, because they replaced the `file` parameter with `files` @_@

(my bad, should've read the [release notes](https://github.com/codecov/codecov-action/releases/tag/v5.0.0))