### PR TITLE
Map webpki RequiredEkuNotFound error to InvalidPurpose

### DIFF
--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -91,6 +91,8 @@ fn pki_error(error: webpki::Error) -> Error {
             CertRevocationListError::BadSignature.into()
         }
 
+        RequiredEkuNotFound => CertificateError::InvalidPurpose.into(),
+
         _ => CertificateError::Other(OtherError(
             #[cfg(feature = "std")]
             Arc::new(error),


### PR DESCRIPTION
In [`map_webpki_errors()`](https://github.com/rustls/rustls-platform-verifier/blob/181756581c25a9b49f585358bc3c1b6fb8f2363a/rustls-platform-verifier/src/verification/others.rs#L227), rustls-platform-verifier currently downcasts the `CertificateError::Other` value to `webpki::Error`. This means that it breaks the abstraction of rustls wrapping the (semver-incompatible) version of webpki being used.

In order to facilitate this usage, map `webpki::Error::RequiredEkuNotFound` to an actual variant of `CertificateError` -- which turned out to have an `InvalidPurpose` variant which currently appears to be unused but does map to the `AlertDescription` of the same name. Seems like a good fit?

Not sure if this is worth doing a 0.23.25 directly for?