### PR TITLE
Adopt benchmarking docs to new rustls-bench crate

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -23,13 +23,12 @@ benchmarks](https://github.com/ctz/openssl-bench), which produce similar measure
 
 #### Building
 
-The benchmarks are implemented in the form of "example code" in `rustls/examples/internal/bench.rs`.
-Use `cargo build --profile=bench -p rustls --example bench` to obtain the corresponding binary (you can
-toggle conditionally compiled code with the `--no-default-features` and `--features` flags) or simply run below, which will build and run the benchmark.
+The benchmarks are implemented in `rustls-bench/src/main.rs`.
+Use `cargo build --profile=bench -p rustls-bench --features aws-lc-rs` to obtain the corresponding
+binary (you can toggle conditionally compiled code with the `--no-default-features` and `--features`
+flags) or simply run below, which will build and run the benchmark.
 
-Note: while `cargo build --release --example bench` also works, it results in surprises when used
-together with `--no-default-features` because of how Cargo's feature unification works (some
-features get enabled automatically by other subcrates). It is also less performant than `--profile=bench`.
+Note: The usage of `--release` instead of `--profile=bench` also works, but it is less performant.
 
 #### Running
 


### PR DESCRIPTION
Fixes a documentation left-over from 9e572fa

I tried running some benchmarks and had some trouble, so I figured others might also be running into this