### PR TITLE
docs: reduce permission scope

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@ name: documentation
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 on:
   workflow_dispatch:
@@ -85,6 +83,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'rustls/rustls'
     needs: generate
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -92,4 +93,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-


### PR DESCRIPTION
Only the `deploy` task needs the "pages/id-token:write" permissions. Let's try to limit the potential for badness by only giving that specific job step elevated permission instead of doing it at the workflow level.

This was [flagged](https://woodruffw.github.io/zizmor/audits/#remediation_2) by running Zizmor on the `.github/workflows` dir with Zizmor 0.7.0 in offline mode and seems like a sensible idea.

If you run this tool in **online** mode w/ a `GH_TOKEN` it also flags several [ref-confusion](https://woodruffw.github.io/zizmor/audits/#ref-confusion) findings for our usage of [install-action](https://github.com/taiki-e/install-action). I'm not 100% sure why it didn't flag the other instances where we specify dependent actions by tag (e.g. `checkout@v4`), but the fix in either case is to [pin our actions by SHA hash](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash). Since that's a bit more invasive I haven't made that change yet pending some discussion on whether it's something folks are on-board for.