### PR TITLE
Enable more lints on internal crates

### DIFF
--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -12,7 +12,7 @@ use rustls_test::KeyType;
 /// Benchmarks can be invalid because of the following reasons:
 ///
 /// - Re-using an already defined benchmark name.
-pub fn validate_benchmarks(benchmarks: &[Benchmark]) -> anyhow::Result<()> {
+pub(crate) fn validate_benchmarks(benchmarks: &[Benchmark]) -> anyhow::Result<()> {
     // Detect duplicate definitions
     let duplicate_names: Vec<_> = benchmarks
         .iter()
@@ -30,7 +30,7 @@ pub fn validate_benchmarks(benchmarks: &[Benchmark]) -> anyhow::Result<()> {
 }
 
 /// Get the reported instruction counts for the provided benchmark
-pub fn get_reported_instr_count(
+pub(crate) fn get_reported_instr_count(
     bench: &Benchmark,
     results: &FxHashMap<&str, InstructionCounts>,
 ) -> InstructionCounts {
@@ -50,8 +50,8 @@ impl BenchmarkKind {
     /// Returns the [`ResumptionKind`] used in the handshake part of the benchmark
     pub fn resumption_kind(self) -> ResumptionKind {
         match self {
-            BenchmarkKind::Handshake(kind) => kind,
-            BenchmarkKind::Transfer => ResumptionKind::No,
+            Self::Handshake(kind) => kind,
+            Self::Transfer => ResumptionKind::No,
         }
     }
 }
@@ -68,7 +68,7 @@ pub enum ResumptionKind {
 }
 
 impl ResumptionKind {
-    pub const ALL: &'static [ResumptionKind] = &[Self::No, Self::SessionId, Self::Tickets];
+    pub const ALL: &'static [Self] = &[Self::No, Self::SessionId, Self::Tickets];
 
     /// Returns a user-facing label that identifies the resumption kind
     pub fn label(&self) -> &'static str {

--- a/openssl-tests/src/ffdhe.rs
+++ b/openssl-tests/src/ffdhe.rs
@@ -7,11 +7,11 @@ use rustls::ffdhe_groups::FfdheGroup;
 use rustls::{CipherSuite, NamedGroup, SupportedCipherSuite, Tls12CipherSuite};
 
 /// The (test-only) TLS1.2 ciphersuite TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
-pub static TLS_DHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
+pub(crate) static TLS_DHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
     SupportedCipherSuite::Tls12(&TLS12_DHE_RSA_WITH_AES_128_GCM_SHA256);
 
 #[derive(Debug)]
-pub struct FfdheKxGroup(pub NamedGroup, pub FfdheGroup<'static>);
+pub(crate) struct FfdheKxGroup(pub NamedGroup, pub FfdheGroup<'static>);
 
 impl SupportedKxGroup for FfdheKxGroup {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, rustls::Error> {

--- a/openssl-tests/src/lib.rs
+++ b/openssl-tests/src/lib.rs
@@ -1,4 +1,19 @@
 #![cfg(test)]
+#![warn(
+    clippy::alloc_instead_of_core,
+    clippy::clone_on_ref_ptr,
+    clippy::manual_let_else,
+    clippy::std_instead_of_core,
+    clippy::use_self,
+    clippy::upper_case_acronyms,
+    elided_lifetimes_in_paths,
+    trivial_casts,
+    trivial_numeric_casts,
+    unreachable_pub,
+    unused_import_braces,
+    unused_extern_crates,
+    unused_qualifications
+)]
 
 mod ffdhe;
 mod ffdhe_kx_with_openssl;

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -90,11 +90,9 @@ mod client {
 
     impl SimpleRpkServerCertVerifier {
         fn new(trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>) -> Self {
-            SimpleRpkServerCertVerifier {
+            Self {
                 trusted_spki,
-                supported_algs: Arc::new(provider::default_provider())
-                    .clone()
-                    .signature_verification_algorithms,
+                supported_algs: provider::default_provider().signature_verification_algorithms,
             }
         }
     }
@@ -107,15 +105,13 @@ mod client {
             _server_name: &ServerName<'_>,
             _ocsp_response: &[u8],
             _now: UnixTime,
-        ) -> Result<ServerCertVerified, rustls::Error> {
+        ) -> Result<ServerCertVerified, Error> {
             let end_entity_as_spki = SubjectPublicKeyInfoDer::from(end_entity.as_ref());
             match self
                 .trusted_spki
                 .contains(&end_entity_as_spki)
             {
-                false => Err(rustls::Error::InvalidCertificate(
-                    CertificateError::UnknownIssuer,
-                )),
+                false => Err(Error::InvalidCertificate(CertificateError::UnknownIssuer)),
                 true => Ok(ServerCertVerified::assertion()),
             }
         }
@@ -125,10 +121,8 @@ mod client {
             _message: &[u8],
             _cert: &CertificateDer<'_>,
             _dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            Err(rustls::Error::PeerIncompatible(
-                PeerIncompatible::Tls12NotOffered,
-            ))
+        ) -> Result<HandshakeSignatureValid, Error> {
+            Err(Error::PeerIncompatible(PeerIncompatible::Tls12NotOffered))
         }
 
         fn verify_tls13_signature(
@@ -136,7 +130,7 @@ mod client {
             message: &[u8],
             cert: &CertificateDer<'_>,
             dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        ) -> Result<HandshakeSignatureValid, Error> {
             verify_tls13_signature_with_raw_key(
                 message,
                 &SubjectPublicKeyInfoDer::from(cert.as_ref()),
@@ -254,12 +248,10 @@ mod server {
     }
 
     impl SimpleRpkClientCertVerifier {
-        pub fn new(trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>) -> Self {
+        pub(crate) fn new(trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>) -> Self {
             Self {
                 trusted_spki,
-                supported_algs: Arc::new(provider::default_provider())
-                    .clone()
-                    .signature_verification_algorithms,
+                supported_algs: provider::default_provider().signature_verification_algorithms,
             }
         }
     }
@@ -274,15 +266,13 @@ mod server {
             end_entity: &CertificateDer<'_>,
             _intermediates: &[CertificateDer<'_>],
             _now: UnixTime,
-        ) -> Result<ClientCertVerified, rustls::Error> {
+        ) -> Result<ClientCertVerified, Error> {
             let end_entity_as_spki = SubjectPublicKeyInfoDer::from(end_entity.as_ref());
             match self
                 .trusted_spki
                 .contains(&end_entity_as_spki)
             {
-                false => Err(rustls::Error::InvalidCertificate(
-                    CertificateError::UnknownIssuer,
-                )),
+                false => Err(Error::InvalidCertificate(CertificateError::UnknownIssuer)),
                 true => Ok(ClientCertVerified::assertion()),
             }
         }
@@ -292,10 +282,8 @@ mod server {
             _message: &[u8],
             _cert: &CertificateDer<'_>,
             _dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            Err(rustls::Error::PeerIncompatible(
-                PeerIncompatible::Tls12NotOffered,
-            ))
+        ) -> Result<HandshakeSignatureValid, Error> {
+            Err(Error::PeerIncompatible(PeerIncompatible::Tls12NotOffered))
         }
 
         fn verify_tls13_signature(
@@ -303,7 +291,7 @@ mod server {
             message: &[u8],
             cert: &CertificateDer<'_>,
             dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        ) -> Result<HandshakeSignatureValid, Error> {
             verify_tls13_signature_with_raw_key(
                 message,
                 &SubjectPublicKeyInfoDer::from(cert.as_ref()),

--- a/openssl-tests/src/utils.rs
+++ b/openssl-tests/src/utils.rs
@@ -1,6 +1,6 @@
 use once_cell::sync::Lazy;
 
-pub fn verify_openssl3_available() {
+pub(crate) fn verify_openssl3_available() {
     static VERIFIED: Lazy<()> = Lazy::new(verify_openssl3_available_internal);
     *VERIFIED
 }
@@ -15,11 +15,11 @@ fn verify_openssl3_available_internal() {
             panic!(
                 "OpenSSL exited with an error status: {}\n{}",
                 output.status,
-                std::str::from_utf8(&output.stderr).unwrap_or_default()
+                str::from_utf8(&output.stderr).unwrap_or_default()
             );
         }
         Ok(output) => {
-            let version_str = std::str::from_utf8(&output.stdout).unwrap();
+            let version_str = str::from_utf8(&output.stdout).unwrap();
             let parts = version_str
                 .split(' ')
                 .collect::<Vec<_>>();

--- a/openssl-tests/src/validate_ffdhe_params.rs
+++ b/openssl-tests/src/validate_ffdhe_params.rs
@@ -64,7 +64,7 @@ fn get_ffdhe_params_from_openssl(ffdhe_group: NamedGroup) -> (Vec<u8>, Vec<u8>) 
 
 /// Parse PEM-encoded DH parameters, returning `(p, g)`
 fn parse_dh_params_pem(data: &[u8]) -> (Vec<u8>, Vec<u8>) {
-    let output_str = std::str::from_utf8(data).unwrap();
+    let output_str = str::from_utf8(data).unwrap();
     let output_str_lines = output_str.lines().collect::<Vec<_>>();
     assert_eq!(output_str_lines[0], "-----BEGIN DH PARAMETERS-----");
 
@@ -86,10 +86,10 @@ fn parse_dh_params_pem(data: &[u8]) -> (Vec<u8>, Vec<u8>) {
         .unwrap();
 
     let res: asn1::ParseResult<_> = asn1::parse(&base64_decoded, |d| {
-        d.read_element::<asn1::Sequence>()?
+        d.read_element::<asn1::Sequence<'_>>()?
             .parse(|d| {
-                let p = d.read_element::<asn1::BigUint>()?;
-                let g = d.read_element::<asn1::BigUint>()?;
+                let p = d.read_element::<asn1::BigUint<'_>>()?;
+                let g = d.read_element::<asn1::BigUint<'_>>()?;
                 Ok((p, g))
             })
     });

--- a/provider-example/src/aead.rs
+++ b/provider-example/src/aead.rs
@@ -10,7 +10,7 @@ use rustls::crypto::cipher::{
 };
 use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};
 
-pub struct Chacha20Poly1305;
+pub(crate) struct Chacha20Poly1305;
 
 impl Tls13AeadAlgorithm for Chacha20Poly1305 {
     fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
@@ -83,7 +83,7 @@ struct Tls13Cipher(chacha20poly1305::ChaCha20Poly1305, Iv);
 impl MessageEncrypter for Tls13Cipher {
     fn encrypt(
         &mut self,
-        m: OutboundPlainMessage,
+        m: OutboundPlainMessage<'_>,
         seq: u64,
     ) -> Result<OutboundOpaqueMessage, rustls::Error> {
         let total_len = self.encrypted_payload_len(m.payload.len());
@@ -134,7 +134,7 @@ struct Tls12Cipher(chacha20poly1305::ChaCha20Poly1305, Iv);
 impl MessageEncrypter for Tls12Cipher {
     fn encrypt(
         &mut self,
-        m: OutboundPlainMessage,
+        m: OutboundPlainMessage<'_>,
         seq: u64,
     ) -> Result<OutboundOpaqueMessage, rustls::Error> {
         let total_len = self.encrypted_payload_len(m.payload.len());

--- a/provider-example/src/hash.rs
+++ b/provider-example/src/hash.rs
@@ -3,7 +3,7 @@ use alloc::boxed::Box;
 use rustls::crypto::hash;
 use sha2::Digest;
 
-pub struct Sha256;
+pub(crate) struct Sha256;
 
 impl hash::Hash for Sha256 {
     fn start(&self) -> Box<dyn hash::Context> {
@@ -31,7 +31,7 @@ impl hash::Context for Sha256Context {
     }
 
     fn fork(&self) -> Box<dyn hash::Context> {
-        Box::new(Sha256Context(self.0.clone()))
+        Box::new(Self(self.0.clone()))
     }
 
     fn finish(self: Box<Self>) -> hash::Output {

--- a/provider-example/src/hmac.rs
+++ b/provider-example/src/hmac.rs
@@ -4,7 +4,7 @@ use hmac::{Hmac, Mac};
 use rustls::crypto;
 use sha2::{Digest, Sha256};
 
-pub struct Sha256Hmac;
+pub(crate) struct Sha256Hmac;
 
 impl crypto::hmac::Hmac for Sha256Hmac {
     fn with_key(&self, key: &[u8]) -> Box<dyn crypto::hmac::Key> {

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -212,7 +212,7 @@ impl HpkeOpener for HpkeRsReceiver {
 }
 
 #[cfg(feature = "std")]
-fn other_err(err: impl std::error::Error + Send + Sync + 'static) -> Error {
+fn other_err(err: impl core::error::Error + Send + Sync + 'static) -> Error {
     Error::Other(OtherError(alloc::sync::Arc::new(err)))
 }
 

--- a/provider-example/src/kx.rs
+++ b/provider-example/src/kx.rs
@@ -4,16 +4,13 @@ use crypto::SupportedKxGroup;
 use rustls::crypto;
 use rustls::ffdhe_groups::FfdheGroup;
 
-pub struct KeyExchange {
+pub(crate) struct KeyExchange {
     priv_key: x25519_dalek::EphemeralSecret,
     pub_key: x25519_dalek::PublicKey,
 }
 
 impl crypto::ActiveKeyExchange for KeyExchange {
-    fn complete(
-        self: Box<KeyExchange>,
-        peer: &[u8],
-    ) -> Result<crypto::SharedSecret, rustls::Error> {
+    fn complete(self: Box<Self>, peer: &[u8]) -> Result<crypto::SharedSecret, rustls::Error> {
         let peer_array: [u8; 32] = peer
             .try_into()
             .map_err(|_| rustls::Error::from(rustls::PeerMisbehaved::InvalidKeyShare))?;
@@ -35,12 +32,12 @@ impl crypto::ActiveKeyExchange for KeyExchange {
     }
 }
 
-pub const ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[&X25519 as &dyn SupportedKxGroup];
+pub(crate) const ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[&X25519];
 
 #[derive(Debug)]
-pub struct X25519;
+pub(crate) struct X25519;
 
-impl crypto::SupportedKxGroup for X25519 {
+impl SupportedKxGroup for X25519 {
     fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::Error> {
         let priv_key = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
         Ok(Box::new(KeyExchange {

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -1,4 +1,19 @@
 #![no_std]
+#![warn(
+    clippy::alloc_instead_of_core,
+    clippy::clone_on_ref_ptr,
+    clippy::manual_let_else,
+    clippy::std_instead_of_core,
+    clippy::use_self,
+    clippy::upper_case_acronyms,
+    elided_lifetimes_in_paths,
+    trivial_casts,
+    trivial_numeric_casts,
+    unreachable_pub,
+    unused_import_braces,
+    unused_extern_crates,
+    unused_qualifications
+)]
 
 extern crate alloc;
 #[cfg(feature = "std")]

--- a/provider-example/src/sign.rs
+++ b/provider-example/src/sign.rs
@@ -9,7 +9,7 @@ use rustls::{SignatureAlgorithm, SignatureScheme};
 use signature::{RandomizedSigner, SignatureEncoding};
 
 #[derive(Clone, Debug)]
-pub struct EcdsaSigningKeyP256 {
+pub(crate) struct EcdsaSigningKeyP256 {
     key: Arc<p256::ecdsa::SigningKey>,
     scheme: SignatureScheme,
 }

--- a/provider-example/src/verify.rs
+++ b/provider-example/src/verify.rs
@@ -7,7 +7,7 @@ use rustls::pki_types::{
     AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm, alg_id,
 };
 
-pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+pub(crate) static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[RSA_PSS_SHA256, RSA_PKCS1_SHA256],
     mapping: &[
         (SignatureScheme::RSA_PSS_SHA256, &[RSA_PSS_SHA256]),
@@ -78,7 +78,7 @@ fn decode_spki_spk(spki_spk: &[u8]) -> Result<RsaPublicKey, InvalidSignature> {
     // public_key: unfortunately this is not a whole SPKI, but just the key material.
     // decode the two integers manually.
     let mut reader = der::SliceReader::new(spki_spk).map_err(|_| InvalidSignature)?;
-    let ne: [der::asn1::UintRef; 2] = reader
+    let ne: [der::asn1::UintRef<'_>; 2] = reader
         .decode()
         .map_err(|_| InvalidSignature)?;
 


### PR DESCRIPTION
Internal crates now enable the default-allow lints that the core crate does, with the exception of ones about documentation for public items.