### PR TITLE
update minimum serde & test all features w/minimum dependency versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,8 +346,8 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
-      - name: Check direct-minimal-versions
-        run: cargo minimal-versions --direct --ignore-private check
+      - name: Test minimal-versions - direct (all features)
+        run: cargo minimal-versions --direct --ignore-private test --all-features
         working-directory: rustls/
 
   cross:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ rcgen = { version = "0.13", features = ["pem", "aws_lc_rs"], default-features = 
 regex = "1"
 ring = "0.17"
 rsa = { version = "0.9", features = ["sha2"], default-features = false }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1"
 sha2 = { version = "0.10", default-features = false }
 signature = "2"


### PR DESCRIPTION
rationale:

- minimum `serde` version `1.0.103` is required for `cargo minimal-versions --direct --ignore-private test` to work (with or without `--all-features` option), seems to be due to issue between `serde` pre-1.0.103 & test(s) in `rustls/src/crypto/aws_lc_rs/hpke.rs`
- test with minimum dependency versions, all features could help ensure updates like proposed PR #2200 continue working with outdated dependency versions, especially for `once_cell` & `portable-atomic`

Note that while the code DOES seem to build with `serde` back to `1.0.0`, bumping the minimum to `1.0.3` which is still 7 years old seems very reasonable to me.