### PR TITLE
Refactor: prefer to take reference on match scrutinee

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -1026,7 +1026,7 @@ fn read_n_bytes(opts: &Options, sess: &mut Connection, conn: &mut net::TcpStream
             sess.read_tls(&mut io::Cursor::new(&mut bytes[..count]))
                 .expect("read_tls not expected to fail reading from buffer");
         }
-        Err(ref err) if err.kind() == io::ErrorKind::ConnectionReset => {}
+        Err(err) if err.kind() == io::ErrorKind::ConnectionReset => {}
         Err(err) => panic!("invalid read: {}", err),
     };
 
@@ -1036,7 +1036,7 @@ fn read_n_bytes(opts: &Options, sess: &mut Connection, conn: &mut net::TcpStream
 fn read_all_bytes(opts: &Options, sess: &mut Connection, conn: &mut net::TcpStream) {
     match sess.read_tls(conn) {
         Ok(_) => {}
-        Err(ref err) if err.kind() == io::ErrorKind::ConnectionReset => {}
+        Err(err) if err.kind() == io::ErrorKind::ConnectionReset => {}
         Err(err) => panic!("invalid read: {}", err),
     };
 
@@ -1097,7 +1097,7 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
         }
 
         if opts.side == Side::Server && opts.enable_early_data {
-            if let Some(ref mut ed) = server(&mut sess).early_data() {
+            if let Some(ed) = &mut server(&mut sess).early_data() {
                 let mut data = Vec::new();
                 let data_len = ed
                     .read_to_end(&mut data)

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
                 match conn.read_tls(&mut stream) {
                     Ok(0) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into()),
                     Ok(_) => break,
-                    Err(ref err) if err.kind() == io::ErrorKind::Interrupted => {}
+                    Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
                     Err(err) => return Err(err.into()),
                 };
             }

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -90,7 +90,7 @@ impl TlsServer {
                     self.connections
                         .insert(token, connection);
                 }
-                Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(()),
                 Err(err) => {
                     println!(
                         "encountered error while accepting connection; err={:?}",

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -100,8 +100,8 @@ pub(super) fn handle_server_hello(
 
     let key_schedule_pre_handshake = match (server_hello.psk_index(), early_key_schedule) {
         (Some(selected_psk), Some(early_key_schedule)) => {
-            match resuming_session {
-                Some(ref resuming) => {
+            match &resuming_session {
+                Some(resuming) => {
                     let Some(resuming_suite) = suite.can_resume_from(resuming.suite()) else {
                         return Err({
                             cx.common.send_fatal_alert(
@@ -323,7 +323,7 @@ pub(super) fn fill_in_psk_binder(
     let key_schedule = KeyScheduleEarly::new(suite, resuming.secret());
     let real_binder = key_schedule.resumption_psk_binder_key_and_sign_verify_data(&handshake_hash);
 
-    if let HandshakePayload::ClientHello(ref mut ch) = hmp.payload {
+    if let HandshakePayload::ClientHello(ch) = &mut hmp.payload {
         ch.set_psk_binder(real_binder.as_ref());
     };
 
@@ -1555,19 +1555,19 @@ impl State<ClientConnectionData> for ExpectTraffic {
             MessagePayload::Handshake {
                 parsed:
                     HandshakeMessagePayload {
-                        payload: HandshakePayload::NewSessionTicketTls13(ref new_ticket),
+                        payload: HandshakePayload::NewSessionTicketTls13(new_ticket),
                         ..
                     },
                 ..
-            } => self.handle_new_ticket_tls13(cx, new_ticket)?,
+            } => self.handle_new_ticket_tls13(cx, &new_ticket)?,
             MessagePayload::Handshake {
                 parsed:
                     HandshakeMessagePayload {
-                        payload: HandshakePayload::KeyUpdate(ref key_update),
+                        payload: HandshakePayload::KeyUpdate(key_update),
                         ..
                     },
                 ..
-            } => self.handle_key_update(cx.common, key_update)?,
+            } => self.handle_key_update(cx.common, &key_update)?,
             payload => {
                 return Err(inappropriate_handshake_message(
                     &payload,

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -638,7 +638,7 @@ impl<Data> ConnectionCommon<Data> {
                         rdlen += n;
                         Some(n)
                     }
-                    Err(ref err) if err.kind() == io::ErrorKind::Interrupted => None, // nothing to do
+                    Err(err) if err.kind() == io::ErrorKind::Interrupted => None, // nothing to do
                     Err(err) => return Err(err),
                 };
                 if read_size.is_some() {

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -726,10 +726,10 @@ fn join<T: fmt::Debug>(items: &[T]) -> String {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
+        match self {
             Self::InappropriateMessage {
-                ref expect_types,
-                ref got_type,
+                expect_types,
+                got_type,
             } => write!(
                 f,
                 "received unexpected message: got {:?} when expecting {}",
@@ -737,30 +737,30 @@ impl fmt::Display for Error {
                 join::<ContentType>(expect_types)
             ),
             Self::InappropriateHandshakeMessage {
-                ref expect_types,
-                ref got_type,
+                expect_types,
+                got_type,
             } => write!(
                 f,
                 "received unexpected handshake message: got {:?} when expecting {}",
                 got_type,
                 join::<HandshakeType>(expect_types)
             ),
-            Self::InvalidMessage(ref typ) => {
+            Self::InvalidMessage(typ) => {
                 write!(f, "received corrupt message of type {:?}", typ)
             }
-            Self::PeerIncompatible(ref why) => write!(f, "peer is incompatible: {:?}", why),
-            Self::PeerMisbehaved(ref why) => write!(f, "peer misbehaved: {:?}", why),
-            Self::AlertReceived(ref alert) => write!(f, "received fatal alert: {:?}", alert),
-            Self::InvalidCertificate(ref err) => {
+            Self::PeerIncompatible(why) => write!(f, "peer is incompatible: {:?}", why),
+            Self::PeerMisbehaved(why) => write!(f, "peer misbehaved: {:?}", why),
+            Self::AlertReceived(alert) => write!(f, "received fatal alert: {:?}", alert),
+            Self::InvalidCertificate(err) => {
                 write!(f, "invalid peer certificate: {}", err)
             }
-            Self::InvalidCertRevocationList(ref err) => {
+            Self::InvalidCertRevocationList(err) => {
                 write!(f, "invalid certificate revocation list: {:?}", err)
             }
             Self::NoCertificatesPresented => write!(f, "peer sent no certificates"),
             Self::UnsupportedNameType => write!(f, "presented server name type wasn't supported"),
             Self::DecryptError => write!(f, "cannot decrypt peer's message"),
-            Self::InvalidEncryptedClientHello(ref err) => {
+            Self::InvalidEncryptedClientHello(err) => {
                 write!(f, "encrypted client hello failure: {:?}", err)
             }
             Self::EncryptError => write!(f, "cannot encrypt message"),
@@ -772,11 +772,11 @@ impl fmt::Display for Error {
             Self::BadMaxFragmentSize => {
                 write!(f, "the supplied max_fragment_size was too small or large")
             }
-            Self::InconsistentKeys(ref why) => {
+            Self::InconsistentKeys(why) => {
                 write!(f, "keys may not be consistent: {:?}", why)
             }
-            Self::General(ref err) => write!(f, "unexpected error: {}", err),
-            Self::Other(ref err) => write!(f, "other error: {}", err),
+            Self::General(err) => write!(f, "unexpected error: {}", err),
+            Self::Other(err) => write!(f, "other error: {}", err),
         }
     }
 }

--- a/rustls/src/key_log_file.rs
+++ b/rustls/src/key_log_file.rs
@@ -45,11 +45,11 @@ impl KeyLogFileInner {
     }
 
     fn try_write(&mut self, label: &str, client_random: &[u8], secret: &[u8]) -> io::Result<()> {
-        let mut file = match self.file {
+        let file = match &mut self.file {
             None => {
                 return Ok(());
             }
-            Some(ref f) => f,
+            Some(f) => f,
         };
 
         self.buf.truncate(0);

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -248,13 +248,13 @@ impl ServerNamePayload {
     }
 
     fn encode(&self, bytes: &mut Vec<u8>) {
-        match *self {
-            Self::HostName(ref name) => {
+        match self {
+            Self::HostName(name) => {
                 (name.as_ref().len() as u16).encode(bytes);
                 bytes.extend_from_slice(name.as_ref().as_bytes());
             }
-            Self::IpAddress(ref r) => r.encode(bytes),
-            Self::Unknown(ref r) => r.encode(bytes),
+            Self::IpAddress(r) => r.encode(bytes),
+            Self::Unknown(r) => r.encode(bytes),
         }
     }
 }
@@ -300,7 +300,7 @@ impl ConvertServerNameList for [ServerName] {
 
     fn single_hostname(&self) -> Option<DnsName<'_>> {
         fn only_dns_hostnames(name: &ServerName) -> Option<DnsName<'_>> {
-            if let ServerNamePayload::HostName(ref dns) = name.payload {
+            if let ServerNamePayload::HostName(dns) = &name.payload {
                 Some(dns.borrow())
             } else {
                 None
@@ -577,7 +577,7 @@ pub enum ClientExtension {
 
 impl ClientExtension {
     pub(crate) fn ext_type(&self) -> ExtensionType {
-        match *self {
+        match self {
             Self::EcPointFormats(_) => ExtensionType::ECPointFormats,
             Self::NamedGroups(_) => ExtensionType::EllipticCurves,
             Self::SignatureAlgorithms(_) => ExtensionType::SignatureAlgorithms,
@@ -602,7 +602,7 @@ impl ClientExtension {
                 ExtensionType::EncryptedClientHelloOuterExtensions
             }
             Self::AuthorityNames(_) => ExtensionType::CertificateAuthorities,
-            Self::Unknown(ref r) => r.typ,
+            Self::Unknown(r) => r.typ,
         }
     }
 }
@@ -612,32 +612,32 @@ impl Codec<'_> for ClientExtension {
         self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
-        match *self {
-            Self::EcPointFormats(ref r) => r.encode(nested.buf),
-            Self::NamedGroups(ref r) => r.encode(nested.buf),
-            Self::SignatureAlgorithms(ref r) => r.encode(nested.buf),
-            Self::ServerName(ref r) => r.encode(nested.buf),
+        match self {
+            Self::EcPointFormats(r) => r.encode(nested.buf),
+            Self::NamedGroups(r) => r.encode(nested.buf),
+            Self::SignatureAlgorithms(r) => r.encode(nested.buf),
+            Self::ServerName(r) => r.encode(nested.buf),
             Self::SessionTicket(ClientSessionTicket::Request)
             | Self::ExtendedMasterSecretRequest
             | Self::EarlyData => {}
-            Self::SessionTicket(ClientSessionTicket::Offer(ref r)) => r.encode(nested.buf),
-            Self::Protocols(ref r) => r.encode(nested.buf),
-            Self::SupportedVersions(ref r) => r.encode(nested.buf),
-            Self::KeyShare(ref r) => r.encode(nested.buf),
-            Self::PresharedKeyModes(ref r) => r.encode(nested.buf),
-            Self::PresharedKey(ref r) => r.encode(nested.buf),
-            Self::Cookie(ref r) => r.encode(nested.buf),
-            Self::CertificateStatusRequest(ref r) => r.encode(nested.buf),
-            Self::ClientCertTypes(ref r) => r.encode(nested.buf),
-            Self::ServerCertTypes(ref r) => r.encode(nested.buf),
-            Self::TransportParameters(ref r) | Self::TransportParametersDraft(ref r) => {
+            Self::SessionTicket(ClientSessionTicket::Offer(r)) => r.encode(nested.buf),
+            Self::Protocols(r) => r.encode(nested.buf),
+            Self::SupportedVersions(r) => r.encode(nested.buf),
+            Self::KeyShare(r) => r.encode(nested.buf),
+            Self::PresharedKeyModes(r) => r.encode(nested.buf),
+            Self::PresharedKey(r) => r.encode(nested.buf),
+            Self::Cookie(r) => r.encode(nested.buf),
+            Self::CertificateStatusRequest(r) => r.encode(nested.buf),
+            Self::ClientCertTypes(r) => r.encode(nested.buf),
+            Self::ServerCertTypes(r) => r.encode(nested.buf),
+            Self::TransportParameters(r) | Self::TransportParametersDraft(r) => {
                 nested.buf.extend_from_slice(r);
             }
-            Self::CertificateCompressionAlgorithms(ref r) => r.encode(nested.buf),
-            Self::EncryptedClientHello(ref r) => r.encode(nested.buf),
-            Self::EncryptedClientHelloOuterExtensions(ref r) => r.encode(nested.buf),
-            Self::AuthorityNames(ref r) => r.encode(nested.buf),
-            Self::Unknown(ref r) => r.encode(nested.buf),
+            Self::CertificateCompressionAlgorithms(r) => r.encode(nested.buf),
+            Self::EncryptedClientHello(r) => r.encode(nested.buf),
+            Self::EncryptedClientHelloOuterExtensions(r) => r.encode(nested.buf),
+            Self::AuthorityNames(r) => r.encode(nested.buf),
+            Self::Unknown(r) => r.encode(nested.buf),
         }
     }
 
@@ -750,7 +750,7 @@ pub enum ServerExtension {
 
 impl ServerExtension {
     pub(crate) fn ext_type(&self) -> ExtensionType {
-        match *self {
+        match self {
             Self::EcPointFormats(_) => ExtensionType::ECPointFormats,
             Self::ServerNameAck => ExtensionType::ServerName,
             Self::SessionTicketAck => ExtensionType::SessionTicket,
@@ -767,7 +767,7 @@ impl ServerExtension {
             Self::TransportParametersDraft(_) => ExtensionType::TransportParametersDraft,
             Self::EarlyData => ExtensionType::EarlyData,
             Self::EncryptedClientHello(_) => ExtensionType::EncryptedClientHello,
-            Self::Unknown(ref r) => r.typ,
+            Self::Unknown(r) => r.typ,
         }
     }
 }
@@ -777,25 +777,25 @@ impl Codec<'_> for ServerExtension {
         self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
-        match *self {
-            Self::EcPointFormats(ref r) => r.encode(nested.buf),
+        match self {
+            Self::EcPointFormats(r) => r.encode(nested.buf),
             Self::ServerNameAck
             | Self::SessionTicketAck
             | Self::ExtendedMasterSecretAck
             | Self::CertificateStatusAck
             | Self::EarlyData => {}
-            Self::RenegotiationInfo(ref r) => r.encode(nested.buf),
-            Self::Protocols(ref r) => r.encode(nested.buf),
-            Self::KeyShare(ref r) => r.encode(nested.buf),
+            Self::RenegotiationInfo(r) => r.encode(nested.buf),
+            Self::Protocols(r) => r.encode(nested.buf),
+            Self::KeyShare(r) => r.encode(nested.buf),
             Self::PresharedKey(r) => r.encode(nested.buf),
             Self::ClientCertType(r) => r.encode(nested.buf),
             Self::ServerCertType(r) => r.encode(nested.buf),
-            Self::SupportedVersions(ref r) => r.encode(nested.buf),
-            Self::TransportParameters(ref r) | Self::TransportParametersDraft(ref r) => {
+            Self::SupportedVersions(r) => r.encode(nested.buf),
+            Self::TransportParameters(r) | Self::TransportParametersDraft(r) => {
                 nested.buf.extend_from_slice(r);
             }
-            Self::EncryptedClientHello(ref r) => r.encode(nested.buf),
-            Self::Unknown(ref r) => r.encode(nested.buf),
+            Self::EncryptedClientHello(r) => r.encode(nested.buf),
+            Self::Unknown(r) => r.encode(nested.buf),
         }
     }
 
@@ -985,7 +985,7 @@ impl ClientHelloPayload {
 
     pub(crate) fn sni_extension(&self) -> Option<&[ServerName]> {
         let ext = self.find_extension(ExtensionType::ServerName)?;
-        match *ext {
+        match ext {
             // Does this comply with RFC6066?
             //
             // [RFC6066][] specifies that literal IP addresses are illegal in
@@ -996,7 +996,7 @@ impl ClientHelloPayload {
             // but then act like the client sent no `server_name` extension.
             //
             // [RFC6066]: https://datatracker.ietf.org/doc/html/rfc6066#section-3
-            ClientExtension::ServerName(ref req)
+            ClientExtension::ServerName(req)
                 if !req
                     .iter()
                     .any(|name| matches!(name.payload, ServerNamePayload::IpAddress(_))) =>
@@ -1009,16 +1009,16 @@ impl ClientHelloPayload {
 
     pub fn sigalgs_extension(&self) -> Option<&[SignatureScheme]> {
         let ext = self.find_extension(ExtensionType::SignatureAlgorithms)?;
-        match *ext {
-            ClientExtension::SignatureAlgorithms(ref req) => Some(req),
+        match ext {
+            ClientExtension::SignatureAlgorithms(req) => Some(req),
             _ => None,
         }
     }
 
     pub(crate) fn namedgroups_extension(&self) -> Option<&[NamedGroup]> {
         let ext = self.find_extension(ExtensionType::EllipticCurves)?;
-        match *ext {
-            ClientExtension::NamedGroups(ref req) => Some(req),
+        match ext {
+            ClientExtension::NamedGroups(req) => Some(req),
             _ => None,
         }
     }
@@ -1026,8 +1026,8 @@ impl ClientHelloPayload {
     #[cfg(feature = "tls12")]
     pub(crate) fn ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
         let ext = self.find_extension(ExtensionType::ECPointFormats)?;
-        match *ext {
-            ClientExtension::EcPointFormats(ref req) => Some(req),
+        match ext {
+            ClientExtension::EcPointFormats(req) => Some(req),
             _ => None,
         }
     }
@@ -1050,8 +1050,8 @@ impl ClientHelloPayload {
 
     pub(crate) fn alpn_extension(&self) -> Option<&Vec<ProtocolName>> {
         let ext = self.find_extension(ExtensionType::ALProtocolNegotiation)?;
-        match *ext {
-            ClientExtension::Protocols(ref req) => Some(req),
+        match ext {
+            ClientExtension::Protocols(req) => Some(req),
             _ => None,
         }
     }
@@ -1060,9 +1060,9 @@ impl ClientHelloPayload {
         let ext = self
             .find_extension(ExtensionType::TransportParameters)
             .or_else(|| self.find_extension(ExtensionType::TransportParametersDraft))?;
-        match *ext {
-            ClientExtension::TransportParameters(ref bytes)
-            | ClientExtension::TransportParametersDraft(ref bytes) => Some(bytes.to_vec()),
+        match ext {
+            ClientExtension::TransportParameters(bytes)
+            | ClientExtension::TransportParametersDraft(bytes) => Some(bytes.to_vec()),
             _ => None,
         }
     }
@@ -1074,16 +1074,16 @@ impl ClientHelloPayload {
 
     pub(crate) fn versions_extension(&self) -> Option<&[ProtocolVersion]> {
         let ext = self.find_extension(ExtensionType::SupportedVersions)?;
-        match *ext {
-            ClientExtension::SupportedVersions(ref vers) => Some(vers),
+        match ext {
+            ClientExtension::SupportedVersions(vers) => Some(vers),
             _ => None,
         }
     }
 
     pub fn keyshare_extension(&self) -> Option<&[KeyShareEntry]> {
         let ext = self.find_extension(ExtensionType::KeyShare)?;
-        match *ext {
-            ClientExtension::KeyShare(ref shares) => Some(shares),
+        match ext {
+            ClientExtension::KeyShare(shares) => Some(shares),
             _ => None,
         }
     }
@@ -1102,8 +1102,8 @@ impl ClientHelloPayload {
 
     pub(crate) fn psk(&self) -> Option<&PresharedKeyOffer> {
         let ext = self.find_extension(ExtensionType::PreSharedKey)?;
-        match *ext {
-            ClientExtension::PresharedKey(ref psk) => Some(psk),
+        match ext {
+            ClientExtension::PresharedKey(psk) => Some(psk),
             _ => None,
         }
     }
@@ -1116,8 +1116,8 @@ impl ClientHelloPayload {
 
     pub(crate) fn psk_modes(&self) -> Option<&[PSKKeyExchangeMode]> {
         let ext = self.find_extension(ExtensionType::PSKKeyExchangeModes)?;
-        match *ext {
-            ClientExtension::PresharedKeyModes(ref psk_modes) => Some(psk_modes),
+        match ext {
+            ClientExtension::PresharedKeyModes(psk_modes) => Some(psk_modes),
             _ => None,
         }
     }
@@ -1150,8 +1150,8 @@ impl ClientHelloPayload {
         &self,
     ) -> Option<&[CertificateCompressionAlgorithm]> {
         let ext = self.find_extension(ExtensionType::CompressCertificate)?;
-        match *ext {
-            ClientExtension::CertificateCompressionAlgorithms(ref algs) => Some(algs),
+        match ext {
+            ClientExtension::CertificateCompressionAlgorithms(algs) => Some(algs),
             _ => None,
         }
     }
@@ -1183,12 +1183,12 @@ pub(crate) enum HelloRetryExtension {
 
 impl HelloRetryExtension {
     pub(crate) fn ext_type(&self) -> ExtensionType {
-        match *self {
+        match self {
             Self::KeyShare(_) => ExtensionType::KeyShare,
             Self::Cookie(_) => ExtensionType::Cookie,
             Self::SupportedVersions(_) => ExtensionType::SupportedVersions,
             Self::EchHelloRetryRequest(_) => ExtensionType::EncryptedClientHello,
-            Self::Unknown(ref r) => r.typ,
+            Self::Unknown(r) => r.typ,
         }
     }
 }
@@ -1198,14 +1198,14 @@ impl Codec<'_> for HelloRetryExtension {
         self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
-        match *self {
-            Self::KeyShare(ref r) => r.encode(nested.buf),
-            Self::Cookie(ref r) => r.encode(nested.buf),
-            Self::SupportedVersions(ref r) => r.encode(nested.buf),
-            Self::EchHelloRetryRequest(ref r) => {
+        match self {
+            Self::KeyShare(r) => r.encode(nested.buf),
+            Self::Cookie(r) => r.encode(nested.buf),
+            Self::SupportedVersions(r) => r.encode(nested.buf),
+            Self::EchHelloRetryRequest(r) => {
                 nested.buf.extend_from_slice(r);
             }
-            Self::Unknown(ref r) => r.encode(nested.buf),
+            Self::Unknown(r) => r.encode(nested.buf),
         }
     }
 
@@ -1292,32 +1292,32 @@ impl HelloRetryRequest {
 
     pub fn requested_key_share_group(&self) -> Option<NamedGroup> {
         let ext = self.find_extension(ExtensionType::KeyShare)?;
-        match *ext {
-            HelloRetryExtension::KeyShare(grp) => Some(grp),
+        match ext {
+            HelloRetryExtension::KeyShare(grp) => Some(*grp),
             _ => None,
         }
     }
 
     pub(crate) fn cookie(&self) -> Option<&PayloadU16> {
         let ext = self.find_extension(ExtensionType::Cookie)?;
-        match *ext {
-            HelloRetryExtension::Cookie(ref ck) => Some(ck),
+        match ext {
+            HelloRetryExtension::Cookie(ck) => Some(ck),
             _ => None,
         }
     }
 
     pub(crate) fn supported_versions(&self) -> Option<ProtocolVersion> {
         let ext = self.find_extension(ExtensionType::SupportedVersions)?;
-        match *ext {
-            HelloRetryExtension::SupportedVersions(ver) => Some(ver),
+        match ext {
+            HelloRetryExtension::SupportedVersions(ver) => Some(*ver),
             _ => None,
         }
     }
 
     pub(crate) fn ech(&self) -> Option<&Vec<u8>> {
         let ext = self.find_extension(ExtensionType::EncryptedClientHello)?;
-        match *ext {
-            HelloRetryExtension::EchHelloRetryRequest(ref ech) => Some(ech),
+        match ext {
+            HelloRetryExtension::EchHelloRetryRequest(ech) => Some(ech),
             _ => None,
         }
     }
@@ -1406,24 +1406,24 @@ impl HasServerExtensions for ServerHelloPayload {
 impl ServerHelloPayload {
     pub(crate) fn key_share(&self) -> Option<&KeyShareEntry> {
         let ext = self.find_extension(ExtensionType::KeyShare)?;
-        match *ext {
-            ServerExtension::KeyShare(ref share) => Some(share),
+        match ext {
+            ServerExtension::KeyShare(share) => Some(share),
             _ => None,
         }
     }
 
     pub(crate) fn psk_index(&self) -> Option<u16> {
         let ext = self.find_extension(ExtensionType::PreSharedKey)?;
-        match *ext {
-            ServerExtension::PresharedKey(ref index) => Some(*index),
+        match ext {
+            ServerExtension::PresharedKey(index) => Some(*index),
             _ => None,
         }
     }
 
     pub(crate) fn ecpoints_extension(&self) -> Option<&[ECPointFormat]> {
         let ext = self.find_extension(ExtensionType::ECPointFormats)?;
-        match *ext {
-            ServerExtension::EcPointFormats(ref fmts) => Some(fmts),
+        match ext {
+            ServerExtension::EcPointFormats(fmts) => Some(fmts),
             _ => None,
         }
     }
@@ -1436,8 +1436,8 @@ impl ServerHelloPayload {
 
     pub(crate) fn supported_versions(&self) -> Option<ProtocolVersion> {
         let ext = self.find_extension(ExtensionType::SupportedVersions)?;
-        match *ext {
-            ServerExtension::SupportedVersions(vers) => Some(vers),
+        match ext {
+            ServerExtension::SupportedVersions(vers) => Some(*vers),
             _ => None,
         }
     }
@@ -1521,15 +1521,15 @@ pub(crate) enum CertificateExtension<'a> {
 
 impl CertificateExtension<'_> {
     pub(crate) fn ext_type(&self) -> ExtensionType {
-        match *self {
+        match self {
             Self::CertificateStatus(_) => ExtensionType::StatusRequest,
-            Self::Unknown(ref r) => r.typ,
+            Self::Unknown(r) => r.typ,
         }
     }
 
     pub(crate) fn cert_status(&self) -> Option<&[u8]> {
-        match *self {
-            Self::CertificateStatus(ref cs) => Some(cs.ocsp_response.0.bytes()),
+        match self {
+            Self::CertificateStatus(cs) => Some(cs.ocsp_response.0.bytes()),
             _ => None,
         }
     }
@@ -1547,9 +1547,9 @@ impl<'a> Codec<'a> for CertificateExtension<'a> {
         self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
-        match *self {
-            Self::CertificateStatus(ref r) => r.encode(nested.buf),
-            Self::Unknown(ref r) => r.encode(nested.buf),
+        match self {
+            Self::CertificateStatus(r) => r.encode(nested.buf),
+            Self::Unknown(r) => r.encode(nested.buf),
         }
     }
 
@@ -2025,9 +2025,9 @@ impl From<ServerKeyExchange> for ServerKeyExchangePayload {
 
 impl Codec<'_> for ServerKeyExchangePayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        match *self {
-            Self::Known(ref x) => x.encode(bytes),
-            Self::Unknown(ref x) => x.encode(bytes),
+        match self {
+            Self::Known(x) => x.encode(bytes),
+            Self::Unknown(x) => x.encode(bytes),
         }
     }
 
@@ -2041,7 +2041,7 @@ impl Codec<'_> for ServerKeyExchangePayload {
 impl ServerKeyExchangePayload {
     #[cfg(feature = "tls12")]
     pub(crate) fn unwrap_given_kxa(&self, kxa: KeyExchangeAlgorithm) -> Option<ServerKeyExchange> {
-        if let Self::Unknown(ref unk) = *self {
+        if let Self::Unknown(unk) = self {
             let mut rd = Reader::init(unk.bytes());
 
             let result = ServerKeyExchange {
@@ -2085,8 +2085,8 @@ pub(crate) trait HasServerExtensions {
 
     fn alpn_protocol(&self) -> Option<&[u8]> {
         let ext = self.find_extension(ExtensionType::ALProtocolNegotiation)?;
-        match *ext {
-            ServerExtension::Protocols(ref protos) => protos.as_single_slice(),
+        match ext {
+            ServerExtension::Protocols(protos) => protos.as_single_slice(),
             _ => None,
         }
     }
@@ -2111,9 +2111,9 @@ pub(crate) trait HasServerExtensions {
         let ext = self
             .find_extension(ExtensionType::TransportParameters)
             .or_else(|| self.find_extension(ExtensionType::TransportParametersDraft))?;
-        match *ext {
-            ServerExtension::TransportParameters(ref bytes)
-            | ServerExtension::TransportParametersDraft(ref bytes) => Some(bytes.to_vec()),
+        match ext {
+            ServerExtension::TransportParameters(bytes)
+            | ServerExtension::TransportParametersDraft(bytes) => Some(bytes.to_vec()),
             _ => None,
         }
     }
@@ -2219,11 +2219,11 @@ pub(crate) enum CertReqExtension {
 
 impl CertReqExtension {
     pub(crate) fn ext_type(&self) -> ExtensionType {
-        match *self {
+        match self {
             Self::SignatureAlgorithms(_) => ExtensionType::SignatureAlgorithms,
             Self::AuthorityNames(_) => ExtensionType::CertificateAuthorities,
             Self::CertificateCompressionAlgorithms(_) => ExtensionType::CompressCertificate,
-            Self::Unknown(ref r) => r.typ,
+            Self::Unknown(r) => r.typ,
         }
     }
 }
@@ -2233,11 +2233,11 @@ impl Codec<'_> for CertReqExtension {
         self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
-        match *self {
-            Self::SignatureAlgorithms(ref r) => r.encode(nested.buf),
-            Self::AuthorityNames(ref r) => r.encode(nested.buf),
-            Self::CertificateCompressionAlgorithms(ref r) => r.encode(nested.buf),
-            Self::Unknown(ref r) => r.encode(nested.buf),
+        match self {
+            Self::SignatureAlgorithms(r) => r.encode(nested.buf),
+            Self::AuthorityNames(r) => r.encode(nested.buf),
+            Self::CertificateCompressionAlgorithms(r) => r.encode(nested.buf),
+            Self::Unknown(r) => r.encode(nested.buf),
         }
     }
 
@@ -2305,16 +2305,16 @@ impl CertificateRequestPayloadTls13 {
 
     pub(crate) fn sigalgs_extension(&self) -> Option<&[SignatureScheme]> {
         let ext = self.find_extension(ExtensionType::SignatureAlgorithms)?;
-        match *ext {
-            CertReqExtension::SignatureAlgorithms(ref sa) => Some(sa),
+        match ext {
+            CertReqExtension::SignatureAlgorithms(sa) => Some(sa),
             _ => None,
         }
     }
 
     pub(crate) fn authorities_extension(&self) -> Option<&[DistinguishedName]> {
         let ext = self.find_extension(ExtensionType::CertificateAuthorities)?;
-        match *ext {
-            CertReqExtension::AuthorityNames(ref an) => Some(an),
+        match ext {
+            CertReqExtension::AuthorityNames(an) => Some(an),
             _ => None,
         }
     }
@@ -2323,8 +2323,8 @@ impl CertificateRequestPayloadTls13 {
         &self,
     ) -> Option<&[CertificateCompressionAlgorithm]> {
         let ext = self.find_extension(ExtensionType::CompressCertificate)?;
-        match *ext {
-            CertReqExtension::CertificateCompressionAlgorithms(ref comps) => Some(comps),
+        match ext {
+            CertReqExtension::CertificateCompressionAlgorithms(comps) => Some(comps),
             _ => None,
         }
     }
@@ -2376,9 +2376,9 @@ pub(crate) enum NewSessionTicketExtension {
 
 impl NewSessionTicketExtension {
     pub(crate) fn ext_type(&self) -> ExtensionType {
-        match *self {
+        match self {
             Self::EarlyData(_) => ExtensionType::EarlyData,
-            Self::Unknown(ref r) => r.typ,
+            Self::Unknown(r) => r.typ,
         }
     }
 }
@@ -2388,9 +2388,9 @@ impl Codec<'_> for NewSessionTicketExtension {
         self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
-        match *self {
+        match self {
             Self::EarlyData(r) => r.encode(nested.buf),
-            Self::Unknown(ref r) => r.encode(nested.buf),
+            Self::Unknown(r) => r.encode(nested.buf),
         }
     }
 
@@ -2449,8 +2449,8 @@ impl NewSessionTicketPayloadTls13 {
 
     pub(crate) fn max_early_data_size(&self) -> Option<u32> {
         let ext = self.find_extension(ExtensionType::EarlyData)?;
-        match *ext {
-            NewSessionTicketExtension::EarlyData(ref sz) => Some(*sz),
+        match ext {
+            NewSessionTicketExtension::EarlyData(sz) => Some(*sz),
             _ => None,
         }
     }
@@ -2598,27 +2598,27 @@ pub enum HandshakePayload<'a> {
 impl HandshakePayload<'_> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         use self::HandshakePayload::*;
-        match *self {
+        match self {
             HelloRequest | ServerHelloDone | EndOfEarlyData => {}
-            ClientHello(ref x) => x.encode(bytes),
-            ServerHello(ref x) => x.encode(bytes),
-            HelloRetryRequest(ref x) => x.encode(bytes),
-            Certificate(ref x) => x.encode(bytes),
-            CertificateTls13(ref x) => x.encode(bytes),
-            CompressedCertificate(ref x) => x.encode(bytes),
-            ServerKeyExchange(ref x) => x.encode(bytes),
-            ClientKeyExchange(ref x) => x.encode(bytes),
-            CertificateRequest(ref x) => x.encode(bytes),
-            CertificateRequestTls13(ref x) => x.encode(bytes),
-            CertificateVerify(ref x) => x.encode(bytes),
-            NewSessionTicket(ref x) => x.encode(bytes),
-            NewSessionTicketTls13(ref x) => x.encode(bytes),
-            EncryptedExtensions(ref x) => x.encode(bytes),
-            KeyUpdate(ref x) => x.encode(bytes),
-            Finished(ref x) => x.encode(bytes),
-            CertificateStatus(ref x) => x.encode(bytes),
-            MessageHash(ref x) => x.encode(bytes),
-            Unknown(ref x) => x.encode(bytes),
+            ClientHello(x) => x.encode(bytes),
+            ServerHello(x) => x.encode(bytes),
+            HelloRetryRequest(x) => x.encode(bytes),
+            Certificate(x) => x.encode(bytes),
+            CertificateTls13(x) => x.encode(bytes),
+            CompressedCertificate(x) => x.encode(bytes),
+            ServerKeyExchange(x) => x.encode(bytes),
+            ClientKeyExchange(x) => x.encode(bytes),
+            CertificateRequest(x) => x.encode(bytes),
+            CertificateRequestTls13(x) => x.encode(bytes),
+            CertificateVerify(x) => x.encode(bytes),
+            NewSessionTicket(x) => x.encode(bytes),
+            NewSessionTicketTls13(x) => x.encode(bytes),
+            EncryptedExtensions(x) => x.encode(bytes),
+            KeyUpdate(x) => x.encode(bytes),
+            Finished(x) => x.encode(bytes),
+            CertificateStatus(x) => x.encode(bytes),
+            MessageHash(x) => x.encode(bytes),
+            Unknown(x) => x.encode(bytes),
         }
     }
 
@@ -2775,8 +2775,8 @@ impl<'a> HandshakeMessagePayload<'a> {
     }
 
     pub(crate) fn total_binder_length(&self) -> usize {
-        match self.payload {
-            HandshakePayload::ClientHello(ref ch) => match ch.extensions.last() {
+        match &self.payload {
+            HandshakePayload::ClientHello(ch) => match ch.extensions.last() {
                 Some(ClientExtension::PresharedKey(offer)) => {
                     let mut binders_encoding = Vec::new();
                     offer
@@ -2999,8 +2999,8 @@ pub enum EchConfigExtension {
 
 impl EchConfigExtension {
     pub(crate) fn ext_type(&self) -> ExtensionType {
-        match *self {
-            Self::Unknown(ref r) => r.typ,
+        match self {
+            Self::Unknown(r) => r.typ,
         }
     }
 }
@@ -3010,8 +3010,8 @@ impl Codec<'_> for EchConfigExtension {
         self.ext_type().encode(bytes);
 
         let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
-        match *self {
-            Self::Unknown(ref r) => r.encode(nested.buf),
+        match self {
+            Self::Unknown(r) => r.encode(nested.buf),
         }
     }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -749,7 +749,7 @@ fn can_clone_all_server_extensions() {
 
 #[test]
 fn can_round_trip_all_tls12_handshake_payloads() {
-    for ref hm in all_tls12_handshake_payloads().iter() {
+    for hm in all_tls12_handshake_payloads().iter() {
         println!("{:?}", hm.typ);
         let bytes = hm.get_encoding();
         let mut rd = Reader::init(&bytes);
@@ -813,7 +813,7 @@ fn can_detect_truncation_of_all_tls12_handshake_payloads() {
 
 #[test]
 fn can_round_trip_all_tls13_handshake_payloads() {
-    for ref hm in all_tls13_handshake_payloads().iter() {
+    for hm in all_tls13_handshake_payloads().iter() {
         println!("{:?}", hm.typ);
         let bytes = hm.get_encoding();
         let mut rd = Reader::init(&bytes);

--- a/rustls/src/msgs/message/outbound.rs
+++ b/rustls/src/msgs/message/outbound.rs
@@ -282,8 +282,8 @@ pub(crate) fn read_opaque_message_header(
 
     let version = ProtocolVersion::read(r).map_err(|_| MessageError::TooShortForHeader)?;
     // Accept only versions 0x03XX for any XX.
-    match version {
-        ProtocolVersion::Unknown(ref v) if (v & 0xff00) != 0x0300 => {
+    match &version {
+        ProtocolVersion::Unknown(v) if (v & 0xff00) != 0x0300 => {
             return Err(MessageError::UnknownProtocolVersion);
         }
         _ => {}

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -313,7 +313,7 @@ pub struct ServerSessionValue {
 
 impl Codec<'_> for ServerSessionValue {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        if let Some(ref sni) = self.sni {
+        if let Some(sni) = &self.sni {
             1u8.encode(bytes);
             let sni_bytes: &str = sni.as_ref();
             PayloadU8::new(Vec::from(sni_bytes)).encode(bytes);
@@ -324,13 +324,13 @@ impl Codec<'_> for ServerSessionValue {
         self.cipher_suite.encode(bytes);
         self.master_secret.encode(bytes);
         (u8::from(self.extended_ms)).encode(bytes);
-        if let Some(ref chain) = self.client_cert_chain {
+        if let Some(chain) = &self.client_cert_chain {
             1u8.encode(bytes);
             chain.encode(bytes);
         } else {
             0u8.encode(bytes);
         }
-        if let Some(ref alpn) = self.alpn {
+        if let Some(alpn) = &self.alpn {
             1u8.encode(bytes);
             alpn.encode(bytes);
         } else {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -92,7 +92,7 @@ impl ExtensionProcessing {
                 .iter()
                 .find(|protocol| their_protocols.contains(&protocol.as_slice()))
                 .cloned();
-            if let Some(ref selected_protocol) = cx.common.alpn_protocol {
+            if let Some(selected_protocol) = &cx.common.alpn_protocol {
                 debug!("Chosen ALPN protocol {:?}", selected_protocol);
                 self.exts
                     .push(ServerExtension::make_alpn(&[selected_protocol]));

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1087,9 +1087,7 @@ impl EarlyDataState {
     #[cfg(read_buf)]
     fn read_buf(&mut self, cursor: core::io::BorrowedCursor<'_>) -> io::Result<()> {
         match self {
-            Self::Accepted {
-                ref mut received, ..
-            } => received.read_buf(cursor),
+            Self::Accepted { received, .. } => received.read_buf(cursor),
             _ => Err(io::Error::from(io::ErrorKind::BrokenPipe)),
         }
     }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -324,7 +324,7 @@ mod client_hello {
                 self.send_tickets = self.config.send_tls13_tickets;
             }
 
-            if let Some(ref resume) = resumedata {
+            if let Some(resume) = &resumedata {
                 cx.data.received_resumption_data = Some(resume.application_data.0.clone());
                 cx.common
                     .peer_certificates
@@ -865,7 +865,7 @@ impl State<ServerConnectionData> for ExpectAndSkipRejectedEarlyData {
          *  content type of "application_data" (indicating that they are encrypted),
          *  up to the configured max_early_data_size."
          * (RFC8446, 14.2.10) */
-        if let MessagePayload::ApplicationData(ref skip_data) = m.payload {
+        if let MessagePayload::ApplicationData(skip_data) = &m.payload {
             if skip_data.bytes().len() <= self.skip_data_left {
                 self.skip_data_left -= skip_data.bytes().len();
                 return Ok(self);


### PR DESCRIPTION
This makes everything take advantage of match ergonomics.

(After this, there are no remaining `ref` uses in this repo.)