### PR TITLE
Prepare 0.23.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "env_logger",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "rustls-post-quantum",
 ]
 
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2126,7 +2126,7 @@ name = "rustls-bench"
 version = "0.1.0"
 dependencies = [
  "clap",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "tikv-jemallocator",
 ]
 
@@ -2142,7 +2142,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "rayon",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "tikv-jemallocator",
 ]
 
@@ -2153,7 +2153,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "tokio",
 ]
 
@@ -2168,7 +2168,7 @@ dependencies = [
  "log",
  "mio 0.8.11",
  "rcgen",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "serde",
  "serde_derive",
  "tokio",
@@ -2184,7 +2184,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.18",
+ "rustls 0.23.19",
 ]
 
 [[package]]
@@ -2198,7 +2198,7 @@ name = "rustls-post-quantum"
 version = "0.2.0"
 dependencies = [
  "aws-lc-rs",
- "rustls 0.23.18",
+ "rustls 0.23.19",
 ]
 
 [[package]]
@@ -2218,7 +2218,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "rustls-webpki",
  "sha2",
  "signature",
@@ -2231,7 +2231,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "rustls-provider-example",
  "serde",
  "serde_json",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls-post-quantum/Cargo.lock
+++ b/rustls-post-quantum/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 edition = "2021"
 rust-version = "1.63"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
# Release notes:

This release is functionally equivalent to 0.23.18, except the MSRV has been relaxed back to 1.63. The next release, 0.23.20, will return to an MSRV of 1.71. This release is intended to give users with conservative MSRV requirements a release that contains the fix for [RUSTSEC-2024-0399](https://rustsec.org/advisories/RUSTSEC-2024-0399.html).

Note that this is a one-off; there will not be future releases with MSRV 1.63 (for future security fixes or otherwise).

# Reviewers note:

The target branch, rel-0.23.19, has its apex at v/0.23.17 with commits up to v/0.23.18 replayed onto it, except:

- 0a15f37b0adc4f6fb6f8543c5f7567b35c945cdd...d138a0c4ef571ad73626b18317112cfd2f34dded
- faca28904efcb3b5a4a5f05be8e03374bf5086df

ref #2239 

