### PR TITLE
Disable `clippy::clone_on_ref_ptr` lint

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -6,7 +6,6 @@
 
 #![warn(
     clippy::alloc_instead_of_core,
-    clippy::clone_on_ref_ptr,
     clippy::manual_let_else,
     clippy::std_instead_of_core,
     clippy::use_self,

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -1,6 +1,5 @@
 #![warn(
     clippy::alloc_instead_of_core,
-    clippy::clone_on_ref_ptr,
     clippy::manual_let_else,
     clippy::std_instead_of_core,
     clippy::use_self,

--- a/openssl-tests/src/lib.rs
+++ b/openssl-tests/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg(test)]
 #![warn(
     clippy::alloc_instead_of_core,
-    clippy::clone_on_ref_ptr,
     clippy::manual_let_else,
     clippy::std_instead_of_core,
     clippy::use_self,

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![warn(
     clippy::alloc_instead_of_core,
-    clippy::clone_on_ref_ptr,
     clippy::manual_let_else,
     clippy::std_instead_of_core,
     clippy::use_self,

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -4,7 +4,6 @@
 // etc. because it's unstable at the time of writing.
 #![warn(
     clippy::alloc_instead_of_core,
-    clippy::clone_on_ref_ptr,
     clippy::manual_let_else,
     clippy::std_instead_of_core,
     clippy::use_self,

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(
     clippy::alloc_instead_of_core,
-    clippy::clone_on_ref_ptr,
     clippy::manual_let_else,
     clippy::std_instead_of_core,
     clippy::use_self,

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(
     clippy::alloc_instead_of_core,
-    clippy::clone_on_ref_ptr,
     clippy::manual_let_else,
     clippy::std_instead_of_core,
     clippy::use_self,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -333,7 +333,6 @@
 #![cfg_attr(not(any(read_buf, bench, coverage_nightly)), forbid(unstable_features))]
 #![warn(
     clippy::alloc_instead_of_core,
-    clippy::clone_on_ref_ptr,
     clippy::manual_let_else,
     clippy::std_instead_of_core,
     clippy::use_self,


### PR DESCRIPTION
This is not contributing significantly to code quality.

In cases where an `Arc<T>` is cloned into an upcast of `Arc<dyn Trait>` (where `T: Trait`) it actively makes the code less readable by forcing the repetition of `Arc::<T>::clone`.

Upstream issue: https://github.com/rust-lang/rust-clippy/issues/2048

I looked into moving our lint configuration in the workspace's Cargo.toml, but actually it would mean reading three files (both lib.rs, and two Cargo.tomls) to determine which lints applied. Unfortunately you cannot layer lints just in Cargo.toml -- upstream issue for that is https://github.com/rust-lang/cargo/issues/13157