### PR TITLE
cleanup: use more parens when calculating ECH seed

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -413,7 +413,7 @@ fn emit_client_hello_for_retry(
             _ => {}
         };
 
-        let seed = (input.hello.extension_order_seed as u32) << 16
+        let seed = ((input.hello.extension_order_seed as u32) << 16)
             | (u16::from(new_ext.ext_type()) as u32);
         match low_quality_integer_hash(seed) {
             u32::MAX => 0,


### PR DESCRIPTION
(with help from `cargo clippy --fix ...`)

as suggested by nightly Clippy precedence rule:

- https://rust-lang.github.io/rust-clippy/master/index.html#precedence

---

Happy 2025 to everyone!

I hope my recent contributions & updates have not been too much of a burden during these holiday weeks.