### PR TITLE
Take rustls-webpki 0.103.0 and improve certificate error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,7 +2573,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.0",
  "rustversion",
  "serde",
  "serde_json",
@@ -2595,7 +2595,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -2660,7 +2660,6 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "rustls 0.23.23",
- "rustls-webpki",
 ]
 
 [[package]]
@@ -2709,7 +2708,6 @@ dependencies = [
  "rcgen",
  "rsa",
  "rustls 0.23.23",
- "rustls-webpki",
  "sha2",
  "signature",
  "webpki-roots",
@@ -2732,6 +2730,17 @@ name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ once_cell = { version = "1.16", default-features = false, features = ["alloc", "
 openssl = "0.10"
 p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecdsa", "pkcs8"] }
 pkcs8 = "0.10.2"
-pki-types = { package = "rustls-pki-types", version = "1.10", features = ["alloc"] }
+pki-types = { package = "rustls-pki-types", version = "1.11", features = ["alloc"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 rayon = "1.7"
 rcgen = { version = "0.13", features = ["pem", "aws_lc_rs"], default-features = false }
@@ -86,7 +86,7 @@ subtle = { version = "2.5.0", default-features = false }
 time = { version = "0.3.6", default-features = false }
 tikv-jemallocator = "0.6"
 tokio = { version = "1.34", features = ["io-util", "macros", "net", "rt"] }
-webpki = { package = "rustls-webpki", version = "0.102.8", features = ["alloc"], default-features = false }
+webpki = { package = "rustls-webpki", version = "0.103", features = ["alloc"], default-features = false }
 webpki-roots = "0.26"
 x25519-dalek = "2"
 x509-parser = "0.17"

--- a/connect-tests/tests/badssl.rs
+++ b/connect-tests/tests/badssl.rs
@@ -15,7 +15,7 @@ mod online {
     fn no_cbc() {
         connect("cbc.badssl.com")
             .fails()
-            .expect(r"TLS error: AlertReceived\(HandshakeFailure\)")
+            .expect(r"TLS error: received fatal alert: HandshakeFailure")
             .go()
             .unwrap();
     }
@@ -24,7 +24,7 @@ mod online {
     fn no_rc4() {
         connect("rc4.badssl.com")
             .fails()
-            .expect(r"TLS error: AlertReceived\(HandshakeFailure\)")
+            .expect(r"TLS error: received fatal alert: HandshakeFailure")
             .go()
             .unwrap();
     }
@@ -33,7 +33,7 @@ mod online {
     fn expired() {
         connect("expired.badssl.com")
             .fails()
-            .expect(r"TLS error: InvalidCertificate\(Expired\)")
+            .expect(r"TLS error: invalid peer certificate: Expired")
             .go()
             .unwrap();
     }
@@ -42,7 +42,7 @@ mod online {
     fn wrong_host() {
         connect("wrong.host.badssl.com")
             .fails()
-            .expect(r"TLS error: InvalidCertificate\(NotValidForName\)")
+            .expect(r"TLS error: invalid peer certificate: NotValidForName")
             .go()
             .unwrap();
     }
@@ -51,7 +51,7 @@ mod online {
     fn self_signed() {
         connect("self-signed.badssl.com")
             .fails()
-            .expect(r"TLS error: InvalidCertificate\(UnknownIssuer\)")
+            .expect(r"TLS error: invalid peer certificate: UnknownIssuer")
             .go()
             .unwrap();
     }
@@ -60,7 +60,7 @@ mod online {
     fn no_dh() {
         connect("dh2048.badssl.com")
             .fails()
-            .expect(r"TLS error: AlertReceived\(HandshakeFailure\)")
+            .expect(r"TLS error: received fatal alert: HandshakeFailure")
             .go()
             .unwrap();
     }
@@ -101,7 +101,7 @@ mod online {
     fn too_many_sans() {
         connect("10000-sans.badssl.com")
             .fails()
-            .expect(r"TLS error: InvalidMessage\(HandshakePayloadTooLarge\)")
+            .expect(r"TLS error: received corrupt message of type HandshakePayloadTooLarge")
             .go()
             .unwrap();
     }
@@ -119,7 +119,7 @@ mod online {
     fn sha1_2016() {
         connect("sha1-2016.badssl.com")
             .fails()
-            .expect(r"TLS error: InvalidCertificate\(Expired\)")
+            .expect(r"TLS error: invalid peer certificate: Expired")
             .go()
             .unwrap();
     }

--- a/connect-tests/tests/badssl.rs
+++ b/connect-tests/tests/badssl.rs
@@ -42,7 +42,7 @@ mod online {
     fn wrong_host() {
         connect("wrong.host.badssl.com")
             .fails()
-            .expect(r"TLS error: invalid peer certificate: NotValidForName")
+            .expect(r#"TLS error: invalid peer certificate: certificate not valid for name \"wrong.host.badssl.com\"; certificate is only valid for DnsName\(\"\*.badssl.com\"\) or DnsName\(\"badssl.com\"\)"#)
             .go()
             .unwrap();
     }

--- a/connect-tests/tests/badssl.rs
+++ b/connect-tests/tests/badssl.rs
@@ -33,7 +33,7 @@ mod online {
     fn expired() {
         connect("expired.badssl.com")
             .fails()
-            .expect(r"TLS error: invalid peer certificate: Expired")
+            .expect(r"TLS error: invalid peer certificate: certificate expired: verification time [0-9]+ \(UNIX\), but certificate is not valid after [0-9]+ \([0-9]+ seconds ago\)")
             .go()
             .unwrap();
     }
@@ -119,7 +119,7 @@ mod online {
     fn sha1_2016() {
         connect("sha1-2016.badssl.com")
             .fails()
-            .expect(r"TLS error: invalid peer certificate: Expired")
+            .expect(r"TLS error: invalid peer certificate: certificate expired: verification time [0-9]+ \(UNIX\), but certificate is not valid after [0-9]+ \([0-9]+ seconds ago\)")
             .go()
             .unwrap();
     }

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -115,7 +115,7 @@ impl TlsClient {
         let io_state = match self.tls_conn.process_new_packets() {
             Ok(io_state) => io_state,
             Err(err) => {
-                println!("TLS error: {:?}", err);
+                println!("TLS error: {err}");
                 self.closing = true;
                 return;
             }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -249,20 +249,19 @@ name = "rustls-fuzzing-provider"
 version = "0.1.0"
 dependencies = [
  "rustls",
- "rustls-webpki",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -21,7 +21,6 @@ rustls = { path = "../rustls", default-features = false, features = ["logging", 
 rsa = { workspace = true }
 sha2 = { workspace = true }
 signature = { workspace = true }
-webpki = { workspace = true }
 x25519-dalek = { workspace = true }
 
 [dev-dependencies]

--- a/provider-example/src/verify.rs
+++ b/provider-example/src/verify.rs
@@ -3,8 +3,9 @@ use rsa::signature::Verifier;
 use rsa::{BigUint, RsaPublicKey, pkcs1v15, pss};
 use rustls::SignatureScheme;
 use rustls::crypto::WebPkiSupportedAlgorithms;
-use rustls::pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
-use webpki::alg_id;
+use rustls::pki_types::{
+    AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm, alg_id,
+};
 
 pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[RSA_PSS_SHA256, RSA_PKCS1_SHA256],

--- a/rustls-fuzzing-provider/Cargo.toml
+++ b/rustls-fuzzing-provider/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 rustls = { path = "../rustls", default-features = false, features = ["logging", "std", "tls12"] }
-webpki = { workspace = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -14,14 +14,13 @@ use rustls::crypto::{
 use rustls::ffdhe_groups::FfdheGroup;
 use rustls::pki_types::{
     AlgorithmIdentifier, CertificateDer, InvalidSignature, PrivateKeyDer,
-    SignatureVerificationAlgorithm,
+    SignatureVerificationAlgorithm, alg_id,
 };
 use rustls::{
     CipherSuite, ConnectionTrafficSecrets, ContentType, Error, NamedGroup, PeerMisbehaved,
     ProtocolVersion, RootCertStore, SignatureAlgorithm, SignatureScheme, SupportedCipherSuite,
     Tls12CipherSuite, Tls13CipherSuite, crypto, server, sign,
 };
-use webpki::alg_id;
 
 /// This is a `CryptoProvider` that provides NO SECURITY and is for fuzzing only.
 pub fn provider() -> crypto::CryptoProvider {

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -18,7 +18,7 @@ build = "build.rs"
 default = ["aws_lc_rs", "logging", "std", "tls12"]
 
 aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
-aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
+aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws-lc-rs"]
 brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
 custom-provider = []
 fips = ["aws_lc_rs", "aws-lc-rs?/fips"]

--- a/rustls/src/crypto/aws_lc_rs/sign.rs
+++ b/rustls/src/crypto/aws_lc_rs/sign.rs
@@ -6,8 +6,7 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::fmt::{self, Debug, Formatter};
 
-use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer};
-use webpki::alg_id;
+use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer, alg_id};
 
 use super::ring_like::rand::SystemRandom;
 use super::ring_like::signature::{self, EcdsaKeyPair, Ed25519KeyPair, KeyPair, RsaKeyPair};

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -6,8 +6,7 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::fmt::{self, Debug, Formatter};
 
-use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer};
-use webpki::alg_id;
+use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer, alg_id};
 
 use super::ring_like::rand::{SecureRandom, SystemRandom};
 use super::ring_like::signature::{self, EcdsaKeyPair, Ed25519KeyPair, KeyPair, RsaKeyPair};

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -487,6 +487,7 @@ impl PartialEq<Self> for CertificateError {
             ) => (left_expected, left_presented) == (right_expected, right_presented),
             (InvalidPurpose, InvalidPurpose) => true,
             (ApplicationVerificationFailure, ApplicationVerificationFailure) => true,
+            (UnknownRevocationStatus, UnknownRevocationStatus) => true,
             (ExpiredRevocationList, ExpiredRevocationList) => true,
             (
                 ExpiredRevocationListContext {
@@ -831,6 +832,8 @@ mod tests {
         assert_eq!(Revoked, Revoked);
         assert_eq!(UnhandledCriticalExtension, UnhandledCriticalExtension);
         assert_eq!(UnknownIssuer, UnknownIssuer);
+        assert_eq!(ExpiredRevocationList, ExpiredRevocationList);
+        assert_eq!(UnknownRevocationStatus, UnknownRevocationStatus);
         let context = ExpiredRevocationListContext {
             time: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
             next_update: UnixTime::since_unix_epoch(Duration::from_secs(123)),

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -2,7 +2,7 @@ use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use pki_types::ServerName;
+use pki_types::{ServerName, UnixTime};
 #[cfg(feature = "std")]
 use std::time::SystemTimeError;
 
@@ -346,8 +346,30 @@ pub enum CertificateError {
     /// The current time is after the `notAfter` time in the certificate.
     Expired,
 
+    /// The current time is after the `notAfter` time in the certificate.
+    ///
+    /// This variant is semantically the same as `Expired`, but includes
+    /// extra data to improve error reports.
+    ExpiredContext {
+        /// The validation time.
+        time: UnixTime,
+        /// The `notAfter` time of the certificate.
+        not_after: UnixTime,
+    },
+
     /// The current time is before the `notBefore` time in the certificate.
     NotValidYet,
+
+    /// The current time is before the `notBefore` time in the certificate.
+    ///
+    /// This variant is semantically the same as `NotValidYet`, but includes
+    /// extra data to improve error reports.
+    NotValidYetContext {
+        /// The validation time.
+        time: UnixTime,
+        /// The `notBefore` time of the certificate.
+        not_before: UnixTime,
+    },
 
     /// The certificate has been revoked.
     Revoked,
@@ -364,6 +386,17 @@ pub enum CertificateError {
 
     /// The certificate's revocation status could not be determined, because the CRL is expired.
     ExpiredRevocationList,
+
+    /// The certificate's revocation status could not be determined, because the CRL is expired.
+    ///
+    /// This variant is semantically the same as `ExpiredRevocationList`, but includes
+    /// extra data to improve error reports.
+    ExpiredRevocationListContext {
+        /// The validation time.
+        time: UnixTime,
+        /// The nextUpdate time of the CRL.
+        next_update: UnixTime,
+    },
 
     /// A certificate is not correctly signed by the key of its alleged
     /// issuer.
@@ -416,7 +449,27 @@ impl PartialEq<Self> for CertificateError {
         match (self, other) {
             (BadEncoding, BadEncoding) => true,
             (Expired, Expired) => true,
+            (
+                ExpiredContext {
+                    time: left_time,
+                    not_after: left_not_after,
+                },
+                ExpiredContext {
+                    time: right_time,
+                    not_after: right_not_after,
+                },
+            ) => (left_time, left_not_after) == (right_time, right_not_after),
             (NotValidYet, NotValidYet) => true,
+            (
+                NotValidYetContext {
+                    time: left_time,
+                    not_before: left_not_before,
+                },
+                NotValidYetContext {
+                    time: right_time,
+                    not_before: right_not_before,
+                },
+            ) => (left_time, left_not_before) == (right_time, right_not_before),
             (Revoked, Revoked) => true,
             (UnhandledCriticalExtension, UnhandledCriticalExtension) => true,
             (UnknownIssuer, UnknownIssuer) => true,
@@ -435,6 +488,16 @@ impl PartialEq<Self> for CertificateError {
             (InvalidPurpose, InvalidPurpose) => true,
             (ApplicationVerificationFailure, ApplicationVerificationFailure) => true,
             (ExpiredRevocationList, ExpiredRevocationList) => true,
+            (
+                ExpiredRevocationListContext {
+                    time: left_time,
+                    next_update: left_next_update,
+                },
+                ExpiredRevocationListContext {
+                    time: right_time,
+                    next_update: right_next_update,
+                },
+            ) => (left_time, left_next_update) == (right_time, right_next_update),
             _ => false,
         }
     }
@@ -454,11 +517,16 @@ impl From<CertificateError> for AlertDescription {
             // RFC 5246/RFC 8446
             // certificate_expired
             //  A certificate has expired or **is not currently valid**.
-            Expired | NotValidYet => Self::CertificateExpired,
+            Expired | ExpiredContext { .. } | NotValidYet | NotValidYetContext { .. } => {
+                Self::CertificateExpired
+            }
             Revoked => Self::CertificateRevoked,
             // OpenSSL, BoringSSL and AWS-LC all generate an Unknown CA alert for
             // the case where revocation status can not be determined, so we do the same here.
-            UnknownIssuer | UnknownRevocationStatus | ExpiredRevocationList => Self::UnknownCA,
+            UnknownIssuer
+            | UnknownRevocationStatus
+            | ExpiredRevocationList
+            | ExpiredRevocationListContext { .. } => Self::UnknownCA,
             BadSignature => Self::DecryptError,
             InvalidPurpose => Self::UnsupportedCertificate,
             ApplicationVerificationFailure => Self::AccessDenied,
@@ -705,10 +773,13 @@ pub use other_error::OtherError;
 
 #[cfg(test)]
 mod tests {
+    use core::time::Duration;
     use std::prelude::v1::*;
     use std::{println, vec};
 
-    use super::{CertRevocationListError, Error, InconsistentKeys, InvalidMessage, OtherError};
+    use super::{
+        CertRevocationListError, Error, InconsistentKeys, InvalidMessage, OtherError, UnixTime,
+    };
     #[cfg(feature = "std")]
     use crate::sync::Arc;
     use pki_types::ServerName;
@@ -718,10 +789,67 @@ mod tests {
         use super::CertificateError::*;
         assert_eq!(BadEncoding, BadEncoding);
         assert_eq!(Expired, Expired);
+        let context = ExpiredContext {
+            time: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
+            not_after: UnixTime::since_unix_epoch(Duration::from_secs(123)),
+        };
+        assert_eq!(context, context);
+        assert_ne!(
+            context,
+            ExpiredContext {
+                time: UnixTime::since_unix_epoch(Duration::from_secs(12345)),
+                not_after: UnixTime::since_unix_epoch(Duration::from_secs(123)),
+            }
+        );
+        assert_ne!(
+            context,
+            ExpiredContext {
+                time: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
+                not_after: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
+            }
+        );
         assert_eq!(NotValidYet, NotValidYet);
+        let context = NotValidYetContext {
+            time: UnixTime::since_unix_epoch(Duration::from_secs(123)),
+            not_before: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
+        };
+        assert_eq!(context, context);
+        assert_ne!(
+            context,
+            NotValidYetContext {
+                time: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
+                not_before: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
+            }
+        );
+        assert_ne!(
+            context,
+            NotValidYetContext {
+                time: UnixTime::since_unix_epoch(Duration::from_secs(123)),
+                not_before: UnixTime::since_unix_epoch(Duration::from_secs(12345)),
+            }
+        );
         assert_eq!(Revoked, Revoked);
         assert_eq!(UnhandledCriticalExtension, UnhandledCriticalExtension);
         assert_eq!(UnknownIssuer, UnknownIssuer);
+        let context = ExpiredRevocationListContext {
+            time: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
+            next_update: UnixTime::since_unix_epoch(Duration::from_secs(123)),
+        };
+        assert_eq!(context, context);
+        assert_ne!(
+            context,
+            ExpiredRevocationListContext {
+                time: UnixTime::since_unix_epoch(Duration::from_secs(12345)),
+                next_update: UnixTime::since_unix_epoch(Duration::from_secs(123)),
+            }
+        );
+        assert_ne!(
+            context,
+            ExpiredRevocationListContext {
+                time: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
+                next_update: UnixTime::since_unix_epoch(Duration::from_secs(1234)),
+            }
+        );
         assert_eq!(BadSignature, BadSignature);
         assert_eq!(NotValidForName, NotValidForName);
         let context = NotValidForNameContext {

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::fmt;
 
 use pki_types::CertificateRevocationListDer;
-use webpki::{CertRevocationList, OwnedCertRevocationList};
+use webpki::{CertRevocationList, InvalidNameContext, OwnedCertRevocationList};
 
 use crate::error::{CertRevocationListError, CertificateError, Error, OtherError};
 #[cfg(feature = "std")]
@@ -61,7 +61,14 @@ fn pki_error(error: webpki::Error) -> Error {
         CertNotValidYet { .. } => CertificateError::NotValidYet.into(),
         CertExpired { .. } | InvalidCertValidity => CertificateError::Expired.into(),
         UnknownIssuer => CertificateError::UnknownIssuer.into(),
-        CertNotValidForName { .. } => CertificateError::NotValidForName.into(),
+        CertNotValidForName(InvalidNameContext {
+            expected,
+            presented,
+        }) => CertificateError::NotValidForNameContext {
+            expected,
+            presented,
+        }
+        .into(),
         CertRevoked => CertificateError::Revoked.into(),
         UnknownRevocationStatus => CertificateError::UnknownRevocationStatus.into(),
         CrlExpired { .. } => CertificateError::ExpiredRevocationList.into(),

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -58,8 +58,13 @@ fn pki_error(error: webpki::Error) -> Error {
     use webpki::Error::*;
     match error {
         BadDer | BadDerTime | TrailingData(_) => CertificateError::BadEncoding.into(),
-        CertNotValidYet { .. } => CertificateError::NotValidYet.into(),
-        CertExpired { .. } | InvalidCertValidity => CertificateError::Expired.into(),
+        CertNotValidYet { time, not_before } => {
+            CertificateError::NotValidYetContext { time, not_before }.into()
+        }
+        CertExpired { time, not_after } => {
+            CertificateError::ExpiredContext { time, not_after }.into()
+        }
+        InvalidCertValidity => CertificateError::Expired.into(),
         UnknownIssuer => CertificateError::UnknownIssuer.into(),
         CertNotValidForName(InvalidNameContext {
             expected,
@@ -71,7 +76,9 @@ fn pki_error(error: webpki::Error) -> Error {
         .into(),
         CertRevoked => CertificateError::Revoked.into(),
         UnknownRevocationStatus => CertificateError::UnknownRevocationStatus.into(),
-        CrlExpired { .. } => CertificateError::ExpiredRevocationList.into(),
+        CrlExpired { time, next_update } => {
+            CertificateError::ExpiredRevocationListContext { time, next_update }.into()
+        }
         IssuerNotCrlSigner => CertRevocationListError::IssuerInvalidForCrl.into(),
 
         InvalidSignatureForPublicKey

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -58,13 +58,13 @@ fn pki_error(error: webpki::Error) -> Error {
     use webpki::Error::*;
     match error {
         BadDer | BadDerTime | TrailingData(_) => CertificateError::BadEncoding.into(),
-        CertNotValidYet => CertificateError::NotValidYet.into(),
-        CertExpired | InvalidCertValidity => CertificateError::Expired.into(),
+        CertNotValidYet { .. } => CertificateError::NotValidYet.into(),
+        CertExpired { .. } | InvalidCertValidity => CertificateError::Expired.into(),
         UnknownIssuer => CertificateError::UnknownIssuer.into(),
-        CertNotValidForName => CertificateError::NotValidForName.into(),
+        CertNotValidForName { .. } => CertificateError::NotValidForName.into(),
         CertRevoked => CertificateError::Revoked.into(),
         UnknownRevocationStatus => CertificateError::UnknownRevocationStatus.into(),
-        CrlExpired => CertificateError::ExpiredRevocationList.into(),
+        CrlExpired { .. } => CertificateError::ExpiredRevocationList.into(),
         IssuerNotCrlSigner => CertRevocationListError::IssuerInvalidForCrl.into(),
 
         InvalidSignatureForPublicKey
@@ -189,7 +189,7 @@ mod tests {
             ),
         ];
         for t in testcases {
-            assert_eq!(crl_error(t.0), t.1);
+            assert_eq!(crl_error(t.0.clone()), t.1);
         }
 
         assert!(matches!(

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1775,12 +1775,12 @@ fn client_check_server_certificate_ee_unknown_revocation() {
             // We expect if we use the forbid_unknown_verifier that the handshake will fail since the
             // server's EE certificate's revocation status is unknown given the CRLs we've provided.
             let err = do_handshake_until_error(&mut client, &mut server);
-            assert!(matches!(
+            assert_eq!(
                 err,
                 Err(ErrorFromPeer::Client(Error::InvalidCertificate(
                     CertificateError::UnknownRevocationStatus
                 )))
-            ));
+            );
 
             // We expect if we use the allow_unknown_verifier that the handshake will not fail.
             let client_config =
@@ -2162,12 +2162,12 @@ fn client_mandatory_auth_client_revocation_works() {
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&client_config, &missing_client_crl_server_config);
             let res = do_handshake_until_error(&mut client, &mut server);
-            assert!(matches!(
+            assert_eq!(
                 res,
                 Err(ErrorFromPeer::Server(Error::InvalidCertificate(
                     CertificateError::UnknownRevocationStatus
                 )))
-            ));
+            );
             // Connecting to the server missing CRL information for the client should not error
             // if the server's verifier allows unknown revocation status.
             let (mut client, mut server) =

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1872,12 +1872,12 @@ fn client_check_server_certificate_ee_crl_expired() {
 
             // We expect the handshake to fail since the CRL is expired.
             let err = do_handshake_until_error(&mut client, &mut server);
-            assert_eq!(
+            assert!(matches!(
                 err,
                 Err(ErrorFromPeer::Client(Error::InvalidCertificate(
-                    CertificateError::ExpiredRevocationList
+                    CertificateError::ExpiredRevocationListContext { .. }
                 )))
-            );
+            ));
 
             let client_config =
                 make_client_config_with_verifier(&[version], ignore_expiration_builder.clone());


### PR DESCRIPTION
This is a preview of the error reporting improvements we can do once we release webpki 0.103.0. I think it looks good, and if other folks agree I think we can go ahead and release that.