### PR TITLE
chore: spelling fixes in rustls/src

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -17,7 +17,7 @@ use crate::client::common::ClientHelloDetails;
 use crate::client::ech::EchState;
 use crate::client::{tls13, ClientConfig, EchMode, EchStatus};
 use crate::common_state::{
-    CommonState, HandshakeKind, KxState, RawKeyNegotationResult, RawKeyNegotiationParams, State,
+    CommonState, HandshakeKind, KxState, RawKeyNegotiationResult, RawKeyNegotiationParams, State,
 };
 use crate::conn::ConnectionRandoms;
 use crate::crypto::{ActiveKeyExchange, KeyExchangeAlgorithm};
@@ -713,7 +713,7 @@ pub(super) fn process_server_cert_type_extension(
         extension_type: ExtensionType::ServerCertificateType,
     };
     match raw_key_negotation_params.validate_raw_key_negotiation() {
-        RawKeyNegotationResult::Err(err) => {
+        RawKeyNegotiationResult::Err(err) => {
             Err(common.send_fatal_alert(AlertDescription::HandshakeFailure, err))
         }
         _ => Ok(()),
@@ -736,7 +736,7 @@ pub(super) fn process_client_cert_type_extension(
         extension_type: ExtensionType::ClientCertificateType,
     };
     match raw_key_negotation_params.validate_raw_key_negotiation() {
-        RawKeyNegotationResult::Err(err) => {
+        RawKeyNegotiationResult::Err(err) => {
             Err(common.send_fatal_alert(AlertDescription::HandshakeFailure, err))
         }
         _ => Ok(()),

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -707,12 +707,12 @@ pub(super) fn process_server_cert_type_extension(
         .requires_raw_public_keys();
     let server_offers_rpk = matches!(server_cert_extension, Some(CertificateType::RawPublicKey));
 
-    let raw_key_negotation_params = RawKeyNegotiationParams {
+    let raw_key_negotiation_params = RawKeyNegotiationParams {
         peer_supports_raw_key: server_offers_rpk,
         local_expects_raw_key: requires_server_rpk,
         extension_type: ExtensionType::ServerCertificateType,
     };
-    match raw_key_negotation_params.validate_raw_key_negotiation() {
+    match raw_key_negotiation_params.validate_raw_key_negotiation() {
         RawKeyNegotiationResult::Err(err) => {
             Err(common.send_fatal_alert(AlertDescription::HandshakeFailure, err))
         }
@@ -730,12 +730,12 @@ pub(super) fn process_client_cert_type_extension(
         .only_raw_public_keys();
     let server_allows_rpk = matches!(client_cert_extension, Some(CertificateType::RawPublicKey));
 
-    let raw_key_negotation_params = RawKeyNegotiationParams {
+    let raw_key_negotiation_params = RawKeyNegotiationParams {
         peer_supports_raw_key: server_allows_rpk,
         local_expects_raw_key: requires_client_rpk,
         extension_type: ExtensionType::ClientCertificateType,
     };
-    match raw_key_negotation_params.validate_raw_key_negotiation() {
+    match raw_key_negotiation_params.validate_raw_key_negotiation() {
         RawKeyNegotiationResult::Err(err) => {
             Err(common.send_fatal_alert(AlertDescription::HandshakeFailure, err))
         }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -17,7 +17,7 @@ use crate::client::common::ClientHelloDetails;
 use crate::client::ech::EchState;
 use crate::client::{tls13, ClientConfig, EchMode, EchStatus};
 use crate::common_state::{
-    CommonState, HandshakeKind, KxState, RawKeyNegotiationResult, RawKeyNegotiationParams, State,
+    CommonState, HandshakeKind, KxState, RawKeyNegotiationParams, RawKeyNegotiationResult, State,
 };
 use crate::conn::ConnectionRandoms;
 use crate::crypto::{ActiveKeyExchange, KeyExchangeAlgorithm};

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -908,14 +908,14 @@ pub(super) struct RawKeyNegotiationParams {
 }
 
 impl RawKeyNegotiationParams {
-    pub(super) fn validate_raw_key_negotiation(&self) -> RawKeyNegotationResult {
+    pub(super) fn validate_raw_key_negotiation(&self) -> RawKeyNegotiationResult {
         match (self.local_expects_raw_key, self.peer_supports_raw_key) {
-            (true, true) => RawKeyNegotationResult::Negotiated(self.extension_type),
-            (false, false) => RawKeyNegotationResult::NotNegotiated,
-            (true, false) => RawKeyNegotationResult::Err(Error::PeerIncompatible(
+            (true, true) => RawKeyNegotiationResult::Negotiated(self.extension_type),
+            (false, false) => RawKeyNegotiationResult::NotNegotiated,
+            (true, false) => RawKeyNegotiationResult::Err(Error::PeerIncompatible(
                 PeerIncompatible::IncorrectCertificateTypeExtension,
             )),
-            (false, true) => RawKeyNegotationResult::Err(Error::PeerIncompatible(
+            (false, true) => RawKeyNegotiationResult::Err(Error::PeerIncompatible(
                 PeerIncompatible::UnsolicitedCertificateTypeExtension,
             )),
         }
@@ -923,7 +923,7 @@ impl RawKeyNegotiationParams {
 }
 
 #[derive(Debug)]
-pub(crate) enum RawKeyNegotationResult {
+pub(crate) enum RawKeyNegotiationResult {
     Negotiated(ExtensionType),
     NotNegotiated,
     Err(Error),

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -8,7 +8,7 @@ use super::server_conn::ServerConnectionData;
 #[cfg(feature = "tls12")]
 use super::tls12;
 use crate::common_state::{
-    KxState, Protocol, RawKeyNegotiationResult, RawKeyNegotiationParams, State,
+    KxState, Protocol, RawKeyNegotiationParams, RawKeyNegotiationResult, State,
 };
 use crate::conn::ConnectionRandoms;
 use crate::crypto::SupportedKxGroup;

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -221,14 +221,14 @@ impl ExtensionProcessing {
             .map(|certificate_types| certificate_types.contains(&CertificateType::RawPublicKey))
             .unwrap_or(false);
 
-        let raw_key_negotation_params = RawKeyNegotiationParams {
+        let raw_key_negotiation_params = RawKeyNegotiationParams {
             peer_supports_raw_key: client_allows_rpk,
             local_expects_raw_key: requires_server_rpk,
             extension_type: ExtensionType::ServerCertificateType,
         };
 
         self.process_cert_type_extension(
-            raw_key_negotation_params.validate_raw_key_negotiation(),
+            raw_key_negotiation_params.validate_raw_key_negotiation(),
             cx,
         )
     }
@@ -247,13 +247,13 @@ impl ExtensionProcessing {
             .map(|certificate_types| certificate_types.contains(&CertificateType::RawPublicKey))
             .unwrap_or(false);
 
-        let raw_key_negotation_params = RawKeyNegotiationParams {
+        let raw_key_negotiation_params = RawKeyNegotiationParams {
             peer_supports_raw_key: client_offers_rpk,
             local_expects_raw_key: requires_client_rpk,
             extension_type: ExtensionType::ClientCertificateType,
         };
         self.process_cert_type_extension(
-            raw_key_negotation_params.validate_raw_key_negotiation(),
+            raw_key_negotiation_params.validate_raw_key_negotiation(),
             cx,
         )
     }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -8,7 +8,7 @@ use super::server_conn::ServerConnectionData;
 #[cfg(feature = "tls12")]
 use super::tls12;
 use crate::common_state::{
-    KxState, Protocol, RawKeyNegotationResult, RawKeyNegotiationParams, State,
+    KxState, Protocol, RawKeyNegotiationResult, RawKeyNegotiationParams, State,
 };
 use crate::conn::ConnectionRandoms;
 use crate::crypto::SupportedKxGroup;
@@ -260,29 +260,29 @@ impl ExtensionProcessing {
 
     fn process_cert_type_extension(
         &mut self,
-        raw_key_negotiation_result: RawKeyNegotationResult,
+        raw_key_negotiation_result: RawKeyNegotiationResult,
         cx: &mut ServerContext<'_>,
     ) -> Result<(), Error> {
         match raw_key_negotiation_result {
-            RawKeyNegotationResult::Negotiated(ExtensionType::ClientCertificateType) => {
+            RawKeyNegotiationResult::Negotiated(ExtensionType::ClientCertificateType) => {
                 self.exts
                     .push(ServerExtension::ClientCertType(
                         CertificateType::RawPublicKey,
                     ));
             }
-            RawKeyNegotationResult::Negotiated(ExtensionType::ServerCertificateType) => {
+            RawKeyNegotiationResult::Negotiated(ExtensionType::ServerCertificateType) => {
                 self.exts
                     .push(ServerExtension::ServerCertType(
                         CertificateType::RawPublicKey,
                     ));
             }
-            RawKeyNegotationResult::Err(err) => {
+            RawKeyNegotiationResult::Err(err) => {
                 return Err(cx
                     .common
                     .send_fatal_alert(AlertDescription::HandshakeFailure, err));
             }
-            RawKeyNegotationResult::NotNegotiated => {}
-            RawKeyNegotationResult::Negotiated(_) => unreachable!(
+            RawKeyNegotiationResult::NotNegotiated => {}
+            RawKeyNegotiationResult::Negotiated(_) => unreachable!(
                 "The extension type should only ever be ClientCertificateType or ServerCertificateType"
             ),
         }


### PR DESCRIPTION
- `RawKeyNegotationResult` -> `RawKeyNegotiationResult` - seems to be `pub(crate) enum` which is NOT exported
- `let raw_key_negotation_params` -> `let raw_key_negotiation_params` in multiple places - seems to be internal to internal fns

discovered with help from `typos`, as I proposed in other PR #2329

---

I think it would be ideal to review & hopefully merge PR #2329 first, then update typos config to stop ignoring this typo pattern.