### PR TITLE
adjust FIPS feature handling w.r.t aws-lc-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ anyhow = "1.0.73"
 asn1 = "0.20"
 async-std = { version = "1.12.0", features = ["attributes"] }
 async-trait = "0.1.74"
-aws-lc-rs = { version = "1.12", default-features = false, features = ["aws-lc-sys", "prebuilt-nasm"] }
+aws-lc-rs = { version = "1.12", default-features = false }
 base64 = "0.22"
 bencher = "0.1.5"
 brotli = { version = "7", default-features = false, features = ["std"] }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -18,10 +18,10 @@ build = "build.rs"
 default = ["aws_lc_rs", "logging", "std", "tls12"]
 
 aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
-aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws-lc-rs"]
+aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws-lc-rs", "aws-lc-rs/aws-lc-sys", "aws-lc-rs/prebuilt-nasm"]
 brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
 custom-provider = []
-fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
+fips = ["aws_lc_rs", "aws-lc-rs?/fips", "webpki/aws-lc-rs-fips"]
 logging = ["log"]
 prefer-post-quantum = ["aws_lc_rs"]
 read_buf = ["rustversion", "std"]


### PR DESCRIPTION
Previously `rustls` unconditionally used the `aws-lc-sys` and `prebuilt-nasm` features of the `aws-lc-rs` dep, meaning we always brought along `aws-lc-sys` (note the `prebuilt-nasm` feature customizes that dep). See https://github.com/rustls/webpki/issues/307

However, when a user is looking for a FIPS crypto provider we want to avoid bringing in `aws-lc-sys` and instead use `aws-lc-rs/fips` to get `aws-lc-fips-sys`.

This commit makes the `aws-lc-rs` feature of webpki activate the "usual" config: `aws-lc-rs/aws-lc-sys` w/ `aws-lc-rs/prebuilt-nasm` to have `aws-lc-sys` with prebuilt assmebly to avoid the `nasm` dep.

The pre-existing `fips` feature of `rustls` now activates `aws-lc-rs/fips`. The new downstream `webpki/fips` feature is activated to have that crate do similar. The net result should be no `aws-lc-sys` dep, just `aws-lc-fips-sys`.