### PR TITLE
Expose SingleCertAndKey server cert resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "env_logger",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-post-quantum",
 ]
 
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2479,7 +2479,7 @@ name = "rustls-bench"
 version = "0.1.0"
 dependencies = [
  "clap",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-post-quantum",
  "tikv-jemallocator",
 ]
@@ -2496,7 +2496,7 @@ dependencies = [
  "fxhash",
  "itertools 0.14.0",
  "rayon",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "tikv-jemallocator",
 ]
 
@@ -2507,7 +2507,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "tokio",
 ]
 
@@ -2522,7 +2522,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "serde",
  "tokio",
  "webpki-roots",
@@ -2533,7 +2533,7 @@ name = "rustls-fuzzing-provider"
 version = "0.1.0"
 dependencies = [
  "env_logger",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-webpki",
 ]
 
@@ -2546,7 +2546,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.22",
+ "rustls 0.23.23",
 ]
 
 [[package]]
@@ -2561,7 +2561,7 @@ version = "0.2.2"
 dependencies = [
  "criterion",
  "env_logger",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "webpki-roots",
 ]
 
@@ -2582,7 +2582,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "rsa",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-webpki",
  "sha2",
  "signature",
@@ -2595,7 +2595,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.23.22",
+ "rustls 0.23.23",
  "rustls-provider-example",
  "serde",
  "serde_json",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 dependencies = [
  "log",
  "once_cell",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -8,7 +8,7 @@ use crate::builder::{ConfigBuilder, WantsVerifier};
 use crate::client::{handy, ClientConfig, EchMode, ResolvesClientCert};
 use crate::error::Error;
 use crate::key_log::NoKeyLog;
-use crate::msgs::handshake::CertificateChain;
+use crate::sign::{CertifiedKey, SingleCertAndKey};
 use crate::sync::Arc;
 use crate::versions::TLS13;
 use crate::webpki::{self, WebPkiServerVerifier};
@@ -148,13 +148,8 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
         cert_chain: Vec<CertificateDer<'static>>,
         key_der: PrivateKeyDer<'static>,
     ) -> Result<ClientConfig, Error> {
-        let private_key = self
-            .provider
-            .key_provider
-            .load_private_key(key_der)?;
-        let resolver =
-            handy::AlwaysResolvesClientCert::new(private_key, CertificateChain(cert_chain))?;
-        Ok(self.with_client_cert_resolver(Arc::new(resolver)))
+        let certified_key = CertifiedKey::from_der(cert_chain, key_der, &self.provider)?;
+        Ok(self.with_client_cert_resolver(Arc::new(SingleCertAndKey::from(certified_key))))
     }
 
     /// Do not support client auth.

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -1,8 +1,6 @@
 use pki_types::ServerName;
 
 use crate::enums::SignatureScheme;
-use crate::error::Error;
-use crate::msgs::handshake::CertificateChain;
 use crate::msgs::persist;
 use crate::sync::Arc;
 use crate::{client, sign, NamedGroup};
@@ -208,35 +206,6 @@ impl client::ResolvesClientCert for FailResolveClientCert {
 
     fn has_certs(&self) -> bool {
         false
-    }
-}
-
-#[derive(Debug)]
-pub(super) struct AlwaysResolvesClientCert(Arc<sign::CertifiedKey>);
-
-impl AlwaysResolvesClientCert {
-    pub(super) fn new(
-        private_key: Arc<dyn sign::SigningKey>,
-        chain: CertificateChain<'static>,
-    ) -> Result<Self, Error> {
-        Ok(Self(Arc::new(sign::CertifiedKey::new(
-            chain.0,
-            private_key,
-        ))))
-    }
-}
-
-impl client::ResolvesClientCert for AlwaysResolvesClientCert {
-    fn resolve(
-        &self,
-        _root_hint_subjects: &[&[u8]],
-        _sigschemes: &[SignatureScheme],
-    ) -> Option<Arc<sign::CertifiedKey>> {
-        Some(Arc::clone(&self.0))
-    }
-
-    fn has_certs(&self) -> bool {
-        true
     }
 }
 

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -88,9 +88,13 @@ pub trait Signer: Debug + Send + Sync {
     fn scheme(&self) -> SignatureScheme;
 }
 
-/// Something which always resolves to the same cert chain.
+/// Server certificate resolver which always resolves to the same certificate and key.
+///
+/// For use with [`ConfigBuilder::with_cert_resolver()`].
+///
+/// [`ConfigBuilder::with_cert_resolver()`]: crate::ConfigBuilder::with_cert_resolver
 #[derive(Debug)]
