### PR TITLE
replace unnecessary use of .map_or() with .is_some_and()

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1107,7 +1107,7 @@ impl ClientHelloPayload {
     pub(crate) fn check_psk_ext_is_last(&self) -> bool {
         self.extensions
             .last()
-            .map_or(false, |ext| ext.ext_type() == ExtensionType::PreSharedKey)
+            .is_some_and(|ext| ext.ext_type() == ExtensionType::PreSharedKey)
     }
 
     pub(crate) fn psk_modes(&self) -> Option<&[PSKKeyExchangeMode]> {


### PR DESCRIPTION
I noticed a warning about this in the clippy nightly output, along with a nice-looking suggestion how to rework this.

---

TODO:

- [x] check CI build status