### PR TITLE
refactor: update namings in internal enum_builder macro

### DIFF
--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -5,9 +5,9 @@ macro_rules! enum_builder {
         #[repr($uint:ty)]
         $enum_vis:vis enum $enum_name:ident
         {
-          $( $enum_var:ident => $enum_val:literal),* $(,)?
+          $( $enum_var_dbg_fmt:ident => $enum_value_dbg_fmt:literal),* $(,)?
           $( !Debug:
-            $( $enum_var_nd:ident => $enum_val_nd:literal),* $(,)?
+            $( $enum_var_no_fmt:ident => $enum_value_no_fmt:literal),* $(,)?
           )?
         }
     ) => {
@@ -15,8 +15,8 @@ macro_rules! enum_builder {
         #[non_exhaustive]
         #[derive(PartialEq, Eq, Clone, Copy)]
         $enum_vis enum $enum_name {
-            $( $enum_var),*
-            $(, $($enum_var_nd),* )?
+            $( $enum_var_dbg_fmt),*
+            $(, $($enum_var_no_fmt),* )?
             ,Unknown($uint)
         }
 
@@ -31,8 +31,8 @@ macro_rules! enum_builder {
             #[allow(dead_code)]
             $enum_vis fn as_str(&self) -> Option<&'static str> {
                 match self {
-                    $( $enum_name::$enum_var => Some(stringify!($enum_var))),*
-                    $(, $( $enum_name::$enum_var_nd => Some(stringify!($enum_var_nd))),* )?
+                    $( $enum_name::$enum_var_dbg_fmt => Some(stringify!($enum_var_dbg_fmt))),*
+                    $(, $( $enum_name::$enum_var_no_fmt => Some(stringify!($enum_var_no_fmt))),* )?
                     ,$enum_name::Unknown(_) => None,
                 }
             }
@@ -56,8 +56,8 @@ macro_rules! enum_builder {
         impl From<$uint> for $enum_name {
             fn from(x: $uint) -> Self {
                 match x {
-                    $($enum_val => $enum_name::$enum_var),*
-                    $(, $($enum_val_nd => $enum_name::$enum_var_nd),* )?
+                    $($enum_value_dbg_fmt => $enum_name::$enum_var_dbg_fmt),*
+                    $(, $($enum_value_no_fmt => $enum_name::$enum_var_no_fmt),* )?
                     , x => $enum_name::Unknown(x),
                 }
             }
@@ -66,8 +66,8 @@ macro_rules! enum_builder {
         impl From<$enum_name> for $uint {
             fn from(value: $enum_name) -> Self {
                 match value {
-                    $( $enum_name::$enum_var => $enum_val),*
-                    $(, $( $enum_name::$enum_var_nd => $enum_val_nd),* )?
+                    $( $enum_name::$enum_var_dbg_fmt => $enum_value_dbg_fmt),*
+                    $(, $( $enum_name::$enum_var_no_fmt => $enum_value_no_fmt),* )?
                     ,$enum_name::Unknown(x) => x
                 }
             }
@@ -76,7 +76,7 @@ macro_rules! enum_builder {
         impl core::fmt::Debug for $enum_name {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 match self {
-                    $( $enum_name::$enum_var => f.write_str(stringify!($enum_var)), )*
+                    $( $enum_name::$enum_var_dbg_fmt => f.write_str(stringify!($enum_var_dbg_fmt)), )*
                     _ => write!(f, "{}(0x{:x?})", stringify!($enum_name), <$uint>::from(*self)),
                 }
             }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6729,6 +6729,19 @@ fn test_multiple_cipher_suite_enum_values() {
         "CipherSuite(0x1)"
     );
     assert_eq!(format!("{:?}", CipherSuite::from(1)), "CipherSuite(0x1)");
+
+    // test enum with CipherSuite::Unknown(...)
+    assert_eq!(CipherSuite::from(9876), CipherSuite::Unknown(9876));
+    assert_eq!(u16::from(CipherSuite::Unknown(9876)), 9876);
+    assert_eq!(CipherSuite::Unknown(9876).as_str(), None);
+    assert_eq!(
+        format!("{:?}", CipherSuite::Unknown(9876)),
+        "CipherSuite(0x2694)"
+    );
+    assert_eq!(
+        format!("{:?}", CipherSuite::from(9876)),
+        "CipherSuite(0x2694)"
+    );
 }
 
 /// Test that secrets can be extracted and used for encryption/decryption.

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6699,6 +6699,23 @@ fn test_no_warning_logging_during_successful_sessions() {
     }
 }
 
+#[test]
+fn test_multiple_cipher_suite_enum_values() {
+    // test enum value with debug fmt:
+    assert_eq!(CipherSuite::from(0), CipherSuite::TLS_NULL_WITH_NULL_NULL);
+    assert_eq!(u16::from(CipherSuite::TLS_NULL_WITH_NULL_NULL), 0);
+    assert_eq!(CipherSuite::TLS_NULL_WITH_NULL_NULL.as_str(), Some("TLS_NULL_WITH_NULL_NULL"));
+    assert_eq!(format!("{:?}", CipherSuite::TLS_NULL_WITH_NULL_NULL), "TLS_NULL_WITH_NULL_NULL");
+    assert_eq!(format!("{:?}", CipherSuite::from(0)), "TLS_NULL_WITH_NULL_NULL");
+
+    // test enum value with no debug fmt:
+    assert_eq!(CipherSuite::from(1), CipherSuite::TLS_RSA_WITH_NULL_MD5);
+    assert_eq!(u16::from(CipherSuite::TLS_RSA_WITH_NULL_MD5), 1);
+    assert_eq!(CipherSuite::TLS_RSA_WITH_NULL_MD5.as_str(), Some("TLS_RSA_WITH_NULL_MD5"));
+    assert_eq!(format!("{:?}", CipherSuite::TLS_RSA_WITH_NULL_MD5), "CipherSuite(0x1)");
+    assert_eq!(format!("{:?}", CipherSuite::from(1)), "CipherSuite(0x1)");
+}
+
 /// Test that secrets can be extracted and used for encryption/decryption.
 #[cfg(feature = "tls12")]
 #[test]

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6704,15 +6704,30 @@ fn test_multiple_cipher_suite_enum_values() {
     // test enum value with debug fmt:
     assert_eq!(CipherSuite::from(0), CipherSuite::TLS_NULL_WITH_NULL_NULL);
     assert_eq!(u16::from(CipherSuite::TLS_NULL_WITH_NULL_NULL), 0);
-    assert_eq!(CipherSuite::TLS_NULL_WITH_NULL_NULL.as_str(), Some("TLS_NULL_WITH_NULL_NULL"));
-    assert_eq!(format!("{:?}", CipherSuite::TLS_NULL_WITH_NULL_NULL), "TLS_NULL_WITH_NULL_NULL");
-    assert_eq!(format!("{:?}", CipherSuite::from(0)), "TLS_NULL_WITH_NULL_NULL");
+    assert_eq!(
+        CipherSuite::TLS_NULL_WITH_NULL_NULL.as_str(),
+        Some("TLS_NULL_WITH_NULL_NULL")
+    );
+    assert_eq!(
+        format!("{:?}", CipherSuite::TLS_NULL_WITH_NULL_NULL),
+        "TLS_NULL_WITH_NULL_NULL"
+    );
+    assert_eq!(
+        format!("{:?}", CipherSuite::from(0)),
+        "TLS_NULL_WITH_NULL_NULL"
+    );
 
     // test enum value with no debug fmt:
     assert_eq!(CipherSuite::from(1), CipherSuite::TLS_RSA_WITH_NULL_MD5);
     assert_eq!(u16::from(CipherSuite::TLS_RSA_WITH_NULL_MD5), 1);
-    assert_eq!(CipherSuite::TLS_RSA_WITH_NULL_MD5.as_str(), Some("TLS_RSA_WITH_NULL_MD5"));
-    assert_eq!(format!("{:?}", CipherSuite::TLS_RSA_WITH_NULL_MD5), "CipherSuite(0x1)");
+    assert_eq!(
+        CipherSuite::TLS_RSA_WITH_NULL_MD5.as_str(),
+        Some("TLS_RSA_WITH_NULL_MD5")
+    );
+    assert_eq!(
+        format!("{:?}", CipherSuite::TLS_RSA_WITH_NULL_MD5),
+        "CipherSuite(0x1)"
+    );
     assert_eq!(format!("{:?}", CipherSuite::from(1)), "CipherSuite(0x1)");
 }
 


### PR DESCRIPTION
splitting this out of other PR #2329 - I think this should read a little better; totally open to any suggestions on this

__TODO__

- [x] I would like to improve the testing on this.
- [ ] check CI testing results
- [ ] update typos config - remove `_nd` pattern from ignore list assuming that PR #2329 is merged first