### PR TITLE
Release notes for rustls 0.23.20 & rustls-post-quantum 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,7 +2331,7 @@ checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-post-quantum"
-version = "0.3.0"
+version = "0.2.0"
 dependencies = [
  "aws-lc-rs",
  "rustls 0.23.20",

--- a/rustls-post-quantum/Cargo.lock
+++ b/rustls-post-quantum/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-post-quantum"
-version = "0.3.0"
+version = "0.2.0"
 dependencies = [
  "aws-lc-rs",
  "env_logger",

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-post-quantum"
-version = "0.3.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls-post-quantum/src/lib.rs
+++ b/rustls-post-quantum/src/lib.rs
@@ -4,11 +4,11 @@
 //! post-quantum-secure key exchange algorithm.
 //!
 //! X25519MLKEM768 is pre-standardization, so you should treat
-//! this as experimental.  You may see unexpected interop failures, and
-//! the algorithm implemented here may not be the one that eventually
-//! becomes widely deployed.
+//! this as experimental.  You may see unexpected connection failures (such as [tldr.fail])
+//! -- [please report these to us][interop-bug].  X25519MLKEM768 is becoming widely
+//! deployed, eg, by [Chrome] and [Cloudflare].
 //!
-//! However, the two components of this key exchange are well regarded:
+//! The two components of this key exchange are well regarded:
 //! X25519 alone is already used by default by rustls, and tends to have
 //! higher quality implementations than other elliptic curves.
 //! ML-KEM-768 was standardized by NIST in [FIPS203].
@@ -25,6 +25,11 @@
 //!
 //! [X25519MLKEM768]: <https://datatracker.ietf.org/doc/draft-kwiatkowski-tls-ecdhe-mlkem/>
 //! [FIPS203]: <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf>
+//! [Chrome]: <https://security.googleblog.com/2024/09/a-new-path-for-kyber-on-web.html>
+//! [Cloudflare]: <https://blog.cloudflare.com/pq-2024/#ml-kem-768-and-x25519>
+//! [interop-bug]: <https://github.com/rustls/rustls/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=>
+//! [tldr.fail]: <https://tldr.fail/>
+//!
 //!
 //! # How to use this crate
 //!

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -15,8 +15,7 @@ use crate::webpki::{RootCertStore, WebPkiServerVerifier};
 
 #[macro_rules_attribute::apply(bench_for_each_provider)]
 mod benchmarks {
-    use super::provider;
-    use super::Context;
+    use super::{provider, Context};
 
     #[bench]
     fn reddit_cert(b: &mut test::Bencher) {


### PR DESCRIPTION
# Draft release notes for 0.23.20

* **Support hybrid key exchange optimization**: this improves efficiency of hybrid post-quantum key exchanges when the classical half of the hybrid is selected, which will be common during the post-quantum transition. This optimization is described in and allowed by [draft-ietf-tls-hybrid-design](https://datatracker.ietf.org/doc/draft-ietf-tls-hybrid-design/); we plan to produce a short report soon illustrating its benefits.

This release, like 0.23.18, has an MSRV of 1.71. We are aware of a [compiler bug in 1.71](https://github.com/rust-lang/rust/issues/133578) that may affect rustls and recommend 1.73 or later.

# Draft release notes for pq 0.2.0

* **Move to standardized X25519MLKEM768**. This removes support for the previous -- pre-standardization -- X25519Kyber768Draft00, which is a breaking change.
* **Support MLKEM768 separately**. Thanks to @dconnolly.

In the near future we plan to integrate rustls-post-quantum into the core rustls crate.