### PR TITLE
Port version bump to 0.23.19 to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "env_logger",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "rustls-post-quantum",
 ]
 
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2286,7 +2286,7 @@ name = "rustls-bench"
 version = "0.1.0"
 dependencies = [
  "clap",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "tikv-jemallocator",
 ]
 
@@ -2302,7 +2302,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "rayon",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "tikv-jemallocator",
 ]
 
@@ -2313,7 +2313,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "tokio",
 ]
 
@@ -2328,7 +2328,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "serde",
  "tokio",
  "webpki-roots",
@@ -2343,7 +2343,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.18",
+ "rustls 0.23.19",
 ]
 
 [[package]]
@@ -2357,7 +2357,7 @@ name = "rustls-post-quantum"
 version = "0.2.0"
 dependencies = [
  "aws-lc-rs",
- "rustls 0.23.18",
+ "rustls 0.23.19",
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "rustls-webpki",
  "sha2",
  "signature",
@@ -2390,7 +2390,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.23.18",
+ "rustls 0.23.19",
  "rustls-provider-example",
  "serde",
  "serde_json",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls-post-quantum/Cargo.lock
+++ b/rustls-post-quantum/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
The 0.23.19 release prep PR bumped the version number on a release branch to enable the one-off old-MSRV-with-security-fix release. However, this resulted in a strange `Cargo.lock` release on main because the workspace-local rustls was one release (0.23.18) behind the crates.io rustls (0.23.19). Port the version number bump PR (via `git cherry-pick`) to main to bring things back in sync.