### PR TITLE
examples: use inner hostname in ech-client HTTPS DNS query

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -117,13 +117,13 @@ jobs:
 
       - name: Check ech-client (research.cloudflare.com)
         run: >
-          cargo run --locked -p rustls-examples --bin ech-client -- research.cloudflare.com cloudflare.com --path /cdn-cgi/trace |
+          cargo run --locked -p rustls-examples --bin ech-client -- cloudflare-ech.com research.cloudflare.com --path /cdn-cgi/trace |
             grep 'sni=encrypted'
 
       - name: Check ech-client (defo.ie)
         run: >
-          cargo run --locked -p rustls-examples --bin ech-client -- --host defo.ie defo.ie www.defo.ie |
-            grep 'SSL_ECH_STATUS: success'
+          cargo run --locked -p rustls-examples --bin ech-client -- --host min-ng.test.defo.ie --path "echstat.php?format=json" public.test.defo.ie min-ng.test.defo.ie |
+            grep '"SSL_ECH_STATUS": "success"'
 
       - name: Check provider-example client
         run: cargo run --locked -p rustls-provider-example --example client

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -54,7 +54,7 @@ async fn main() {
         true => None, // Force the use of the GREASE ext by skipping ECH config lookup
         false => match args.ech_config {
             Some(path) => Some(read_ech(&path)),
-            None => lookup_ech_configs(&resolver, &args.outer_hostname, args.port).await,
+            None => lookup_ech_configs(&resolver, &args.inner_hostname, args.port).await,
         },
     };
 


### PR DESCRIPTION
In the `ech-client.rs` example we want to look up the _inner_ hostname's HTTPS SRV record to get an ECH config to use, not the outer hostname. Importantly the inner hostname isn't leaked by this process because we're using DNS-over-HTTPS. This fell unnoticed because the test servers we were using had a workable ECH config queryable with the outer hostname by happenstance.

This branch fixes the example bug and adjusts the daily-tests CI config accordingly. Here's an example [passing run](https://github.com/cpu/rustls/actions/runs/12262136237) from a manual dispatch.

Thanks to @sftcd for noticing :-)

