### PR TITLE
Small clippy fixes

### DIFF
--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -290,10 +290,7 @@ pub mod async_io {
 
         fn poll(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Self::Output> {
             if !self.writer.inner.open.get() {
-                return Poll::Ready(Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "channel was closed",
-                )));
+                return Poll::Ready(Err(io::Error::other("channel was closed")));
             }
 
             let mut pipe_buf = self.writer.inner.buf.borrow_mut();

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -28,15 +28,14 @@ fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str, port:
         .expect("invalid DNS name")
         .to_owned();
     let mut conn = rustls::ClientConnection::new(Arc::clone(config), server_name).unwrap();
-    let mut sock = TcpStream::connect(format!("{}:{}", domain_name, port)).unwrap();
+    let mut sock = TcpStream::connect(format!("{domain_name}:{port}")).unwrap();
     sock.set_nodelay(true).unwrap();
     let request = format!(
         "GET / HTTP/1.1\r\n\
-         Host: {}\r\n\
+         Host: {domain_name}\r\n\
          Connection: close\r\n\
          Accept-Encoding: identity\r\n\
-         \r\n",
-        domain_name
+         \r\n"
     );
 
     // If early data is available with this server, then early_data()
@@ -69,7 +68,7 @@ fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str, port:
     BufReader::new(stream)
         .read_line(&mut first_response_line)
         .unwrap();
-    println!("  * Server response: {:?}", first_response_line);
+    println!("  * Server response: {first_response_line:?}");
 }
 
 fn main() {

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -91,7 +91,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
                     .unwrap();
 
                 if bytes_read != 0 {
-                    println!("Early data from client: {:?}", buf);
+                    println!("Early data from client: {buf:?}");
                 }
             }
         }

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -93,7 +93,7 @@ impl TlsClient {
                 if error.kind() == io::ErrorKind::WouldBlock {
                     return;
                 }
-                println!("TLS read error: {:?}", error);
+                println!("TLS read error: {error:?}");
                 self.closing = true;
                 return;
             }
@@ -291,7 +291,7 @@ fn lookup_suites(suites: &[String]) -> Vec<rustls::SupportedCipherSuite> {
         let scs = find_suite(csname);
         match scs {
             Some(s) => out.push(s),
-            None => panic!("cannot look up ciphersuite '{}'", csname),
+            None => panic!("cannot look up ciphersuite '{csname}'"),
         }
     }
 
@@ -306,10 +306,7 @@ fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtoco
         let version = match vname.as_ref() {
             "1.2" => &rustls::version::TLS12,
             "1.3" => &rustls::version::TLS13,
-            _ => panic!(
-                "cannot look up version '{}', valid are '1.2' and '1.3'",
-                vname
-            ),
+            _ => panic!("cannot look up version '{vname}', valid are '1.2' and '1.3'"),
         };
         out.push(version);
     }
@@ -526,7 +523,7 @@ fn main() {
             // Polling can be interrupted (e.g. by a debugger) - retry if so.
             Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
             Err(e) => {
-                panic!("poll failed: {:?}", e)
+                panic!("poll failed: {e:?}")
             }
         }
 

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -76,7 +76,7 @@ impl TlsServer {
         loop {
             match self.server.accept() {
                 Ok((socket, addr)) => {
-                    debug!("Accepting new connection from {:?}", addr);
+                    debug!("Accepting new connection from {addr:?}");
 
                     let tls_conn =
                         rustls::ServerConnection::new(Arc::clone(&self.tls_config)).unwrap();
@@ -92,10 +92,7 @@ impl TlsServer {
                 }
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(()),
                 Err(err) => {
-                    println!(
-                        "encountered error while accepting connection; err={:?}",
-                        err
-                    );
+                    println!("encountered error while accepting connection; err={err:?}");
                     return Err(err);
                 }
             }
@@ -224,7 +221,7 @@ impl OpenConnection {
                     return;
                 }
 
-                error!("read error {:?}", err);
+                error!("read error {err:?}");
                 self.closing = true;
                 return;
             }
@@ -238,7 +235,7 @@ impl OpenConnection {
 
         // Process newly-received TLS messages.
         if let Err(err) = self.tls_conn.process_new_packets() {
-            error!("cannot process packet: {:?}", err);
+            error!("cannot process packet: {err:?}");
 
             // last gasp write to send any alerts
             self.do_tls_write_and_handle_error();
@@ -288,7 +285,7 @@ impl OpenConnection {
         let rc = try_read(back.read(&mut buf));
 
         if rc.is_err() {
-            error!("backend read failed: {:?}", rc);
+            error!("backend read failed: {rc:?}");
             self.closing = true;
             return;
         }
@@ -355,7 +352,7 @@ impl OpenConnection {
     fn do_tls_write_and_handle_error(&mut self) {
         let rc = self.tls_write();
         if rc.is_err() {
-            error!("write failed {:?}", rc);
+            error!("write failed {rc:?}");
             self.closing = true;
         }
     }
@@ -494,7 +491,7 @@ fn lookup_suites(suites: &[String]) -> Vec<rustls::SupportedCipherSuite> {
         let scs = find_suite(csname);
         match scs {
             Some(s) => out.push(s),
-            None => panic!("cannot look up ciphersuite '{}'", csname),
+            None => panic!("cannot look up ciphersuite '{csname}'"),
         }
     }
 
@@ -509,10 +506,7 @@ fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtoco
         let version = match vname.as_ref() {
             "1.2" => &rustls::version::TLS12,
             "1.3" => &rustls::version::TLS13,
-            _ => panic!(
-                "cannot look up version '{}', valid are '1.2' and '1.3'",
-                vname
-            ),
+            _ => panic!("cannot look up version '{vname}', valid are '1.2' and '1.3'"),
         };
         out.push(version);
     }
@@ -669,7 +663,7 @@ fn main() {
             // Polling can be interrupted (e.g. by a debugger) - retry if so.
             Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
             Err(e) => {
-                panic!("poll failed: {:?}", e)
+                panic!("poll failed: {e:?}")
             }
         }
 

--- a/rustls/build.rs
+++ b/rustls/build.rs
@@ -1,7 +1,7 @@
-/// This build script allows us to enable the `read_buf` language feature only
-/// for Rust Nightly.
-///
-/// See the comment in lib.rs to understand why we need this.
+//! This build script allows us to enable the `read_buf` language feature only
+//! for Rust Nightly.
+//!
+//! See the comment in lib.rs to understand why we need this.
 
 #[cfg_attr(feature = "read_buf", rustversion::not(nightly))]
 fn main() {}

--- a/rustls/src/bs_debug.rs
+++ b/rustls/src/bs_debug.rs
@@ -31,7 +31,7 @@ impl fmt::Debug for BsDebug<'_> {
             } else if (0x20..0x7f).contains(&c) {
                 write!(fmt, "{}", c as char)?;
             } else {
-                write!(fmt, "\\x{:02x}", c)?;
+                write!(fmt, "\\x{c:02x}")?;
             }
         }
         write!(fmt, "\"")?;

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -183,7 +183,7 @@ impl<Side: ConfigSide, State: fmt::Debug> fmt::Debug for ConfigBuilder<Side, Sta
             .unwrap_or((side_name, ""));
         let (_, name) = ty.rsplit_once("::").unwrap_or(("", ty));
 
-        f.debug_struct(&format!("ConfigBuilder<{}, _>", name,))
+        f.debug_struct(&format!("ConfigBuilder<{name}, _>",))
             .field("state", &self.state)
             .finish()
     }

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -60,7 +60,7 @@ impl ClientHelloDetails {
             let ext_type = ext.ext_type();
             if !self.sent_extensions.contains(&ext_type) && !allowed_unsolicited.contains(&ext_type)
             {
-                trace!("Unsolicited extension {:?}", ext_type);
+                trace!("Unsolicited extension {ext_type:?}");
                 return true;
             }
         }

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -685,7 +685,7 @@ impl EchState {
             };
         }
 
-        trace!("ECH Inner Hello: {:#?}", inner_hello);
+        trace!("ECH Inner Hello: {inner_hello:#?}");
 
         // Encode the inner hello according to the rules required for ECH. This differs
         // from the standard encoding in several ways. Notably this is where we will

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -85,7 +85,7 @@ fn find_session(
             }
         })
         .or_else(|| {
-            debug!("No cached session for {:?}", server_name);
+            debug!("No cached session for {server_name:?}");
             None
         });
 
