### PR TITLE
chore: resolve overindented doc list items

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -151,7 +151,7 @@ pub trait ResolvesClientCert: fmt::Debug + Send + Sync {
 ///
 /// * [`ClientConfig::max_fragment_size`]: the default is `None` (meaning 16kB).
 /// * [`ClientConfig::resumption`]: supports resumption with up to 256 server names, using session
-///    ids or tickets, with a max of eight tickets per server.
+///   ids or tickets, with a max of eight tickets per server.
 /// * [`ClientConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ClientConfig::key_log`]: key material is not logged.
 /// * [`ClientConfig::cert_decompressors`]: depends on the crate features, see [`compress::default_cert_decompressors()`].

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -300,7 +300,7 @@
 //!   for more details.
 //!
 //! - `custom-provider`: disables implicit use of built-in providers (`aws-lc-rs` or `ring`). This forces
-//!    applications to manually install one, for instance, when using a custom `CryptoProvider`.
+//!   applications to manually install one, for instance, when using a custom `CryptoProvider`.
 //!
 //! - `tls12` (enabled by default): enable support for TLS version 1.2. Note that, due to the
 //!   additive nature of Cargo features and because it is enabled by default, other crates


### PR DESCRIPTION
found in Clippy nightly ref: https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items