### PR TITLE
Reduce use of library internals in tests

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -476,8 +476,8 @@ pub mod internal {
         }
         pub mod enums {
             pub use crate::msgs::enums::{
-                AlertLevel, CertificateType, Compression, EchVersion, HpkeAead, HpkeKdf, HpkeKem,
-                NamedGroup,
+                AlertLevel, CertificateType, Compression, EchVersion, ExtensionType, HpkeAead,
+                HpkeKdf, HpkeKem, NamedGroup,
             };
         }
         pub mod fragmenter {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -15,10 +15,10 @@ use rustls::client::{ResolvesClientCert, Resumption, verify_server_cert_signed_b
 use rustls::crypto::{ActiveKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup};
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
-use rustls::internal::msgs::enums::{AlertLevel, CertificateType, Compression};
+use rustls::internal::msgs::enums::{AlertLevel, CertificateType, Compression, ExtensionType};
 use rustls::internal::msgs::handshake::{
     ClientExtension, ClientHelloPayload, HandshakeMessagePayload, HandshakePayload, Random,
-    ServerExtension, ServerName as ServerNameExtensionItem, SessionId,
+    ServerExtension, SessionId,
 };
 use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
@@ -1518,87 +1518,39 @@ fn client_trims_terminating_dot() {
 
 #[test]
 fn server_ignores_sni_with_ip_address() {
-    fn insert_ip_address_server_name(msg: &mut Message) -> Altered {
-        alter_sni_extension(
-            msg,
-            |snr| {
-                snr.clear();
-                snr.push(ServerNameExtensionItem::read_bytes(b"\x00\x00\x071.1.1.1").unwrap());
-            },
-            |parsed, _encoded| Payload::new(parsed.get_encoding()),
-        )
-    }
-
     check_sni_error(
-        insert_ip_address_server_name,
+        encoding::Extension::new_sni(b"1.1.1.1"),
         Error::General("no server certificate chain resolved".to_string()),
     );
 }
 
 #[test]
 fn server_rejects_sni_with_illegal_dns_name() {
-    fn insert_illegal_server_name(msg: &mut Message) -> Altered {
-        alter_sni_extension(
-            msg,
-            |_| (),
-            |_, encoded| {
-                // replace "localhost" with invalid DNS name
-                let mut altered = encoded.clone().into_vec();
-                let needle = b"localhost";
-                let index = altered
-                    .windows(needle.len())
-                    .position(|window| window == needle)
-                    .unwrap();
-                altered[index..index + needle.len()].copy_from_slice(b"ab@cd.com");
-                Payload::new(altered)
-            },
-        )
-    }
-
     check_sni_error(
-        insert_illegal_server_name,
+        encoding::Extension::new_sni(b"ab@cd.com"),
         Error::InvalidMessage(InvalidMessage::InvalidServerName),
     );
 }
 
-fn alter_sni_extension(
-    msg: &mut Message,
-    alter_inner: impl Fn(&mut Vec<ServerNameExtensionItem>),
-    alter_encoding: impl Fn(&mut HandshakeMessagePayload, &mut Payload) -> Payload<'static>,
-) -> Altered {
-    if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
-        if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
-            for mut ext in ch.extensions.iter_mut() {
-                if let ClientExtension::ServerName(snr) = &mut ext {
-                    alter_inner(snr);
-                }
-            }
-            *encoded = alter_encoding(parsed, encoded);
-        }
-    }
-
-    Altered::InPlace
-}
-
-fn check_sni_error(alteration: impl Fn(&mut Message) -> Altered, expected_error: Error) {
+fn check_sni_error(sni_extension: encoding::Extension, expected_error: Error) {
     for kt in ALL_KEY_TYPES {
-        let client_config = make_client_config(*kt);
         let mut server_config = make_server_config(*kt);
-
         server_config.cert_resolver = Arc::new(ServerCheckNoSni {});
 
-        let client =
-            ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
-        let server = ServerConnection::new(Arc::new(server_config)).unwrap();
-        let (mut client, mut server) = (client.into(), server.into());
+        let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+        server
+            .read_tls(
+                &mut encoding::message_framing(
+                    ContentType::Handshake,
+                    ProtocolVersion::TLSv1_2,
+                    encoding::basic_client_hello(vec![sni_extension.clone()]),
+                )
+                .as_slice(),
+            )
+            .unwrap();
 
-        transfer_altered(&mut client, &alteration, &mut server);
         assert_eq!(server.process_new_packets(), Err(expected_error.clone()),);
-
-        let rustls::Connection::Server(server_inner) = server else {
-            unreachable!();
-        };
-        assert_eq!(None, server_inner.server_name());
+        assert_eq!(None, server.server_name());
     }
 }
 
@@ -6305,45 +6257,25 @@ fn connection_types_are_not_huge() {
 
 #[test]
 fn test_server_rejects_duplicate_sni_names() {
-    fn duplicate_sni_payload(msg: &mut Message) -> Altered {
-        alter_sni_extension(
-            msg,
-            |snr| {
-                snr.push(snr[0].clone());
-            },
-            |parsed, _encoded| Payload::new(parsed.get_encoding()),
-        )
-    }
-
-    let (client, server) = make_pair(KeyType::Rsa2048);
-    let (mut client, mut server) = (client.into(), server.into());
-    transfer_altered(&mut client, duplicate_sni_payload, &mut server);
-    assert_eq!(
-        server.process_new_packets(),
-        Err(Error::PeerMisbehaved(
-            PeerMisbehaved::DuplicateServerNameTypes
-        ))
+    let mut body = encoding::Extension::sni_dns_hostname(b"example.com");
+    body.extend_from_slice(&encoding::Extension::sni_dns_hostname(b"example.com"));
+    check_sni_error(
+        encoding::Extension {
+            typ: ExtensionType::ServerName,
+            body: encoding::len_u16(body),
+        },
+        Error::PeerMisbehaved(PeerMisbehaved::DuplicateServerNameTypes),
     );
 }
 
 #[test]
 fn test_server_rejects_empty_sni_extension() {
-    fn empty_sni_payload(msg: &mut Message) -> Altered {
-        alter_sni_extension(
-            msg,
-            |snr| snr.clear(),
-            |parsed, _encoded| Payload::new(parsed.get_encoding()),
-        )
-    }
-
-    let (client, server) = make_pair(KeyType::Rsa2048);
-    let (mut client, mut server) = (client.into(), server.into());
-    transfer_altered(&mut client, empty_sni_payload, &mut server);
-    assert_eq!(
-        server.process_new_packets(),
-        Err(Error::PeerMisbehaved(
-            PeerMisbehaved::ServerNameMustContainOneHostName
-        ))
+    check_sni_error(
+        encoding::Extension {
+            typ: ExtensionType::ServerName,
+            body: encoding::len_u16(vec![]),
+        },
+        Error::PeerMisbehaved(PeerMisbehaved::ServerNameMustContainOneHostName),
     );
 }
 


### PR DESCRIPTION
This PR reduces the reliance of our tests on internal types for the future benefit of #1475.

Instead of that, `tests::common::encoding` is some very stupid code that can produce a variety of client hellos. Making that separate also means we're not testing rustls against itself, and the test code is not fighting against the type-safe internals code when constructing invalid input (see, eg, `server_rejects_sni_with_illegal_dns_name`).