### PR TITLE
unbuffered: introduce `PeerClosed` state

### DIFF
--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -40,6 +40,8 @@ pub struct CommonState {
     pub(crate) may_receive_application_data: bool,
     pub(crate) early_traffic: bool,
     sent_fatal_alert: bool,
+    /// If we signaled end of stream.
+    pub(crate) has_sent_close_notify: bool,
     /// If the peer has signaled end of stream.
     pub(crate) has_received_close_notify: bool,
     #[cfg(feature = "std")]
@@ -74,6 +76,7 @@ impl CommonState {
             may_receive_application_data: false,
             early_traffic: false,
             sent_fatal_alert: false,
+            has_sent_close_notify: false,
             has_received_close_notify: false,
             #[cfg(feature = "std")]
             has_seen_eof: false,
@@ -573,6 +576,7 @@ impl CommonState {
         }
         debug!("Sending warning alert {:?}", AlertDescription::CloseNotify);
         self.sent_fatal_alert = true;
+        self.has_sent_close_notify = true;
         self.send_warning_alert_no_log(AlertDescription::CloseNotify);
     }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -811,6 +811,7 @@ impl<Data> From<ConnectionCore<Data>> for ConnectionCommon<Data> {
 pub struct UnbufferedConnectionCommon<Data> {
     pub(crate) core: ConnectionCore<Data>,
     wants_write: bool,
+    emitted_peer_closed: bool,
 }
 
 impl<Data> From<ConnectionCore<Data>> for UnbufferedConnectionCommon<Data> {
@@ -818,6 +819,7 @@ impl<Data> From<ConnectionCore<Data>> for UnbufferedConnectionCommon<Data> {
         Self {
             core,
             wants_write: false,
+            emitted_peer_closed: false,
         }
     }
 }

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -131,6 +131,18 @@ impl<Data> UnbufferedConnectionCommon<Data> {
                 .core
                 .common_state
                 .has_received_close_notify
+                && !self.emitted_peer_closed
+            {
+                self.emitted_peer_closed = true;
+                break (buffer.pending_discard(), ConnectionState::PeerClosed);
+            } else if self
+                .core
+                .common_state
+                .has_received_close_notify
+                && self
+                    .core
+                    .common_state
+                    .has_sent_close_notify
             {
                 break (buffer.pending_discard(), ConnectionState::Closed);
             } else if self
@@ -185,7 +197,26 @@ pub enum ConnectionState<'c, 'i, Data> {
     /// the received data.
     ReadTraffic(ReadTraffic<'c, 'i, Data>),
 
-    /// Connection has been cleanly closed by the peer
+    /// Connection has been cleanly closed by the peer.
+    ///
+    /// This state is encountered at most once by each connection -- it is
+    /// "edge" triggered, rather than "level" triggered.
+    ///
+    /// It delimits the data received from the peer, meaning you can be sure you
+    /// have received all the data the peer sent.
+    ///
+    /// No further application data will be received from the peer, so no further
+    /// `ReadTraffic` states will be produced.
+    ///
+    /// However, it is possible to _send_ further application data via `WriteTraffic`
+    /// states, or close the connection cleanly by calling
+    /// [`WriteTraffic::queue_close_notify()`].
+    PeerClosed,
+
+    /// Connection has been cleanly closed by both us and the peer.
+    ///
+    /// This is a terminal state.  No other states will be produced for this
+    /// connection.
     Closed,
 
     /// One, or more, early (RTT-0) data records are available
@@ -261,6 +292,8 @@ impl<Data> fmt::Debug for ConnectionState<'_, '_, Data> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ReadTraffic(..) => f.debug_tuple("ReadTraffic").finish(),
+
+            Self::PeerClosed => write!(f, "PeerClosed"),
 
             Self::Closed => write!(f, "Closed"),
 

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -5,8 +5,8 @@ use std::num::NonZeroUsize;
 use rustls::client::{ClientConnectionData, EarlyDataError, UnbufferedClientConnection};
 use rustls::server::{ServerConnectionData, UnbufferedServerConnection};
 use rustls::unbuffered::{
-    ConnectionState, EncodeError, EncryptError, InsufficientSizeError, UnbufferedConnectionCommon,
-    UnbufferedStatus, WriteTraffic,
+    ConnectionState, EncodeError, EncryptError, InsufficientSizeError, ReadTraffic,
+    UnbufferedConnectionCommon, UnbufferedStatus, WriteTraffic,
 };
 use rustls::version::TLS13;
 use rustls::{
@@ -329,10 +329,10 @@ fn run(
                     .client_received_app_data
                     .extend(records);
             }
-            State::Closed => {
-                client_handshake_done = true;
-                outcome.client_reached_connection_closed_state = true
+            State::PeerClosed => {
+                outcome.client_saw_peer_closed_state = true;
             }
+            State::Closed => {}
             state => unreachable!("{state:?}"),
         }
 
@@ -385,10 +385,10 @@ fn run(
                     .server_received_app_data
                     .extend(records);
             }
-            State::Closed => {
-                server_handshake_done = true;
-                outcome.server_reached_connection_closed_state = true
+            State::PeerClosed => {
+                outcome.server_saw_peer_closed_state = true;
             }
+            State::Closed => {}
         }
 
         count += 1;
@@ -435,7 +435,7 @@ fn close_notify_client_to_server() {
         );
 
         assert!(!client_actions.send_close_notify);
-        assert!(outcome.server_reached_connection_closed_state);
+        assert!(outcome.server_saw_peer_closed_state);
     }
 }
 
@@ -459,7 +459,59 @@ fn close_notify_server_to_client() {
         );
 
         assert!(!server_actions.send_close_notify);
-        assert!(outcome.client_reached_connection_closed_state);
+        assert!(outcome.client_saw_peer_closed_state);
+    }
+}
+
+#[test]
+fn full_closure_server_to_client() {
+    for version in rustls::ALL_VERSIONS {
+        eprintln!("{version:?}");
+        let mut outcome = handshake(version);
+        let mut client = outcome.client.take().unwrap();
+        let mut server = outcome.server.take().unwrap();
+
+        let mut buf = Buffer::default();
+
+        // server sends message followed by close_notify, in one flight
+        write_traffic(
+            server.process_tls_records(&mut []),
+            |mut wt: WriteTraffic<_>| {
+                encrypt(&mut wt, b"hello", &mut buf);
+                queue_close_notify(&mut wt, &mut buf);
+            },
+        );
+
+        let (_, discard) = read_traffic(client.process_tls_records(buf.filled()), |mut rt| {
+            assert_eq!(rt.peek_len(), NonZeroUsize::new(5));
+            let app_data = rt.next_record().unwrap().unwrap();
+            assert_eq!(app_data.payload, b"hello");
+        });
+        buf.discard(discard);
+
+        let discard = peer_closed(client.process_tls_records(buf.filled()));
+        buf.discard(discard);
+        assert_eq!(buf.used, 0);
+
+        // client replies with its own data and close_notify
+        write_traffic(client.process_tls_records(&mut []), |mut wt| {
+            encrypt(&mut wt, b"goodbye", &mut buf);
+            queue_close_notify(&mut wt, &mut buf);
+        });
+
+        let (_, discard) = read_traffic(server.process_tls_records(buf.filled()), |mut rt| {
+            assert_eq!(rt.peek_len(), NonZeroUsize::new(7));
+            let app_data = rt.next_record().unwrap().unwrap();
+            assert_eq!(app_data.payload, b"goodbye");
+        });
+        buf.discard(discard);
+
+        let discard = peer_closed(server.process_tls_records(buf.filled()));
+        buf.discard(discard);
+        assert_eq!(buf.used, 0);
+
+        closed(client.process_tls_records(&mut []));
+        closed(server.process_tls_records(&mut []));
     }
 }
 
@@ -483,13 +535,13 @@ fn junk_after_close_notify_received() {
     let discard = match dbg!(server.process_tls_records(dbg!(&mut client_send_buf[..len]))) {
         UnbufferedStatus {
             discard,
-            state: Ok(ConnectionState::Closed),
+            state: Ok(ConnectionState::PeerClosed),
         } => {
             assert_eq!(discard, 24);
             discard
         }
         st => {
-            panic!("unexpected server state {st:?} (wanted Closed)");
+            panic!("unexpected server state {st:?} (wanted PeerClosed)");
         }
     };
 
@@ -785,7 +837,7 @@ fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
     match server.process_tls_records(&mut data) {
         UnbufferedStatus {
             discard,
-            state: Ok(ConnectionState::Closed),
+            state: Ok(ConnectionState::PeerClosed),
         } if discard == data_len => {}
         st => panic!("unexpected server state {st:?}"),
     }
@@ -870,6 +922,39 @@ fn write_traffic<T: SideData, R, F: FnMut(WriteTraffic<T>) -> R>(
     }
 }
 
+fn read_traffic<T: SideData, R, F: FnMut(ReadTraffic<T>) -> R>(
+    status: UnbufferedStatus<'_, '_, T>,
+    mut f: F,
+) -> (R, usize) {
+    let UnbufferedStatus { discard, state } = status;
+    let state = state.unwrap();
+    if let ConnectionState::ReadTraffic(state) = state {
+        (f(state), discard)
+    } else {
+        panic!("unexpected client state {state:?} (wanted ReadTraffic)");
+    }
+}
+
+fn peer_closed<T: SideData>(status: UnbufferedStatus<'_, '_, T>) -> usize {
+    let UnbufferedStatus { discard, state } = status;
+    let state = state.unwrap();
+    if let ConnectionState::PeerClosed = state {
+        discard
+    } else {
+        panic!("unexpected client state {state:?} (wanted PeerClosed)");
+    }
+}
+
+fn closed<T: SideData>(status: UnbufferedStatus<'_, '_, T>) -> usize {
+    let UnbufferedStatus { discard, state } = status;
+    let state = state.unwrap();
+    if let ConnectionState::Closed = state {
+        discard
+    } else {
+        panic!("unexpected client state {state:?} (wanted Closed)");
+    }
+}
+
 fn encode_tls_data<T: SideData>(status: UnbufferedStatus<'_, '_, T>) -> (Vec<u8>, usize) {
     match status {
         UnbufferedStatus {
@@ -909,6 +994,7 @@ fn confirm_transmit_tls_data<T: SideData>(status: UnbufferedStatus<'_, '_, T>) {
 #[derive(Debug)]
 enum State {
     Closed,
+    PeerClosed,
     EncodedTlsData,
     TransmitTlsData {
         sent_app_data: bool,
@@ -955,11 +1041,11 @@ struct Outcome {
     server_transcript: Vec<String>,
     server_received_early_data: Vec<Vec<u8>>,
     server_received_app_data: Vec<Vec<u8>>,
-    server_reached_connection_closed_state: bool,
+    server_saw_peer_closed_state: bool,
     client: Option<UnbufferedClientConnection>,
     client_transcript: Vec<String>,
     client_received_app_data: Vec<Vec<u8>>,
-    client_reached_connection_closed_state: bool,
+    client_saw_peer_closed_state: bool,
 }
 
 fn advance_client(
@@ -1136,6 +1222,7 @@ fn handle_state<Data>(
             State::ReceivedAppData { records }
         }
 
+        ConnectionState::PeerClosed => State::PeerClosed,
         ConnectionState::Closed => State::Closed,
 
         _ => unreachable!(),


### PR DESCRIPTION
`Closed` was, and remains, the bi-directional, terminal closure state.

Because `rustls::unbuffered::ConnectionState` is a `non_exhaustive` enum, this is not a breaking API change. However, it demands a clear release note because downstream users will now encounter the new state.

fixes #1895
