### PR TITLE
improve provider-example CI testing & coverage testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,8 +104,14 @@ jobs:
       - name: cargo build (debug; rustls-provider-example lib in no-std mode)
         run: cargo build --locked -p rustls-provider-example --no-default-features
 
+      - name: cargo test (debug; rustls-provider-example; all features)
+        run: cargo test --all-features -p rustls-provider-example
+
       - name: cargo build (debug; rustls-provider-test)
         run: cargo build --locked -p rustls-provider-test
+
+      - name: cargo test (debug; rustls-provider-test; all features)
+        run: cargo test --all-features -p rustls-provider-test
 
       - name: cargo package --all-features -p rustls
         run: cargo package --all-features -p rustls

--- a/admin/coverage
+++ b/admin/coverage
@@ -17,7 +17,10 @@ cargo test --locked $(admin/all-features-except brotli rustls)
 ## bogo
 cargo test --locked --test bogo -- --ignored --test-threads 1
 
-## provider tests
+# provider example unit tests
+cargo test --locked --package rustls-provider-example
+
+## provider example tests
 cargo test --locked --package rustls-provider-test
 
 cargo llvm-cov report "$@"


### PR DESCRIPTION
Recently merged PR #2269 had a CI failure since some affected code was not included in the coverage testing. This update is also needed to remove coverage failure from PR #2200 which is still in progress & should be almost ready.

I think the provider-example testing should also be included in the Build+test CI job, as proposed here.