### PR TITLE
Incidental/preparatory parts of #2288

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -34,16 +34,17 @@ zlib-rs = { workspace = true, optional = true }
 
 [features]
 default = ["aws_lc_rs", "logging", "std", "tls12"]
-std = ["webpki/std", "pki-types/std", "once_cell/std"]
-logging = ["log"]
-aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
+
 aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
+aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
-ring = ["dep:ring", "webpki/ring"]
 custom-provider = []
-tls12 = []
-read_buf = ["rustversion", "std"]
 fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
+logging = ["log"]
+read_buf = ["rustversion", "std"]
+ring = ["dep:ring", "webpki/ring"]
+std = ["webpki/std", "pki-types/std", "once_cell/std"]
+tls12 = []
 zlib = ["dep:zlib-rs"]
 
 [dev-dependencies]

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -50,7 +50,7 @@ pub fn default_provider() -> CryptoProvider {
 fn default_kx_groups() -> Vec<&'static dyn SupportedKxGroup> {
     #[cfg(feature = "fips")]
     {
-        ALL_KX_GROUPS
+        DEFAULT_KX_GROUPS
             .iter()
             .filter(|cs| cs.fips())
             .copied()
@@ -58,7 +58,7 @@ fn default_kx_groups() -> Vec<&'static dyn SupportedKxGroup> {
     }
     #[cfg(not(feature = "fips"))]
     {
-        ALL_KX_GROUPS.to_vec()
+        DEFAULT_KX_GROUPS.to_vec()
     }
 }
 
@@ -224,9 +224,13 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms
 /// All defined key exchange groups supported by aws-lc-rs appear in this module.
 ///
 /// [`ALL_KX_GROUPS`] is provided as an array of all of these values.
+/// [`DEFAULT_KX_GROUPS`] is provided as an array of this provider's defaults.
 pub mod kx_group {
     pub use super::kx::{SECP256R1, SECP384R1, X25519};
 }
+
+/// A list of the default key exchange groups supported by this provider.
+pub static DEFAULT_KX_GROUPS: &[&dyn SupportedKxGroup] = ALL_KX_GROUPS;
 
 /// A list of all the key exchange groups supported by this provider.
 pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] =

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use aws_lc_rs as ring_like;
 use pki_types::PrivateKeyDer;
 use webpki::aws_lc_rs as webpki_algs;
 
-use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom};
+use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom, SupportedKxGroup};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
@@ -228,11 +228,12 @@ pub mod kx_group {
     pub use super::kx::{SECP256R1, SECP384R1, X25519};
 }
 
-pub use kx::ALL_KX_GROUPS;
+/// A list of all the key exchange groups supported by this provider.
+pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] =
+    &[kx_group::X25519, kx_group::SECP256R1, kx_group::SECP384R1];
+
 #[cfg(any(feature = "std", feature = "hashbrown"))]
 pub use ticketer::Ticketer;
-
-use super::SupportedKxGroup;
 
 /// Compatibility shims between ring 0.16.x and 0.17.x API
 mod ring_shim {

--- a/rustls/src/crypto/ring/kx.rs
+++ b/rustls/src/crypto/ring/kx.rs
@@ -11,9 +11,6 @@ use crate::msgs::enums::NamedGroup;
 use crate::rand::GetRandomFailed;
 
 /// A key-exchange group supported by *ring*.
-///
-/// All possible instances of this class are provided by the library in
-/// the [`ALL_KX_GROUPS`] array.
 struct KxGroup {
     /// The IANA "TLS Supported Groups" name of the group
     name: NamedGroup,
@@ -117,9 +114,6 @@ fn uncompressed_point(point: &[u8]) -> bool {
     // <https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.8.2>
     matches!(point.first(), Some(0x04))
 }
-
-/// A list of all the key exchange groups supported by rustls.
-pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[X25519, SECP256R1, SECP384R1];
 
 /// An in-progress key exchange.  This has the algorithm,
 /// our private key, and our public key.

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -4,7 +4,7 @@ use pki_types::PrivateKeyDer;
 pub(crate) use ring as ring_like;
 use webpki::ring as webpki_algs;
 
-use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom};
+use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom, SupportedKxGroup};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
@@ -170,7 +170,10 @@ pub mod kx_group {
     pub use super::kx::{SECP256R1, SECP384R1, X25519};
 }
 
