### PR TITLE
unbuffered: introduce dangerous_extract_secrets, analogous to buffered API

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -18,7 +18,7 @@ use crate::log::trace;
 use crate::msgs::enums::NamedGroup;
 use crate::msgs::handshake::ClientExtension;
 use crate::msgs::persist;
-use crate::suites::SupportedCipherSuite;
+use crate::suites::{ExtractedSecrets, SupportedCipherSuite};
 use crate::sync::Arc;
 #[cfg(feature = "std")]
 use crate::time_provider::DefaultTimeProvider;
@@ -846,6 +846,12 @@ impl UnbufferedClientConnection {
         Ok(Self {
             inner: ConnectionCore::for_client(config, name, Vec::new(), Protocol::Tcp)?.into(),
         })
+    }
+
+    /// Extract secrets, so they can be used when configuring kTLS, for example.
+    /// Should be used with care as it exposes secret key material.
+    pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
+        self.inner.dangerous_extract_secrets()
     }
 }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -813,6 +813,14 @@ impl<Data> From<ConnectionCore<Data>> for UnbufferedConnectionCommon<Data> {
     }
 }
 
+impl<Data> UnbufferedConnectionCommon<Data> {
+    /// Extract secrets, so they can be used when configuring kTLS, for example.
+    /// Should be used with care as it exposes secret key material.
+    pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
+        self.core.dangerous_extract_secrets()
+    }
+}
+
 impl<T> Deref for UnbufferedConnectionCommon<T> {
     type Target = CommonState;
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -25,6 +25,7 @@ use crate::msgs::base::Payload;
 use crate::msgs::enums::CertificateType;
 use crate::msgs::handshake::{ClientHelloPayload, ProtocolName, ServerExtension};
 use crate::msgs::message::Message;
+use crate::suites::ExtractedSecrets;
 use crate::sync::Arc;
 #[cfg(feature = "std")]
 use crate::time_provider::DefaultTimeProvider;
@@ -890,6 +891,12 @@ impl UnbufferedServerConnection {
                 Vec::new(),
             )?),
         })
+    }
+
+    /// Extract secrets, so they can be used when configuring kTLS, for example.
+    /// Should be used with care as it exposes secret key material.
+    pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
+        self.inner.dangerous_extract_secrets()
     }
 }
 


### PR DESCRIPTION
This moves the actual *implementation* of dangerous_extract_secrets into ConnectionCore, since that's a) where the goods actually are, and b) shared between the unbuffered and buffered APIs. This is only made `pub(crate)` and outfitted with the appropriate facades for public API, for both the new and old `dangerous_extract_secrets`.

The test is largely copied from the buffered API tests, and doesn't provide full coverage. They are testing the same underlying code, so this seems minor compared to creating further unnecessary duplication.

# Proposed release notes
* Expose `dangerous_extract_secrets` on UnbufferedClientConnection, UnbufferedServerConnection, and UnbufferedConnectionCommon