### PR TITLE
once_cell dependency updates (for no-std usage)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ itertools = "0.13"
 log = { version = "0.4.8" }
 mio = { version = "1", features = ["net", "os-poll"] }
 num-bigint = "0.4.4"
-once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }
+once_cell = { version = "1.20.2", default-features = false }
 openssl = "0.10"
 p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecdsa", "pkcs8"] }
 pkcs8 = "0.10.2"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -23,8 +23,7 @@ brotli = { workspace = true, optional = true }
 brotli-decompressor = { workspace = true, optional = true }
 hashbrown = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
-# only required for no-std
-once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }
+once_cell = { workspace = true, default-features = false, features = ["alloc", "race"] } # only required for no-std
 ring = { workspace = true, optional = true }
 subtle = { workspace = true }
 webpki = { workspace = true }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -23,7 +23,7 @@ brotli = { workspace = true, optional = true }
 brotli-decompressor = { workspace = true, optional = true }
 hashbrown = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
-once_cell = { workspace = true, default-features = false, features = ["alloc", "race"] } # only required for no-std
+once_cell = { workspace = true, default-features = false, features = ["alloc", "race"] } # (only required for no-std)
 ring = { workspace = true, optional = true }
 subtle = { workspace = true }
 webpki = { workspace = true }


### PR DESCRIPTION
- specify most recent version in top-level `Cargo.toml`
- remove redundant version specifier from `rustls/Cargo.toml`
- specify required features in `rustls/Cargo.toml` instead of top-level `Cargo.toml`
- move comment to the end of the line for `once_cell` dependency in `rustls/Cargo.toml`

__RATIONALE - updated:__

I think this would help ensure downstream user is using the more recent version of `once_cell`, as I think would be needed with the updates I proposed in PR #2200.

It looks to me like `once_cell` is only required for `no-std`, and usage may change somewhat further if PR #2200 is accepted. I was thinking that putting everything for `once_cell` (except for version spec) together could help improve cohesiveness and help further preparations for PR #2200.