### PR TITLE
Reorganize extensions testing

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -484,10 +484,8 @@ pub mod internal {
         }
         pub mod handshake {
             pub use crate::msgs::handshake::{
-                CertificateChain, ClientExtension, ClientHelloPayload, DistinguishedName,
                 EchConfigContents, EchConfigPayload, HandshakeMessagePayload, HandshakePayload,
-                HpkeKeyConfig, HpkeSymmetricCipherSuite, KeyShareEntry, Random, ServerExtension,
-                SessionId,
+                HpkeKeyConfig, HpkeSymmetricCipherSuite, SessionId,
             };
         }
         pub mod message {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -228,7 +228,7 @@ impl TlsListElement for SignatureScheme {
 }
 
 #[derive(Clone, Debug)]
-pub enum ServerNamePayload<'a> {
+pub(crate) enum ServerNamePayload<'a> {
     /// A successfully decoded value:
     SingleDnsName(DnsName<'a>),
 
@@ -358,7 +358,7 @@ impl HostNamePayload {
 
 wrapped_payload!(
     /// RFC7301: `opaque ProtocolName<1..2^8-1>;`
-    pub struct ProtocolName, PayloadU8<NonEmpty>,
+    pub(crate) struct ProtocolName, PayloadU8<NonEmpty>,
 );
 
 /// RFC7301: `ProtocolName protocol_name_list<2..2^16-1>`
@@ -494,7 +494,7 @@ impl TlsListElement for PresharedKeyBinder {
 }
 
 #[derive(Clone, Debug)]
-pub struct PresharedKeyOffer {
+pub(crate) struct PresharedKeyOffer {
     pub(crate) identities: Vec<PresharedKeyIdentity>,
     pub(crate) binders: Vec<PresharedKeyBinder>,
 }
@@ -532,7 +532,7 @@ impl TlsListElement for ResponderId {
 }
 
 #[derive(Clone, Debug)]
-pub struct OcspCertificateStatusRequest {
+pub(crate) struct OcspCertificateStatusRequest {
     pub(crate) responder_ids: Vec<ResponderId>,
     pub(crate) extensions: PayloadU16,
 }
@@ -553,7 +553,7 @@ impl Codec<'_> for OcspCertificateStatusRequest {
 }
 
 #[derive(Clone, Debug)]
-pub enum CertificateStatusRequest {
+pub(crate) enum CertificateStatusRequest {
     Ocsp(OcspCertificateStatusRequest),
     Unknown((CertificateStatusType, Payload<'static>)),
 }
@@ -617,7 +617,7 @@ impl TlsListElement for KeyShareEntry {
 ///
 /// RFC8446: `ProtocolVersion versions<2..254>;`
 #[derive(Clone, Copy, Debug, Default)]
-pub struct SupportedProtocolVersions {
+pub(crate) struct SupportedProtocolVersions {
     pub(crate) tls13: bool,
     pub(crate) tls12: bool,
 }
@@ -692,7 +692,7 @@ impl TlsListElement for CertificateCompressionAlgorithm {
 }
 
 #[derive(Clone, Debug)]
-pub enum ClientExtension {
+pub(crate) enum ClientExtension {
     EcPointFormats(Vec<ECPointFormat>),
     NamedGroups(Vec<NamedGroup>),
     SignatureAlgorithms(Vec<SignatureScheme>),
@@ -863,7 +863,7 @@ fn trim_hostname_trailing_dot_for_sni(dns_name: &DnsName<'_>) -> DnsName<'static
 }
 
 #[derive(Clone, Debug)]
-pub enum ClientSessionTicket {
+pub(crate) enum ClientSessionTicket {
     Request,
     Offer(Payload<'static>),
 }
@@ -997,7 +997,7 @@ pub struct ClientHelloPayload {
     pub session_id: SessionId,
     pub cipher_suites: Vec<CipherSuite>,
     pub compression_methods: Vec<Compression>,
-    pub extensions: Vec<ClientExtension>,
+    pub(crate) extensions: Vec<ClientExtension>,
 }
 
 impl Codec<'_> for ClientHelloPayload {
@@ -1490,7 +1490,7 @@ impl HelloRetryRequest {
 
 #[derive(Clone, Debug)]
 pub struct ServerHelloPayload {
-    pub extensions: Vec<ServerExtension>,
+    pub(crate) extensions: Vec<ServerExtension>,
     pub(crate) legacy_version: ProtocolVersion,
     pub(crate) random: Random,
     pub(crate) session_id: SessionId,
@@ -3199,7 +3199,7 @@ impl TlsListElement for EchConfigExtension {
 ///
 /// [draft-ietf-tls-esni Section 5]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-18.html#section-5>
 #[derive(Clone, Debug)]
-pub enum EncryptedClientHello {
+pub(crate) enum EncryptedClientHello {
     /// A `ECHClientHello` with type [EchClientHelloType::ClientHelloOuter].
     Outer(EncryptedClientHelloOuter),
     /// An empty `ECHClientHello` with type [EchClientHelloType::ClientHelloInner].
@@ -3238,7 +3238,7 @@ impl Codec<'_> for EncryptedClientHello {
 ///
 /// [draft-ietf-tls-esni Section 5]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-18.html#section-5>
 #[derive(Clone, Debug)]
-pub struct EncryptedClientHelloOuter {
+pub(crate) struct EncryptedClientHelloOuter {
     /// The cipher suite used to encrypt ClientHelloInner. Must match a value from
     /// ECHConfigContents.cipher_suites list.
     pub cipher_suite: HpkeSymmetricCipherSuite,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1027,31 +1027,6 @@ impl Codec<'_> for ClientHelloPayload {
     }
 }
 
-/// RFC8446: `CipherSuite cipher_suites<2..2^16-2>;`
-impl TlsListElement for CipherSuite {
-    const SIZE_LEN: ListLength = ListLength::NonZeroU16 {
-        empty_error: InvalidMessage::IllegalEmptyList("CipherSuites"),
-    };
-}
-
-/// RFC5246: `CompressionMethod compression_methods<1..2^8-1>;`
-impl TlsListElement for Compression {
-    const SIZE_LEN: ListLength = ListLength::NonZeroU8 {
-        empty_error: InvalidMessage::IllegalEmptyList("Compressions"),
-    };
-}
-
-impl TlsListElement for ClientExtension {
-    const SIZE_LEN: ListLength = ListLength::U16;
-}
-
-/// draft-ietf-tls-esni-17: `ExtensionType OuterExtensions<2..254>;`
-impl TlsListElement for ExtensionType {
-    const SIZE_LEN: ListLength = ListLength::NonZeroU8 {
-        empty_error: InvalidMessage::IllegalEmptyList("ExtensionTypes"),
-    };
-}
-
 impl ClientHelloPayload {
     pub(crate) fn ech_inner_encoding(&self, to_compress: Vec<ExtensionType>) -> Vec<u8> {
         let mut bytes = Vec::new();
@@ -1302,6 +1277,31 @@ impl ClientHelloPayload {
             _ => unreachable!("extension type checked"),
         }
     }
+}
+
+/// RFC8446: `CipherSuite cipher_suites<2..2^16-2>;`
+impl TlsListElement for CipherSuite {
+    const SIZE_LEN: ListLength = ListLength::NonZeroU16 {
+        empty_error: InvalidMessage::IllegalEmptyList("CipherSuites"),
+    };
+}
+
+/// RFC5246: `CompressionMethod compression_methods<1..2^8-1>;`
+impl TlsListElement for Compression {
+    const SIZE_LEN: ListLength = ListLength::NonZeroU8 {
+        empty_error: InvalidMessage::IllegalEmptyList("Compressions"),
+    };
+}
+
+impl TlsListElement for ClientExtension {
+    const SIZE_LEN: ListLength = ListLength::U16;
+}
+
+/// draft-ietf-tls-esni-17: `ExtensionType OuterExtensions<2..254>;`
+impl TlsListElement for ExtensionType {
+    const SIZE_LEN: ListLength = ListLength::NonZeroU8 {
+        empty_error: InvalidMessage::IllegalEmptyList("ExtensionTypes"),
+    };
 }
 
 #[derive(Clone, Debug)]

--- a/rustls/tests/api_ffdhe.rs
+++ b/rustls/tests/api_ffdhe.rs
@@ -3,12 +3,11 @@
 #![allow(clippy::duplicate_mod)]
 
 mod common;
+
 use common::*;
 use rustls::crypto::CryptoProvider;
-use rustls::internal::msgs::base::Payload;
-use rustls::internal::msgs::codec::Codec;
-use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
-use rustls::internal::msgs::message::{Message, MessagePayload};
+use rustls::internal::msgs::enums::ExtensionType;
+use rustls::internal::msgs::message::Message;
 use rustls::version::{TLS12, TLS13};
 use rustls::{CipherSuite, ClientConfig, NamedGroup};
 
@@ -74,18 +73,15 @@ fn ffdhe_ciphersuite() {
 #[test]
 fn server_picks_ffdhe_group_when_clienthello_has_no_ffdhe_group_in_groups_ext() {
     fn clear_named_groups_ext(msg: &mut Message) -> Altered {
-        if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
-            if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
-                for mut ext in ch.extensions.iter_mut() {
-                    if let ClientExtension::NamedGroups(ngs) = &mut ext {
-                        ngs.clear();
-                        ngs.push(NamedGroup::X448);
-                    }
-                }
-            }
-            *encoded = Payload::new(parsed.get_encoding());
-        }
-        Altered::InPlace
+        edit_client_hello_extensions(
+            msg,
+            &[ExtensionEdit::Replace(
+                ExtensionType::EllipticCurves,
+                encoding::len_u16(encoding::len_u16(encoding::vector_of(
+                    [NamedGroup::X448].into_iter(),
+                ))),
+            )],
+        )
     }
 
     let client_config = finish_client_config(
@@ -110,14 +106,7 @@ fn server_picks_ffdhe_group_when_clienthello_has_no_ffdhe_group_in_groups_ext() 
 #[test]
 fn server_picks_ffdhe_group_when_clienthello_has_no_groups_ext() {
     fn remove_named_groups_ext(msg: &mut Message) -> Altered {
-        if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
-            if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
-                ch.extensions
-                    .retain(|ext| !matches!(ext, ClientExtension::NamedGroups(_)));
-            }
-            *encoded = Payload::new(parsed.get_encoding());
-        }
-        Altered::InPlace
+        edit_client_hello_extensions(msg, &[ExtensionEdit::Skip(ExtensionType::EllipticCurves)])
     }
 
     let client_config = finish_client_config(
@@ -198,14 +187,7 @@ fn server_avoids_dhe_cipher_suites_when_client_has_no_known_dhe_in_groups_ext() 
 #[test]
 fn server_accepts_client_with_no_ecpoints_extension_and_only_ffdhe_cipher_suites() {
     fn remove_ecpoints_ext(msg: &mut Message) -> Altered {
-        if let MessagePayload::Handshake { parsed, encoded } = &mut msg.payload {
-            if let HandshakePayload::ClientHello(ch) = &mut parsed.payload {
-                ch.extensions
-                    .retain(|ext| !matches!(ext, ClientExtension::EcPointFormats(_)));
-            }
-            *encoded = Payload::new(parsed.get_encoding());
-        }
-        Altered::InPlace
+        edit_client_hello_extensions(msg, &[ExtensionEdit::Skip(ExtensionType::ECPointFormats)])
     }
 
     let client_config = finish_client_config(


### PR DESCRIPTION
The goal of this PR is to provide a single internal API surface for all our extension testing needs. A similar idea was previously included in #1475; this is a variation that replaces that.

That allows us to remove `ClientExtension` and `ServerExtension` from `rustls::internals`, and then further privatize types that were reachable from there.