### PR TITLE
CI: deny all Clippy nightly warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -463,10 +463,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      # - we want to be free of any warnings, so deny them
-      # - disable incompatible_msrv as it does not understand that we apply our
-      #   MSRV to the just the core crate.
-      - run: ./admin/clippy -- --deny warnings --allow clippy::incompatible_msrv
+      # We want to be free of any warnings, so deny them.
+      - run: ./admin/clippy -- --deny warnings
 
   clippy-nightly:
     name: Clippy (Nightly)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -483,8 +483,8 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
-      # do not deny warnings, as nightly clippy sometimes has false negatives
-      - run: ./admin/clippy
+      # We want to be free of any warnings, so deny them.
+      - run: ./admin/clippy -- --deny warnings
 
   check-external-types:
     name: Validate external types appearing in public API


### PR DESCRIPTION
Based on other PR that I think should be reviewed & hopefully merged first:

- [ ] #2310

---

My impression is that new Clippy nightly warnings have not been much of an issue over the past year and it has been pretty easy to resolve the few issues I have seen come up.

I think the ideal situation for PR #2285 is to assume that we will only ignore a single warning that it introduces for most crates, and deny all other warnings for Clippy nightly as well.

I do totally think this would require a discussion & decision among the @rustls maintainers for consideration, will totally understand if this proposal need to be rejected & closed.