### PR TITLE
manual: add a short howto debugging section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,3 +27,5 @@ A clear and concise description of what you expected to happen.
 
 **Additional context**
 Add any other context about the problem here.
+For example, consider including verbose logs or a packet capture. For help
+with this [see the manual](https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#debugging).


### PR DESCRIPTION
Cover how to collect verbose logs with `RUST_LOG` and offer some starting point instructions on collecting a pcap and using `SSLKEYLOGFILE`.

The new issue template for bug reports is updated to include a pointer to the new manual section.