-pub use kx::ALL_KX_GROUPS;
+/// A list of all the key exchange groups supported by this provider.
+pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] =
+    &[kx_group::X25519, kx_group::SECP256R1, kx_group::SECP384R1];
+
 #[cfg(any(feature = "std", feature = "hashbrown"))]
 pub use ticketer::Ticketer;
 

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod tls13;
 pub fn default_provider() -> CryptoProvider {
     CryptoProvider {
         cipher_suites: DEFAULT_CIPHER_SUITES.to_vec(),
-        kx_groups: ALL_KX_GROUPS.to_vec(),
+        kx_groups: DEFAULT_KX_GROUPS.to_vec(),
         signature_verification_algorithms: SUPPORTED_SIG_ALGS,
         secure_random: &Ring,
         key_provider: &Ring,
@@ -166,9 +166,13 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms
 /// All defined key exchange groups supported by *ring* appear in this module.
 ///
 /// [`ALL_KX_GROUPS`] is provided as an array of all of these values.
+/// [`DEFAULT_KX_GROUPS`] is provided as an array of this provider's defaults.
 pub mod kx_group {
     pub use super::kx::{SECP256R1, SECP384R1, X25519};
 }
+
+/// A list of the default key exchange groups supported by this provider.
+pub static DEFAULT_KX_GROUPS: &[&dyn SupportedKxGroup] = ALL_KX_GROUPS;
 
 /// A list of all the key exchange groups supported by this provider.
 pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] =

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -24,36 +24,13 @@ const MAX_ITERATIONS: usize = 100;
 #[test]
 fn tls12_handshake() {
     let outcome = handshake(&rustls::version::TLS12);
+
     assert_eq!(
-        outcome.client_transcript,
-        vec![
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "WriteTraffic"
-        ],
+        outcome.client_transcript, TLS12_CLIENT_TRANSCRIPT,
         "client transcript mismatch"
     );
     assert_eq!(
-        outcome.server_transcript,
-        vec![
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "WriteTraffic"
-        ],
+        outcome.server_transcript, TLS12_SERVER_TRANSCRIPT,
         "server transcript mismatch"
     );
 }
@@ -65,46 +42,13 @@ fn tls12_handshake_fragmented() {
         client.cert_decompressors = vec![];
         server.max_fragment_size = Some(512);
     });
+
     assert_eq!(
-        outcome.client_transcript,
-        vec![
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "WriteTraffic"
-        ],
+        outcome.client_transcript, TLS12_CLIENT_TRANSCRIPT_FRAGMENTED,
         "client transcript mismatch"
     );
     assert_eq!(
-        outcome.server_transcript,
-        vec![
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "WriteTraffic"
-        ],
+        outcome.server_transcript, TLS12_SERVER_TRANSCRIPT_FRAGMENTED,
         "server transcript mismatch"
     );
 }
@@ -112,34 +56,13 @@ fn tls12_handshake_fragmented() {
 #[test]
 fn tls13_handshake() {
     let outcome = handshake(&rustls::version::TLS13);
+
     assert_eq!(
-        outcome.client_transcript,
-        vec![
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "WriteTraffic",
-            "WriteTraffic"
-        ],
+        outcome.client_transcript, TLS13_CLIENT_TRANSCRIPT,
         "client transcript mismatch"
     );
     assert_eq!(
-        outcome.server_transcript,
-        vec![
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "WriteTraffic"
-        ],
+        outcome.server_transcript, TLS13_SERVER_TRANSCRIPT,
         "server transcript mismatch"
     );
 }
@@ -151,44 +74,13 @@ fn tls13_handshake_fragmented() {
         client.cert_decompressors = vec![];
         server.max_fragment_size = Some(512);
     });
+
     assert_eq!(
-        outcome.client_transcript,
-        vec![
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "WriteTraffic",
-            "WriteTraffic"
-        ],
+        outcome.client_transcript, TLS13_CLIENT_TRANSCRIPT_FRAGMENTED,
         "client transcript mismatch"
     );
     assert_eq!(
-        outcome.server_transcript,
-        vec![
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "BlockedHandshake",
-            "EncodeTlsData",
-            "TransmitTlsData",
-            "WriteTraffic"
-        ],
+        outcome.server_transcript, TLS13_SERVER_TRANSCRIPT_FRAGMENTED,
         "server transcript mismatch"
     );
 }
@@ -1424,3 +1316,123 @@ fn server_receives_incorrect_first_handshake_message() {
         _ => panic!("unexpected alert sending state"),
     };
 }
