### PR TITLE
Fix RFC 7250 Compliance (#2257)

### DIFF
--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -329,6 +329,9 @@ mod tests {
     use std::sync::mpsc::channel;
     use std::thread;
 
+    use rustls::pki_types::pem::PemObject;
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
     use super::{client, server};
     use crate::utils::verify_openssl3_available;
 
@@ -383,6 +386,56 @@ mod tests {
                 panic!("Server failed to communicate with the client: {:?}", e);
             }
         }
+    }
+
+    #[test]
+    fn test_rust_x509_server_with_openssl_raw_key_and_x509_client() {
+        verify_openssl3_available();
+
+        let listener = tcp_listener();
+        let port = listener.local_addr().unwrap().port();
+
+        let cert_file = SERVER_CERT_KEY_FILE;
+        let private_key_file = SERVER_PRIV_KEY_FILE;
+
+        let certs = CertificateDer::pem_file_iter(cert_file)
+            .unwrap()
+            .map(|cert| cert.unwrap())
+            .collect();
+        let private_key = PrivateKeyDer::from_pem_file(private_key_file).unwrap();
+        let config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, private_key)
+            .unwrap();
+        let server_thread = thread::spawn(move || {
+            server::run_server(config, listener).expect("failed to run server to completion")
+        });
+
+        // Start the OpenSSL client
+        let mut openssl_client = Command::new("openssl")
+            .arg("s_client")
+            .arg("-connect")
+            .arg(format!("[::]:{:?}", port))
+            .arg("-enable_client_rpk")
+            .arg("-key")
+            .arg(CLIENT_PRIV_KEY_FILE)
+            .arg("-cert")
+            .arg(CLIENT_CERT_KEY_FILE)
+            .arg("-tls1_3")
+            .arg("-debug")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to execute OpenSSL client");
+
+        let stdin = openssl_client.stdin.take().unwrap();
+        let stdout = openssl_client.stdout.take().unwrap();
+        let received_server_msg =
+            process_openssl_client_interaction(stdin, stdout, "Hello, from openssl client!");
+
+        assert!(received_server_msg);
+        assert_eq!(server_thread.join().unwrap(), "Hello, from openssl client!");
+        openssl_client.wait().unwrap();
     }
 
     #[test]

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -11,7 +11,7 @@ use crate::log::{debug, error, warn};
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::{AlertLevel, ExtensionType, KeyUpdateRequest};
+use crate::msgs::enums::{AlertLevel, KeyUpdateRequest};
 use crate::msgs::fragmenter::MessageFragmenter;
 use crate::msgs::handshake::{CertificateChain, HandshakeMessagePayload};
 use crate::msgs::message::{
@@ -24,7 +24,7 @@ use crate::suites::{PartiallyExtractedSecrets, SupportedCipherSuite};
 use crate::tls12::ConnectionSecrets;
 use crate::unbuffered::{EncryptError, InsufficientSizeError};
 use crate::vecbuf::ChunkVecBuffer;
-use crate::{quic, record_layer, PeerIncompatible};
+use crate::{quic, record_layer};
 
 /// Connection state common to both client and server connections.
 pub struct CommonState {
@@ -898,35 +898,6 @@ enum Limit {
     #[cfg(feature = "std")]
     Yes,
     No,
-}
-
-#[derive(Debug)]
-pub(super) struct RawKeyNegotiationParams {
-    pub(super) peer_supports_raw_key: bool,
-    pub(super) local_expects_raw_key: bool,
-    pub(super) extension_type: ExtensionType,
-}
-
-impl RawKeyNegotiationParams {
-    pub(super) fn validate_raw_key_negotiation(&self) -> RawKeyNegotationResult {
-        match (self.local_expects_raw_key, self.peer_supports_raw_key) {
-            (true, true) => RawKeyNegotationResult::Negotiated(self.extension_type),
-            (false, false) => RawKeyNegotationResult::NotNegotiated,
-            (true, false) => RawKeyNegotationResult::Err(Error::PeerIncompatible(
-                PeerIncompatible::IncorrectCertificateTypeExtension,
-            )),
-            (false, true) => RawKeyNegotationResult::Err(Error::PeerIncompatible(
-                PeerIncompatible::UnsolicitedCertificateTypeExtension,
-            )),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) enum RawKeyNegotationResult {
-    Negotiated(ExtensionType),
-    NotNegotiated,
-    Err(Error),
 }
 
 /// Tracking technically-allowed protocol actions


### PR DESCRIPTION
This pull requests fixes issue #2257 by changing the way the server validates the `client_certificate_type_extension` and the `server_certificate_type_extension` in the `ServerHello`.  

Considerations
- Initially the validation logic for the certificate type extensions resided in `common_state` and validated the negotation of raw keys only, hence we called the struct `RawKeyNegotationParams`. The validation logic is different for the server and client now and we are not only negotiating raw keys, I moved this to `client::hs::CertificateTypeExtensionParams` and `server::hs::CertificateTypeExtensionParams`.