### PR TITLE
Add kernel connection API

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -16,6 +16,7 @@ use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
+use crate::kernel::KernelConnection;
 use crate::log::trace;
 use crate::msgs::enums::NamedGroup;
 use crate::msgs::handshake::ClientExtension;
@@ -898,6 +899,23 @@ impl UnbufferedClientConnection {
     /// Should be used with care as it exposes secret key material.
     pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
         self.inner.dangerous_extract_secrets()
+    }
+
+    /// Extract secrets and a [`KernelConnection`] object.
+    ///
+    /// This allows you use rustls to manage keys and then manage encryption and
+    /// decryption yourself (e.g. for kTLS).
+    ///
+    /// Should be used with care as it exposes secret key material.
+    ///
+    /// See the [`crate::kernel`] documentations for details on prerequisites
+    /// for calling this method.
+    pub fn dangerous_into_kernel_connection(
+        self,
+    ) -> Result<(ExtractedSecrets, KernelConnection<ClientConnectionData>), Error> {
+        self.inner
+            .core
+            .dangerous_into_kernel_connection()
     }
 }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -897,6 +897,8 @@ impl UnbufferedClientConnection {
 
     /// Extract secrets, so they can be used when configuring kTLS, for example.
     /// Should be used with care as it exposes secret key material.
+    #[deprecated = "dangerous_extract_secrets() does not support session tickets or \
+                    key updates, use dangerous_into_kernel_connection() instead"]
     pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
         self.inner.dangerous_extract_secrets()
     }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use pki_types::CertificateDer;
 
+use crate::conn::kernel::KernelState;
 use crate::crypto::SupportedKxGroup;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
@@ -866,6 +867,10 @@ pub(crate) trait State<Data>: Send + Sync {
     }
 
     fn handle_decrypt_error(&self) {}
+
+    fn into_external_state(self: Box<Self>) -> Result<Box<dyn KernelState + 'static>, Error> {
+        Err(Error::HandshakeNotComplete)
+    }
 
     fn into_owned(self: Box<Self>) -> Box<dyn State<Data> + 'static>;
 }

