### PR TITLE
docs: update CONTRIBUTING.md to mention `mod` order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,10 @@ single user, or just a few co-located users).
 
 The `#[cfg(test)] mod tests {}` module goes on the very bottom, if present.
 
+When defining new module definitions with `mod` they should be placed after
+private `use`'s, and before `pub use`'s. Files that have many `mod`'s should aim
+to avoid non-trivial code alongside the module definitions.
+
 #### Ordering for a given type
 
 For a given type, we prefer to order items as follows:


### PR DESCRIPTION
Consensus from https://github.com/rustls/rustls/pull/2259#discussion_r1871801247 is that we prefer to order:

1. private `use`'s
2. `mod`'s
3. `pub use`'s

Also note that if there are a lot of `mod`'s (e.g. for a `lib.rs`) there should probably not be any non-trivial code alongside.