### PR TITLE
Prepare 0.23.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
  "base64",
  "env_logger",
  "nix",
- "rustls 0.23.24",
+ "rustls 0.23.25",
  "rustls-post-quantum",
 ]
 
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.24"
+version = "0.23.25"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2629,7 +2629,7 @@ name = "rustls-bench"
 version = "0.1.0"
 dependencies = [
  "clap",
- "rustls 0.23.24",
+ "rustls 0.23.25",
  "rustls-post-quantum",
  "tikv-jemallocator",
 ]
@@ -2646,7 +2646,7 @@ dependencies = [
  "fxhash",
  "itertools 0.14.0",
  "rayon",
- "rustls 0.23.24",
+ "rustls 0.23.25",
  "tikv-jemallocator",
 ]
 
@@ -2657,7 +2657,7 @@ dependencies = [
  "hickory-resolver",
  "regex",
  "ring",
- "rustls 0.23.24",
+ "rustls 0.23.25",
  "tokio",
 ]
 
@@ -2672,7 +2672,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.23.24",
+ "rustls 0.23.25",
  "serde",
  "tokio",
  "webpki-roots",
@@ -2683,7 +2683,7 @@ name = "rustls-fuzzing-provider"
 version = "0.1.0"
 dependencies = [
  "env_logger",
- "rustls 0.23.24",
+ "rustls 0.23.25",
 ]
 
 [[package]]
@@ -2695,7 +2695,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "openssl",
- "rustls 0.23.24",
+ "rustls 0.23.25",
 ]
 
 [[package]]
@@ -2710,7 +2710,7 @@ version = "0.2.2"
 dependencies = [
  "criterion",
  "env_logger",
- "rustls 0.23.24",
+ "rustls 0.23.25",
  "webpki-roots",
 ]
 
@@ -2731,7 +2731,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rcgen",
  "rsa",
- "rustls 0.23.24",
+ "rustls 0.23.25",
  "sha2",
  "signature",
  "webpki-roots",
@@ -2743,7 +2743,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.23.24",
+ "rustls 0.23.25",
  "rustls-provider-example",
  "serde",
  "serde_json",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.24"
+version = "0.23.25"
 dependencies = [
  "log",
  "once_cell",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.24"
+version = "0.23.25"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
Release notes:

- Translate `webpki::Error::RequiredEkuNotFound` to `rustls::CertificateError::InvalidPurpose`. This allows `rustls-platform-verifier` to stop requiring that `rustls` shares its version of its private `webpki` dependency, which is a semver hazard.