--- a/rustls/src/conn/kernel.rs
+++ b/rustls/src/conn/kernel.rs
@@ -1,0 +1,269 @@
+//! Kernel connection API.
+//!
+//! This module gives you the bare minimum you need to implement a TLS connection
+//! that does its own encryption and decryption while still using rustls to manage
+//! connection secrets and session tickets. It is intended for use cases like kTLS
+//! where you want to use rustls to establish the connection but want to use
+//! something else to do the encryption/decryption after that.
+//!
+//! There are only two things that [`KernelConnection`] is able to do:
+//! 1. Compute new traffic secrets when a key update occurs.
+//! 2. Save received session tickets sent by a server peer.
+//!
+//! That's it. Everything else you will need to implement yourself.
+//!
+//! # Entry Point
+//! The entry points into this API are
+//! [`UnbufferedClientConnection::dangerous_into_kernel_connection`][client-into]
+//! and
+//! [`UnbufferedServerConnection::dangerous_into_kernel_connection`][server-into].
+//!
+//! In order to actually create an [`KernelConnection`] all of the following
+//! must be true:
+//! - the connection must have completed its handshake,
+//! - the connection must have no buffered TLS data waiting to be sent, and,
+//! - the config used to create the connection must have `enable_extract_secrets`
+//!   set to true.
+//!
+//! This sounds fairly complicated to achieve at first glance. However, if you
+//! drive an unbuffered connection through the handshake until it returns
+//! [`WriteTraffic`] then it will end up in an appropriate state to convert
+//! into an external connection.
+//!
+//! [client-into]: crate::client::UnbufferedClientConnection::dangerous_into_kernel_connection
+//! [server-into]: crate::server::UnbufferedServerConnection::dangerous_into_kernel_connection
+//! [`WriteTraffic`]: crate::unbuffered::ConnectionState::WriteTraffic
+//!
+//! # Cipher Suite Confidentiality Limits
+//! Some cipher suites (notably AES-GCM) have vulnerabilities where they are no
+//! longer secure once a certain number of messages have been sent. Normally,
+//! rustls tracks how many messages have been written or read and will
+//! automatically either refresh keys or emit an error when approaching the
+//! confidentiality limit of the cipher suite.
+//!
+//! [`KernelConnection`] has no way to track this. It is the responsibility
+//! of the user of the API to track approximately how many messages have been
+//! sent and either refresh the traffic keys or abort the connection before the
+//! confidentiality limit is reached.
+//!
+//! You can find the current confidentiality limit by looking at
+//! [`CipherSuiteCommon::confidentiality_limit`] for the cipher suite selected
+//! by the connection.
+//!
+//! [`CipherSuiteCommon::confidentiality_limit`]: crate::CipherSuiteCommon::confidentiality_limit
+//! [`KernelConnection`]: crate::kernel::KernelConnection
+
+use core::marker::PhantomData;
+
+use alloc::boxed::Box;
+
+use crate::client::ClientConnectionData;
+use crate::common_state::Protocol;
+use crate::msgs::codec::Codec;
+use crate::msgs::handshake::{CertificateChain, NewSessionTicketPayloadTls13};
+use crate::quic::Quic;
+use crate::{CommonState, ConnectionTrafficSecrets, Error, ProtocolVersion, SupportedCipherSuite};
+
+/// A kernel connection.
+///
+/// This does not directly wrap a kernel connection, rather it gives you the
+/// minimal interfaces you need to implement a well-behaved TLS connection on
+/// top of kTLS.
+///
+/// See the [`crate::kernel`] module docs for more details.
+pub struct KernelConnection<Data> {
+    state: Box<dyn KernelState>,
+
+    peer_certificates: Option<CertificateChain<'static>>,
+    quic: Quic,
+
+    negotiated_version: ProtocolVersion,
+    protocol: Protocol,
+    suite: SupportedCipherSuite,
+
+    _data: PhantomData<Data>,
+}
+
+impl<Data> KernelConnection<Data> {
+    pub(crate) fn new(state: Box<dyn KernelState>, common: CommonState) -> Result<Self, Error> {
+        Ok(Self {
+            state,
+
+            peer_certificates: common.peer_certificates,
+            quic: common.quic,
+            negotiated_version: common
+                .negotiated_version
+                .ok_or(Error::HandshakeNotComplete)?,
+            protocol: common.protocol,
+            suite: common
+                .suite
+                .ok_or(Error::HandshakeNotComplete)?,
+
+            _data: PhantomData,
+        })
+    }
+
+    /// Retrieves the ciphersuite agreed with the peer.
+    pub fn negotiated_cipher_suite(&self) -> SupportedCipherSuite {
+        self.suite
+    }
+
+    /// Retrieves the protocol version agreed with the peer.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.negotiated_version
+    }
+
+    /// Update the traffic secret used for encrypting messages sent to the peer.
+    ///
+    /// Returns the new traffic secret and initial sequence number to use.
+    ///
+    /// In order to use the new secret you should send a TLS 1.3 key update to
+    /// the peer and then use the new traffic secrets to encrypt any future
+    /// messages.
+    ///
+    /// Note that it is only possible to update the traffic secrets on a TLS 1.3
+    /// connection. Attempting to do so on a non-TLS 1.3 connection will result
+    /// in an error.
+    pub fn update_tx_secret(&mut self) -> Result<(u64, ConnectionTrafficSecrets), Error> {
+        // The sequence number always starts at 0 after a key update.
+        self.state
+            .update_secrets(Direction::Transmit)
+            .map(|secret| (0, secret))
+    }
+
+    /// Update the traffic secret used for decrypting messages received from the
+    /// peer.
+    ///
+    /// Returns the new traffic secret and initial sequence number to use.
+    ///
+    /// You should call this method once you receive a TLS 1.3 key update message
+    /// from the peer.
+    ///
+    /// Note that it is only possible to update the traffic secrets on a TLS 1.3
+    /// connection. Attempting to do so on a non-TLS 1.3 connection will result
+    /// in an error.
+    pub fn update_rx_secret(&mut self) -> Result<(u64, ConnectionTrafficSecrets), Error> {
+        // The sequence number always starts at 0 after a key update.
+        self.state
+            .update_secrets(Direction::Receive)
+            .map(|secret| (0, secret))
+    }
+}
+
+impl KernelConnection<ClientConnectionData> {
+    /// Handle a `new_session_ticket` message from the peer.
+    ///
+    /// This will register the session ticket within with rustls so that it can
+    /// be used to establish future TLS connections.
+    ///
+    /// # Getting the right payload
+    ///
+    /// This method expects to be passed the inner payload of the handshake
+    /// message. This means that you will need to parse the header of the
+    /// handshake message in order to determine the correct payload to pass in.
+    /// The message format is described in [RFC 8446 section 4][0]. `payload`
+    /// should not include the `msg_type` or `length` fields.
+    ///
+    /// Code to parse out the payload should look something like this
+    /// ```no_run
+    /// use rustls::{ContentType, HandshakeType};
+    /// use rustls::kernel::KernelConnection;
+    /// use rustls::client::ClientConnectionData;
+    ///
+    /// # fn doctest(conn: &mut KernelConnection<ClientConnectionData>, typ: ContentType, message: &[u8]) -> Result<(), rustls::Error> {
+    /// let conn: &mut KernelConnection<ClientConnectionData> = // ...
+    /// #   conn;
+    /// let typ: ContentType = // ...
+    /// #   typ;
+    /// let mut message: &[u8] = // ...
+    /// #   message;
+    ///
+    /// // Processing for other messages not included in this example
+    /// assert_eq!(typ, ContentType::Handshake);
+    ///
+    /// // There may be multiple handshake payloads within a single handshake message.
+    /// while !message.is_empty() {
+    ///     let (typ, len, rest) = match message {
+    ///         &[typ, a, b, c, ref rest @ ..] => (
+    ///             HandshakeType::from(typ),
+    ///             u32::from_be_bytes([0, a, b, c]) as usize,
+    ///             rest
+    ///         ),
+    ///         _ => panic!("error handling not included in this example")
+    ///     };
+    ///
+    ///     // Processing for other messages not included in this example.
+    ///     assert_eq!(typ, HandshakeType::NewSessionTicket);
+    ///     assert!(rest.len() >= len, "invalid handshake message");
+    ///
+    ///     let (payload, rest) = rest.split_at(len);
+    ///     message = rest;
+    ///
+    ///     conn.handle_new_session_ticket(payload)?;
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    /// This method will return an error if:
+    /// - This connection is not a TLS 1.3 connection (in TLS 1.2 session tickets
+    ///   are sent as part of the handshake).
+    /// - The provided payload is not a valid `new_session_ticket` payload or has
+    ///   extra unparsed trailing data.
+    /// - An error occurs while the connection updates the session ticket store.
+    ///
+    /// [0]: https://datatracker.ietf.org/doc/html/rfc8446#section-4
+    pub fn handle_new_session_ticket(&mut self, payload: &[u8]) -> Result<(), Error> {
+        // We want to return a more specific error here first if this is called
+        // on a non-TLS 1.3 connection since a parsing error isn't the real issue
+        // here.
+        if self.protocol_version() != ProtocolVersion::TLSv1_3 {
+            return Err(Error::General(
+                "TLS 1.2 session tickets may not be sent once the handshake has completed".into(),
+            ));
+        }
+
+        let nst = NewSessionTicketPayloadTls13::read_bytes(payload)?;
+        let mut cx = KernelContext {
+            peer_certificates: self.peer_certificates.as_ref(),
+            protocol: self.protocol,
+            quic: &self.quic,
+        };
+        self.state
+            .handle_new_session_ticket(&mut cx, &nst)
+    }
+}
+
+pub(crate) trait KernelState: Send + Sync {
+    /// Update the traffic secret for the specified direction on the connection.
+    fn update_secrets(&mut self, dir: Direction) -> Result<ConnectionTrafficSecrets, Error>;
+
+    /// Handle a new session ticket.
+    ///
+    /// This will only ever be called for client connections, as [`KernelConnection`]
+    /// only exposes the relevant API for client connections.
+    fn handle_new_session_ticket(
+        &mut self,
+        cx: &mut KernelContext<'_>,
+        message: &NewSessionTicketPayloadTls13,
+    ) -> Result<(), Error>;
+}
+
+pub(crate) struct KernelContext<'a> {
+    pub(crate) peer_certificates: Option<&'a CertificateChain<'static>>,
+    pub(crate) protocol: Protocol,
+    pub(crate) quic: &'a Quic,
+}
+
+impl KernelContext<'_> {
+    pub(crate) fn is_quic(&self) -> bool {
+        self.protocol == Protocol::Quic
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum Direction {
+    Transmit,
+    Receive,
+}

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -545,6 +545,7 @@ pub mod unbuffered {
 // The public interface is:
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier, WantsVersions};
 pub use crate::common_state::{CommonState, HandshakeKind, IoState, Side};
+pub use crate::conn::kernel;
 #[cfg(feature = "std")]
 pub use crate::conn::{Connection, Reader, Writer};
 pub use crate::conn::{ConnectionCommon, SideData};

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -22,6 +22,7 @@ use crate::crypto;
 use crate::crypto::CryptoProvider;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
+use crate::kernel::KernelConnection;
 use crate::log::trace;
 use crate::msgs::base::Payload;
 use crate::msgs::enums::CertificateType;
@@ -928,6 +929,23 @@ impl UnbufferedServerConnection {
     /// Should be used with care as it exposes secret key material.
     pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
         self.inner.dangerous_extract_secrets()
+    }
+
+    /// Extract secrets and an [`KernelConnection`] object.
+    ///
+    /// This allows you use rustls to manage keys and then manage encryption and
+    /// decryption yourself (e.g. for kTLS).
+    ///
+    /// Should be used with care as it exposes secret key material.
+    ///
+    /// See the [`crate::kernel`] documentations for details on prerequisites
+    /// for calling this method.
+    pub fn dangerous_into_kernel_connection(
+        self,
+    ) -> Result<(ExtractedSecrets, KernelConnection<ServerConnectionData>), Error> {
+        self.inner
+            .core
+            .dangerous_into_kernel_connection()
     }
 }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -927,6 +927,8 @@ impl UnbufferedServerConnection {
 
     /// Extract secrets, so they can be used when configuring kTLS, for example.
     /// Should be used with care as it exposes secret key material.
+    #[deprecated = "dangerous_extract_secrets() does not support session tickets or \
+                    key updates, use dangerous_into_kernel_connection() instead"]
     pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
         self.inner.dangerous_extract_secrets()
     }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -13,7 +13,8 @@ use pki_types::{
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::{
-    AlwaysResolvesClientRawPublicKeys, ServerCertVerifierBuilder, WebPkiServerVerifier,
+    AlwaysResolvesClientRawPublicKeys, ServerCertVerifierBuilder, UnbufferedClientConnection,
+    WebPkiServerVerifier,
 };
 use rustls::crypto::cipher::{InboundOpaqueMessage, MessageDecrypter, MessageEncrypter};
 use rustls::crypto::{CryptoProvider, verify_tls13_signature_with_raw_key};
@@ -21,9 +22,13 @@ use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::message::{Message, OutboundOpaqueMessage, PlainMessage};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::server::{
-    AlwaysResolvesServerRawPublicKeys, ClientCertVerifierBuilder, WebPkiClientVerifier,
+    AlwaysResolvesServerRawPublicKeys, ClientCertVerifierBuilder, UnbufferedServerConnection,
+    WebPkiClientVerifier,
 };
 use rustls::sign::CertifiedKey;
+use rustls::unbuffered::{
+    ConnectionState, EncodeError, UnbufferedConnectionCommon, UnbufferedStatus,
+};
 use rustls::{
     ClientConfig, ClientConnection, Connection, ConnectionCommon, ContentType,
     DigitallySignedStruct, DistinguishedName, Error, InconsistentKeys, NamedGroup, ProtocolVersion,
@@ -752,6 +757,87 @@ pub fn do_handshake(
         client.process_new_packets().unwrap();
     }
     (to_server, to_client)
+}
+
+// Drive a handshake using unbuffered connections.
+//
+// Note that this drives the connection beyond the handshake until both
+// connections are idle and there is no pending data waiting to be processed
+// by either. In practice this just means that session tickets are processed
+// by the client.
+pub fn do_unbuffered_handshake(
+    client: &mut UnbufferedClientConnection,
+    server: &mut UnbufferedServerConnection,
+) {
+    fn is_idle<Data>(conn: &UnbufferedConnectionCommon<Data>, data: &[u8]) -> bool {
+        !conn.is_handshaking() && !conn.wants_write() && data.is_empty()
+    }
+
+    let mut client_data = Vec::with_capacity(1024);
+    let mut server_data = Vec::with_capacity(1024);
+
+    while !is_idle(client, &client_data) || !is_idle(server, &server_data) {
+        loop {
+            let UnbufferedStatus { discard, state } = client.process_tls_records(&mut client_data);
+            let state = state.unwrap();
+
+            match state {
+                ConnectionState::BlockedHandshake | ConnectionState::WriteTraffic(_) => {
+                    client_data.drain(..discard);
+                    break;
+                }
+                ConnectionState::Closed | ConnectionState::PeerClosed => unreachable!(),
+                ConnectionState::ReadEarlyData(_) => (),
+                ConnectionState::EncodeTlsData(mut data) => {
+                    let required = match data.encode(&mut []) {
+                        Err(EncodeError::InsufficientSize(err)) => err.required_size,
+                        _ => unreachable!(),
+                    };
+
+                    let old_len = server_data.len();
+                    server_data.resize(old_len + required, 0);
+                    data.encode(&mut server_data[old_len..])
+                        .unwrap();
+                }
+                ConnectionState::TransmitTlsData(data) => data.done(),
+                st => unreachable!("unexpected connection state: {st:?}"),
+            }
+
+            client_data.drain(..discard);
+        }
+
+        loop {
+            let UnbufferedStatus { discard, state } = server.process_tls_records(&mut server_data);
+            let state = state.unwrap();
+
+            match state {
+                ConnectionState::BlockedHandshake | ConnectionState::WriteTraffic(_) => {
+                    server_data.drain(..discard);
+                    break;
+                }
+                ConnectionState::Closed | ConnectionState::PeerClosed => unreachable!(),
+                ConnectionState::ReadEarlyData(_) => unreachable!(),
+                ConnectionState::EncodeTlsData(mut data) => {
+                    let required = match data.encode(&mut []) {
+                        Err(EncodeError::InsufficientSize(err)) => err.required_size,
+                        _ => unreachable!(),
+                    };
+
+                    let old_len = client_data.len();
+                    client_data.resize(old_len + required, 0);
+                    data.encode(&mut client_data[old_len..])
+                        .unwrap();
+                }
+                ConnectionState::TransmitTlsData(data) => data.done(),
+                _ => unreachable!(),
+            }
+
+            server_data.drain(..discard);
+        }
+    }
+
+    assert!(server_data.is_empty());
+    assert!(client_data.is_empty());
 }
 
 #[derive(PartialEq, Debug)]

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1559,6 +1559,179 @@ fn test_secret_extraction_enabled() {
     }
 }
 
