### PR TITLE
docs: link to manual from front page

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -266,6 +266,10 @@
 //!
 //! [`mio`]: https://docs.rs/mio/latest/mio/
 //!
+//! # Manual
+//!
+//! The [rustls manual](crate::manual) explains design decisions and includes how-to guidance.
+//!
 //! # Crate features
 //! Here's a list of what features are exposed by the rustls crate and what
 //! they mean.


### PR DESCRIPTION
This adds a link to the manual from the front page of the documentation. It is distilled from #2356 

fixes #2356 