### PR TITLE
Defensiveness improvements to `ChunkVecBuffer`

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -290,7 +290,8 @@ mod connection {
         }
 
         fn consume(&mut self, amt: usize) {
-            self.received_plaintext.consume(amt)
+            self.received_plaintext
+                .consume_first_chunk(amt)
         }
     }
 

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -142,7 +142,20 @@ impl ChunkVecBuffer {
         Ok(offs)
     }
 
-    pub(crate) fn consume(&mut self, used: usize) {
+    pub(crate) fn consume_first_chunk(&mut self, used: usize) {
+        // this backs (infallible) `BufRead::consume`, where `used` is
+        // user-supplied.
+        assert!(
+            used <= self
+                .chunk()
+                .map(|ch| ch.len())
+                .unwrap_or_default(),
+            "illegal `BufRead::consume` usage",
+        );
+        self.consume(used);
+    }
+
+    fn consume(&mut self, used: usize) {
         // first, mark the rightmost extent of the used buffer
         self.prefix_used += used;
 

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -76,6 +76,10 @@ impl ChunkVecBuffer {
         let len = bytes.len();
 
         if !bytes.is_empty() {
+            if self.chunks.is_empty() {
+                debug_assert_eq!(self.prefix_used, 0);
+            }
+
             self.chunks.push_back(bytes);
         }
 
@@ -190,6 +194,7 @@ impl ChunkVecBuffer {
         }
         let len = cmp::min(bufs.len(), self.chunks.len());
         let used = wr.write_vectored(&bufs[..len])?;
+        assert!(used <= self.len(), "illegal write_vectored return value");
         self.consume(used);
         Ok(used)
     }


### PR DESCRIPTION
In pursuit of #2316 I took #2318, added some extra checks (which are release-mode asserts where something external has gone wrong).

Note that on main right now, `ChunkVecBuffer::consume()` is externally callable with any value (via `BufRead::consume`) but this is not the case in any released version and therefore not under suspicion for #2316. However, this PR adds a release-mode assert for misuse of that.

During investigating this bug, I did this to model-check `ChunkVecBuffer`:

1. Wrote a very simplified model of `ChunkVecBuffer`, which is slow.

2. Had a fuzz target that takes as input a sequence of

```rust
#[derive(Arbitrary, Debug)]
enum Operation {
    Append(Data),
    Pop,
    ConsumeFirstChunk { max: usize },
    WriteTo { max: usize },
}
```

3. Performs those actions against a `ChunkVecBuffer` and a model, in lockstep. 
5. After each operation, ensures the real and model versions agree what the contents of the buffer is.

That fuzzer is not included in this PR (since it cloned the whole of `ChuckVecBuffer`, and therefore is not useful.)

In any case, I ran it for many millions of iterations with no panics, assertions or divergence :(

