### PR TITLE
rustls-post-quantum: 0.2.1 -> 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,7 +2558,7 @@ checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-post-quantum"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aws-lc-rs",
  "criterion",

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-post-quantum"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Releases a crate update that takes aws-lc-rs 1.12 without the 'non-fips' feature flag, and the stable KEM API.

There's a separate plan in-flight in https://github.com/rustls/rustls/pull/2288 to move `rustls-post-quantum` into the core crate, and to publish a stub re-exporting from `rustls` as the final `rustls-post-quantum@0.2.2` release.

However, for https://github.com/rustls/rustls-ffi/issues/507 it would be helpful if there was a `rustls-post-quantum` I could use today that doesn't activate `non-fips` in `aws-lc-rs`. When we run `cbindgen` in that crate we enable all features so we can translate feature-conditional APIs into equivalent C `#if defined ...` guards in our `.h`. That makes a feature flag that activates post-quantum support tricky, because fips & rustls-post-quantum 0.2.1 are mutually exclusive. The required work already landed in https://github.com/rustls/rustls/pull/2286, but wasn't published.

Ultimately I can also just wait for https://github.com/rustls/rustls/pull/2288 to be finalized. WDYT @ctz?

### Proposed release notes

Updates the `aws-lc-rs` dependency to [1.12](https://github.com/aws/aws-lc-rs/releases/tag/v1.12.0). Notably this release switches to a stable ML-KEM API, and includes a [FIPS module with ML-KEM support](https://aws.amazon.com/blogs/security/aws-lc-fips-3-0-first-cryptographic-library-to-include-ml-kem-in-fips-140-3-validation/). 
