### PR TITLE
server: remove ClientHello constructor

### DIFF
--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -200,9 +200,9 @@ impl server::ResolvesServerCert for AlwaysResolvesChain {
 }
 
 /// An exemplar `ResolvesServerCert` implementation that always resolves to a single
-/// [RFC 7250] raw public key.  
+/// [RFC 7250] raw public key.
 ///
-/// [RFC 7250]: https://tools.ietf.org/html/rfc7250  
+/// [RFC 7250]: https://tools.ietf.org/html/rfc7250
 #[derive(Clone, Debug)]
 pub struct AlwaysResolvesServerRawPublicKeys(Arc<sign::CertifiedKey>);
 
@@ -306,7 +306,14 @@ mod sni_resolver {
         fn test_resolvesservercertusingsni_requires_sni() {
             let rscsni = ResolvesServerCertUsingSni::new();
             assert!(rscsni
-                .resolve(ClientHello::new(&None, &[], None, None, None, &[]))
+                .resolve(ClientHello {
+                    server_name: &None,
+                    signature_schemes: &[],
+                    alpn: None,
+                    server_cert_types: None,
+                    client_cert_types: None,
+                    cipher_suites: &[]
+                })
                 .is_none());
         }
 
@@ -317,7 +324,14 @@ mod sni_resolver {
                 .unwrap()
                 .to_owned();
             assert!(rscsni
-                .resolve(ClientHello::new(&Some(name), &[], None, None, None, &[]))
+                .resolve(ClientHello {
+                    server_name: &Some(name),
+                    signature_schemes: &[],
+                    alpn: None,
+                    server_cert_types: None,
+                    client_cert_types: None,
+                    cipher_suites: &[]
+                })
                 .is_none());
         }
     }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -400,14 +400,15 @@ impl ExpectClientHello {
 
         // Choose a certificate.
         let certkey = {
-            let client_hello = ClientHello::new(
-                &cx.data.sni,
-                &sig_schemes,
-                client_hello.alpn_extension(),
-                client_hello.server_certificate_extension(),
-                client_hello.client_certificate_extension(),
-                &client_hello.cipher_suites,
-            );
+            let client_hello = ClientHello {
+                server_name: &cx.data.sni,
+                signature_schemes: &sig_schemes,
+                alpn: client_hello.alpn_extension(),
+                client_cert_types: client_hello.server_certificate_extension(),
+                server_cert_types: client_hello.client_certificate_extension(),
+                cipher_suites: &client_hello.cipher_suites,
+            };
+            trace!("Resolving server certificate: {client_hello:#?}");
 
             let certkey = self
                 .config


### PR DESCRIPTION
Slightly fewer lines of code via logging abstraction and better readability. Worth it?

cc @s-arash from reviewing #2265.