### PR TITLE
implement quic multipath encryption

### DIFF
--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -214,18 +214,32 @@ impl Nonce {
     /// This is `iv ^ seq` where `seq` is encoded as a 96-bit big-endian integer.
     #[inline]
     pub fn new(iv: &Iv, seq: u64) -> Self {
-        let mut nonce = Self([0u8; NONCE_LEN]);
-        codec::put_u64(seq, &mut nonce.0[4..]);
+        let mut seq_bytes = [0u8; NONCE_LEN];
+        codec::put_u64(seq, &mut seq_bytes[4..]);
+        Self::new_from_seq(iv, seq_bytes)
+    }
 
-        nonce
-            .0
-            .iter_mut()
+    /// Creates a unique nonce based on the multipath `path_id`, the `iv` and packet number `pn`.
+    ///
+    /// The nonce is computed as the XOR between the `iv` and the 96-bit big-endian integer formed
+    /// by concatenating `path_id` and `pn`.
+    pub fn for_path(path_id: u32, iv: &Iv, pn: u64) -> Self {
+        let mut seq_bytes = [0u8; NONCE_LEN];
+        seq_bytes[0..4].copy_from_slice(&path_id.to_be_bytes());
+        codec::put_u64(pn, &mut seq_bytes[4..]);
+        Self::new_from_seq(iv, seq_bytes)
+    }
+
+    /// Creates a unique nonce based on the `iv` and sequence number `seq`.
+    #[inline]
+    fn new_from_seq(iv: &Iv, mut seq: [u8; NONCE_LEN]) -> Self {
+        seq.iter_mut()
             .zip(iv.0.iter())
-            .for_each(|(nonce, iv)| {
-                *nonce ^= *iv;
+            .for_each(|(s, iv)| {
+                *s ^= *iv;
             });
 
-        nonce
+        Self(seq)
     }
 }
 
@@ -346,5 +360,21 @@ impl MessageDecrypter for InvalidMessageDecrypter {
         _seq: u64,
     ) -> Result<InboundPlainMessage<'a>, Error> {
         Err(Error::DecryptError)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Using test values provided in the spec in
+    /// <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-15.html#section-2.4>
+    #[test]
+    fn multipath_nonce() {
+        const PATH_ID: u32 = 3;
+        const PN: u64 = 54321;
+        const IV: [u8; 16] = 0x6b26114b9cba2b63a9e8dd4fu128.to_be_bytes();
+        const EXPECTED_NONCE: [u8; 16] = 0x6b2611489cba2b63a9e8097eu128.to_be_bytes();
+        let nonce = Nonce::for_path(PATH_ID, &Iv::copy(&IV[4..]), PN).0;
+        assert_eq!(EXPECTED_NONCE[4..], nonce);
     }
 }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -719,30 +719,38 @@ pub trait HeaderProtectionKey: Send + Sync {
 pub trait PacketKey: Send + Sync {
     /// Encrypt a QUIC packet
     ///
-    /// Takes a `packet_number`, used to derive the nonce; the packet `header`, which is used as
-    /// the additional authenticated data; and the `payload`. The authentication tag is returned if
-    /// encryption succeeds.
+    /// Takes a `packet_number` and optional `path_id`, used to derive the nonce; the packet
+    /// `header`, which is used as the additional authenticated data; and the `payload`. The
+    /// authentication tag is returned if encryption succeeds.
     ///
     /// Fails if and only if the payload is longer than allowed by the cipher suite's AEAD algorithm.
+    ///
+    /// When provided, the `path_id` is used for multipath ecryption as described in
+    /// <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-15.html#section-2.4>.
     fn encrypt_in_place(
         &self,
         packet_number: u64,
         header: &[u8],
         payload: &mut [u8],
+        path_id: Option<u32>,
     ) -> Result<Tag, Error>;
 
     /// Decrypt a QUIC packet
     ///
-    /// Takes the packet `header`, which is used as the additional authenticated data, and the
-    /// `payload`, which includes the authentication tag.
+    /// Takes a `packet_number` and optional `path_id`, used to derive the nonce; the packet
+    /// `header`, which is used as the additional authenticated data, and the `payload`, which
+    /// includes the authentication tag.
     ///
-    /// If the return value is `Ok`, the decrypted payload can be found in `payload`, up to the
-    /// length found in the return value.
+    /// On success, returns the slice of `payload` containing the decrypted data.
+    ///
+    /// When provided, the `path_id` is used for multipath ecryption as described in
+    /// <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-15.html#section-2.4>.
     fn decrypt_in_place<'a>(
         &self,
         packet_number: u64,
         header: &[u8],
         payload: &'a mut [u8],
+        path_id: Option<u32>,
     ) -> Result<&'a [u8], Error>;
 
     /// Tag length for the underlying AEAD algorithm

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4910,11 +4910,11 @@ mod test_quic {
             let (header, payload_tag) = buf.split_at_mut(8);
             let (payload, tag_buf) = payload_tag.split_at_mut(8);
             let tag = x
-                .encrypt_in_place(42, header, payload)
+                .encrypt_in_place(42, header, payload, None)
                 .unwrap();
             tag_buf.copy_from_slice(tag.as_ref());
 
-            let result = y.decrypt_in_place(42, header, payload_tag);
+            let result = y.decrypt_in_place(42, header, payload_tag, None);
             match result {
                 Ok(payload) => payload == [0; 8],
                 Err(_) => false,
@@ -5345,7 +5345,7 @@ mod test_quic {
         let tag = client_keys
             .local
             .packet
-            .encrypt_in_place(PACKET_NUMBER, header, payload)
+            .encrypt_in_place(PACKET_NUMBER, header, payload, None)
             .unwrap();
 
         let sample_len = client_keys.local.header.sample_len();
@@ -5474,7 +5474,7 @@ mod test_quic {
         let payload = server_keys
             .remote
             .packet
-            .decrypt_in_place(PACKET_NUMBER, header, payload)
+            .decrypt_in_place(PACKET_NUMBER, header, payload, None)
             .unwrap();
 
         assert_eq!(&payload[..PAYLOAD.len()], PAYLOAD);


### PR DESCRIPTION
At https://github.com/n0-computer we are working on implementing [multipath](https://datatracker.ietf.org/doc/draft-ietf-quic-multipath/) in [`quinn`](https://github.com/quinn-rs/quinn). Multipath requires a few changes in the nonce calculation for packet protection (described in section 4.1).

This PR implements those changes to the best of my knowledge (which is fairly limited for this repo). The tests are based on the multipath implementation for [`picoquic`](https://github.com/private-octopus/picoquic/tree/master)

On an implementation note, I opted for separate functions to avoid disrupting implementations that do not support multipath. Let me know if you would rather have them merged