### PR TITLE
Fix SSL 2 version constant to 0x0002

### DIFF
--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -95,7 +95,7 @@ enum_builder! {
     /// The `Unknown` item is used when processing unrecognised ordinals.
     #[repr(u16)]
     pub enum ProtocolVersion {
-        SSLv2 => 0x0200,
+        SSLv2 => 0x0002,
         SSLv3 => 0x0300,
         TLSv1_0 => 0x0301,
         TLSv1_1 => 0x0302,


### PR DESCRIPTION
SSL 2 uses a version field of 0x0002, not 0x0200.  This is confirmed not only in the original Netscape spec [1] and RFC draft of the time [2], but also in major implementations such as OpenSSL [3] and Wireshark [4] as well as packet captures of SSL 2 traffic [5].

[1] https://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html
[2] https://datatracker.ietf.org/doc/html/draft-hickman-netscape-ssl-00
[3] https://github.com/openssl/openssl/blob/OpenSSL_0_9_6m/ssl/ssl2.h#L66-L71
[4] https://github.com/wireshark/wireshark/blob/release-4.4/epan/dissectors/packet-tls-utils.h#L266-L277
[5] https://github.com/Lekensteyn/wireshark-notes/blob/master/ssl3/sslv2.pcapng