+
+const TLS12_CLIENT_TRANSCRIPT: &[&str] = &[
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "WriteTraffic",
+];
+
+const TLS12_SERVER_TRANSCRIPT: &[&str] = &[
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "WriteTraffic",
+];
+
+const TLS12_CLIENT_TRANSCRIPT_FRAGMENTED: &[&str] = &[
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "WriteTraffic",
+];
+
+const TLS12_SERVER_TRANSCRIPT_FRAGMENTED: &[&str] = &[
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "WriteTraffic",
+];
+
+const TLS13_CLIENT_TRANSCRIPT: &[&str] = &[
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "WriteTraffic",
+    "WriteTraffic",
+];
+
+const TLS13_SERVER_TRANSCRIPT: &[&str] = &[
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "WriteTraffic",
+];
+
+const TLS13_CLIENT_TRANSCRIPT_FRAGMENTED: &[&str] = &[
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "WriteTraffic",
+    "WriteTraffic",
+];
+
+const TLS13_SERVER_TRANSCRIPT_FRAGMENTED: &[&str] = &[
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "BlockedHandshake",
+    "EncodeTlsData",
+    "TransmitTlsData",
+    "WriteTraffic",
+];

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -27,32 +27,32 @@ fn tls12_handshake() {
     assert_eq!(
         outcome.client_transcript,
         vec![
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(WriteTraffic)"
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "WriteTraffic"
         ],
         "client transcript mismatch"
     );
     assert_eq!(
         outcome.server_transcript,
         vec![
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(WriteTraffic)"
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "WriteTraffic"
         ],
         "server transcript mismatch"
     );
@@ -68,42 +68,42 @@ fn tls12_handshake_fragmented() {
     assert_eq!(
         outcome.client_transcript,
         vec![
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(WriteTraffic)"
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "WriteTraffic"
         ],
         "client transcript mismatch"
     );
     assert_eq!(
         outcome.server_transcript,
         vec![
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(WriteTraffic)"
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "WriteTraffic"
         ],
         "server transcript mismatch"
     );
@@ -115,30 +115,30 @@ fn tls13_handshake() {
     assert_eq!(
         outcome.client_transcript,
         vec![
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(WriteTraffic)",
-            "Ok(WriteTraffic)"
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "WriteTraffic",
+            "WriteTraffic"
         ],
         "client transcript mismatch"
     );
     assert_eq!(
         outcome.server_transcript,
         vec![
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(WriteTraffic)"
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "WriteTraffic"
         ],
         "server transcript mismatch"
     );
@@ -154,40 +154,40 @@ fn tls13_handshake_fragmented() {
     assert_eq!(
         outcome.client_transcript,
         vec![
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(WriteTraffic)",
-            "Ok(WriteTraffic)"
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "WriteTraffic",
+            "WriteTraffic"
         ],
         "client transcript mismatch"
     );
     assert_eq!(
         outcome.server_transcript,
         vec![
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(WriteTraffic)"
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "WriteTraffic"
         ],
         "server transcript mismatch"
     );
@@ -312,31 +312,31 @@ fn early_data() {
     assert_eq!(
         outcome.client_transcript,
         vec![
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(WriteTraffic)",
-            "Ok(WriteTraffic)"
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "WriteTraffic",
+            "WriteTraffic"
         ]
     );
     assert_eq!(
         outcome.server_transcript,
         vec![
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(EncodeTlsData)",
-            "Ok(ReadEarlyData)",
-            "Ok(TransmitTlsData)",
-            "Ok(BlockedHandshake)",
-            "Ok(EncodeTlsData)",
-            "Ok(TransmitTlsData)",
-            "Ok(WriteTraffic)"
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "EncodeTlsData",
+            "ReadEarlyData",
+            "TransmitTlsData",
+            "BlockedHandshake",
+            "EncodeTlsData",
+            "TransmitTlsData",
+            "WriteTraffic"
         ]
     );
     assert!(client_actions
@@ -1058,10 +1058,11 @@ fn advance_client(
     transcript: &mut Vec<String>,
 ) -> State {
     let UnbufferedStatus { discard, state } = conn.process_tls_records(buffers.incoming.filled());
+    let state = state.unwrap();
 
     transcript.push(format!("{:?}", state));
 
-    let state = match state.unwrap() {
+    let state = match state {
         ConnectionState::TransmitTlsData(mut state) => {
             let mut sent_early_data = false;
             if let Some(early_data) = actions.early_data_to_send {
@@ -1104,10 +1105,11 @@ fn advance_server(
     transcript: &mut Vec<String>,
 ) -> State {
     let UnbufferedStatus { discard, state } = conn.process_tls_records(buffers.incoming.filled());
+    let state = state.unwrap();
 
     transcript.push(format!("{:?}", state));
 
-    let state = match state.unwrap() {
+    let state = match state {
         ConnectionState::ReadEarlyData(mut state) => {
             let mut records = vec![];
             let mut peeked_len = state.peek_len();


### PR DESCRIPTION
This PR sloughs off the incidental parts of #2288, to reduce the size of that PR.

I think this is pretty uncontroversial, though note that (eg) `rustls::crypto::ring::DEFAULT_KX_GROUPS` is a new public item.