### PR TITLE
CI: deny all Clippy warnings including clippy::incompatible_msrv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -463,10 +463,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      # - we want to be free of any warnings, so deny them
-      # - disable incompatible_msrv as it does not understand that we apply our
-      #   MSRV to the just the core crate.
-      - run: ./admin/clippy -- --deny warnings --allow clippy::incompatible_msrv
+      # We want to be free of any warnings, so deny them.
+      - run: ./admin/clippy -- --deny warnings
 
   clippy-nightly:
     name: Clippy (Nightly)


### PR DESCRIPTION
It looks to me like there is no need to ignore `clippy::incompatible_msrv` in Clippy CI task to succeed with `--deny warnings`.

Context comes from this comment: https://github.com/rustls/rustls/pull/2285#discussion_r1925385243

For PR #2285 I would like to update CI to allow a single warning in most crates & deny all other warnings. I have already tried this with XXX TODO comments; PR #2285 still has green status with these updates.

Considering that ignoring `clippy::incompatible_msrv` is not what we want for PR #2285, and that CI can succeed without ignoring this warning, I think we should remove this allow option as proposed here. I would also like to keep this update separate from PR #2285.