-pub(crate) struct SingleCertAndKey(Arc<CertifiedKey>);
+pub struct SingleCertAndKey(Arc<CertifiedKey>);
 
 impl From<CertifiedKey> for SingleCertAndKey {
     fn from(certified_key: CertifiedKey) -> Self {

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -90,16 +90,11 @@ pub trait Signer: Debug + Send + Sync {
 pub(crate) struct SingleCertAndKey(Arc<CertifiedKey>);
 
 impl SingleCertAndKey {
-    /// Creates an `AlwaysResolvesChain`, using the supplied `CertifiedKey`.
-    pub(crate) fn new(certified_key: CertifiedKey) -> Self {
-        Self(Arc::new(certified_key))
-    }
-
     /// Creates an `AlwaysResolvesChain`, using the supplied `CertifiedKey` and OCSP response.
     ///
     /// If non-empty, the given OCSP response is attached.
     pub(crate) fn new_with_extras(certified_key: CertifiedKey, ocsp: Vec<u8>) -> Self {
-        let mut r = Self::new(certified_key);
+        let mut r = Self::from(certified_key);
 
         {
             let cert = Arc::make_mut(&mut r.0);
@@ -109,6 +104,12 @@ impl SingleCertAndKey {
         }
 
         r
+    }
+}
+
+impl From<CertifiedKey> for SingleCertAndKey {
+    fn from(certified_key: CertifiedKey) -> Self {
+        Self(Arc::new(certified_key))
     }
 }
 

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -89,24 +89,6 @@ pub trait Signer: Debug + Send + Sync {
 #[derive(Debug)]
 pub(crate) struct SingleCertAndKey(Arc<CertifiedKey>);
 
-impl SingleCertAndKey {
-    /// Creates an `AlwaysResolvesChain`, using the supplied `CertifiedKey` and OCSP response.
-    ///
-    /// If non-empty, the given OCSP response is attached.
-    pub(crate) fn new_with_extras(certified_key: CertifiedKey, ocsp: Vec<u8>) -> Self {
-        let mut r = Self::from(certified_key);
-
-        {
-            let cert = Arc::make_mut(&mut r.0);
-            if !ocsp.is_empty() {
-                cert.ocsp = Some(ocsp);
-            }
-        }
-
-        r
-    }
-}
-
 impl From<CertifiedKey> for SingleCertAndKey {
     fn from(certified_key: CertifiedKey) -> Self {
         Self(Arc::new(certified_key))

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -4,6 +4,7 @@ use core::fmt::Debug;
 
 use pki_types::{AlgorithmIdentifier, CertificateDer, PrivateKeyDer, SubjectPublicKeyInfoDer};
 
+use crate::client::ResolvesClientCert;
 use crate::enums::{SignatureAlgorithm, SignatureScheme};
 use crate::error::{Error, InconsistentKeys};
 use crate::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
@@ -94,6 +95,20 @@ pub(crate) struct SingleCertAndKey(Arc<CertifiedKey>);
 impl From<CertifiedKey> for SingleCertAndKey {
     fn from(certified_key: CertifiedKey) -> Self {
         Self(Arc::new(certified_key))
+    }
+}
+
+impl ResolvesClientCert for SingleCertAndKey {
+    fn resolve(
+        &self,
+        _root_hint_subjects: &[&[u8]],
+        _sigschemes: &[SignatureScheme],
+    ) -> Option<Arc<CertifiedKey>> {
+        Some(Arc::clone(&self.0))
+    }
+
+    fn has_certs(&self) -> bool {
+        true
     }
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -668,6 +668,7 @@ pub mod pki_types {
 
 /// Message signing interfaces.
 pub mod sign {
+    pub(crate) use crate::crypto::signer::SingleCertAndKey;
     pub use crate::crypto::signer::{CertifiedKey, Signer, SigningKey};
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -668,8 +668,7 @@ pub mod pki_types {
 
 /// Message signing interfaces.
 pub mod sign {
-    pub(crate) use crate::crypto::signer::SingleCertAndKey;
-    pub use crate::crypto::signer::{CertifiedKey, Signer, SigningKey};
+    pub use crate::crypto::signer::{CertifiedKey, Signer, SigningKey, SingleCertAndKey};
 }
 
 /// APIs for implementing QUIC TLS

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -3,10 +3,10 @@ use core::marker::PhantomData;
 
 use pki_types::{CertificateDer, PrivateKeyDer};
 
+use super::{handy, ResolvesServerCert, ServerConfig};
 use crate::builder::{ConfigBuilder, WantsVerifier};
 use crate::error::Error;
-use crate::server::{handy, ResolvesServerCert, ServerConfig};
-use crate::sign::CertifiedKey;
+use crate::sign::{CertifiedKey, SingleCertAndKey};
 use crate::sync::Arc;
 use crate::verify::{ClientCertVerifier, NoClientAuth};
 use crate::{compress, versions, InconsistentKeys, NoKeyLog};
@@ -79,7 +79,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             Err(err) => return Err(err),
         }
 
-        let resolver = handy::SingleCertAndKey::new(certified_key);
+        let resolver = SingleCertAndKey::new(certified_key);
         Ok(self.with_cert_resolver(Arc::new(resolver)))
     }
 
@@ -114,7 +114,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             Err(err) => return Err(err),
         }
 
-        let resolver = handy::SingleCertAndKey::new_with_extras(certified_key, ocsp);
+        let resolver = SingleCertAndKey::new_with_extras(certified_key, ocsp);
         Ok(self.with_cert_resolver(Arc::new(resolver)))
     }
 

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -79,8 +79,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             Err(err) => return Err(err),
         }
 
-        let resolver = SingleCertAndKey::new(certified_key);
-        Ok(self.with_cert_resolver(Arc::new(resolver)))
+        Ok(self.with_cert_resolver(Arc::new(SingleCertAndKey::from(certified_key))))
     }
 
     /// Sets a single certificate chain, matching private key and optional OCSP

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -106,15 +106,15 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             .key_provider
             .load_private_key(key_der)?;
 
-        let certified_key = CertifiedKey::new(cert_chain, private_key);
+        let mut certified_key = CertifiedKey::new(cert_chain, private_key);
         match certified_key.keys_match() {
             // Don't treat unknown consistency as an error
             Ok(()) | Err(Error::InconsistentKeys(InconsistentKeys::Unknown)) => (),
             Err(err) => return Err(err),
         }
 
-        let resolver = SingleCertAndKey::new_with_extras(certified_key, ocsp);
-        Ok(self.with_cert_resolver(Arc::new(resolver)))
+        certified_key.ocsp = Some(ocsp);
+        Ok(self.with_cert_resolver(Arc::new(SingleCertAndKey::from(certified_key))))
     }
 
     /// Sets a custom [`ResolvesServerCert`].

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -79,7 +79,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             Err(err) => return Err(err),
         }
 
-        let resolver = handy::AlwaysResolvesChain::new(certified_key);
+        let resolver = handy::SingleCertAndKey::new(certified_key);
         Ok(self.with_cert_resolver(Arc::new(resolver)))
     }
 
@@ -114,7 +114,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             Err(err) => return Err(err),
         }
 
-        let resolver = handy::AlwaysResolvesChain::new_with_extras(certified_key, ocsp);
+        let resolver = handy::SingleCertAndKey::new_with_extras(certified_key, ocsp);
         Ok(self.with_cert_resolver(Arc::new(resolver)))
     }
 

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -166,39 +166,6 @@ impl server::ProducesTickets for NeverProducesTickets {
     }
 }
 
