### PR TITLE
docs: fix CONTRIBUTING.md broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ If you believe you've found a security bug please
 in GitHub, and not as a regular repository issue. See [SECURITY.md] for more
 information.
 
+[SECURITY.md]: SECURITY.md
+
 ## Code changes
 
 Some ideas and guidelines for contributions:


### PR DESCRIPTION
The links to `SECURITY.md` weren't being rendered correctly in the `CONTRIBUTING.md` markdown.