@@ -553,7 +553,7 @@ fn emit_client_hello_for_retry(
         tls13::emit_fake_ccs(&mut input.sent_tls13_fake_ccs, cx.common);
     }
 
-    trace!("Sending ClientHello {:#?}", ch);
+    trace!("Sending ClientHello {ch:#?}");
 
     transcript_buffer.add_message(&ch);
     cx.common.send_msg(ch, false);
@@ -752,7 +752,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
     {
         let server_hello =
             require_handshake_msg!(m, HandshakeType::ServerHello, HandshakePayload::ServerHello)?;
-        trace!("We got ServerHello {:#?}", server_hello);
+        trace!("We got ServerHello {server_hello:#?}");
 
         use crate::ProtocolVersion::{TLSv1_2, TLSv1_3};
         let config = &self.input.config;
@@ -878,7 +878,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
                 });
             }
             _ => {
-                debug!("Using ciphersuite {:?}", suite);
+                debug!("Using ciphersuite {suite:?}");
                 self.suite = Some(suite);
                 cx.common.suite = Some(suite);
             }
@@ -983,7 +983,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
             HandshakeType::HelloRetryRequest,
             HandshakePayload::HelloRetryRequest
         )?;
-        trace!("Got HRR {:?}", hrr);
+        trace!("Got HRR {hrr:?}");
 
         cx.common.check_aligned_handshake()?;
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -733,7 +733,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest<'_> {
             HandshakePayload::CertificateRequest
         )?;
         self.transcript.add_message(&m);
-        debug!("Got CertificateRequest {:?}", certreq);
+        debug!("Got CertificateRequest {certreq:?}");
 
         // The RFC jovially describes the design here as 'somewhat complicated'
         // and 'somewhat underspecified'.  So thanks for that.

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -470,7 +470,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
             HandshakeType::EncryptedExtensions,
             HandshakePayload::EncryptedExtensions
         )?;
-        debug!("TLS1.3 encrypted extensions: {:?}", exts);
+        debug!("TLS1.3 encrypted extensions: {exts:?}");
         self.transcript.add_message(&m);
 
         validate_encrypted_extensions(cx.common, &self.hello, exts)?;
@@ -854,7 +854,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             HandshakePayload::CertificateRequestTls13
         )?;
         self.transcript.add_message(&m);
