### PR TITLE
REJECTED: reorganize features in Cargo.toml; use document_features; document `std` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +1761,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2452,7 @@ dependencies = [
  "bencher",
  "brotli",
  "brotli-decompressor",
+ "document-features",
  "env_logger",
  "hashbrown",
  "hex",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -14,6 +14,65 @@ autotests = false
 exclude = ["src/testdata", "tests/**"]
 build = "build.rs"
 
+[features]
+default = ["aws_lc_rs", "logging", "std", "tls12"]
+
+## Enable some more advanced connection support APIs.
+std = ["webpki/std", "pki-types/std", "once_cell/std"]
+
+## Makes the rustls crate depend on the [`aws-lc-rs`] crate.
+## Use `rustls::crypto::aws_lc_rs::default_provider().install_default()` to
+## use it as the default `CryptoProvider`, or provide it explicitly
+## when making a `ClientConfig` or `ServerConfig`.
+##
+## Note that aws-lc-rs has additional build-time dependencies like cmake.
+## See [the documentation](https://aws.github.io/aws-lc-rs/requirements/index.html) for details.
+aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
+
+aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
+
+## Makes the rustls crate depend on the *ring* crate for cryptography.
+## Use `rustls::crypto::ring::default_provider().install_default()` to
+## use it as the default `CryptoProvider`, or provide it explicitly
+## when making a `ClientConfig` or `ServerConfig`.
+ring = ["dep:ring", "webpki/ring"]
+
+## Enable support for FIPS140-3-approved cryptography, via the aws-lc-rs crate.
+## This feature enables the `aws_lc_rs` feature, which makes the rustls crate depend
+## on [aws-lc-rs](https://github.com/aws/aws-lc-rs).  It also changes the default
+## for [`ServerConfig::require_ems`] and [`ClientConfig::require_ems`].
+##
+## See [manual::_06_fips] for more details.
+fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
+
+## Disables implicit use of built-in providers (`aws-lc-rs` or `ring`). This forces
+## applications to manually install one, for instance, when using a custom `CryptoProvider`.
+custom-provider = []
+
+## Enable support for TLS version 1.2. Note that, due to the additive
+## nature of Cargo features and because it is enabled by default, other crates
+## in your dependency graph could re-enable it for your application. If you want to disable
+## TLS 1.2 for security reasons, consider explicitly enabling TLS 1.3 only in the config
+## builder API.
+tls12 = []
+
+## Make the rustls crate depend on the `log` crate.
+## rustls outputs interesting protocol-level messages at `trace!` and `debug!` level,
+## and protocol-level errors at `warn!` and `error!` level.  The log messages do not
+## contain secret key data, and so are safe to archive without affecting session security.
+logging = ["log"]
+
+## When building with Rust Nightly, adds support for the unstable
+## `std::io::ReadBuf` and related APIs. This reduces costs from initializing
+## buffers. Will do nothing on non-Nightly releases.
+read_buf = ["rustversion", "std"]
+
+## Uses the `brotli` crate for RFC8879 certificate compression support.
+brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
+
+## Uses the `zlib-rs` crate for RFC8879 certificate compression support.
+zlib = ["dep:zlib-rs"]
+
 [build-dependencies]
 rustversion = { version = "1.0.6", optional = true }
 
@@ -31,21 +90,8 @@ webpki = { workspace = true }
 pki-types = { workspace = true }
 zeroize = { workspace = true }
 zlib-rs = { workspace = true, optional = true }
-
-[features]
-default = ["aws_lc_rs", "logging", "std", "tls12"]
-
-aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
-aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
-brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
-custom-provider = []
-fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
-logging = ["log"]
-read_buf = ["rustversion", "std"]
-ring = ["dep:ring", "webpki/ring"]
-std = ["webpki/std", "pki-types/std", "once_cell/std"]
-tls12 = []
-zlib = ["dep:zlib-rs"]
+# doc utility
+document-features = "0.2.10"
 
 [dev-dependencies]
 base64 = { workspace = true }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -273,47 +273,7 @@
 //! Here's a list of what features are exposed by the rustls crate and what
 //! they mean.
 //!
-//! - `aws_lc_rs` (enabled by default): makes the rustls crate depend on the [`aws-lc-rs`] crate.
-//!   Use `rustls::crypto::aws_lc_rs::default_provider().install_default()` to
-//!   use it as the default `CryptoProvider`, or provide it explicitly
-//!   when making a `ClientConfig` or `ServerConfig`.
-//!
-//!   Note that aws-lc-rs has additional build-time dependencies like cmake.
-//!   See [the documentation](https://aws.github.io/aws-lc-rs/requirements/index.html) for details.
-//!
-//! - `ring`: makes the rustls crate depend on the *ring* crate for cryptography.
-//!   Use `rustls::crypto::ring::default_provider().install_default()` to
-//!   use it as the default `CryptoProvider`, or provide it explicitly
-//!   when making a `ClientConfig` or `ServerConfig`.
-//!
-//! - `fips`: enable support for FIPS140-3-approved cryptography, via the aws-lc-rs crate.
-//!   This feature enables the `aws_lc_rs` feature, which makes the rustls crate depend
-//!   on [aws-lc-rs](https://github.com/aws/aws-lc-rs).  It also changes the default
-//!   for [`ServerConfig::require_ems`] and [`ClientConfig::require_ems`].
-//!
-//!   See [manual::_06_fips] for more details.
-//!
-//! - `custom-provider`: disables implicit use of built-in providers (`aws-lc-rs` or `ring`). This forces
-//!    applications to manually install one, for instance, when using a custom `CryptoProvider`.
-//!
-//! - `tls12` (enabled by default): enable support for TLS version 1.2. Note that, due to the
-//!   additive nature of Cargo features and because it is enabled by default, other crates
-//!   in your dependency graph could re-enable it for your application. If you want to disable
-//!   TLS 1.2 for security reasons, consider explicitly enabling TLS 1.3 only in the config
-//!   builder API.
-//!
-//! - `logging` (enabled by default): make the rustls crate depend on the `log` crate.
-//!   rustls outputs interesting protocol-level messages at `trace!` and `debug!` level,
-//!   and protocol-level errors at `warn!` and `error!` level.  The log messages do not
-//!   contain secret key data, and so are safe to archive without affecting session security.
-//!
-//! - `read_buf`: when building with Rust Nightly, adds support for the unstable
-//!   `std::io::ReadBuf` and related APIs. This reduces costs from initializing
-//!   buffers. Will do nothing on non-Nightly releases.
-//!
-//! - `brotli`: uses the `brotli` crate for RFC8879 certificate compression support.
-//!
-//! - `zlib`: uses the `zlib-rs` crate for RFC8879 certificate compression support.
+#![doc = document_features::document_features!()]
 //!
 
 // Require docs for public APIs, deny unsafe code, etc.


### PR DESCRIPTION
STATUS: Closing as REJECTED; I would like to find a way to improve support from the Rust tooling (someday).

---

- organize features as discussed in https://github.com/rustls/rustls/pull/2306#issuecomment-2605412127
- add missing documentation for `std` feature
- use `document_features` to document features in `rustls/Cargo.toml` & maintain consistency with doc comments