### PR TITLE
CI: enable doc tests on all CI hosts (and update CI doc test comments)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,10 +81,9 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-      # nb. this is separate so it can be skipped on macOS & windows, where
-      # doctests don't work: https://github.com/rust-lang/cargo/issues/8531
+      # nb. this is separate since `--doc` option cannot be combined with other target option(s) ref:
+      # - https://doc.rust-lang.org/cargo/commands/cargo-test.html
       - name: cargo test --doc (release; all-features)
-        if: ${{ runner.os != 'macOS' && runner.os != 'Windows' }}
         run: cargo test --release --locked --all-features --doc
         env:
           RUST_BACKTRACE: 1


### PR DESCRIPTION
possible now that this issue has been resolved (already tried it in my own fork): https://github.com/rust-lang/cargo/issues/8531