-/// Something which always resolves to the same cert chain.
-#[derive(Debug)]
-pub(super) struct SingleCertAndKey(Arc<sign::CertifiedKey>);
-
-impl SingleCertAndKey {
-    /// Creates an `AlwaysResolvesChain`, using the supplied `CertifiedKey`.
-    pub(super) fn new(certified_key: sign::CertifiedKey) -> Self {
-        Self(Arc::new(certified_key))
-    }
-
-    /// Creates an `AlwaysResolvesChain`, using the supplied `CertifiedKey` and OCSP response.
-    ///
-    /// If non-empty, the given OCSP response is attached.
-    pub(super) fn new_with_extras(certified_key: sign::CertifiedKey, ocsp: Vec<u8>) -> Self {
-        let mut r = Self::new(certified_key);
-
-        {
-            let cert = Arc::make_mut(&mut r.0);
-            if !ocsp.is_empty() {
-                cert.ocsp = Some(ocsp);
-            }
-        }
-
-        r
-    }
-}
-
-impl server::ResolvesServerCert for SingleCertAndKey {
-    fn resolve(&self, _client_hello: ClientHello<'_>) -> Option<Arc<sign::CertifiedKey>> {
-        Some(Arc::clone(&self.0))
-    }
-}
-
 /// An exemplar `ResolvesServerCert` implementation that always resolves to a single
 /// [RFC 7250] raw public key.
 ///

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -168,9 +168,9 @@ impl server::ProducesTickets for NeverProducesTickets {
 
 /// Something which always resolves to the same cert chain.
 #[derive(Debug)]
-pub(super) struct AlwaysResolvesChain(Arc<sign::CertifiedKey>);
+pub(super) struct SingleCertAndKey(Arc<sign::CertifiedKey>);
 
-impl AlwaysResolvesChain {
+impl SingleCertAndKey {
     /// Creates an `AlwaysResolvesChain`, using the supplied `CertifiedKey`.
     pub(super) fn new(certified_key: sign::CertifiedKey) -> Self {
         Self(Arc::new(certified_key))
@@ -193,7 +193,7 @@ impl AlwaysResolvesChain {
     }
 }
 
-impl server::ResolvesServerCert for AlwaysResolvesChain {
+impl server::ResolvesServerCert for SingleCertAndKey {
     fn resolve(&self, _client_hello: ClientHello<'_>) -> Option<Arc<sign::CertifiedKey>> {
         Some(Arc::clone(&self.0))
     }


### PR DESCRIPTION
Motivated by:

- https://github.com/hickory-dns/hickory-dns/pull/2764

(Should we start deprecating OCSP API?)

## Proposed release notes

- Export `SingleCertAndKey` implementation of `ResolvesServerCert` (was already used internally).
- Expose `CertifiedKey::from_der()` to help create `CertifiedKey`s with necessary checks.