### PR TITLE
Avoid handshake message round-tripping for binders

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2769,8 +2769,13 @@ impl<'a> HandshakeMessagePayload<'a> {
 
     pub(crate) fn encoding_for_binder_signing(&self) -> Vec<u8> {
         let mut ret = self.get_encoding();
+        let ret_len = ret.len() - self.total_binder_length();
+        ret.truncate(ret_len);
+        ret
+    }
 
-        let binder_len = match self.payload {
+    pub(crate) fn total_binder_length(&self) -> usize {
+        match self.payload {
             HandshakePayload::ClientHello(ref ch) => match ch.extensions.last() {
                 Some(ClientExtension::PresharedKey(offer)) => {
                     let mut binders_encoding = Vec::new();
@@ -2782,11 +2787,7 @@ impl<'a> HandshakeMessagePayload<'a> {
                 _ => 0,
             },
             _ => 0,
-        };
-
-        let ret_len = ret.len() - binder_len;
-        ret.truncate(ret_len);
-        ret
+        }
     }
 
     pub(crate) fn payload_encode(&self, bytes: &mut Vec<u8>, encoding: Encoding) {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -97,13 +97,15 @@ mod client_hello {
             binder: &[u8],
         ) -> bool {
             let binder_plaintext = match &client_hello.payload {
-                MessagePayload::Handshake { parsed, .. } => parsed.encoding_for_binder_signing(),
+                MessagePayload::Handshake { parsed, encoded } => {
+                    &encoded.bytes()[..encoded.bytes().len() - parsed.total_binder_length()]
+                }
                 _ => unreachable!(),
             };
 
             let handshake_hash = self
                 .transcript
-                .hash_given(&binder_plaintext);
+                .hash_given(binder_plaintext);
 
             let key_schedule = KeyScheduleEarly::new(suite, psk);
             let real_binder =


### PR DESCRIPTION
Verifying a _received_ `ClientHello` binder should be done against the original received bytes, not our re-encoding of them.

This previously worked, because we required and tested that we could accurately round-trip handshake messages. But that is a less-robust approach.

(change split out from #1475)