### PR TITLE
cleanup: use internal alias for std::error::Error (etc.) - REJECTED

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,7 +334,7 @@ unnecessary. The one exception to this is when the symbol name is overly
 generic, or easily confused between different crates. In this case we prefer to
 import the symbol name under an alias, or if the parent module name is short,
 using a one-level qualified path. E.g. for a crate with a local `Error` type,
-prefer to `import std::error::Error as StdError`.
+prefer to import (use) `std::error::Error` as `StdError`.
 
 ### Exports
 

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -28,7 +28,7 @@
 //! "SSL_ECH_STATUS": "success"
 //! ```
 
-use std::error::Error;
+use std::error::Error as StdError;
 use std::fs;
 use std::io::{stdout, BufReader, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -49,7 +49,7 @@ use rustls::pki_types::{CertificateDer, EchConfigListBytes, ServerName};
 use rustls::RootCertStore;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), Box<dyn StdError>> {
     let args = Args::parse();
 
     let server_ech_configs = match (args.grease, args.ech_config) {

--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -2,7 +2,7 @@
 //! handle the buffers required to receive, process and send TLS data. Additionally it demonstrates
 //! using asynchronous I/O using either async-std or tokio.
 
-use std::error::Error;
+use std::error::Error as StdError;
 use std::sync::Arc;
 
 #[cfg(feature = "async-std")]
@@ -23,7 +23,7 @@ use tokio::net::TcpStream;
 
 #[cfg_attr(not(feature = "async-std"), tokio::main(flavor = "current_thread"))]
 #[cfg_attr(feature = "async-std", async_std::main)]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), Box<dyn StdError>> {
     let root_store = RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.into(),
     };

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -1,7 +1,7 @@
 //! This is a simple client using rustls' unbuffered API. Meaning that the application layer must
 //! handle the buffers required to receive, process and send TLS data.
 
-use std::error::Error;
+use std::error::Error as StdError;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ use rustls::unbuffered::{
 use rustls::version::TLS13;
 use rustls::{ClientConfig, RootCertStore};
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn StdError>> {
     let root_store = RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.into(),
     };

--- a/examples/src/bin/unbuffered-server.rs
+++ b/examples/src/bin/unbuffered-server.rs
@@ -2,7 +2,7 @@
 //! handle the buffers required to receive, process and send TLS data.
 
 use std::env;
-use std::error::Error;
+use std::error::Error as StdError;
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
@@ -17,7 +17,7 @@ use rustls::unbuffered::{
 };
 use rustls::ServerConfig;
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn StdError>> {
     let mut args = env::args();
     args.next();
     let cert_file = args

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -1,6 +1,7 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::Debug;
+use std::error::Error as StdError;
 
 use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
 use hpke_rs_crypto::HpkeCrypto;
@@ -212,7 +213,7 @@ impl HpkeOpener for HpkeRsReceiver {
 }
 
 #[cfg(feature = "std")]
-fn other_err(err: impl std::error::Error + Send + Sync + 'static) -> Error {
+fn other_err(err: impl StdError + Send + Sync + 'static) -> Error {
     Error::Other(OtherError(alloc::sync::Arc::new(err)))
 }
 

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -1,6 +1,7 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::Debug;
+#[cfg(feature = "std")]
 use std::error::Error as StdError;
 
 use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};

--- a/rustls/examples/internal/test_ca.rs
+++ b/rustls/examples/internal/test_ca.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::env;
+use std::error::Error as StdError;
 use std::fs::{self, File};
 use std::io::Write;
 use std::net::IpAddr;
@@ -17,7 +18,7 @@ use rcgen::{
 };
 use time::OffsetDateTime;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn StdError>> {
     let mut certified_keys = HashMap::with_capacity(ROLES.len() * SIG_ALGS.len());
     for role in ROLES {
         for alg in SIG_ALGS {

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -14,6 +14,8 @@ use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
+#[cfg(feature = "std")]
+use crate::error::StdError;
 use crate::log::trace;
 use crate::msgs::enums::NamedGroup;
 use crate::msgs::handshake::ClientExtension;
@@ -941,7 +943,7 @@ impl fmt::Display for EarlyDataError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for EarlyDataError {}
+impl StdError for EarlyDataError {}
 
 /// State associated with a client connection.
 #[derive(Debug)]

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -3,11 +3,11 @@
 use alloc::vec::Vec;
 use core::num::NonZeroUsize;
 use core::{fmt, mem};
-#[cfg(feature = "std")]
-use std::error::Error as StdError;
 
 use super::UnbufferedConnectionCommon;
 use crate::client::ClientConnectionData;
+#[cfg(feature = "std")]
+use crate::error::StdError;
 use crate::msgs::deframer::buffers::DeframerSliceBuffer;
 use crate::server::ServerConnectionData;
 use crate::Error;

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -6,6 +6,8 @@ use zeroize::Zeroize;
 
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::Error;
+#[cfg(feature = "std")]
+use crate::error::StdError;
 use crate::msgs::codec;
 pub use crate::msgs::message::{
     BorrowedPayload, InboundOpaqueMessage, InboundPlainMessage, OutboundChunks,
@@ -103,7 +105,7 @@ impl fmt::Display for UnsupportedOperationError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for UnsupportedOperationError {}
+impl StdError for UnsupportedOperationError {}
 
 /// How a TLS1.2 `key_block` is partitioned.
 ///

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -9,6 +9,9 @@ use crate::enums::{AlertDescription, ContentType, HandshakeType};
 use crate::msgs::handshake::{EchConfigPayload, KeyExchangeAlgorithm};
 use crate::rand;
 
+#[cfg(feature = "std")]
+pub(crate) use std::error::Error as StdError;
+
 /// rustls reports protocol errors using this type.
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Clone)]
@@ -612,7 +615,7 @@ impl From<SystemTimeError> for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl StdError for Error {}
 
 impl From<rand::GetRandomFailed> for Error {
     fn from(_: rand::GetRandomFailed) -> Self {
@@ -622,10 +625,10 @@ impl From<rand::GetRandomFailed> for Error {
 
 mod other_error {
     use core::fmt;
-    #[cfg(feature = "std")]
-    use std::error::Error as StdError;
 
     use super::Error;
+    #[cfg(feature = "std")]
+    use super::StdError;
     #[cfg(feature = "std")]
     use crate::sync::Arc;
 

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -4,6 +4,8 @@ use core::fmt;
 use pki_types::CertificateRevocationListDer;
 use webpki::{CertRevocationList, OwnedCertRevocationList};
 
+#[cfg(feature = "std")]
+use crate::error::StdError;
 use crate::error::{CertRevocationListError, CertificateError, Error, OtherError};
 #[cfg(feature = "std")]
 use crate::sync::Arc;
@@ -52,7 +54,7 @@ impl fmt::Display for VerifierBuilderError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for VerifierBuilderError {}
+impl StdError for VerifierBuilderError {}
 
 fn pki_error(error: webpki::Error) -> Error {
     use webpki::Error::*;


### PR DESCRIPTION
I think this would be a little cleaner and would make it a little easier to switch to using `core::error::Error` once this is possible.

---

__TODO__

- [ ] cleanup remaining uses of `std::error::Error`