### PR TITLE
Allow `AeadKey` to be constructed outside crate

### DIFF
--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -183,10 +183,10 @@ impl ConnectionSecrets {
         (
             self.suite
                 .aead_alg
-                .decrypter(AeadKey::new(read_key), read_iv),
+                .decrypter(AeadKey::from_slice(read_key).unwrap(), read_iv),
             self.suite
                 .aead_alg
-                .encrypter(AeadKey::new(write_key), write_iv, extra),
+                .encrypter(AeadKey::from_slice(write_key).unwrap(), write_iv, extra),
         )
     }
 
@@ -270,12 +270,12 @@ impl ConnectionSecrets {
         let (server_iv, explicit_nonce) = key_block.split_at(shape.fixed_iv_len);
 
         let client_secrets = self.suite.aead_alg.extract_keys(
-            AeadKey::new(client_key),
+            AeadKey::from_slice(client_key).unwrap(),
             client_iv,
             explicit_nonce,
         )?;
         let server_secrets = self.suite.aead_alg.extract_keys(
-            AeadKey::new(server_key),
+            AeadKey::from_slice(server_key).unwrap(),
             server_iv,
             explicit_nonce,
         )?;

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -827,9 +827,10 @@ pub(crate) fn hkdf_expand_label_aead_key(
     label: &[u8],
     context: &[u8],
 ) -> AeadKey {
-    hkdf_expand_label_inner(expander, label, context, key_len, |e, info| {
-        let key: AeadKey = expand(e, info);
-        key.with_length(key_len)
+    hkdf_expand_label_inner(expander, label, context, key_len, |e, info| match key_len {
+        16 => expand::<AeadKey, 16>(e, info),
+        32 => expand::<AeadKey, 32>(e, info),
+        _ => unimplemented!("only 128-bit or 256-bit AeadKeys supported"),
     })
 }
 


### PR DESCRIPTION
Previously this was constructable, but only for 256-bit keys via `From<[u8; 32]>`.

Instead of just publicising `AeadKey::new`, recast the type as an enum containing variants for the two usual symmetric key lengths (this prevents misuses like empty keys, one byte keys, etc).  Unfortunately for semver reasons this needs to be wrapped in the original struct type.

The underlying rationale for this change is to support some changes I want to make in quinn; this is draft while I solidify those.