### PR TITLE
Revert "Pin cargo-hack@0.6.33 for now"

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -145,9 +145,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo hack
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hack@0.6.33
+        uses: taiki-e/install-action@cargo-hack
 
       - name: Check feature powerset
         run: >


### PR DESCRIPTION
This reverts commit 4ec06b638c427b333401af8b96f014a293e236df.

(cargo-hack 0.6.36 was released)