### PR TITLE
cleanup: use typos to avoid spelling errors

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -2,5 +2,5 @@ upper-case-acronyms-aggressive = true
 
 # only intended to affect main rustls crate - need to allow disallowed-types in all other crates in Clippy CI job
 disallowed-types = [
-  { path = "std::sync::Arc", reason = "must use Arc from sync module to support downstream forks targetting architectures without atomic ptrs" },
+  { path = "std::sync::Arc", reason = "must use Arc from sync module to support downstream forks targeting architectures without atomic ptrs" },
 ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -526,6 +526,20 @@ jobs:
       - run: cargo install taplo-cli --locked
       - run: taplo format --check
 
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - run: cargo install typos-cli --locked
+      - run: admin/typos
+
   openssl-tests:
     name: Run openssl-tests
     runs-on: ubuntu-latest

--- a/admin/typos
+++ b/admin/typos
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Checks for known typos in all files known by git, with limited exceptions.
+#
+# To auto-correct all detected typos:
+# $ ./admin/typos --write-changes
+#
+# To show other options:
+# $ ./admin/typos --help
+
+set -e
+
+EXCLUDE_FILE_PATTERNS=$(echo \
+  ':!:*.cert' \
+  ':!:*.svg' \
+  ':!:*.chain' \
+  ':!:*.fullchain' \
+  ':!:*.pem' \
+  ':!:*rfc*.json' \
+  ':!:website/templates/macros.html' \
+  ':!:*.png' \
+  ':!:*.pdf' \
+  ':!:*.bin' \
+  ':!:*.der' \
+  ':!:*.woff2' \
+)
+
+git ls-files . $EXCLUDE_FILE_PATTERNS | xargs typos "$@"

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -125,7 +125,7 @@ pub use crate::suites::CipherSuiteCommon;
 /// ```
 /// # #[cfg(feature = "aws_lc_rs")] {
 /// # use std::sync::Arc;
-/// # mod fictious_hsm_api { pub fn load_private_key(key_der: pki_types::PrivateKeyDer<'static>) -> ! { unreachable!(); } }
+/// # mod fictitious_hsm_api { pub fn load_private_key(key_der: pki_types::PrivateKeyDer<'static>) -> ! { unreachable!(); } }
 /// use rustls::crypto::aws_lc_rs;
 ///
 /// pub fn provider() -> rustls::crypto::CryptoProvider {
@@ -140,7 +140,7 @@ pub use crate::suites::CipherSuiteCommon;
 ///
 /// impl rustls::crypto::KeyProvider for HsmKeyLoader {
 ///     fn load_private_key(&self, key_der: pki_types::PrivateKeyDer<'static>) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
-///          fictious_hsm_api::load_private_key(key_der)
+///          fictitious_hsm_api::load_private_key(key_der)
 ///     }
 /// }
 /// # }

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -225,7 +225,7 @@ mod tests {
     use crate::quic::*;
 
     fn test_short_packet(version: Version, expected: &[u8]) {
-        const PN: u64 = 654360564;
+        const PACKET_NUMBER: u64 = 654360564;
         const SECRET: &[u8] = &[
             0x9a, 0xc3, 0x12, 0xa7, 0xf8, 0x77, 0x46, 0x8e, 0xbe, 0x69, 0x42, 0x27, 0x48, 0xad,
             0x00, 0xa1, 0x54, 0x43, 0xf1, 0x82, 0x03, 0xa0, 0x7d, 0x60, 0x60, 0xf6, 0x88, 0xf3,
@@ -249,7 +249,7 @@ mod tests {
         let mut buf = PLAIN.to_vec();
         let (header, payload) = buf.split_at_mut(4);
         let tag = packet
-            .encrypt_in_place(PN, header, payload)
+            .encrypt_in_place(PACKET_NUMBER, header, payload)
             .unwrap();
         buf.extend(tag.as_ref());
 
@@ -270,7 +270,7 @@ mod tests {
 
         let (header, payload_tag) = buf.split_at_mut(4);
         let plain = packet
-            .decrypt_in_place(PN, header, payload_tag)
+            .decrypt_in_place(PACKET_NUMBER, header, payload_tag)
             .unwrap();
 
         assert_eq!(plain, &PLAIN[4..]);

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -409,7 +409,7 @@ mod log {
 mod test_macros;
 
 /// This internal `sync` module aliases the `Arc` implementation to allow downstream forks
-/// of rustls targetting architectures without atomic pointers to replace the implementation
+/// of rustls targeting architectures without atomic pointers to replace the implementation
 /// with another implementation such as `portable_atomic_util::Arc` in one central location.
 mod sync {
     #[allow(clippy::disallowed_types)]

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -5,9 +5,9 @@ macro_rules! enum_builder {
         #[repr($uint:ty)]
         $enum_vis:vis enum $enum_name:ident
         {
-          $( $enum_var:ident => $enum_val:literal),* $(,)?
+          $( $enum_var_debug:ident => $enum_val_debug:literal),* $(,)?
           $( !Debug:
-            $( $enum_var_nd:ident => $enum_val_nd:literal),* $(,)?
+            $( $enum_var_no_debug:ident => $enum_val_no_debug:literal),* $(,)?
           )?
         }
     ) => {
@@ -15,8 +15,8 @@ macro_rules! enum_builder {
         #[non_exhaustive]
         #[derive(PartialEq, Eq, Clone, Copy)]
         $enum_vis enum $enum_name {
-            $( $enum_var),*
-            $(, $($enum_var_nd),* )?
+            $( $enum_var_debug),*
+            $(, $($enum_var_no_debug),* )?
             ,Unknown($uint)
         }
 
@@ -31,8 +31,8 @@ macro_rules! enum_builder {
             #[allow(dead_code)]
             $enum_vis fn as_str(&self) -> Option<&'static str> {
                 match self {
-                    $( $enum_name::$enum_var => Some(stringify!($enum_var))),*
-                    $(, $( $enum_name::$enum_var_nd => Some(stringify!($enum_var_nd))),* )?
+                    $( $enum_name::$enum_var_debug => Some(stringify!($enum_var_debug))),*
+                    $(, $( $enum_name::$enum_var_no_debug => Some(stringify!($enum_var_no_debug))),* )?
                     ,$enum_name::Unknown(_) => None,
                 }
             }
@@ -56,8 +56,8 @@ macro_rules! enum_builder {
         impl From<$uint> for $enum_name {
             fn from(x: $uint) -> Self {
                 match x {
-                    $($enum_val => $enum_name::$enum_var),*
-                    $(, $($enum_val_nd => $enum_name::$enum_var_nd),* )?
+                    $($enum_val_debug => $enum_name::$enum_var_debug),*
+                    $(, $($enum_val_no_debug => $enum_name::$enum_var_no_debug),* )?
                     , x => $enum_name::Unknown(x),
                 }
             }
@@ -66,8 +66,8 @@ macro_rules! enum_builder {
         impl From<$enum_name> for $uint {
             fn from(value: $enum_name) -> Self {
                 match value {
-                    $( $enum_name::$enum_var => $enum_val),*
-                    $(, $( $enum_name::$enum_var_nd => $enum_val_nd),* )?
+                    $( $enum_name::$enum_var_debug => $enum_val_debug),*
+                    $(, $( $enum_name::$enum_var_no_debug => $enum_val_no_debug),* )?
                     ,$enum_name::Unknown(x) => x
                 }
             }
@@ -76,7 +76,7 @@ macro_rules! enum_builder {
         impl core::fmt::Debug for $enum_name {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 match self {
-                    $( $enum_name::$enum_var => f.write_str(stringify!($enum_var)), )*
+                    $( $enum_name::$enum_var_debug => f.write_str(stringify!($enum_var_debug)), )*
                     _ => write!(f, "{}(0x{:x?})", stringify!($enum_name), <$uint>::from(*self)),
                 }
             }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -258,7 +258,7 @@ impl ExtensionProcessing {
             extension_type == ExtensionType::ClientCertificateType
                 || extension_type == ExtensionType::ServerCertificateType
         );
-        let raw_key_negotation_result = match (
+        let raw_key_negotiation_result = match (
             requires_raw_keys,
             client_supports.contains(&CertificateType::RawPublicKey),
             client_supports.contains(&CertificateType::X509),
@@ -274,7 +274,7 @@ impl ExtensionProcessing {
             (false, false, false) => return Ok(()),
         };
 
-        match raw_key_negotation_result {
+        match raw_key_negotiation_result {
             Ok((ExtensionType::ClientCertificateType, cert_type)) => {
                 self.exts
                     .push(ServerExtension::ClientCertType(cert_type));

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -401,7 +401,7 @@ mod test_raw_keys {
             }
             Payload::new(parsed.get_encoding())
         } else {
-            panic!("Expected to succesfully encode handshake message");
+            panic!("Expected to successfully encode handshake message");
         };
 
         // // Re-encrypt
@@ -6138,7 +6138,7 @@ fn bad_client_max_fragment_sizes() {
 }
 
 #[test]
-fn handshakes_complete_and_data_flows_with_gratuitious_max_fragment_sizes() {
+fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
     // general exercising of msgs::fragmenter and msgs::deframer
     for kt in ALL_KEY_TYPES {
         for version in rustls::ALL_VERSIONS {
@@ -8245,7 +8245,7 @@ fn large_client_hello_acceptor() {
 }
 
 #[test]
-fn hybrid_kx_component_share_offered_if_supported_seperately() {
+fn hybrid_kx_component_share_offered_if_supported_separately() {
     let kt = KeyType::Rsa2048;
     let client_config = finish_client_config(
         kt,
@@ -8271,7 +8271,7 @@ fn hybrid_kx_component_share_offered_if_supported_seperately() {
 }
 
 #[test]
-fn hybrid_kx_component_share_not_offered_unless_supported_seperately() {
+fn hybrid_kx_component_share_not_offered_unless_supported_separately() {
     let kt = KeyType::Rsa2048;
     let client_config = finish_client_config(
         kt,

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,18 @@
+[default]
+extend-ignore-re = [
+  # Auto-fixing these patterns would introduce many changes to the source & potentially affect public API
+  ".*Encrypter.*",
+  ".*encrypter.*",
+  # packet number field names in: rustls/src/quic.rs
+  "pn_offset",
+  "pn_len",
+  "pn_mask",
+  "EDE_*", # needed for public enums
+  "Josh Aas", # This name shows up in README.md - do not auto-correct this
+  "hel.*lo", # split-up contents for a test binary pattern
+  "mis-encoded", # needed for some documentation
+  "thr", # shortened from "thread" in some bench code
+  "ture dat", # partial contents split from  "fixture data" in a binary data test
+]
+
+# NOTE: List of excluded file patterns is part of admin script: admin/typos


### PR DESCRIPTION
__PROPOSED UPDATES__

- configure some patterns & files to ignore in `typos.toml`
- update CI with new Typos job
- resolve spelling error in `clippy.toml`
- resolve spelling errors in doc comments
- update tests to resolve spelling errors
- resolve misspelling of negotiation in rustls src (was originally part of other PR now closed & partially obsolete - #2331)

---

__BLOCKED BY__

- [x] ~~wait for other PR to be merged to avoid extra burden on that contribution: #2274 (as discussed below); PR #2274 will also reduce the number of fixes needed in rustls/src~~

__TODO__

- [x] ~~rebase & squash the updates needed _now that_  PR #2274 is merged (only 2 updates beyond doc comments needed with updates from PR #2274; I did revert some updates to rustls/src & do `typos --write-changes` to fix the remaining typos automatically)~~
- [ ] resolve review suggestions
- [ ] check that CI DOES CATCH some typos that I injected with XXX comments in multiple places
- [ ] rebase & cleanup commits - keep typo fixes & config updates in separate commits as discussed below
- [ ] add recommendation to contribute any new typos ~~poeple~~ _people_ ~~mayh~~ sorry may find - ~~poiter~~ sorry pointer to this: https://github.com/crate-ci/typos/blob/master/CONTRIBUTING.md#updating-the-dictionary

---

__ADDITIONAL NOTES__

- Personal CI testing in my fork _now outdated_: https://github.com/brody4hire/rustls/pull/9
- ~~riased sorry raised (typos also seems to miss my typo here)~~ _reported_ a few more typo ~~correctionsn~~ sorry correction patterns I found: https://github.com/crate-ci/typos/issues/1221#issuecomment-2648925186
- I made `admin/typos` to check *all* files known by git, with limited exception patterns, as hinted in the following resources:
  - https://github.com/crate-ci/typos/issues/788#issuecomment-1668539988
  - https://stackoverflow.com/questions/36753573/how-do-i-exclude-files-from-git-ls-files/53083343#53083343

---

__BACKSTORY__

While working on something else using VS Code, with a spell checking extension, I noticed that a recent contribution from myself in #2285 had a minor misspelling. This could have been avoided by using `typos`, as I propose now.