### PR TITLE
Add `prefer-post-quantum` to default features

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["src/testdata", "tests/**"]
 build = "build.rs"
 
 [features]
-default = ["aws_lc_rs", "logging", "std", "tls12"]
+default = ["aws_lc_rs", "logging", "prefer-post-quantum", "std", "tls12"]
 
 aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
 aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws-lc-rs", "aws-lc-rs/aws-lc-sys", "aws-lc-rs/prebuilt-nasm"]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -296,11 +296,10 @@
 //!
 //!   See [manual::_06_fips] for more details.
 //!
-//! - `prefer-post-quantum`: for the [`aws-lc-rs`]-backed provider, prioritizes post-quantum secure
-//!   key exchange by default (using X25519MLKEM768).  This feature merely alters the order
-//!   of `rustls::crypto::aws_lc_rs::DEFAULT_KX_GROUPS`.  We expect to add this feature
-//!   to the default set in a future minor release.  See [the manual][x25519mlkem768-manual]
-//!   for more details.
+//! - `prefer-post-quantum` (enabled by default): for the [`aws-lc-rs`]-backed provider,
+//!   prioritizes post-quantum secure key exchange by default (using X25519MLKEM768).
+//!   This feature merely alters the order of `rustls::crypto::aws_lc_rs::DEFAULT_KX_GROUPS`.
+//!   See [the manual][x25519mlkem768-manual] for more details.
 //!
 //! - `custom-provider`: disables implicit use of built-in providers (`aws-lc-rs` or `ring`). This forces
 //!   applications to manually install one, for instance, when using a custom `CryptoProvider`.


### PR DESCRIPTION
This enables, for dependents who use default-features, X25519MLKEM768 as the most-preferred key exchange.

This is another step on the way to enabling this by default. In a future release, I plan to deprecate this feature, make it do nothing, and therefore unconditionally have `X25519MLKEM768` as the most preferred key exchange in the default aws-lc-rs provider.

Users who wish to opt-out from that change would then have to construct a customized `CryptoProvider` in their code.