### PR TITLE
feat: expose the number of received TLS1.3 resumption tickets

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -774,6 +774,11 @@ mod connection {
             self.inner.core.data.ech_status
         }
 
+        /// Returns the number of TLS1.3 tickets that have been received.
+        pub fn tls13_tickets_received(&self) -> u32 {
+            self.inner.tls13_tickets_received
+        }
+
         /// Return true if the connection was made with a `ClientConfig` that is FIPS compatible.
         ///
         /// This is different from [`crate::crypto::CryptoProvider::fips()`]:
@@ -918,6 +923,11 @@ impl UnbufferedClientConnection {
         self.inner
             .core
             .dangerous_into_kernel_connection()
+    }
+
+    /// Returns the number of TLS1.3 tickets that have been received.
+    pub fn tls13_tickets_received(&self) -> u32 {
+        self.inner.tls13_tickets_received
     }
 }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1527,6 +1527,10 @@ impl ExpectTraffic {
             protocol: cx.common.protocol,
             quic: &cx.common.quic,
         };
+        cx.common.tls13_tickets_received = cx
+            .common
+            .tls13_tickets_received
+            .saturating_add(1);
         self.handle_new_ticket_impl(&mut kcx, nst)
     }
 

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -60,6 +60,7 @@ pub struct CommonState {
     temper_counters: TemperCounters,
     pub(crate) refresh_traffic_keys_pending: bool,
     pub(crate) fips: bool,
+    pub(crate) tls13_tickets_received: u32,
 }
 
 impl CommonState {
@@ -92,6 +93,7 @@ impl CommonState {
             temper_counters: TemperCounters::default(),
             refresh_traffic_keys_pending: false,
             fips: false,
+            tls13_tickets_received: 0,
         }
     }
 

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -219,6 +219,11 @@ mod connection {
         pub fn is_early_data_accepted(&self) -> bool {
             self.inner.core.is_early_data_accepted()
         }
+
+        /// Returns the number of TLS1.3 tickets that have been received.
+        pub fn tls13_tickets_received(&self) -> u32 {
+            self.inner.tls13_tickets_received
+        }
     }
 
     impl Deref for ClientConnection {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4753,6 +4753,7 @@ fn tls13_stateful_resumption() {
     // full handshake
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
     let (full_c2s, full_s2c) = do_handshake(&mut client, &mut server);
+    assert_eq!(client.tls13_tickets_received(), 2);
     assert_eq!(storage.puts(), 2);
     assert_eq!(storage.gets(), 0);
     assert_eq!(storage.takes(), 0);
@@ -5234,6 +5235,7 @@ mod test_quic {
         assert!(!server.is_handshaking());
         assert!(compatible_keys(&server_1rtt, &client_1rtt));
         assert!(!compatible_keys(&server_hs, &server_1rtt));
+
         assert!(
             step(&mut client, &mut server)
                 .unwrap()
@@ -5244,6 +5246,7 @@ mod test_quic {
                 .unwrap()
                 .is_none()
         );
+        assert_eq!(client.tls13_tickets_received(), 2);
 
         // 0-RTT handshake
         let mut client = quic::ClientConnection::new(
@@ -5286,7 +5289,6 @@ mod test_quic {
             .unwrap()
             .unwrap();
         assert!(client.is_early_data_accepted());
-
         // 0-RTT rejection
         {
             let client_config = (*client_config).clone();

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -216,11 +216,19 @@ fn early_data() {
     let client_config = Arc::new(client_config);
 
     // first handshake allows the second to be a resumption and use 0-RTT
-    run(
+    let outcome = run(
         client_config.clone(),
         &mut NO_ACTIONS.clone(),
         server_config.clone(),
         &mut NO_ACTIONS.clone(),
+    );
+
+    assert_eq!(
+        outcome
+            .client
+            .unwrap()
+            .tls13_tickets_received(),
+        2
     );
 
     let mut client_actions = Actions {


### PR DESCRIPTION
This adds a public function to get the count of TLS1.3 resumption tickets that were received in a client-side rustls session.

Currently, this information is not available outside of the session store. Downstream users may want to access this, though, to keep a connection open until tickets are received. When doing a 0RTT connection, it may happen that the application-side logic is done before the tickets are received. In that case, if expecting to do further 0rtt connections in the future, it may be beneficial to keep the connection open until the tickets are received. With this patch, this is possible without having to wrap or hack around the session store.