### PR TITLE
Fix "Format (unstable)" job in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -445,10 +445,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rust nightly toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-          toolchain: nightly-2024-02-21
       - name: Check formatting (unstable)
         run: cargo fmt --all -- --check --config-path .rustfmt.unstable.toml
         continue-on-error: true

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,3 @@
+# keep in sync with .rustfmt.unstable.toml
 chain_width = 40
 style_edition = "2024"

--- a/.rustfmt.unstable.toml
+++ b/.rustfmt.unstable.toml
@@ -1,5 +1,6 @@
 # keep in sync with .rustfmt.toml
 chain_width = 40
+style_edition = "2024"
 
 # format imports
 group_imports = "StdExternalCrate"

--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use fxhash::FxHashMap;
 use itertools::Itertools;
+use rustls_test::KeyType;
 
 use crate::Side;
 use crate::callgrind::InstructionCounts;
-use rustls_test::KeyType;
 
 /// Validates a benchmark collection, returning an error if the provided benchmarks are invalid
 ///

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -16,14 +16,7 @@
 
 use core::ops::DerefMut;
 use std::io;
-use std::sync::Arc;
-use std::sync::OnceLock;
-
-use rustls::pki_types::pem::PemObject;
-use rustls::pki_types::{
-    CertificateDer, CertificateRevocationListDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName,
-    SubjectPublicKeyInfoDer, UnixTime,
-};
+use std::sync::{Arc, OnceLock};
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::{
@@ -36,6 +29,11 @@ use rustls::crypto::{
 };
 use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::message::{Message, OutboundOpaqueMessage, PlainMessage};
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{
+    CertificateDer, CertificateRevocationListDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName,
+    SubjectPublicKeyInfoDer, UnixTime,
+};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::server::{
     AlwaysResolvesServerRawPublicKeys, ClientCertVerifierBuilder, UnbufferedServerConnection,

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -1,13 +1,12 @@
 #![cfg(feature = "ring")]
 #![allow(clippy::disallowed_types)]
 
-use bencher::{Bencher, benchmark_group, benchmark_main};
-use rustls::crypto::ring as provider;
-
 use std::io;
 use std::sync::Arc;
 
+use bencher::{Bencher, benchmark_group, benchmark_main};
 use rustls::ServerConnection;
+use rustls::crypto::ring as provider;
 use rustls_test::{FailsReads, KeyType, make_server_config};
 
 fn bench_ewouldblock(c: &mut Bencher) {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -6,10 +6,9 @@ use core::ops::Deref;
 
 use pki_types::ServerName;
 
-use super::ResolvesClientCert;
-use super::Tls12Resumption;
 #[cfg(feature = "tls12")]
 use super::tls12;
+use super::{ResolvesClientCert, Tls12Resumption};
 use crate::SupportedCipherSuite;
 #[cfg(feature = "logging")]
 use crate::bs_debug;
@@ -29,12 +28,10 @@ use crate::msgs::base::Payload;
 use crate::msgs::enums::{
     CertificateType, Compression, ECPointFormat, ExtensionType, PskKeyExchangeMode,
 };
-use crate::msgs::handshake::ProtocolName;
-use crate::msgs::handshake::SupportedProtocolVersions;
 use crate::msgs::handshake::{
     CertificateStatusRequest, ClientExtension, ClientHelloPayload, ClientSessionTicket,
     HandshakeMessagePayload, HandshakePayload, HasServerExtensions, HelloRetryRequest,
-    KeyShareEntry, Random, SessionId,
+    KeyShareEntry, ProtocolName, Random, SessionId, SupportedProtocolVersions,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -2,9 +2,10 @@ use alloc::boxed::Box;
 use core::fmt::Debug;
 use core::mem;
 use core::ops::{Deref, DerefMut, Range};
-use kernel::KernelConnection;
 #[cfg(feature = "std")]
 use std::io;
+
+use kernel::KernelConnection;
 
 use crate::common_state::{CommonState, Context, DEFAULT_BUFFER_LIMIT, IoState, State};
 use crate::enums::{AlertDescription, ContentType, ProtocolVersion};

--- a/rustls/src/conn/kernel.rs
+++ b/rustls/src/conn/kernel.rs
@@ -53,9 +53,8 @@
 //! [`CipherSuiteCommon::confidentiality_limit`]: crate::CipherSuiteCommon::confidentiality_limit
 //! [`KernelConnection`]: crate::kernel::KernelConnection
 
-use core::marker::PhantomData;
-
 use alloc::boxed::Box;
+use core::marker::PhantomData;
 
 use crate::client::ClientConnectionData;
 use crate::common_state::Protocol;

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -4,14 +4,13 @@ use core::fmt::Debug;
 
 use pki_types::{AlgorithmIdentifier, CertificateDer, PrivateKeyDer, SubjectPublicKeyInfoDer};
 
+use super::CryptoProvider;
 use crate::client::ResolvesClientCert;
 use crate::enums::{SignatureAlgorithm, SignatureScheme};
 use crate::error::{Error, InconsistentKeys};
 use crate::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
 use crate::sync::Arc;
 use crate::x509;
-
-use super::CryptoProvider;
 
 /// An abstract signing key.
 ///

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -950,12 +950,13 @@ mod tests {
     use std::prelude::v1::*;
     use std::{println, vec};
 
+    use pki_types::ServerName;
+
     use super::{
         CertRevocationListError, Error, InconsistentKeys, InvalidMessage, OtherError, UnixTime,
     };
     #[cfg(feature = "std")]
     use crate::sync::Arc;
-    use pki_types::ServerName;
 
     #[test]
     fn certificate_error_equality() {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -545,10 +545,9 @@ pub mod unbuffered {
 // The public interface is:
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier, WantsVersions};
 pub use crate::common_state::{CommonState, HandshakeKind, IoState, Side};
-pub use crate::conn::kernel;
 #[cfg(feature = "std")]
 pub use crate::conn::{Connection, Reader, Writer};
-pub use crate::conn::{ConnectionCommon, SideData};
+pub use crate::conn::{ConnectionCommon, SideData, kernel};
 pub use crate::enums::{
     AlertDescription, CertificateCompressionAlgorithm, CipherSuite, ContentType, HandshakeType,
     ProtocolVersion, SignatureAlgorithm, SignatureScheme,

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -10,7 +10,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{fmt, mem};
 
 use pki_types::{CertificateDer, IpAddr, ServerName, UnixTime};
-
 use rustls::client::{ResolvesClientCert, Resumption, verify_server_cert_signed_by_trust_anchor};
 use rustls::crypto::{ActiveKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup};
 use rustls::internal::msgs::base::Payload;

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -12,7 +12,6 @@ use common::{
     make_client_config_with_versions_with_auth, make_pair_for_arc_configs, server_config_builder,
     server_name,
 };
-
 use rustls::server::danger::ClientCertVerified;
 use rustls::{
     AlertDescription, ClientConnection, Error, InvalidMessage, ServerConfig, ServerConnection,

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -12,9 +12,7 @@ use common::{
     do_handshake_until_error, make_client_config_with_versions, make_pair_for_arc_configs,
     make_server_config, server_config_builder, transfer_altered,
 };
-
 use pki_types::{CertificateDer, ServerName};
-
 use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
@@ -26,7 +24,6 @@ use rustls::{
     AlertDescription, CertificateError, DigitallySignedStruct, DistinguishedName, Error,
     InvalidMessage, RootCertStore,
 };
-
 use x509_parser::prelude::FromDer;
 use x509_parser::x509::X509Name;
 


### PR DESCRIPTION
This has been quietly complaining to itself[^1] for a little bit since 177cb0cef4d97b09335948b9265112deb03f2b23 as it wanted to undo the `style_edition = "2024"` changes. Fix that, and then do a pass tidying imports.

[^1]:  recall it is a `continue-on-error` job to avoid actually relying on the behaviour of nightly rustfmt