### PR TITLE
Allow changing the limit on plaintext buffer size

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -135,6 +135,16 @@ mod connection {
             }
         }
 
+        /// Sets a limit on the internal plaintext buffer.
+        ///
+        /// See [`ConnectionCommon::set_plaintext_buffer_limit()`] for more information.
+        pub fn set_plaintext_buffer_limit(&mut self, limit: Option<usize>) {
+            match self {
+                Self::Client(client) => client.set_plaintext_buffer_limit(limit),
+                Self::Server(server) => server.set_plaintext_buffer_limit(limit),
+            }
+        }        
+
         /// Sends a TLS1.3 `key_update` message to refresh a connection's keys
         ///
         /// See [`ConnectionCommon::refresh_traffic_keys()`] for more information.
@@ -515,6 +525,13 @@ impl<Data> ConnectionCommon<Data> {
     pub fn set_buffer_limit(&mut self, limit: Option<usize>) {
         self.sendable_plaintext.set_limit(limit);
         self.sendable_tls.set_limit(limit);
+    }
+
+    /// Sets a limit on the internal buffers used to buffer decoded plaintext.
+    /// 
+    /// See [`Self::set_buffer_limit`] for more information on how limits are applied.
+    pub fn set_plaintext_buffer_limit(&mut self, limit: Option<usize>) {
+        self.core.common_state.received_plaintext.set_limit(limit);
     }
 
     /// Sends a TLS1.3 `key_update` message to refresh a connection's keys.


### PR DESCRIPTION
This trivial PR adds `Connection::set_plaintext_buffer_limit`, analog to the existing `Connection::set_buffer_limit` (which changes send buffer sizes).

**Usecase**: In my scenario, I cannot handle the decoded plaintext intermediately while feeding encrypted data into rustls. If a larger packet arrives, rustls may reject decoding it because there is a [hardcoded 16kb limit](https://github.com/rustls/rustls/blob/main/rustls/src/common_state.rs#L1041) on how many bytes the `ChunkVecBuffer` is allowed to hold. 

While I could implement additional buffering in my application, this introduces unnecessary overhead. Providing a method to adjust the plaintext buffer limit would eliminate the need for an extra layer of buffering.