### PR TITLE
admin/coverage: only measure core crate coverage

### DIFF
--- a/admin/coverage
+++ b/admin/coverage
@@ -17,10 +17,4 @@ cargo test --locked $(admin/all-features-except brotli rustls)
 ## bogo
 cargo test --locked --test bogo -- --ignored --test-threads 1
 
-# provider example unit tests
-cargo test --locked --package rustls-provider-example
-
-## provider example tests
-cargo test --locked --package rustls-provider-test
-
-cargo llvm-cov report "$@"
+cargo llvm-cov report --ignore-filename-regex bogo/ "$@"


### PR DESCRIPTION
At the minute the "headline" coverage number includes the core crate, the bogo test runner, and the provider-example example code:

![image](https://github.com/user-attachments/assets/ba7347d2-84b1-49ab-909a-65bf87d58342)

This PR removes two of those components.