### PR TITLE
Prevent resumption between "incompatible" clients

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -3,4 +3,5 @@ upper-case-acronyms-aggressive = true
 # only intended to affect main rustls crate - need to allow disallowed-types in all other crates in Clippy CI job
 disallowed-types = [
   { path = "std::sync::Arc", reason = "must use Arc from sync module to support downstream forks targetting architectures without atomic ptrs" },
+  { path = "std::sync::Weak", reason = "must use Weak from sync module to support downstream forks targetting architectures without atomic ptrs" },
 ]

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -166,6 +166,22 @@ pub struct ClientConfig {
     pub alpn_protocols: Vec<Vec<u8>>,
 
     /// How and when the client can resume a previous session.
+    ///
+    /// # Sharing `resumption` between `ClientConfig`s
+    /// In a program using many `ClientConfig`s it may improve resumption rates
+    /// (which has a significant impact on connection performance) if those
+    /// configs share a single `Resumption`.
+    ///
+    /// However, resumption is only allowed between two `ClientConfig`s if their
+    /// `client_auth_cert_resolver` (ie, potential client authentication credentials)
+    /// and `verifier` (ie, server certificate verification settings) are
+    /// the same (according to `Arc::ptr_eq`).
+    ///
+    /// To illustrate, imagine two `ClientConfig`s `A` and `B`.  `A` fully validates
+    /// the server certificate, `B` does not.  If `A` and `B` shared a resumption store,
+    /// it would be possible for a session originated by `B` to be inserted into the
+    /// store, and then resumed by `A`.  This would give a false impression to the user
+    /// of `A` that the server certificate is fully validated.
     pub resumption: Resumption,
 
     /// The maximum size of plaintext input to be emitted in a single TLS record.

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -253,21 +253,26 @@ mod tests {
 
     use super::NoClientSessionStorage;
     use super::provider::cipher_suite;
-    use crate::client::ClientSessionStore;
+    use crate::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+    use crate::client::{ClientSessionStore, ResolvesClientCert};
     use crate::msgs::base::PayloadU16;
     use crate::msgs::enums::NamedGroup;
     use crate::msgs::handshake::CertificateChain;
     #[cfg(feature = "tls12")]
     use crate::msgs::handshake::SessionId;
     use crate::msgs::persist::Tls13ClientSessionValue;
+    use crate::pki_types::CertificateDer;
     use crate::suites::SupportedCipherSuite;
     use crate::sync::Arc;
+    use crate::{DigitallySignedStruct, Error, SignatureScheme, sign};
 
     #[test]
     fn test_noclientsessionstorage_does_nothing() {
         let c = NoClientSessionStorage {};
         let name = ServerName::try_from("example.com").unwrap();
         let now = UnixTime::now();
+        let server_cert_verifier: Arc<dyn ServerCertVerifier> = Arc::new(DummyServerCertVerifier);
+        let resolves_client_cert: Arc<dyn ResolvesClientCert> = Arc::new(DummyResolvesClientCert);
 
         c.set_kx_hint(name.clone(), NamedGroup::X25519);
         assert_eq!(None, c.kx_hint(&name));
@@ -289,6 +294,8 @@ mod tests {
                     Arc::new(PayloadU16::empty()),
                     &[],
                     CertificateChain::default(),
+                    &server_cert_verifier,
+                    &resolves_client_cert,
                     now,
                     0,
                     true,
@@ -309,6 +316,8 @@ mod tests {
                 Arc::new(PayloadU16::empty()),
                 &[],
                 CertificateChain::default(),
+                &server_cert_verifier,
+                &resolves_client_cert,
                 now,
                 0,
                 0,
@@ -316,5 +325,60 @@ mod tests {
             ),
         );
         assert!(c.take_tls13_ticket(&name).is_none());
+    }
+
+    #[derive(Debug)]
+    struct DummyServerCertVerifier;
+
+    impl ServerCertVerifier for DummyServerCertVerifier {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName<'_>,
+            _ocsp_response: &[u8],
+            _now: UnixTime,
+        ) -> Result<ServerCertVerified, Error> {
+            unreachable!()
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            unreachable!()
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            unreachable!()
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            unreachable!()
+        }
+    }
+
+    #[derive(Debug)]
+    struct DummyResolvesClientCert;
+
+    impl ResolvesClientCert for DummyResolvesClientCert {
+        fn resolve(
+            &self,
+            _root_hint_subjects: &[&[u8]],
+            _sigschemes: &[SignatureScheme],
+        ) -> Option<Arc<sign::CertifiedKey>> {
+            unreachable!()
+        }
+
+        fn has_certs(&self) -> bool {
+            unreachable!()
+        }
     }
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1199,6 +1199,8 @@ impl ExpectFinished {
                 .peer_certificates
                 .clone()
                 .unwrap_or_default(),
+            &self.config.verifier,
+            &self.config.client_auth_cert_resolver,
             now,
             lifetime,
             self.using_ems,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1486,6 +1486,8 @@ impl ExpectTraffic {
                 .peer_certificates
                 .clone()
                 .unwrap_or_default(),
+            &self.config.verifier,
+            &self.config.client_auth_cert_resolver,
             now,
             nst.lifetime,
             nst.age_add,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -413,6 +413,8 @@ mod test_macros;
 mod sync {
     #[allow(clippy::disallowed_types)]
     pub(crate) type Arc<T> = alloc::sync::Arc<T>;
+    #[allow(clippy::disallowed_types)]
+    pub(crate) type Weak<T> = alloc::sync::Weak<T>;
 }
 
 #[macro_use]

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -4,6 +4,7 @@ use core::cmp;
 use pki_types::{DnsName, UnixTime};
 use zeroize::Zeroizing;
 
+use crate::client::ResolvesClientCert;
 use crate::enums::{CipherSuite, ProtocolVersion};
 use crate::error::InvalidMessage;
 use crate::msgs::base::{PayloadU8, PayloadU16};
@@ -11,10 +12,11 @@ use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::handshake::CertificateChain;
 #[cfg(feature = "tls12")]
 use crate::msgs::handshake::SessionId;
-use crate::sync::Arc;
+use crate::sync::{Arc, Weak};
 #[cfg(feature = "tls12")]
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
+use crate::verify::ServerCertVerifier;
 
 pub(crate) struct Retrieved<T> {
     pub(crate) value: T,
@@ -82,6 +84,8 @@ impl Tls13ClientSessionValue {
         ticket: Arc<PayloadU16>,
         secret: &[u8],
         server_cert_chain: CertificateChain<'static>,
+        server_cert_verifier: &Arc<dyn ServerCertVerifier>,
+        client_creds: &Arc<dyn ResolvesClientCert>,
         time_now: UnixTime,
         lifetime_secs: u32,
         age_add: u32,
@@ -97,6 +101,8 @@ impl Tls13ClientSessionValue {
                 time_now,
                 lifetime_secs,
                 server_cert_chain,
+                server_cert_verifier,
+                client_creds,
             ),
             quic_params: PayloadU16(Vec::new()),
         }
@@ -160,6 +166,8 @@ impl Tls12ClientSessionValue {
         ticket: Arc<PayloadU16>,
         master_secret: &[u8],
         server_cert_chain: CertificateChain<'static>,
+        server_cert_verifier: &Arc<dyn ServerCertVerifier>,
+        client_creds: &Arc<dyn ResolvesClientCert>,
         time_now: UnixTime,
         lifetime_secs: u32,
         extended_ms: bool,
@@ -174,6 +182,8 @@ impl Tls12ClientSessionValue {
                 time_now,
                 lifetime_secs,
                 server_cert_chain,
+                server_cert_verifier,
+                client_creds,
             ),
         }
     }
@@ -213,6 +223,8 @@ pub struct ClientSessionCommon {
     epoch: u64,
     lifetime_secs: u32,
     server_cert_chain: Arc<CertificateChain<'static>>,
+    server_cert_verifier: Weak<dyn ServerCertVerifier>,
+    client_creds: Weak<dyn ResolvesClientCert>,
 }
 
 impl ClientSessionCommon {
@@ -222,6 +234,8 @@ impl ClientSessionCommon {
         time_now: UnixTime,
         lifetime_secs: u32,
         server_cert_chain: CertificateChain<'static>,
+        server_cert_verifier: &Arc<dyn ServerCertVerifier>,
+        client_creds: &Arc<dyn ResolvesClientCert>,
     ) -> Self {
         Self {
             ticket,
@@ -229,6 +243,34 @@ impl ClientSessionCommon {
             epoch: time_now.as_secs(),
             lifetime_secs: cmp::min(lifetime_secs, MAX_TICKET_LIFETIME),
             server_cert_chain: Arc::new(server_cert_chain),
+            server_cert_verifier: Arc::downgrade(server_cert_verifier),
+            client_creds: Arc::downgrade(client_creds),
+        }
+    }
+
+    pub(crate) fn compatible_config(
+        &self,
+        server_cert_verifier: &Arc<dyn ServerCertVerifier>,
+        client_creds: &Arc<dyn ResolvesClientCert>,
+    ) -> bool {
+        let same_verifier = Weak::ptr_eq(
+            &Arc::downgrade(server_cert_verifier),
+            &self.server_cert_verifier,
+        );
+        let same_creds = Weak::ptr_eq(&Arc::downgrade(client_creds), &self.client_creds);
+
+        match (same_verifier, same_creds) {
+            (true, true) => true,
+            (false, _) => {
+                crate::log::trace!("resumption not allowed between different ServerCertVerifiers");
+                false
+            }
+            (_, _) => {
+                crate::log::trace!(
+                    "resumption not allowed between different ResolvesClientCert values"
+                );
+                false
+            }
         }
     }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6722,20 +6722,20 @@ fn test_no_warning_logging_during_successful_sessions() {
     if cfg!(feature = "logging") {
         COUNTS.with(|c| {
             println!("After tests: {:?}", c.borrow());
-            assert_eq!(c.borrow().warn, 0);
-            assert_eq!(c.borrow().error, 0);
-            assert_eq!(c.borrow().info, 0);
-            assert!(c.borrow().trace > 0);
-            assert!(c.borrow().debug > 0);
+            assert!(c.borrow().warn.is_empty());
+            assert!(c.borrow().error.is_empty());
+            assert!(c.borrow().info.is_empty());
+            assert!(!c.borrow().trace.is_empty());
+            assert!(!c.borrow().debug.is_empty());
         });
     } else {
         COUNTS.with(|c| {
             println!("After tests: {:?}", c.borrow());
-            assert_eq!(c.borrow().warn, 0);
-            assert_eq!(c.borrow().error, 0);
-            assert_eq!(c.borrow().info, 0);
-            assert_eq!(c.borrow().trace, 0);
-            assert_eq!(c.borrow().debug, 0);
+            assert!(c.borrow().warn.is_empty());
+            assert!(c.borrow().error.is_empty());
+            assert!(c.borrow().info.is_empty());
+            assert!(c.borrow().trace.is_empty());
+            assert!(c.borrow().debug.is_empty());
         });
     }
 }

--- a/rustls/tests/runners/api.rs
+++ b/rustls/tests/runners/api.rs
@@ -60,7 +60,8 @@ impl log::Log for CountingLogger {
         println!("logging at {:?}: {:?}", record.level(), record.args());
 
         COUNTS.with(|c| {
-            c.borrow_mut().add(record.level());
+            c.borrow_mut()
+                .add(record.level(), format!("{}", record.args()));
         });
     }
 
@@ -69,11 +70,11 @@ impl log::Log for CountingLogger {
 
 #[derive(Default, Debug)]
 struct LogCounts {
-    trace: usize,
-    debug: usize,
-    info: usize,
-    warn: usize,
-    error: usize,
+    trace: Vec<String>,
+    debug: Vec<String>,
+    info: Vec<String>,
+    warn: Vec<String>,
+    error: Vec<String>,
 }
 
 impl LogCounts {
@@ -87,13 +88,14 @@ impl LogCounts {
         *self = Self::new();
     }
 
-    fn add(&mut self, level: log::Level) {
+    fn add(&mut self, level: log::Level, message: String) {
         match level {
-            log::Level::Trace => self.trace += 1,
-            log::Level::Debug => self.debug += 1,
-            log::Level::Info => self.info += 1,
-            log::Level::Warn => self.warn += 1,
-            log::Level::Error => self.error += 1,
+            log::Level::Trace => &mut self.trace,
+            log::Level::Debug => &mut self.debug,
+            log::Level::Info => &mut self.info,
+            log::Level::Warn => &mut self.warn,
+            log::Level::Error => &mut self.error,
         }
+        .push(message);
     }
 }


### PR DESCRIPTION
"Compatible" here means they have ~interchangeable security, which means they have the same server certificate verifier and same potentially-offered client credentials.
    
"Same" is defined by `Arc` equality, which means a rustls user wishing to arrange for multiple `ClientConfig`s to share a `resumption` _also_ now need to share the `client_auth_cert_resolver` and `verifier`.  A non-`dangerous` function is provided which does this, and also provides a convenient place to document the problem we are solving here.

If we think this is a reasonably-shaped solution to this problem, I will do similar for servers.

fixes #2284 