-        debug!("Got CertificateRequest {:?}", certreq);
+        debug!("Got CertificateRequest {certreq:?}");
 
         // Fortunately the problems here in TLS1.2 and prior are corrected in
         // TLS1.3.

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -503,7 +503,7 @@ impl CommonState {
     }
 
     fn send_warning_alert(&mut self, desc: AlertDescription) {
-        warn!("Sending warning alert {:?}", desc);
+        warn!("Sending warning alert {desc:?}");
         self.send_warning_alert_no_log(desc);
     }
 

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -564,8 +564,7 @@ impl fmt::Display for EncodeError {
         match self {
             Self::InsufficientSize(InsufficientSizeError { required_size }) => write!(
                 f,
-                "cannot encode due to insufficient size, {} bytes are required",
-                required_size
+                "cannot encode due to insufficient size, {required_size} bytes are required"
             ),
             Self::AlreadyEncoded => "cannot encode, data has already been encoded".fmt(f),
         }

--- a/rustls/src/crypto/aws_lc_rs/sign.rs
+++ b/rustls/src/crypto/aws_lc_rs/sign.rs
@@ -117,7 +117,7 @@ impl RsaSigningKey {
             }
         }
         .map_err(|key_rejected| {
-            Error::General(format!("failed to parse RSA private key: {}", key_rejected))
+            Error::General(format!("failed to parse RSA private key: {key_rejected}"))
         })?;
 
         Ok(Self {
@@ -428,7 +428,7 @@ mod tests {
         ));
 
         let k = any_supported_type(&key).unwrap();
-        assert_eq!(format!("{:?}", k), "EcdsaSigningKey { algorithm: ECDSA }");
+        assert_eq!(format!("{k:?}"), "EcdsaSigningKey { algorithm: ECDSA }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::ECDSA);
 
         assert!(
@@ -443,7 +443,7 @@ mod tests {
             .choose_scheme(&[SignatureScheme::ECDSA_NISTP256_SHA256])
             .unwrap();
         assert_eq!(
-            format!("{:?}", s),
+            format!("{s:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256 }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP256_SHA256);
@@ -481,7 +481,7 @@ mod tests {
         ));
 
         let k = any_supported_type(&key).unwrap();
-        assert_eq!(format!("{:?}", k), "EcdsaSigningKey { algorithm: ECDSA }");
+        assert_eq!(format!("{k:?}"), "EcdsaSigningKey { algorithm: ECDSA }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::ECDSA);
 
         assert!(
@@ -496,7 +496,7 @@ mod tests {
             .choose_scheme(&[SignatureScheme::ECDSA_NISTP384_SHA384])
             .unwrap();
         assert_eq!(
-            format!("{:?}", s),
+            format!("{s:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384 }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP384_SHA384);
@@ -534,7 +534,7 @@ mod tests {
         ));
 
         let k = any_supported_type(&key).unwrap();
-        assert_eq!(format!("{:?}", k), "EcdsaSigningKey { algorithm: ECDSA }");
+        assert_eq!(format!("{k:?}"), "EcdsaSigningKey { algorithm: ECDSA }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::ECDSA);
 
         assert!(
@@ -553,7 +553,7 @@ mod tests {
             .choose_scheme(&[SignatureScheme::ECDSA_NISTP521_SHA512])
             .unwrap();
         assert_eq!(
-            format!("{:?}", s),
+            format!("{s:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP521_SHA512 }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP521_SHA512);
@@ -579,10 +579,7 @@ mod tests {
         let key = PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/eddsakey.der")[..]);
 
         let k = any_eddsa_type(&key).unwrap();
-        assert_eq!(
-            format!("{:?}", k),
-            "Ed25519SigningKey { algorithm: ED25519 }"
-        );
+        assert_eq!(format!("{k:?}"), "Ed25519SigningKey { algorithm: ED25519 }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::ED25519);
 
         assert!(
@@ -596,7 +593,7 @@ mod tests {
         let s = k
             .choose_scheme(&[SignatureScheme::ED25519])
             .unwrap();
-        assert_eq!(format!("{:?}", s), "Ed25519Signer { scheme: ED25519 }");
+        assert_eq!(format!("{s:?}"), "Ed25519Signer { scheme: ED25519 }");
         assert_eq!(s.scheme(), SignatureScheme::ED25519);
         assert_eq!(s.sign(b"hello").unwrap().len(), 64);
     }
@@ -627,7 +624,7 @@ mod tests {
         ));
 
         let k = any_supported_type(&key).unwrap();
-        assert_eq!(format!("{:?}", k), "RsaSigningKey { algorithm: RSA }");
+        assert_eq!(format!("{k:?}"), "RsaSigningKey { algorithm: RSA }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::RSA);
 
         assert!(
@@ -642,7 +639,7 @@ mod tests {
         let s = k
             .choose_scheme(&[SignatureScheme::RSA_PSS_SHA256])
             .unwrap();
-        assert_eq!(format!("{:?}", s), "RsaSigner { scheme: RSA_PSS_SHA256 }");
+        assert_eq!(format!("{s:?}"), "RsaSigner { scheme: RSA_PSS_SHA256 }");
         assert_eq!(s.scheme(), SignatureScheme::RSA_PSS_SHA256);
         assert_eq!(s.sign(b"hello").unwrap().len(), 256);
 

--- a/rustls/src/crypto/aws_lc_rs/ticketer.rs
+++ b/rustls/src/crypto/aws_lc_rs/ticketer.rs
@@ -404,7 +404,7 @@ mod tests {
 
         let t = make_ticket_generator().unwrap();
 
-        assert_eq!(format!("{:?}", t), "Rfc5077Ticketer { lifetime: 43200 }");
+        assert_eq!(format!("{t:?}"), "Rfc5077Ticketer { lifetime: 43200 }");
         assert!(t.enabled());
         assert_eq!(t.lifetime(), 43200);
     }

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -110,7 +110,7 @@ impl RsaSigningKey {
             }
         }
         .map_err(|key_rejected| {
-            Error::General(format!("failed to parse RSA private key: {}", key_rejected))
+            Error::General(format!("failed to parse RSA private key: {key_rejected}"))
         })?;
 
         Ok(Self {
@@ -461,7 +461,7 @@ mod tests {
         ));
 
         let k = any_supported_type(&key).unwrap();
-        assert_eq!(format!("{:?}", k), "EcdsaSigningKey { algorithm: ECDSA }");
+        assert_eq!(format!("{k:?}"), "EcdsaSigningKey { algorithm: ECDSA }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::ECDSA);
 
         assert!(
@@ -476,7 +476,7 @@ mod tests {
             .choose_scheme(&[SignatureScheme::ECDSA_NISTP256_SHA256])
             .unwrap();
         assert_eq!(
-            format!("{:?}", s),
+            format!("{s:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256 }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP256_SHA256);
@@ -514,7 +514,7 @@ mod tests {
         ));
 
         let k = any_supported_type(&key).unwrap();
-        assert_eq!(format!("{:?}", k), "EcdsaSigningKey { algorithm: ECDSA }");
+        assert_eq!(format!("{k:?}"), "EcdsaSigningKey { algorithm: ECDSA }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::ECDSA);
 
         assert!(
@@ -529,7 +529,7 @@ mod tests {
             .choose_scheme(&[SignatureScheme::ECDSA_NISTP384_SHA384])
             .unwrap();
         assert_eq!(
-            format!("{:?}", s),
+            format!("{s:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384 }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP384_SHA384);
@@ -555,10 +555,7 @@ mod tests {
         let key = PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/eddsakey.der")[..]);
 
         let k = any_eddsa_type(&key).unwrap();
-        assert_eq!(
-            format!("{:?}", k),
-            "Ed25519SigningKey { algorithm: ED25519 }"
-        );
+        assert_eq!(format!("{k:?}"), "Ed25519SigningKey { algorithm: ED25519 }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::ED25519);
 
         assert!(
@@ -572,7 +569,7 @@ mod tests {
         let s = k
             .choose_scheme(&[SignatureScheme::ED25519])
             .unwrap();
-        assert_eq!(format!("{:?}", s), "Ed25519Signer { scheme: ED25519 }");
+        assert_eq!(format!("{s:?}"), "Ed25519Signer { scheme: ED25519 }");
         assert_eq!(s.scheme(), SignatureScheme::ED25519);
         assert_eq!(s.sign(b"hello").unwrap().len(), 64);
     }
@@ -603,7 +600,7 @@ mod tests {
         ));
 
         let k = any_supported_type(&key).unwrap();
-        assert_eq!(format!("{:?}", k), "RsaSigningKey { algorithm: RSA }");
+        assert_eq!(format!("{k:?}"), "RsaSigningKey { algorithm: RSA }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::RSA);
 
         assert!(
@@ -618,7 +615,7 @@ mod tests {
         let s = k
             .choose_scheme(&[SignatureScheme::RSA_PSS_SHA256])
             .unwrap();
-        assert_eq!(format!("{:?}", s), "RsaSigner { scheme: RSA_PSS_SHA256 }");
+        assert_eq!(format!("{s:?}"), "RsaSigner { scheme: RSA_PSS_SHA256 }");
         assert_eq!(s.scheme(), SignatureScheme::RSA_PSS_SHA256);
         assert_eq!(s.sign(b"hello").unwrap().len(), 256);
 

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -370,7 +370,7 @@ mod tests {
         let t = make_ticket_generator().unwrap();
 
         let expect = format!("AeadTicketer {{ alg: {TICKETER_AEAD:?}, lifetime: 43200 }}");
-        assert_eq!(format!("{:?}", t), expect);
+        assert_eq!(format!("{t:?}"), expect);
         assert!(t.enabled());
         assert_eq!(t.lifetime(), 43200);
     }

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -591,7 +591,7 @@ impl fmt::Display for CertificateError {
                         f,
                         "is not valid for any names (according to its subjectAltName extension)"
                     ),
-                    [one] => write!(f, "is only valid for {}", one),
+                    [one] => write!(f, "is only valid for {one}"),
                     many => {
                         write!(f, "is only valid for ")?;
 
@@ -600,12 +600,12 @@ impl fmt::Display for CertificateError {
                         let last = &many[n - 1];
 
                         for (i, name) in all_but_last.iter().enumerate() {
-                            write!(f, "{}", name)?;
+                            write!(f, "{name}")?;
                             if i < n - 2 {
                                 write!(f, ", ")?;
                             }
                         }
-                        write!(f, " or {}", last)
+                        write!(f, " or {last}")
                     }
                 }
             }
@@ -662,7 +662,7 @@ impl fmt::Display for CertificateError {
                 Ok(())
             }
 
-            other => write!(f, "{:?}", other),
+            other => write!(f, "{other:?}"),
         }
     }
 }
@@ -812,7 +812,7 @@ impl From<EncryptedClientHelloError> for Error {
 fn join<T: fmt::Debug>(items: &[T]) -> String {
     items
         .iter()
-        .map(|x| format!("{:?}", x))
+        .map(|x| format!("{x:?}"))
         .collect::<Vec<String>>()
         .join(" or ")
 }
@@ -839,22 +839,22 @@ impl fmt::Display for Error {
                 join::<HandshakeType>(expect_types)
             ),
             Self::InvalidMessage(typ) => {
-                write!(f, "received corrupt message of type {:?}", typ)
+                write!(f, "received corrupt message of type {typ:?}")
             }
-            Self::PeerIncompatible(why) => write!(f, "peer is incompatible: {:?}", why),
-            Self::PeerMisbehaved(why) => write!(f, "peer misbehaved: {:?}", why),
-            Self::AlertReceived(alert) => write!(f, "received fatal alert: {:?}", alert),
+            Self::PeerIncompatible(why) => write!(f, "peer is incompatible: {why:?}"),
+            Self::PeerMisbehaved(why) => write!(f, "peer misbehaved: {why:?}"),
+            Self::AlertReceived(alert) => write!(f, "received fatal alert: {alert:?}"),
             Self::InvalidCertificate(err) => {
-                write!(f, "invalid peer certificate: {}", err)
+                write!(f, "invalid peer certificate: {err}")
             }
             Self::InvalidCertRevocationList(err) => {
-                write!(f, "invalid certificate revocation list: {:?}", err)
+                write!(f, "invalid certificate revocation list: {err:?}")
             }
             Self::NoCertificatesPresented => write!(f, "peer sent no certificates"),
             Self::UnsupportedNameType => write!(f, "presented server name type wasn't supported"),
             Self::DecryptError => write!(f, "cannot decrypt peer's message"),
             Self::InvalidEncryptedClientHello(err) => {
-                write!(f, "encrypted client hello failure: {:?}", err)
+                write!(f, "encrypted client hello failure: {err:?}")
             }
             Self::EncryptError => write!(f, "cannot encrypt message"),
             Self::PeerSentOversizedRecord => write!(f, "peer sent excess record size"),
@@ -866,10 +866,10 @@ impl fmt::Display for Error {
                 write!(f, "the supplied max_fragment_size was too small or large")
             }
             Self::InconsistentKeys(why) => {
-                write!(f, "keys may not be consistent: {:?}", why)
+                write!(f, "keys may not be consistent: {why:?}")
             }
-            Self::General(err) => write!(f, "unexpected error: {}", err),
-            Self::Other(err) => write!(f, "other error: {}", err),
+            Self::General(err) => write!(f, "unexpected error: {err}"),
+            Self::Other(err) => write!(f, "other error: {err}"),
         }
     }
 }
@@ -1174,8 +1174,8 @@ mod tests {
         ];
 
         for err in all {
-            println!("{:?}:", err);
-            println!("  fmt '{}'", err);
+            println!("{err:?}:");
+            println!("  fmt '{err}'");
         }
     }
 

--- a/rustls/src/key_log_file.rs
+++ b/rustls/src/key_log_file.rs
@@ -33,7 +33,7 @@ impl KeyLogFileInner {
         {
             Ok(f) => Some(f),
             Err(e) => {
-                warn!("unable to create key log file {:?}: {}", path, e);
+                warn!("unable to create key log file {path:?}: {e}");
                 None
             }
         };
@@ -53,13 +53,13 @@ impl KeyLogFileInner {
         };
 
         self.buf.truncate(0);
-        write!(self.buf, "{} ", label)?;
+        write!(self.buf, "{label} ")?;
         for b in client_random.iter() {
-            write!(self.buf, "{:02x}", b)?;
+            write!(self.buf, "{b:02x}")?;
         }
         write!(self.buf, " ")?;
         for b in secret.iter() {
-            write!(self.buf, "{:02x}", b)?;
+            write!(self.buf, "{b:02x}")?;
         }
         writeln!(self.buf)?;
         file.write_all(&self.buf)
@@ -105,7 +105,7 @@ impl KeyLog for KeyLogFile {
         {
             Ok(()) => {}
             Err(e) => {
-                warn!("error writing to key log file: {}", e);
+                warn!("error writing to key log file: {e}");
             }
         }
     }
@@ -114,7 +114,7 @@ impl KeyLog for KeyLogFile {
 impl Debug for KeyLogFile {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self.0.try_lock() {
-            Ok(key_log_file) => write!(f, "{:?}", key_log_file),
+            Ok(key_log_file) => write!(f, "{key_log_file:?}"),
             Err(_) => write!(f, "KeyLogFile {{ <locked> }}"),
         }
     }

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -232,7 +232,7 @@ pub(super) fn hex<'a>(
     payload: impl IntoIterator<Item = &'a u8>,
 ) -> fmt::Result {
     for b in payload {
-        write!(f, "{:02x}", b)?;
+        write!(f, "{b:02x}")?;
     }
     Ok(())
 }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -310,8 +310,7 @@ impl<'a> Codec<'a> for ServerNamePayload<'a> {
 
                 HostNamePayload::IpAddress(_invalid) => {
                     warn!(
-                        "Illegal SNI extension: ignoring IP address presented as hostname ({:?})",
-                        _invalid
+                        "Illegal SNI extension: ignoring IP address presented as hostname ({_invalid:?})"
                     );
                     Some(Self::IpAddress)
                 }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -41,7 +41,7 @@ fn reads_random() {
     let bytes = [0x01; 32];
     let mut rd = Reader::init(&bytes);
     let rnd = Random::read(&mut rd).unwrap();
-    println!("{:?}", rnd);
+    println!("{rnd:?}");
 
     assert!(!rd.any_left());
 }
@@ -80,7 +80,7 @@ fn accepts_short_session_id() {
     let bytes = [1; 2];
     let mut rd = Reader::init(&bytes);
     let sess = SessionId::read(&mut rd).unwrap();
-    println!("{:?}", sess);
+    println!("{sess:?}");
 
     #[cfg(feature = "tls12")]
     assert!(!sess.is_empty());
@@ -93,7 +93,7 @@ fn accepts_empty_session_id() {
     let bytes = [0; 1];
     let mut rd = Reader::init(&bytes);
     let sess = SessionId::read(&mut rd).unwrap();
-    println!("{:?}", sess);
+    println!("{sess:?}");
 
     #[cfg(feature = "tls12")]
     assert!(sess.is_empty());
@@ -111,7 +111,7 @@ fn debug_session_id() {
     let sess = SessionId::read(&mut rd).unwrap();
     assert_eq!(
         "0101010101010101010101010101010101010101010101010101010101010101",
-        format!("{:?}", sess)
+        format!("{sess:?}")
     );
 }
 
@@ -121,7 +121,7 @@ fn can_round_trip_unknown_client_ext() {
     let mut rd = Reader::init(&bytes);
     let ext = ClientExtension::read(&mut rd).unwrap();
 
-    println!("{:?}", ext);
+    println!("{ext:?}");
     assert_eq!(ext.ext_type(), ExtensionType::Unknown(0x1234));
     assert_eq!(bytes.to_vec(), ext.get_encoding());
 }
@@ -173,7 +173,7 @@ fn can_round_trip_single_sni() {
     let bytes = [0, 0, 0, 7, 0, 5, 0, 0, 2, 0x6c, 0x6f];
     let mut rd = Reader::init(&bytes);
     let ext = ClientExtension::read(&mut rd).unwrap();
-    println!("{:?}", ext);
+    println!("{ext:?}");
 
     assert_eq!(ext.ext_type(), ExtensionType::ServerName);
     assert_eq!(bytes.to_vec(), ext.get_encoding());
@@ -184,7 +184,7 @@ fn can_round_trip_mixed_case_sni() {
     let bytes = [0, 0, 0, 7, 0, 5, 0, 0, 2, 0x4c, 0x6f];
     let mut rd = Reader::init(&bytes);
     let ext = ClientExtension::read(&mut rd).unwrap();
-    println!("{:?}", ext);
+    println!("{ext:?}");
 
     assert_eq!(ext.ext_type(), ExtensionType::ServerName);
     assert_eq!(bytes.to_vec(), ext.get_encoding());
@@ -195,7 +195,7 @@ fn single_hostname_returns_none_for_other_sni_name_types() {
     let bytes = [0, 0, 0, 7, 0, 5, 1, 0, 2, 0x6c, 0x6f];
     let mut rd = Reader::init(&bytes);
     let ext = ClientExtension::read(&mut rd).unwrap();
-    println!("{:?}", ext);
+    println!("{ext:?}");
 
     assert_eq!(ext.ext_type(), ExtensionType::ServerName);
     assert!(matches!(
@@ -232,13 +232,13 @@ fn rejects_truncated_sni() {
 fn can_round_trip_psk_identity() {
     let bytes = [0, 1, 0x99, 0x11, 0x22, 0x33, 0x44];
     let psk_id = PresharedKeyIdentity::read(&mut Reader::init(&bytes)).unwrap();
-    println!("{:?}", psk_id);
+    println!("{psk_id:?}");
     assert_eq!(psk_id.obfuscated_ticket_age, 0x11223344);
     assert_eq!(psk_id.get_encoding(), bytes.to_vec());
 
     let bytes = [0, 5, 0x1, 0x2, 0x3, 0x4, 0x5, 0x11, 0x22, 0x33, 0x44];
     let psk_id = PresharedKeyIdentity::read(&mut Reader::init(&bytes)).unwrap();
-    println!("{:?}", psk_id);
+    println!("{psk_id:?}");
     assert_eq!(psk_id.identity.0, vec![0x1, 0x2, 0x3, 0x4, 0x5]);
     assert_eq!(psk_id.obfuscated_ticket_age, 0x11223344);
     assert_eq!(psk_id.get_encoding(), bytes.to_vec());
@@ -250,7 +250,7 @@ fn can_round_trip_psk_offer() {
         0, 7, 0, 1, 0x99, 0x11, 0x22, 0x33, 0x44, 0, 4, 3, 0x01, 0x02, 0x3,
     ];
     let psko = PresharedKeyOffer::read(&mut Reader::init(&bytes)).unwrap();
-    println!("{:?}", psko);
+    println!("{psko:?}");
 
     assert_eq!(psko.identities.len(), 1);
     assert_eq!(psko.identities[0].identity.0, vec![0x99]);
@@ -263,7 +263,7 @@ fn can_round_trip_psk_offer() {
 #[test]
 fn can_round_trip_cert_status_req_for_ocsp() {
     let ext = ClientExtension::CertificateStatusRequest(CertificateStatusRequest::build_ocsp());
-    println!("{:?}", ext);
+    println!("{ext:?}");
 
     let bytes = [
         0, 5, // CertificateStatusRequest
@@ -272,7 +272,7 @@ fn can_round_trip_cert_status_req_for_ocsp() {
     ];
 
     let csr = ClientExtension::read(&mut Reader::init(&bytes)).unwrap();
-    println!("{:?}", csr);
+    println!("{csr:?}");
     assert_eq!(csr.get_encoding(), bytes.to_vec());
 }
 
@@ -285,7 +285,7 @@ fn can_round_trip_cert_status_req_for_other() {
     ];
 
     let csr = ClientExtension::read(&mut Reader::init(&bytes)).unwrap();
-    println!("{:?}", csr);
+    println!("{csr:?}");
     assert_eq!(csr.get_encoding(), bytes.to_vec());
 }
 
@@ -294,7 +294,7 @@ fn can_round_trip_multi_proto() {
     let bytes = [0, 16, 0, 8, 0, 6, 2, 0x68, 0x69, 2, 0x6c, 0x6f];
     let mut rd = Reader::init(&bytes);
     let ext = ClientExtension::read(&mut rd).unwrap();
-    println!("{:?}", ext);
+    println!("{ext:?}");
 
     assert_eq!(ext.ext_type(), ExtensionType::ALProtocolNegotiation);
     assert_eq!(ext.get_encoding(), bytes.to_vec());
@@ -317,7 +317,7 @@ fn can_round_trip_single_proto() {
     let bytes = [0, 16, 0, 5, 0, 3, 2, 0x68, 0x69];
     let mut rd = Reader::init(&bytes);
     let ext = ClientExtension::read(&mut rd).unwrap();
-    println!("{:?}", ext);
+    println!("{ext:?}");
 
     assert_eq!(ext.ext_type(), ExtensionType::ALProtocolNegotiation);
     assert_eq!(bytes.to_vec(), ext.get_encoding());
@@ -367,7 +367,7 @@ fn test_truncated_psk_offer() {
     });
 
     let mut enc = ext.get_encoding();
-    println!("testing {:?} enc {:?}", ext, enc);
+    println!("testing {ext:?} enc {enc:?}");
     for l in 0..enc.len() {
         if l == 9 {
             continue;
@@ -382,7 +382,7 @@ fn test_truncated_psk_offer() {
 fn test_truncated_client_hello_is_detected() {
     let ch = sample_client_hello_payload();
     let enc = ch.get_encoding();
-    println!("testing {:?} enc {:?}", ch, enc);
+    println!("testing {ch:?} enc {enc:?}");
 
     for l in 0..enc.len() {
         println!("len {:?} enc {:?}", l, &enc[..l]);
@@ -399,7 +399,7 @@ fn test_truncated_client_extension_is_detected() {
 
     for ext in &chp.extensions {
         let mut enc = ext.get_encoding();
-        println!("testing {:?} enc {:?}", ext, enc);
+        println!("testing {ext:?} enc {enc:?}");
 
         // "outer" truncation, i.e., where the extension-level length is longer than
         // the input
@@ -419,7 +419,7 @@ fn test_truncated_client_extension_is_detected() {
         // length, but isn't long enough for the type of extension
         for l in 0..(enc.len() - 4) {
             put_u16(l as u16, &mut enc[2..]);
-            println!("  encoding {:?} len {:?}", enc, l);
+            println!("  encoding {enc:?} len {l:?}");
             assert!(ClientExtension::read_bytes(&enc).is_err());
         }
     }
@@ -533,7 +533,7 @@ fn test_truncated_hello_retry_extension_is_detected() {
 
     for ext in &hrr.extensions {
         let mut enc = ext.get_encoding();
-        println!("testing {:?} enc {:?}", ext, enc);
+        println!("testing {ext:?} enc {enc:?}");
 
         // "outer" truncation, i.e., where the extension-level length is longer than
         // the input
@@ -550,7 +550,7 @@ fn test_truncated_hello_retry_extension_is_detected() {
         // length, but isn't long enough for the type of extension
         for l in 0..(enc.len() - 4) {
             put_u16(l as u16, &mut enc[2..]);
-            println!("  encoding {:?} len {:?}", enc, l);
+            println!("  encoding {enc:?} len {l:?}");
             assert!(HelloRetryExtension::read_bytes(&enc).is_err());
         }
     }
@@ -599,7 +599,7 @@ fn test_truncated_server_extension_is_detected() {
 
     for ext in &shp.extensions {
         let mut enc = ext.get_encoding();
-        println!("testing {:?} enc {:?}", ext, enc);
+        println!("testing {ext:?} enc {enc:?}");
 
         // "outer" truncation, i.e., where the extension-level length is longer than
         // the input
@@ -619,7 +619,7 @@ fn test_truncated_server_extension_is_detected() {
         // length, but isn't long enough for the type of extension
         for l in 0..(enc.len() - 4) {
             put_u16(l as u16, &mut enc[2..]);
-            println!("  encoding {:?} len {:?}", enc, l);
+            println!("  encoding {enc:?} len {l:?}");
             assert!(ServerExtension::read_bytes(&enc).is_err());
         }
     }
@@ -728,8 +728,8 @@ fn can_round_trip_all_tls12_handshake_payloads() {
         assert!(!rd.any_left());
         assert_eq!(hm.get_encoding(), other.get_encoding());
 
-        println!("{:?}", hm);
-        println!("{:?}", other);
+        println!("{hm:?}");
+        println!("{other:?}");
     }
 }
 
@@ -748,7 +748,7 @@ fn can_into_owned_all_tls12_handshake_payloads() {
 fn can_detect_truncation_of_all_tls12_handshake_payloads() {
     for hm in all_tls12_handshake_payloads().iter() {
         let mut enc = hm.get_encoding();
-        println!("test {:?} enc {:?}", hm, enc);
+        println!("test {hm:?} enc {enc:?}");
 
         // outer truncation
         for l in 0..enc.len() {
@@ -758,7 +758,7 @@ fn can_detect_truncation_of_all_tls12_handshake_payloads() {
         // inner truncation
         for l in 0..enc.len() - 4 {
             put_u24(l as u32, &mut enc[1..]);
-            println!("  check len {:?} enc {:?}", l, enc);
+            println!("  check len {l:?} enc {enc:?}");
 
             match (hm.typ, l) {
                 (HandshakeType::ClientHello, 41)
@@ -794,8 +794,8 @@ fn can_round_trip_all_tls13_handshake_payloads() {
         assert!(!rd.any_left());
         assert_eq!(hm.get_encoding(), other.get_encoding());
 
-        println!("{:?}", hm);
-        println!("{:?}", other);
+        println!("{hm:?}");
+        println!("{other:?}");
     }
 }
 
@@ -814,7 +814,7 @@ fn can_into_owned_all_tls13_handshake_payloads() {
 fn can_detect_truncation_of_all_tls13_handshake_payloads() {
     for hm in all_tls13_handshake_payloads().iter() {
         let mut enc = hm.get_encoding();
-        println!("test {:?} enc {:?}", hm, enc);
+        println!("test {hm:?} enc {enc:?}");
 
         // outer truncation
         for l in 0..enc.len() {
@@ -824,7 +824,7 @@ fn can_detect_truncation_of_all_tls13_handshake_payloads() {
         // inner truncation
         for l in 0..enc.len() - 4 {
             put_u24(l as u32, &mut enc[1..]);
-            println!("  check len {:?} enc {:?}", l, enc);
+            println!("  check len {l:?} enc {enc:?}");
 
             match (hm.typ, l) {
                 (HandshakeType::ClientHello, 41)
@@ -859,7 +859,7 @@ fn cannot_read_message_hash_from_network() {
         typ: HandshakeType::MessageHash,
         payload: HandshakePayload::MessageHash(Payload::new(vec![1, 2, 3])),
     };
-    println!("mh {:?}", mh);
+    println!("mh {mh:?}");
     let enc = mh.get_encoding();
     assert!(HandshakeMessagePayload::read_bytes(&enc).is_err());
 }
@@ -898,7 +898,7 @@ fn can_decode_server_hello_from_api_devicecheck_apple_com() {
     let data = include_bytes!("../testdata/hello-api.devicecheck.apple.com.bin");
     let mut r = Reader::init(data);
     let hm = HandshakeMessagePayload::read(&mut r).unwrap();
-    println!("msg: {:?}", hm);
+    println!("msg: {hm:?}");
 }
 
 #[test]

--- a/rustls/src/msgs/message/outbound.rs
+++ b/rustls/src/msgs/message/outbound.rs
@@ -318,7 +318,7 @@ mod tests {
         let borrowed_payload = OutboundChunks::Single(owner);
 
         let (before, after) = borrowed_payload.split_at(6);
-        println!("before:{:?}\nafter:{:?}", before, after);
+        println!("before:{before:?}\nafter:{after:?}");
         assert_eq!(before.to_vec(), &[0, 1, 2, 3, 4, 5]);
         assert_eq!(after.to_vec(), &[6, 7]);
     }
@@ -329,17 +329,17 @@ mod tests {
         let borrowed_payload = OutboundChunks::new(&owner);
 
         let (before, after) = borrowed_payload.split_at(3);
-        println!("before:{:?}\nafter:{:?}", before, after);
+        println!("before:{before:?}\nafter:{after:?}");
         assert_eq!(before.to_vec(), &[0, 1, 2]);
         assert_eq!(after.to_vec(), &[3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
         let (before, after) = borrowed_payload.split_at(8);
-        println!("before:{:?}\nafter:{:?}", before, after);
+        println!("before:{before:?}\nafter:{after:?}");
         assert_eq!(before.to_vec(), &[0, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(after.to_vec(), &[8, 9, 10, 11, 12]);
 
         let (before, after) = borrowed_payload.split_at(11);
-        println!("before:{:?}\nafter:{:?}", before, after);
+        println!("before:{before:?}\nafter:{after:?}");
         assert_eq!(before.to_vec(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         assert_eq!(after.to_vec(), &[11, 12]);
     }
@@ -350,19 +350,19 @@ mod tests {
 
         let single_payload = OutboundChunks::Single(owner[0]);
         let (before, after) = single_payload.split_at(17);
-        println!("before:{:?}\nafter:{:?}", before, after);
+        println!("before:{before:?}\nafter:{after:?}");
         assert_eq!(before.to_vec(), &[0, 1, 2, 3]);
         assert!(after.is_empty());
 
         let multiple_payload = OutboundChunks::new(&owner);
         let (before, after) = multiple_payload.split_at(17);
-        println!("before:{:?}\nafter:{:?}", before, after);
+        println!("before:{before:?}\nafter:{after:?}");
         assert_eq!(before.to_vec(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
         assert!(after.is_empty());
 
         let empty_payload = OutboundChunks::new_empty();
         let (before, after) = empty_payload.split_at(17);
-        println!("before:{:?}\nafter:{:?}", before, after);
+        println!("before:{before:?}\nafter:{after:?}");
         assert!(before.is_empty());
         assert!(after.is_empty());
     }
@@ -393,7 +393,7 @@ mod tests {
         let payload = OutboundChunks::new(&slices);
 
         assert_eq!(payload.to_vec(), owner);
-        println!("{:#?}", payload);
+        println!("{payload:#?}");
 
         for start in 0..128 {
             for end in start..128 {

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -32,7 +32,7 @@ fn test_read_fuzz_corpus() {
         let msg = OutboundOpaqueMessage::read(&mut rd)
             .unwrap()
             .into_plain_message();
-        println!("{:?}", msg);
+        println!("{msg:?}");
 
         let Ok(msg) = Message::try_from(msg) else {
             continue;
@@ -70,7 +70,7 @@ fn can_read_safari_client_hello_with_ip_address_in_sni_extension() {
         \x01\x00\x00\x0a\x00\x0a\x00\x08\x00\x1d\x00\x17\x00\x18\x00\x19";
     let mut rd = Reader::init(bytes);
     let m = OutboundOpaqueMessage::read(&mut rd).unwrap();
-    println!("m = {:?}", m);
+    println!("m = {m:?}");
     Message::try_from(m.into_plain_message()).unwrap();
 }
 
@@ -91,9 +91,9 @@ fn construct_all_types() {
     ];
     for &bytes in samples.iter() {
         let m = OutboundOpaqueMessage::read(&mut Reader::init(bytes)).unwrap();
-        println!("m = {:?}", m);
+        println!("m = {m:?}");
         let m = Message::try_from(m.into_plain_message());
-        println!("m' = {:?}", m);
+        println!("m' = {m:?}");
     }
 }
 

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -435,11 +435,7 @@ impl ServerSessionValue {
             .saturating_sub(self.creation_time_sec) as u32)
             .saturating_mul(1000);
 
-        let age_difference = if client_age_ms < server_age_ms {
-            server_age_ms - client_age_ms
-        } else {
-            client_age_ms - server_age_ms
-        };
+        let age_difference = server_age_ms.abs_diff(client_age_ms);
 
         self.freshness = Some(age_difference <= MAX_FRESHNESS_SKEW_MS);
         self
@@ -469,7 +465,7 @@ mod tests {
             UnixTime::now(),
             0x12345678,
         );
-        println!("{:?}", ssv);
+        println!("{ssv:?}");
     }
 
     #[test]

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -91,7 +91,7 @@ impl ExtensionProcessing {
                 })
                 .cloned();
             if let Some(selected_protocol) = &cx.common.alpn_protocol {
-                debug!("Chosen ALPN protocol {:?}", selected_protocol);
+                debug!("Chosen ALPN protocol {selected_protocol:?}");
                 self.exts
                     .push(ServerExtension::Protocols(SingleProtocolName::new(
                         selected_protocol.clone(),
@@ -449,7 +449,7 @@ impl ExpectClientHello {
                     .send_fatal_alert(AlertDescription::HandshakeFailure, incompat)
             })?;
 
-        debug!("decided upon suite {:?}", suite);
+        debug!("decided upon suite {suite:?}");
         cx.common.suite = Some(suite);
         cx.common.kx_state = KxState::Start(skxg);
 
@@ -672,7 +672,7 @@ pub(super) fn process_client_hello<'m>(
 ) -> Result<(&'m ClientHelloPayload, Vec<SignatureScheme>), Error> {
     let client_hello =
         require_handshake_msg!(m, HandshakeType::ClientHello, HandshakePayload::ClientHello)?;
-    trace!("we got a clienthello {:?}", client_hello);
+    trace!("we got a clienthello {client_hello:?}");
 
     if !client_hello
         .compression_methods

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -91,7 +91,7 @@ mod client_hello {
                 .ecpoints_extension()
                 .unwrap_or(&[ECPointFormat::Uncompressed]);
 
-            trace!("ecpoints {:?}", ecpoints_ext);
+            trace!("ecpoints {ecpoints_ext:?}");
 
             if !ecpoints_ext.contains(&ECPointFormat::Uncompressed) {
                 return Err(cx.common.send_fatal_alert(
@@ -358,7 +358,7 @@ mod client_hello {
                 extensions: ep.exts,
             }),
         };
-        trace!("sending server hello {:?}", sh);
+        trace!("sending server hello {sh:?}");
         flight.add(sh);
 
         Ok(ep.send_ticket)
@@ -445,7 +445,7 @@ mod client_hello {
             payload: HandshakePayload::CertificateRequest(cr),
         };
 
-        trace!("Sending CertificateRequest {:?}", creq);
+        trace!("Sending CertificateRequest {creq:?}");
         flight.add(creq);
         Ok(true)
     }
@@ -492,7 +492,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
             .verifier
             .client_auth_mandatory();
 
-        trace!("certs {:?}", cert_chain);
+        trace!("certs {cert_chain:?}");
 
         let client_cert = match cert_chain.split_first() {
             None if mandatory => {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -532,7 +532,7 @@ mod client_hello {
 
         let client_hello_hash = transcript.hash_given(&[]);
 
-        trace!("sending server hello {:?}", sh);
+        trace!("sending server hello {sh:?}");
         transcript.add_message(&sh);
         cx.common.send_msg(sh, false);
 
@@ -605,7 +605,7 @@ mod client_hello {
             }),
         };
 
-        trace!("Requesting retry {:?}", m);
+        trace!("Requesting retry {m:?}");
         transcript.rollup_for_hrr();
         transcript.add_message(&m);
         common.send_msg(m, false);
@@ -691,7 +691,7 @@ mod client_hello {
             payload: HandshakePayload::EncryptedExtensions(ep.exts),
         };
 
-        trace!("sending encrypted extensions {:?}", ee);
+        trace!("sending encrypted extensions {ee:?}");
         flight.add(ee);
         Ok(early_data)
     }
@@ -737,7 +737,7 @@ mod client_hello {
             payload: HandshakePayload::CertificateRequestTls13(cr),
         };
 
-        trace!("Sending CertificateRequest {:?}", creq);
+        trace!("Sending CertificateRequest {creq:?}");
         flight.add(creq);
         Ok(true)
     }
@@ -755,7 +755,7 @@ mod client_hello {
             )),
         };
 
-        trace!("sending certificate {:?}", cert);
+        trace!("sending certificate {cert:?}");
         flight.add(cert);
     }
 
@@ -780,7 +780,7 @@ mod client_hello {
             payload: HandshakePayload::CompressedCertificate(entry.compressed_cert_payload()),
         };
 
-        trace!("sending compressed certificate {:?}", c);
+        trace!("sending compressed certificate {c:?}");
         flight.add(c);
     }
 
@@ -811,7 +811,7 @@ mod client_hello {
             payload: HandshakePayload::CertificateVerify(cv),
         };
 
-        trace!("sending certificate-verify {:?}", cv);
+        trace!("sending certificate-verify {cv:?}");
         flight.add(cv);
         Ok(())
     }
@@ -832,7 +832,7 @@ mod client_hello {
             payload: HandshakePayload::Finished(verify_data_payload),
         };
 
-        trace!("sending finished {:?}", fin);
+        trace!("sending finished {fin:?}");
         flight.add(fin);
         let hash_at_server_fin = flight.transcript.current_hash();
         flight.finish(cx.common);
@@ -1344,7 +1344,7 @@ impl ExpectFinished {
             typ: HandshakeType::NewSessionTicket,
             payload: HandshakePayload::NewSessionTicketTls13(payload),
         };
-        trace!("sending new ticket {:?} (stateless: {})", t, stateless);
+        trace!("sending new ticket {t:?} (stateless: {stateless})");
         flight.add(t);
 
         Ok(())

--- a/rustls/src/webpki/anchors.rs
+++ b/rustls/src/webpki/anchors.rs
@@ -45,15 +45,14 @@ impl RootCertStore {
                 }
                 Err(err) => {
                     trace!("invalid cert der {:?}", der_cert.as_ref());
-                    debug!("certificate parsing failed: {:?}", err);
+                    debug!("certificate parsing failed: {err:?}");
                     invalid_count += 1;
                 }
             };
         }
 
         debug!(
-            "add_parsable_certificates processed {} valid and {} invalid certs",
-            valid_count, invalid_count
+            "add_parsable_certificates processed {valid_count} valid and {invalid_count} invalid certs"
         );
 
         (valid_count, invalid_count)
@@ -138,7 +137,7 @@ fn root_cert_store_debug() {
     let store = RootCertStore::from_iter(iter::repeat(ta).take(138));
 
     assert_eq!(
-        format!("{:?}", store),
+        format!("{store:?}"),
         "RootCertStore { roots: \"(138 roots)\" }"
     );
 }

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -488,7 +488,7 @@ mod tests {
             provider::default_provider().into(),
         );
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -502,7 +502,7 @@ mod tests {
         )
         .allow_unauthenticated();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -516,7 +516,7 @@ mod tests {
             provider::default_provider().into(),
         );
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -530,7 +530,7 @@ mod tests {
         )
         .allow_unauthenticated();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -564,7 +564,7 @@ mod tests {
         // There should be the expected number of crls.
         assert_eq!(builder.crls.len(), initial_crls.len() + extra_crls.len());
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -578,7 +578,7 @@ mod tests {
         )
         .with_crls(test_crls());
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -593,7 +593,7 @@ mod tests {
         .with_crls(test_crls())
         .allow_unauthenticated();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -607,7 +607,7 @@ mod tests {
         .with_crls(test_crls())
         .only_check_end_entity_revocation();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -621,7 +621,7 @@ mod tests {
         .with_crls(test_crls())
         .allow_unknown_revocation_status();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -635,7 +635,7 @@ mod tests {
         .with_crls(test_crls())
         .enforce_revocation_expiration();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -658,8 +658,8 @@ mod tests {
         ];
 
         for err in all {
-            let _ = format!("{:?}", err);
-            let _ = format!("{}", err);
+            let _ = format!("{err:?}");
+            let _ = format!("{err}");
         }
     }
 }

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -48,7 +48,7 @@ impl fmt::Display for VerifierBuilderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NoRootAnchors => write!(f, "no root trust anchors were provided"),
-            Self::InvalidCrl(e) => write!(f, "provided CRL could not be parsed: {:?}", e),
+            Self::InvalidCrl(e) => write!(f, "provided CRL could not be parsed: {e:?}"),
         }
     }
 }

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -375,7 +375,7 @@ mod tests {
         // There should be the expected number of crls.
         assert_eq!(builder.crls.len(), initial_crls.len() + extra_crls.len());
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -399,7 +399,7 @@ mod tests {
         )
         .only_check_end_entity_revocation();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -413,7 +413,7 @@ mod tests {
         )
         .allow_unknown_revocation_status();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -428,7 +428,7 @@ mod tests {
         .allow_unknown_revocation_status()
         .only_check_end_entity_revocation();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 
@@ -442,7 +442,7 @@ mod tests {
         )
         .enforce_revocation_expiration();
         // The builder should be Debug.
-        println!("{:?}", builder);
+        println!("{builder:?}");
         builder.build().unwrap();
     }
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -561,10 +561,7 @@ fn version_test(
     let client_config = make_client_config_with_versions(KeyType::Rsa2048, client_versions);
     let server_config = make_server_config_with_versions(KeyType::Rsa2048, server_versions);
 
-    println!(
-        "version {:?} {:?} -> {:?}",
-        client_versions, server_versions, result
-    );
+    println!("version {client_versions:?} {server_versions:?} -> {result:?}");
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
@@ -1090,11 +1087,11 @@ fn test_config_builders_debug() {
         }
         .into(),
     );
-    let _ = format!("{:?}", b);
+    let _ = format!("{b:?}");
     let b = server_config_builder_with_versions(&[&rustls::version::TLS13]);
-    let _ = format!("{:?}", b);
+    let _ = format!("{b:?}");
     let b = b.with_no_client_auth();
-    let _ = format!("{:?}", b);
+    let _ = format!("{b:?}");
 
     let b = ClientConfig::builder_with_provider(
         CryptoProvider {
@@ -1104,9 +1101,9 @@ fn test_config_builders_debug() {
         }
         .into(),
     );
-    let _ = format!("{:?}", b);
+    let _ = format!("{b:?}");
     let b = client_config_builder_with_versions(&[&rustls::version::TLS13]);
-    let _ = format!("{:?}", b);
+    let _ = format!("{b:?}");
 }
 
 /// Test that the server handles combination of `offer_client_auth()` returning true
@@ -2762,7 +2759,7 @@ fn client_fill_buf_returns_wouldblock_when_no_data() {
 fn new_server_returns_initial_io_state() {
     let (_, mut server) = make_pair(KeyType::Rsa2048);
     let io_state = server.process_new_packets().unwrap();
-    println!("IoState is Debug {:?}", io_state);
+    println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
     assert!(!io_state.peer_has_closed());
     assert_eq!(io_state.tls_bytes_to_write(), 0);
@@ -2772,7 +2769,7 @@ fn new_server_returns_initial_io_state() {
 fn new_client_returns_initial_io_state() {
     let (mut client, _) = make_pair(KeyType::Rsa2048);
     let io_state = client.process_new_packets().unwrap();
-    println!("IoState is Debug {:?}", io_state);
+    println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
     assert!(!io_state.peer_has_closed());
     assert!(io_state.tls_bytes_to_write() > 200);
@@ -3259,7 +3256,7 @@ fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
         .unwrap();
     let mut client_stream = Stream::new(&mut client, &mut pipe);
     let rc = client_stream.write(b"world");
-    assert_eq!(format!("{:?}", rc), "Ok(5)");
+    assert_eq!(format!("{rc:?}"), "Ok(5)");
 }
 
 fn make_disjoint_suite_configs() -> (ClientConfig, ServerConfig) {
@@ -3300,13 +3297,13 @@ fn client_stream_handshake_error() {
         let rc = client_stream.write(b"hello");
         assert!(rc.is_err());
         assert_eq!(
-            format!("{:?}", rc),
+            format!("{rc:?}"),
             "Err(Custom { kind: InvalidData, error: AlertReceived(HandshakeFailure) })"
         );
         let rc = client_stream.write(b"hello");
         assert!(rc.is_err());
         assert_eq!(
-            format!("{:?}", rc),
+            format!("{rc:?}"),
             "Err(Custom { kind: InvalidData, error: AlertReceived(HandshakeFailure) })"
         );
     }
@@ -3322,13 +3319,13 @@ fn client_streamowned_handshake_error() {
     let rc = client_stream.write(b"hello");
     assert!(rc.is_err());
     assert_eq!(
-        format!("{:?}", rc),
+        format!("{rc:?}"),
         "Err(Custom { kind: InvalidData, error: AlertReceived(HandshakeFailure) })"
     );
     let rc = client_stream.write(b"hello");
     assert!(rc.is_err());
     assert_eq!(
-        format!("{:?}", rc),
+        format!("{rc:?}"),
         "Err(Custom { kind: InvalidData, error: AlertReceived(HandshakeFailure) })"
     );
 
@@ -3352,7 +3349,7 @@ fn server_stream_handshake_error() {
         let rc = server_stream.read(&mut bytes);
         assert!(rc.is_err());
         assert_eq!(
-            format!("{:?}", rc),
+            format!("{rc:?}"),
             "Err(Custom { kind: InvalidData, error: PeerIncompatible(NoCipherSuitesInCommon) })"
         );
     }
@@ -3374,7 +3371,7 @@ fn server_streamowned_handshake_error() {
     let rc = server_stream.read(&mut bytes);
     assert!(rc.is_err());
     assert_eq!(
-        format!("{:?}", rc),
+        format!("{rc:?}"),
         "Err(Custom { kind: InvalidData, error: PeerIncompatible(NoCipherSuitesInCommon) })"
     );
 }
@@ -3392,13 +3389,13 @@ fn client_config_is_clone() {
 #[test]
 fn client_connection_is_debug() {
     let (client, _) = make_pair(KeyType::Rsa2048);
-    println!("{:?}", client);
+    println!("{client:?}");
 }
 
 #[test]
 fn server_connection_is_debug() {
     let (_, server) = make_pair(KeyType::Rsa2048);
-    println!("{:?}", server);
+    println!("{server:?}");
 }
 
 #[test]
@@ -5350,7 +5347,7 @@ mod test_quic {
         ];
 
         for &(size, ok) in cases.iter() {
-            println!("early data size case: {:?}", size);
+            println!("early data size case: {size:?}");
             if let Some(new) = size {
                 server_config.max_early_data_size = new;
             }
@@ -5929,7 +5926,7 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     do_handshake_until_error(&mut client_1, &mut server).unwrap();
 
     let ops = shared_storage.ops();
-    println!("storage {:#?}", ops);
+    println!("storage {ops:#?}");
     assert_eq!(ops.len(), 7);
     assert!(matches!(
         ops[3],
@@ -5985,7 +5982,7 @@ fn test_client_sends_share_for_less_preferred_group() {
     do_handshake_until_error(&mut client_1, &mut server).unwrap();
 
     let ops = shared_storage.ops();
-    println!("storage {:#?}", ops);
+    println!("storage {ops:#?}");
     assert_eq!(ops.len(), 7);
     assert!(matches!(
         ops[3],
@@ -6003,9 +6000,9 @@ fn test_client_sends_share_for_less_preferred_group() {
                     assert_eq!(keyshares.len(), 1);
                     assert_eq!(keyshares[0].group(), rustls::NamedGroup::secp384r1);
                 }
-                _ => panic!("unexpected handshake message {:?}", parsed),
+                _ => panic!("unexpected handshake message {parsed:?}"),
             },
-            _ => panic!("unexpected non-handshake message {:?}", msg),
+            _ => panic!("unexpected non-handshake message {msg:?}"),
         };
         Altered::InPlace
     };
@@ -6017,10 +6014,10 @@ fn test_client_sends_share_for_less_preferred_group() {
                     let group = hrr.requested_key_share_group();
                     assert_eq!(group, Some(rustls::NamedGroup::X25519));
                 }
-                _ => panic!("unexpected handshake message {:?}", parsed),
+                _ => panic!("unexpected handshake message {parsed:?}"),
             },
             MessagePayload::ChangeCipherSpec(_) => (),
-            _ => panic!("unexpected non-handshake message {:?}", msg),
+            _ => panic!("unexpected non-handshake message {msg:?}"),
         };
         Altered::InPlace
     };
@@ -6059,7 +6056,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     do_handshake_until_error(&mut client, &mut server).unwrap();
 
     let ops = shared_storage.ops_and_reset();
-    println!("storage {:#?}", ops);
+    println!("storage {ops:#?}");
     assert_eq!(ops.len(), 10);
     assert!(matches!(ops[5], ClientStorageOp::InsertTls13Ticket(_)));
     assert!(matches!(ops[6], ClientStorageOp::InsertTls13Ticket(_)));
@@ -6090,7 +6087,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     server.process_new_packets().unwrap();
 
     let ops = shared_storage.ops_and_reset();
-    println!("last {:?}", ops);
+    println!("last {ops:?}");
     assert!(matches!(ops[0], ClientStorageOp::TakeTls13Ticket(_, false)));
 }
 
@@ -6134,7 +6131,7 @@ fn test_client_mtu_reduction() {
         let mut client =
             ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
         let writes = collect_write_lengths(&mut client);
-        println!("writes at mtu=64: {:?}", writes);
+        println!("writes at mtu=64: {writes:?}");
         assert!(writes.iter().all(|x| *x <= 64));
         assert!(writes.len() > 1);
     }
@@ -6250,7 +6247,7 @@ fn handshakes_complete_and_data_flows_with_gratuitious_max_fragment_sizes() {
 
 fn assert_lt(left: usize, right: usize) {
     if left >= right {
-        panic!("expected {} < {}", left, right);
+        panic!("expected {left} < {right}");
     }
 }
 
@@ -6395,7 +6392,7 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
 fn test_client_rejects_illegal_tls13_ccs() {
     fn corrupt_ccs(msg: &mut Message) -> Altered {
         if let MessagePayload::ChangeCipherSpec(_) = &mut msg.payload {
-            println!("seen CCS {:?}", msg);
+            println!("seen CCS {msg:?}");
             return Altered::Raw(encoding::message_framing(
                 ContentType::ChangeCipherSpec,
                 ProtocolVersion::TLSv1_2,

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -1084,8 +1084,7 @@ impl ServerCertVerifier for MockServerVerifier {
         now: UnixTime,
     ) -> Result<ServerCertVerified, Error> {
         println!(
-            "verify_server_cert({:?}, {:?}, {:?}, {:?}, {:?})",
-            end_entity, intermediates, server_name, ocsp_response, now
+            "verify_server_cert({end_entity:?}, {intermediates:?}, {server_name:?}, {ocsp_response:?}, {now:?})"
         );
         if let Some(expected_ocsp) = &self.expected_ocsp_response {
             assert_eq!(expected_ocsp, ocsp_response);
@@ -1102,10 +1101,7 @@ impl ServerCertVerifier for MockServerVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
-        println!(
-            "verify_tls12_signature({:?}, {:?}, {:?})",
-            message, cert, dss
-        );
+        println!("verify_tls12_signature({message:?}, {cert:?}, {dss:?})");
         match &self.tls12_signature_error {
             Some(error) => Err(error.clone()),
             _ => Ok(HandshakeSignatureValid::assertion()),
@@ -1118,10 +1114,7 @@ impl ServerCertVerifier for MockServerVerifier {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, Error> {
-        println!(
-            "verify_tls13_signature({:?}, {:?}, {:?})",
-            message, cert, dss
-        );
+        println!("verify_tls13_signature({message:?}, {cert:?}, {dss:?})");
         match &self.tls13_signature_error {
             Some(error) => Err(error.clone()),
             _ if self.requires_raw_public_keys => verify_tls13_signature_with_raw_key(

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1107,7 +1107,7 @@ fn advance_client(
     let UnbufferedStatus { discard, state } = conn.process_tls_records(buffers.incoming.filled());
     let state = state.unwrap();
 
-    transcript.push(format!("{:?}", state));
+    transcript.push(format!("{state:?}"));
 
     let state = match state {
         ConnectionState::TransmitTlsData(mut state) => {
@@ -1152,7 +1152,7 @@ fn advance_server(
     let UnbufferedStatus { discard, state } = conn.process_tls_records(buffers.incoming.filled());
     let state = state.unwrap();
 
-    transcript.push(format!("{:?}", state));
+    transcript.push(format!("{state:?}"));
 
     let state = match state {
         ConnectionState::ReadEarlyData(mut state) => {
@@ -1424,7 +1424,7 @@ fn server_receives_handshake_byte_by_byte() {
         _ => panic!("unexpected first client event"),
     };
 
-    println!("client hello: {:?}", client_hello_buffer);
+    println!("client hello: {client_hello_buffer:?}");
 
     for prefix in 0..client_hello_buffer.len() - 1 {
         let UnbufferedStatus { discard, state } =


### PR DESCRIPTION
The first two commits fix the [clippy task failing for `main`](https://github.com/rustls/rustls/actions/runs/15052009760/job/42308873568) from new findings spit out by the brand new [1.87 release](https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/). The third commit fixes nightly clippy for me locally. If it's too noisy of a diff we can drop the 3rd commit and take only the 1st/2nd for now.