### PR TITLE
docs: improve some more links, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,13 @@ from [`RustCrypto`] for cryptography.
 
 #### Custom provider
 
-We also provide a simple example of writing your own provider in the [`custom-provider`]
-example. This example implements a minimal provider using parts of the [`RustCrypto`]
-ecosystem.
+We also provide a simple example of writing your own provider in the [custom provider example].
+This example implements a minimal provider using parts of the [`RustCrypto`] ecosystem.
 
 See the [Making a custom CryptoProvider] section of the documentation for more information
 on this topic.
 
-[`custom-provider`]: https://github.com/rustls/rustls/tree/main/provider-example/
+[custom provider example]: https://github.com/rustls/rustls/tree/main/provider-example/
 [`RustCrypto`]: https://github.com/RustCrypto
 [Making a custom CryptoProvider]: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#making-a-custom-cryptoprovider
 

--- a/rustls-post-quantum/README.md
+++ b/rustls-post-quantum/README.md
@@ -16,4 +16,3 @@ using post-quantum algorithms instead of using this crate.
 This crate is release under the same licenses as the [main rustls crate][rustls].
 
 [rustls]: https://crates.io/crates/rustls
-[`rustls::crypto::CryptoProvider`]: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -93,9 +93,9 @@ impl EchConfig {
     /// One of the provided ECH configurations must be compatible with the HPKE provider's supported
     /// suites or an error will be returned.
     ///
-    /// See the [ech-client.rs] example for a complete example of fetching ECH configs from DNS.
+    /// See the [`ech-client.rs`] example for a complete example of fetching ECH configs from DNS.
     ///
-    /// [ech-client.rs]: https://github.com/rustls/rustls/blob/main/examples/src/bin/ech-client.rs
+    /// [`ech-client.rs`]: https://github.com/rustls/rustls/blob/main/examples/src/bin/ech-client.rs
     pub fn new(
         ech_config_list: EchConfigListBytes<'_>,
         hpke_suites: &[&'static dyn Hpke],

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -110,12 +110,12 @@ pub use crate::suites::CipherSuiteCommon;
 ///
 /// # Making a custom `CryptoProvider`
 ///
-/// Your goal will be to populate a [`crypto::CryptoProvider`] struct instance.
+/// Your goal will be to populate an instance of this `CryptoProvider` struct.
 ///
 /// ## Which elements are required?
 ///
-/// There is no requirement that the individual elements (`SupportedCipherSuite`, `SupportedKxGroup`,
-/// `SigningKey`, etc.) come from the same crate.  It is allowed and expected that uninteresting
+/// There is no requirement that the individual elements ([`SupportedCipherSuite`], [`SupportedKxGroup`],
+/// [`SigningKey`], etc.) come from the same crate.  It is allowed and expected that uninteresting
 /// elements would be delegated back to one of the default providers (statically) or a parent
 /// provider (dynamically).
 ///
@@ -160,8 +160,8 @@ pub use crate::suites::CipherSuiteCommon;
 ///
 /// # Example code
 ///
-/// See [provider-example/] for a full client and server example that uses
-/// cryptography from the [rust-crypto] and [dalek-cryptography] projects.
+/// See custom [`provider-example/`] for a full client and server example that uses
+/// cryptography from the [`RustCrypto`] and [`dalek-cryptography`] projects.
 ///
 /// ```shell
 /// $ cargo run --example client | head -3
@@ -171,9 +171,9 @@ pub use crate::suites::CipherSuiteCommon;
 /// Content-Length: 19899
 /// ```
 ///
-/// [provider-example/]: https://github.com/rustls/rustls/tree/main/provider-example/
-/// [rust-crypto]: https://github.com/rustcrypto
-/// [dalek-cryptography]: https://github.com/dalek-cryptography
+/// [`provider-example/`]: https://github.com/rustls/rustls/tree/main/provider-example/
+/// [`RustCrypto`]: https://github.com/RustCrypto
+/// [`dalek-cryptography`]: https://github.com/dalek-cryptography
 ///
 /// # FIPS-approved cryptography
 /// The `fips` crate feature enables use of the `aws-lc-rs` crate in FIPS mode.
@@ -323,7 +323,7 @@ pub trait SecureRandom: Send + Sync + Debug {
     }
 }
 
-/// A mechanism for loading private [SigningKey]s from [PrivateKeyDer].
+/// A mechanism for loading private [`SigningKey`]s from [`PrivateKeyDer`].
 ///
 /// This trait is intended to be used with private key material that is sourced from DER,
 /// such as a private-key that may be present on-disk. It is not intended to be used with

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -80,14 +80,13 @@
 //!
 //! #### Custom provider
 //!
-//! We also provide a simple example of writing your own provider in the [`custom-provider`]
-//! example. This example implements a minimal provider using parts of the [`RustCrypto`]
-//! ecosystem.
+//! We also provide a simple example of writing your own provider in the [custom provider example].
+//! This example implements a minimal provider using parts of the [`RustCrypto`] ecosystem.
 //!
 //! See the [Making a custom CryptoProvider] section of the documentation for more information
 //! on this topic.
 //!
-//! [`custom-provider`]: https://github.com/rustls/rustls/tree/main/provider-example/
+//! [custom provider example]: https://github.com/rustls/rustls/tree/main/provider-example/
 //! [`RustCrypto`]: https://github.com/RustCrypto
 //! [Making a custom CryptoProvider]: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#making-a-custom-cryptoprovider
 //!

--- a/rustls/src/manual/howto.rs
+++ b/rustls/src/manual/howto.rs
@@ -6,7 +6,7 @@ However, if your private key resides in a HSM, or in another process, or perhaps
 another machine, rustls has some extension points to support this:
 
 The main trait you must implement is [`sign::SigningKey`][signing_key]. The primary method here
-is [`choose_scheme`][choose_scheme] where you are given a set of [`SignatureScheme`s][sig_scheme] the client says
+is [`choose_scheme()`][choose_scheme] where you are given a set of [`SignatureScheme`s][sig_scheme] the client says
 it supports: you must choose one (or return `None` -- this aborts the handshake). Having
 done that, you return an implementation of the [`sign::Signer`][signer] trait.
 The [`sign()`][sign_method] performs the signature and returns it.
@@ -21,18 +21,18 @@ Once you have these two pieces, configuring a server to use them involves, brief
 - making a [`ResolvesServerCertUsingSni`][cert_using_sni] and feeding in your [`sign::CertifiedKey`][certified_key] for all SNI hostnames you want to use it for,
 - setting that as your `ServerConfig`'s [`cert_resolver`][cert_resolver]
 
-For a complete example of implementing a custom [`sign::SigningKey`][signing_key]
-and [`sign::Signer`][signer] see the [rustls-cng] crate.
+For a complete example of implementing a custom [`sign::SigningKey`][signing_key] and
+[`sign::Signer`][signer] see the [`signer` module in the `rustls-cng` crate][rustls-cng-signer].
 
 [signing_key]: crate::crypto::signer::SigningKey
-[choose_scheme]: crate::crypto::signer::SigningKey.choose_scheme()
+[choose_scheme]: crate::crypto::signer::SigningKey::choose_scheme
 [sig_scheme]: crate::SignatureScheme
 [signer]: crate::crypto::signer::Signer
-[sign_method]: crate::crypto::Signer.sign()
+[sign_method]: crate::crypto::signer::Signer::sign
 [certified_key]: crate::crypto::signer::CertifiedKey
 [cert_using_sni]: crate::server::ResolvesServerCertUsingSni
 [cert_resolver]: crate::ServerConfig::cert_resolver
-[rustls-cng]: https://github.com/rustls/rustls-cng/blob/dev/src/signer.rs
+[rustls-cng-signer]: https://github.com/rustls/rustls-cng/blob/dev/src/signer.rs
 
 [^1]: For PKCS#8 it does not support password encryption -- there's not a meaningful threat
       model addressed by this, and the encryption supported is typically extremely poor.


### PR DESCRIPTION
__STATUS:__ KEEPING AS DRAFT FOR NOW - KNOWN TODO ITEM(S) BELOW

- update link to custom provider example in top-level documentation
- update wording in __Making a custom `CryptoProvider`__ section
- replace extra self-linking with unlinked reference to `CryptoProvider` struct, which I think is is more consitent with other parts of documentation for `CryptoProvider`
- update reference to RustCrypto which now uses "upper camel case" instead of kebab-case
- use backticks for multiple references in __Example code__ section
- use backticks for a couple more references in `crypto/mod.rs` that I missed in recent other PR #2353
- adding brackets to add linking to an enum & 2 traits referenced in some text in `crypto/mod.rs`
- add the word "custom" before reference to `provider-example/`

__TODO__

- [x] resolve a couple dead links I found in: https://docs.rs/portable-rustls/latest/portable_rustls/manual/_03_howto/index.html#customising-private-key-usage
- ~~add more explicit reference to the manual that is referenced here & there~~ - see PR #2356
- [x] link to https://github.com/rustls/rustls-cng/blob/dev/src/signer.rs could use some improvement in howto.rs

__FURTHER INVESTIGATION DEFERRED FOR NOW__

- I noticed that some (I think most) but not all links to methods show `()`, found some methods without `()` for example:
  - `ServerConfig::require_ems` & `ClientConfig::require_ems` in lib.rs
  - `crypto::signer::SigningKey::choose_scheme` in `manual/howto.rs`
  - `ConfigBuilder::with_single_cert` in `crypto/mod.rs`

---

__RELATED UPDATES__

- PR #2353 - minor updates to `CryptoProvider` already merged
- PR #2356 - proposed updates for "detailed manual"

---

__MOVING FORWARD__

My apologies for so much noise. I think this should be ready for review. A bunch of things are combined, and I would be happy to separate some of these things if needed.

I have raised some more PRs that may be related to this. I would be happy to combine or separate changes out in a different way if needed.