### PR TITLE
Fix bug in crypto::aws_lc_rs::pq::hybrid::Layout

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/pq/hybrid.rs
+++ b/rustls/src/crypto/aws_lc_rs/pq/hybrid.rs
@@ -174,6 +174,7 @@ impl Layout {
         self.split(share, self.post_quantum_server_share_len)
     }
 
+    /// Return the PQ and classical component of a key share.
     fn split<'a>(
         &self,
         share: &'a [u8],
@@ -184,8 +185,14 @@ impl Layout {
         }
 
         Some(match self.post_quantum_first {
-            true => share.split_at(post_quantum_share_len),
-            false => share.split_at(self.classical_share_len),
+            true => {
+                let (first_share, second_share) = share.split_at(post_quantum_share_len);
+                (first_share, second_share)
+            }
+            false => {
+                let (first_share, second_share) = share.split_at(self.classical_share_len);
+                (second_share, first_share)
+            }
         })
     }
 


### PR DESCRIPTION
The share splitter function swaps the order of the shares whenever `post_quantum_first` is `true`.