### PR TITLE
fix rustls-provider-example hpke no-std support

### DIFF
--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -1,8 +1,6 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
-use std::error::Error as StdError;
 
 use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
 use hpke_rs_crypto::HpkeCrypto;
@@ -214,13 +212,13 @@ impl HpkeOpener for HpkeRsReceiver {
 }
 
 #[cfg(feature = "std")]
-fn other_err(err: impl StdError + Send + Sync + 'static) -> Error {
-    Error::Other(OtherError(Arc::new(err)))
+fn other_err(err: impl std::error::Error + Send + Sync + 'static) -> Error {
+    Error::Other(OtherError(alloc::sync::Arc::new(err)))
 }
 
 #[cfg(not(feature = "std"))]
-fn other_err(err: impl Send + Sync + 'static) -> Error {
-    Error::General(alloc::format!("{}", err));
+fn other_err(_err: impl core::any::Any) -> Error {
+    Error::Other(OtherError())
 }
 
 #[cfg(test)]

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -12,7 +12,6 @@ use rustls::pki_types::PrivateKeyDer;
 mod aead;
 mod hash;
 mod hmac;
-#[cfg(feature = "std")]
 pub mod hpke;
 mod kx;
 mod sign;


### PR DESCRIPTION
(with some very minor refactoring)

---

should be finally ready now ... apologies for so much noise ... looks like codecov is complaining about 2 lines of code for `no-std` since I don't think we can unit-test this; I don't think this should be an issue since CI does already verify that we can compile this for `no-std`