### PR TITLE
unbuffered: do not prematurely consume data

### DIFF
--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -918,6 +918,10 @@ impl UnbufferedConnectionCommon<ServerConnectionData> {
     pub(crate) fn pop_early_data(&mut self) -> Option<Vec<u8>> {
         self.core.data.early_data.pop()
     }
+
+    pub(crate) fn peek_early_data(&self) -> Option<&[u8]> {
+        self.core.data.early_data.peek()
+    }
 }
 
 /// Represents a `ClientHello` message received through the [`Acceptor`].
@@ -1056,6 +1060,13 @@ impl EarlyDataState {
 
     pub(super) fn was_rejected(&self) -> bool {
         matches!(self, Self::Rejected)
+    }
+
+    fn peek(&self) -> Option<&[u8]> {
+        match self {
+            Self::Accepted { received, .. } => received.peek(),
+            _ => None,
+        }
     }
 
     fn pop(&mut self) -> Option<Vec<u8>> {

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -113,6 +113,13 @@ impl ChunkVecBuffer {
 
         Ok(())
     }
+
+    /// Inspect the first chunk from this object.
+    pub(crate) fn peek(&self) -> Option<&[u8]> {
+        self.chunks
+            .front()
+            .map(|ch| ch.as_slice())
+    }
 }
 
 #[cfg(feature = "std")]

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -919,6 +919,53 @@ fn rejects_junk() {
     confirm_transmit_tls_data(server.process_tls_records(&mut []));
 }
 
+#[test]
+fn read_traffic_not_consumed_too_early() {
+    let mut outcome = handshake(&rustls::version::TLS13);
+    let mut client = outcome.client.take().unwrap();
+    let mut server = outcome.server.take().unwrap();
+
+    let mut client_to_server_buf = Buffer::default();
+    write_traffic(client.process_tls_records(&mut []), |mut wt| {
+        encrypt(&mut wt, b"hello", &mut client_to_server_buf)
+    });
+
+    // if we just peek, we are presented the same data again
+    let (_, discard) = read_traffic(
+        server.process_tls_records(client_to_server_buf.filled()),
+        |rt| assert_eq!(rt.peek_len(), NonZeroUsize::new(5)),
+    );
+    assert!(discard > 0);
+    client_to_server_buf.discard(discard);
+
+    // ditto
+    let (_, discard) = read_traffic(
+        server.process_tls_records(client_to_server_buf.filled()),
+        |rt| assert_eq!(rt.peek_len(), NonZeroUsize::new(5)),
+    );
+    assert_eq!(discard, 0);
+
+    // now consume
+    let (data, discard) = read_traffic(
+        server.process_tls_records(client_to_server_buf.filled()),
+        |mut rt| {
+            rt.next_record()
+                .unwrap()
+                .unwrap()
+                .payload
+                .to_vec()
+        },
+    );
+    assert_eq!(discard, 0);
+    assert_eq!(data, b"hello");
+
+    // server is now idle
+    write_traffic(
+        server.process_tls_records(client_to_server_buf.filled()),
+        |_| (),
+    );
+}
+
 fn write_traffic<T: SideData, R, F: FnMut(WriteTraffic<T>) -> R>(
     status: UnbufferedStatus<'_, '_, T>,
     mut f: F,


### PR DESCRIPTION
This alters `ReadTraffic` and `ReadEarlyData` so that their `next_record()` functions are where the data is consumed, allowing `peek_len()` functions work as intended.

fixes #2031