### PR TITLE
Implement BufRead for Reader, Stream, and StreamOwned

### DIFF
--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -227,6 +227,21 @@ where
     }
 }
 
+impl<C, T, S> BufRead for StreamOwned<C, T>
+where
+    C: DerefMut + Deref<Target = ConnectionCommon<S>>,
+    T: Read + Write,
+    S: 'static + SideData,
+{
+    fn fill_buf(&mut self) -> Result<&[u8]> {
+        self.as_stream().fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.as_stream().consume(amt)
+    }
+}
+
 impl<C, T, S> Write for StreamOwned<C, T>
 where
     C: DerefMut + Deref<Target = ConnectionCommon<S>>,

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -142,7 +142,7 @@ impl ChunkVecBuffer {
         Ok(offs)
     }
 
-    fn consume(&mut self, used: usize) {
+    pub(crate) fn consume(&mut self, used: usize) {
         // first, mark the rightmost extent of the used buffer
         self.prefix_used += used;
 
@@ -174,6 +174,13 @@ impl ChunkVecBuffer {
         let used = wr.write_vectored(&bufs[..len])?;
         self.consume(used);
         Ok(used)
+    }
+
+    /// Returns the first contiguous chunk of data, or None if empty.
+    pub(crate) fn chunk(&self) -> Option<&[u8]> {
+        self.chunks
+            .front()
+            .map(|chunk| &chunk[self.prefix_used..])
     }
 }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2458,6 +2458,37 @@ fn client_respects_buffer_limit_post_handshake() {
     check_read(&mut server.reader(), b"01234567890123456789012345");
 }
 
+#[test]
+fn buf_read() {
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048);
+
+    do_handshake(&mut client, &mut server);
+
+    // Write two separate messages
+    assert_eq!(client.writer().write(b"hello").unwrap(), 5);
+    transfer(&mut client, &mut server);
+    assert_eq!(client.writer().write(b"world").unwrap(), 5);
+    transfer(&mut client, &mut server);
+    server.process_new_packets().unwrap();
+
+    let mut reader = server.reader();
+    // fill_buf() returns each record separately (this is an implementation detail)
+    assert_eq!(reader.fill_buf().unwrap(), b"hello");
+    // partially consuming the buffer is OK
+    reader.consume(1);
+    assert_eq!(reader.fill_buf().unwrap(), b"ello");
+    // Read::read is compatible with BufRead
+    let mut b = [0u8; 2];
+    reader.read_exact(&mut b).unwrap();
+    assert_eq!(b, *b"el");
+    assert_eq!(reader.fill_buf().unwrap(), b"lo");
+    reader.consume(2);
+    // once the first packet is consumed, the next one is available
+    assert_eq!(reader.fill_buf().unwrap(), b"world");
+    reader.consume(5);
+    check_fill_buf_err(&mut reader, io::ErrorKind::WouldBlock);
+}
+
 struct OtherSession<'a, C, S>
 where
     C: DerefMut + Deref<Target = ConnectionCommon<S>>,
@@ -2592,6 +2623,20 @@ fn server_read_returns_wouldblock_when_no_data() {
 fn client_read_returns_wouldblock_when_no_data() {
     let (mut client, _) = make_pair(KeyType::Rsa2048);
     assert!(matches!(client.reader().read(&mut [0u8; 1]),
+                     Err(err) if err.kind() == io::ErrorKind::WouldBlock));
+}
+
+#[test]
+fn server_fill_buf_returns_wouldblock_when_no_data() {
+    let (_, mut server) = make_pair(KeyType::Rsa2048);
+    assert!(matches!(server.reader().fill_buf(),
+                     Err(err) if err.kind() == io::ErrorKind::WouldBlock));
+}
+
+#[test]
+fn client_fill_buf_returns_wouldblock_when_no_data() {
+    let (mut client, _) = make_pair(KeyType::Rsa2048);
+    assert!(matches!(client.reader().fill_buf(),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 


### PR DESCRIPTION
This is basically a reroll of #870 against the latest version of the code.

New in this PR is an alternate method `Reader::into_first_chunk` (other naming suggestions welcome) that acts like `fill_buf` but returns a slice with a longer lifetime, at the cost of consuming `self` (needed in order to steal the `&mut ConnectionCommon` borrow). This makes it possible to implement AsyncBufRead in tokio_rustls without necessarily implementing BufRead directly on ConnectionCommon. It's also needed to implement BufRead for StreamOwned.