### PR TITLE
cleanup: specify once_cell version etc. in only 1 place

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -40,7 +40,7 @@ brotli-decompressor = { workspace = true, optional = true }
 hashbrown = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 # only required for no-std
-once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }
+once_cell = { workspace = true }
 ring = { workspace = true, optional = true }
 subtle = { workspace = true }
 webpki = { workspace = true }


### PR DESCRIPTION
as I proposed in PR #2350 which I nuked (my bad)

To keep things simple I would like to simply update `rustls/Cargo.toml` to inherit the version, default-features = false, and features from top-level `Cargo.toml`.