### PR TITLE
bogo: implement -wait-for-debugger in shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "env_logger",
+ "nix",
  "rustls 0.23.23",
  "rustls-post-quantum",
 ]
@@ -567,6 +568,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -1892,6 +1899,18 @@ dependencies = [
  "tagptr",
  "thiserror 1.0.69",
  "uuid",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/bogo/Cargo.toml
+++ b/bogo/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 base64 = { workspace = true }
 env_logger = { workspace = true }
+nix = { version = "0.29", default-features = false, features = ["signal"] }
 rustls = { path = "../rustls", features = ["aws_lc_rs", "ring", "tls12"] }
 rustls-post-quantum = { path = "../rustls-post-quantum", optional = true }
 

--- a/bogo/runme
+++ b/bogo/runme
@@ -38,10 +38,14 @@ fi
 # Best effort on OS-X
 case $OSTYPE in darwin*) set +e ;; esac
 
+# Set default timeout unless -wait-for-debugger flag is present.
+# When this flag is set the shim will pause itself, and the runner will
+# print the PID to attach to in order to continue.
+runner_args="-pipe -allow-unimplemented"
+[[ ! "$*" =~ "-wait-for-debugger" ]] && runner_args+=" -test.timeout 60s"
+
 ( cd bogo/ssl/test/runner && ./runner.test -shim-path ../../../../../target/debug/bogo \
      -shim-config ../../../../config.json \
-     -pipe \
-     -allow-unimplemented \
-     -test.timeout 60s \
+     $runner_args \
      "$@") # you can pass in `-test "Foo;Bar"` to run specific tests
 true

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -4,6 +4,8 @@
 // https://boringssl.googlesource.com/boringssl/+/master/ssl/test
 //
 
+#![allow(clippy::disallowed_types)]
+
 use std::fmt::{Debug, Formatter};
 use std::io::{self, Read, Write};
 use std::sync::Arc;


### PR DESCRIPTION
Also updates the `runme` script to conditionally exclude the `-test.timeout` flag given to the BoGo runner when `-wait-for-debugger` is in use.

The implementation in the shim depends on UNIX SIGSTOP signalling, and so is conditional to UNIX-like systems. Providing the flag on another platform will panic with an error message.

Having this support makes it possible to debug the Rustls-side of the BoGo testing process by having the BoringSSL-side Go test runner start the shim process in a suspended state. In this mode the test runner turns off some timeouts, reduces parallelism to 1 task at a time, and prints the PID of the shim process to attach to with a Rust-friendly debugger. By using `delve` or another Go debugger it's also possible to debug the runner-side in conjugation with the shim. This should be a nice alternative to the tedious print-style-debugging I've used in the past :-)