+// Tests for the kernel API.
+//
+// We don't have anything set up to actually encrypt/decrypt the connection
+// content so these tests all just check that the updated traffic secrets are
+// equivalent on each side of the connection, if supported by the protocol
+// version.
+
+#[test]
+fn kernel_err_on_secret_extraction_not_enabled() {
+    let server_config = make_server_config(KeyType::Rsa2048);
+    let server_config = Arc::new(server_config);
+
+    let client_config = make_client_config(KeyType::Rsa2048);
+    let client_config = Arc::new(client_config);
+
+    let mut server = UnbufferedServerConnection::new(server_config).unwrap();
+    let mut client =
+        UnbufferedClientConnection::new(client_config, "localhost".try_into().unwrap()).unwrap();
+
+    do_unbuffered_handshake(&mut client, &mut server);
+
+    assert!(
+        client
+            .dangerous_into_kernel_connection()
+            .is_err()
+    );
+    assert!(
+        server
+            .dangerous_into_kernel_connection()
+            .is_err()
+    );
+}
+
+#[test]
+fn kernel_err_on_handshake_not_complete() {
+    let mut server_config = make_server_config(KeyType::Rsa2048);
+    server_config.enable_secret_extraction = true;
+    let server_config = Arc::new(server_config);
+
+    let mut client_config = make_client_config(KeyType::Rsa2048);
+    client_config.enable_secret_extraction = true;
+    let client_config = Arc::new(client_config);
+
+    let server = UnbufferedServerConnection::new(server_config).unwrap();
+    let client =
+        UnbufferedClientConnection::new(client_config, "localhost".try_into().unwrap()).unwrap();
+
+    assert!(matches!(
+        client.dangerous_into_kernel_connection(),
+        Err(Error::HandshakeNotComplete)
+    ));
+    assert!(matches!(
+        server.dangerous_into_kernel_connection(),
+        Err(Error::HandshakeNotComplete)
+    ));
+}
+
+#[test]
+fn kernel_initial_traffic_secrets_match() {
+    let mut server_config = make_server_config(KeyType::Rsa2048);
+    server_config.enable_secret_extraction = true;
+    let server_config = Arc::new(server_config);
+
+    let mut client_config = make_client_config(KeyType::Rsa2048);
+    client_config.enable_secret_extraction = true;
+    let client_config = Arc::new(client_config);
+
+    let mut server = UnbufferedServerConnection::new(server_config).unwrap();
+    let mut client =
+        UnbufferedClientConnection::new(client_config, "localhost".try_into().unwrap()).unwrap();
+
+    do_unbuffered_handshake(&mut client, &mut server);
+
+    let (client_secrets, _) = client
+        .dangerous_into_kernel_connection()
+        .expect("failed to convert client connection to an KernelConnection");
+    let (server_secrets, _) = server
+        .dangerous_into_kernel_connection()
+        .expect("failed to convert server connection to an KernelConnection");
+
+    assert_secrets_equal(client_secrets.tx, server_secrets.rx);
+    assert_secrets_equal(server_secrets.tx, client_secrets.rx);
+}
+
+#[test]
+fn kernel_key_updates_tls13() {
+    let mut server_config = make_server_config_with_versions(KeyType::Rsa2048, &[&TLS13]);
+    server_config.enable_secret_extraction = true;
+    let server_config = Arc::new(server_config);
+
+    let mut client_config = make_client_config_with_versions(KeyType::Rsa2048, &[&TLS13]);
+    client_config.enable_secret_extraction = true;
+    let client_config = Arc::new(client_config);
+
+    let mut server = UnbufferedServerConnection::new(server_config).unwrap();
+    let mut client =
+        UnbufferedClientConnection::new(client_config, "localhost".try_into().unwrap()).unwrap();
+
+    do_unbuffered_handshake(&mut client, &mut server);
+
+    let (_, mut client) = client
+        .dangerous_into_kernel_connection()
+        .expect("failed to convert client connection to an KernelConnection");
+    let (_, mut server) = server
+        .dangerous_into_kernel_connection()
+        .expect("failed to convert server connection to an KernelConnection");
+
+    let new_client_tx = client.update_tx_secret().unwrap();
+    let new_client_rx = client.update_rx_secret().unwrap();
+
+    let new_server_tx = server.update_tx_secret().unwrap();
+    let new_server_rx = server.update_rx_secret().unwrap();
+
+    assert_secrets_equal(new_server_tx, new_client_rx);
+    assert_secrets_equal(new_server_rx, new_client_tx);
+}
+
+#[test]
+#[cfg(feature = "tls12")]
+fn kernel_key_updates_tls12() {
+    use rustls::version::TLS12;
+
+    let _ = env_logger::try_init();
+
+    let mut server_config = make_server_config_with_versions(KeyType::Rsa2048, &[&TLS12]);
+    server_config.enable_secret_extraction = true;
+    let server_config = Arc::new(server_config);
+
+    let mut client_config = make_client_config_with_versions(KeyType::Rsa2048, &[&TLS12]);
+    client_config.enable_secret_extraction = true;
+    let client_config = Arc::new(client_config);
+
+    let mut server = UnbufferedServerConnection::new(server_config).unwrap();
+    let mut client =
+        UnbufferedClientConnection::new(client_config, "localhost".try_into().unwrap()).unwrap();
+
+    do_unbuffered_handshake(&mut client, &mut server);
+
+    let (_, mut client) = client
+        .dangerous_into_kernel_connection()
+        .expect("failed to convert client connection to an KernelConnection");
+    let (_, mut server) = server
+        .dangerous_into_kernel_connection()
+        .expect("failed to convert server connection to an KernelConnection");
+
+    // TLS 1.2 does not allow key updates so these should all error
+    assert!(client.update_tx_secret().is_err());
+    assert!(client.update_rx_secret().is_err());
+
+    assert!(server.update_tx_secret().is_err());
+    assert!(server.update_rx_secret().is_err());
+}
+
+fn assert_secrets_equal(
+    (l_seq, l_sec): (u64, ConnectionTrafficSecrets),
+    (r_seq, r_sec): (u64, ConnectionTrafficSecrets),
+) {
+    assert_eq!(l_seq, r_seq);
+    assert_eq!(explode_secrets(&l_sec), explode_secrets(&r_sec));
+}
+
+// Comparing secrets for equality is something you should never have to
+// do in production code, so ConnectionTrafficSecrets doesn't implement
+// PartialEq/Eq on purpose. Instead, we have to get creative.
+fn explode_secrets(s: &ConnectionTrafficSecrets) -> (&[u8], &[u8]) {
+    match s {
+        ConnectionTrafficSecrets::Aes128Gcm { key, iv } => (key.as_ref(), iv.as_ref()),
+        ConnectionTrafficSecrets::Aes256Gcm { key, iv } => (key.as_ref(), iv.as_ref()),
+        ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv } => (key.as_ref(), iv.as_ref()),
+        _ => panic!("unexpected secret type"),
+    }
+}
+
 const TLS12_CLIENT_TRANSCRIPT: &[&str] = &[
     "EncodeTlsData",
     "TransmitTlsData",

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1526,11 +1526,13 @@ fn test_secret_extraction_enabled() {
 
         // The handshake is finished, we're now able to extract traffic secrets
         let client_secrets = client
-            .dangerous_extract_secrets()
-            .unwrap();
+            .dangerous_into_kernel_connection()
+            .unwrap()
+            .0;
         let server_secrets = server
-            .dangerous_extract_secrets()
-            .unwrap();
+            .dangerous_into_kernel_connection()
+            .unwrap()
+            .0;
 
         // Comparing secrets for equality is something you should never have to
         // do in production code, so ConnectionTrafficSecrets doesn't implement


### PR DESCRIPTION
This is an attempt at addressing #2362 by following the API suggested there. 

It introduces a new `ExternalConnection` type which allows users to pass received session tickets back to rustls and perform key updates. An `ExternalConnection` can be constructed from an `Unbuffered(Client|Server)Connection` by calling `dangerous_into_external_connection` which will return both an `ExtractedSecrets` and an `ExternalConnection`. It does not include support any other connection types at this time. However, it should be easy enough to extend in the future as more as new features become needed.

Internally this is implemented by adding a new `ExternalState` trait and a `State::into_external_state` conversion method. `ExternalState` is implemented for the `ExpectTraffic` state for tls 1.2 and 1.3, and for server and client modes, respectively. 

I have also included a complete example that shows how to use `ExternalConnection` with a kTLS connection. It ends up serving more as an example in getting kTLS to work using rustls than actually using `ExternalConnection`, since `ExternalConnection` has a pretty minimal API surface, but I think it works better that way.

This PR ended up being quite a bit larger than I thought it would be initially. If there's anything I can do that would help make this easier to review (e.g. moving the ktls example to a separate PR), please let me know.

Closes #2362