### PR TITLE
CI: no atomic ptr build test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,18 @@ jobs:
         run: cargo test --locked --release --no-run
         working-directory: rustls
 
+  portable-build:
+    name: Portable build test
+    steps:
+      - name: Install rust nightly toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          target: riscv32imc-unknown-none-elf # with no atomic ptr
+
+      - name: cargo build (debug; no default features; no-std) # no std; no built-in provider; XXX TBD hashbrown - ???
+        run: cargo build --locked --no-default-features --target riscv32imc-unknown-none-elf
+        working-directory: rustls
+
   bogo:
     name: BoGo test suite
     runs-on: ubuntu-latest


### PR DESCRIPTION
- [ ] this should fail with build error using built-in `Arc` due to missing atomic ptr functionality on this test target - want to ensure this will test that using `portable_atomic_util::Arc` will resolve this issue