### PR TITLE
docs: remove irrelevant phrase from custom CryptoProvider doc

### DIFF
--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -120,7 +120,7 @@ pub use crate::suites::CipherSuiteCommon;
 /// provider (dynamically).
 ///
 /// For example, if we want to make a provider that just overrides key loading in the config builder
-/// API (with [`ConfigBuilder::with_single_cert`], etc.), it might look like this:
+/// API, it might look like this:
 ///
 /// ```
 /// # #[cfg(feature = "aws_lc_rs")] {


### PR DESCRIPTION
I think this phrase should not be there, as I do not see use of `ConfigBuilder::with_single_cert` in the example code.

In case I am mistaken, let's just close this.