### PR TITLE
chore: enforce taplo toml formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -506,6 +506,20 @@ jobs:
         working-directory: rustls/
         run: cargo check-external-types
 
+  taplo:
+      name: Taplo
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout sources
+          uses: actions/checkout@v4
+          with:
+            persist-credentials: false
+
+        - name: Install rust toolchain
+          uses: dtolnay/rust-toolchain@stable
+        - run: cargo install taplo-cli --locked
+        - run: taplo format --check
+
   openssl-tests:
     name: Run openssl-tests
     runs-on: ubuntu-latest

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,1 @@
-chain_width=40
+chain_width = 40

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,3 @@
+[formatting]
+align_comments = false
+column_width = 110

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ exclude = [
 ]
 
 default-members = [
+  # ---
   "examples",
   "rustls",
 ]
@@ -84,7 +85,7 @@ signature = "2"
 subtle = { version = "2.5.0", default-features = false }
 time = { version = "0.3.6", default-features = false }
 tikv-jemallocator = "0.6"
-tokio = { version = "1.34", features = ["io-util", "macros", "net", "rt"]}
+tokio = { version = "1.34", features = ["io-util", "macros", "net", "rt"] }
 webpki = { package = "rustls-webpki", version = "0.102.8", features = ["alloc"], default-features = false }
 webpki-roots = "0.26"
 x25519-dalek = "2"

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -7,7 +7,7 @@ description = "Rustls connectivity based integration tests."
 publish = false
 
 [dependencies]
-rustls = { path = "../rustls", features = [ "logging" ]}
+rustls = { path = "../rustls", features = ["logging"] }
 
 [dev-dependencies]
 hickory-resolver = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ hickory-resolver = { workspace = true }
 log = { workspace = true }
 mio = { workspace = true }
 rcgen = { workspace = true }
-rustls = { path = "../rustls", features = [ "logging" ]}
+rustls = { path = "../rustls", features = ["logging"] }
 serde = { workspace = true }
 tokio = { workspace = true }
 webpki-roots = { workspace = true }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 env_logger = "0.11"
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-rustls = { path = "../rustls", default-features = false, features = ["std", "tls12", "custom-provider"]}
+rustls = { path = "../rustls", default-features = false, features = ["std", "tls12", "custom-provider"] }
 rustls-fuzzing-provider = { path = "../rustls-fuzzing-provider" }
 
 # Prevent this from interfering with workspaces

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -116,6 +116,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
-    "rustls_pki_types",
-    "rustls_pki_types::*",
+  # ---
+  "rustls_pki_types",
+  "rustls_pki_types::*",
 ]


### PR DESCRIPTION
This would have helped me with some of the toml updates needed for PR #2285.

I am proposing here that we keep the line width at 100, vertically expanding some of the dependency feature lists. This might have made it a little easier for me when adjusting some of the dependency features when working on the rejected draft PR #2200.

I would be happy to set the line width to 120 & revert many of the formatting updates I proposed, if needed.