### PR TITLE
[SECURITY(deps)] update dependency ring to >=0.17.12 to remove panic vulnerability GHSA-4p46-pwfr-66x6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 rayon = "1.7"
 rcgen = { version = "0.13", features = ["pem", "aws_lc_rs"], default-features = false }
 regex = "1"
-ring = "0.17"
+ring = ">=0.17.12"
 rsa = { version = "0.9", features = ["sha2"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
GHSA-ID GHSA-4p46-pwfr-66x6
Vulnerability description from Github

> 
"ring::aead::quic::HeaderProtectionKey::new_mask() may panic when overflow checking is enabled. In the QUIC protocol, an attacker can induce this panic by sending a specially-crafted packet. Even unintentionally it is likely to occur in 1 out of every 2**32 packets sent and/or received.

On 64-bit targets operations using ring::aead::{AES_128_GCM, AES_256_GCM} may panic when overflow checking is enabled, when encrypting/decrypting approximately 68,719,476,700 bytes (about 64 gigabytes) of data in a single chunk. Protocols like TLS and SSH are not affected by this because those protocols break large amounts of data into small chunks. Similarly, most applications will not attempt to encrypt/decrypt 64GB of data in one chunk.

Overflow checking is not enabled in release mode by default, but RUSTFLAGS="-C overflow-checks" or overflow-checks = true in the Cargo.toml profile can override this. Overflow checking is usually enabled by default in debug mode."
