### PR TITLE
Server fuzzing harness improvements

### DIFF
--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -50,7 +50,10 @@ fn fuzz_acceptor_api(data: &[u8]) {
     let mut stream = io::Cursor::new(data);
 
     loop {
-        let rd = server.read_tls(&mut stream).unwrap();
+        let rd = server
+            .read_tls(&mut stream)
+            .unwrap_or(0);
+
         match server.accept() {
             Ok(Some(_)) | Err(_) => {
                 break;


### PR DESCRIPTION
First commit aims to fix https://oss-fuzz.com/testcase-detail/4979312264019968 introduced in 9fd25dcf49ad2ec346c40b14137142f998a32c23, aka

```
thread '<unnamed>' panicked at fuzzers/server.rs:53:47:
called `Result::unwrap()` on an `Err` value: Custom { kind: InvalidData, error: "message buffer full" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
==407== ERROR: libFuzzer: deadly signal
```

Second is to cover `Accepted::into_connection`