### PR TITLE
Eliminate redundant `HandshakeMessagePayload::typ` field 

### DIFF
--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -10,10 +10,9 @@ use crate::msgs::message::MessagePayload;
 macro_rules! require_handshake_msg(
   ( $m:expr, $handshake_type:path, $payload_type:path ) => (
     match &$m.payload {
-        MessagePayload::Handshake { parsed: $crate::msgs::handshake::HandshakeMessagePayload {
-            payload: $payload_type(hm),
-            ..
-        }, .. } => Ok(hm),
+        MessagePayload::Handshake { parsed: $crate::msgs::handshake::HandshakeMessagePayload(
+            $payload_type(hm),
+        ), .. } => Ok(hm),
         payload => Err($crate::check::inappropriate_handshake_message(
             payload,
             &[$crate::ContentType::Handshake],
@@ -26,10 +25,9 @@ macro_rules! require_handshake_msg(
 macro_rules! require_handshake_msg_move(
   ( $m:expr, $handshake_type:path, $payload_type:path ) => (
     match $m.payload {
-        MessagePayload::Handshake { parsed: $crate::msgs::handshake::HandshakeMessagePayload {
-            payload: $payload_type(hm),
-            ..
-        }, .. } => Ok(hm),
+        MessagePayload::Handshake { parsed: $crate::msgs::handshake::HandshakeMessagePayload(
+            $payload_type(hm),
+        ), .. } => Ok(hm),
         payload =>
             Err($crate::check::inappropriate_handshake_message(
                 &payload,
@@ -61,13 +59,14 @@ pub(crate) fn inappropriate_handshake_message(
 ) -> Error {
     match payload {
         MessagePayload::Handshake { parsed, .. } => {
+            let got_type = parsed.0.handshake_type();
             warn!(
                 "Received a {:?} handshake message while expecting {:?}",
-                parsed.typ, handshake_types
+                got_type, handshake_types
             );
             Error::InappropriateHandshakeMessage {
                 expect_types: handshake_types.to_vec(),
-                got_type: parsed.typ,
+                got_type,
             }
         }
         payload => inappropriate_message(payload, content_types),

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -504,10 +504,7 @@ fn emit_client_hello_for_retry(
         .map(ClientExtension::ext_type)
         .collect();
 
-    let mut chp = HandshakeMessagePayload {
-        typ: HandshakeType::ClientHello,
-        payload: HandshakePayload::ClientHello(chp_payload),
-    };
+    let mut chp = HandshakeMessagePayload(HandshakePayload::ClientHello(chp_payload));
 
     let tls13_early_data_key_schedule = match (ech_state.as_mut(), tls13_session) {
         // If we're performing ECH and resuming, then the PSK binder will have been dealt with
@@ -1187,21 +1184,13 @@ impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
     {
         match m.payload {
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::ServerHello(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::ServerHello(..)),
                 ..
             } => self
                 .into_expect_server_hello()
                 .handle(cx, m),
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::HelloRetryRequest(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::HelloRetryRequest(..)),
                 ..
             } => self.handle_hello_retry_request(cx, m),
             payload => Err(inappropriate_handshake_message(

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -7,7 +7,7 @@ use pki_types::{CertificateDer, ServerName};
 
 use crate::client::{ClientConfig, ClientConnection, Resumption, Tls12Resumption};
 use crate::crypto::CryptoProvider;
-use crate::enums::{CipherSuite, HandshakeType, ProtocolVersion, SignatureScheme};
+use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::msgs::base::PayloadU16;
 use crate::msgs::codec::Reader;
 use crate::msgs::enums::{Compression, NamedGroup};
@@ -93,9 +93,8 @@ mod tests {
         // server replies with HRR, but does not echo `session_id` as required.
         let hrr = Message {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::HelloRetryRequest,
-                payload: HandshakePayload::HelloRetryRequest(HelloRetryRequest {
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::HelloRetryRequest(HelloRetryRequest {
                     cipher_suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
                     legacy_version: ProtocolVersion::TLSv1_2,
                     session_id: SessionId::empty(),
@@ -103,7 +102,7 @@ mod tests {
                         1, 2, 3, 4,
                     ]))],
                 }),
-            }),
+            )),
         };
 
         conn.read_tls(&mut hrr.into_wire_bytes().as_slice())
@@ -138,9 +137,8 @@ mod tests {
 
         let sh = Message {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ServerHello,
-                payload: HandshakePayload::ServerHello(ServerHelloPayload {
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ServerHello(ServerHelloPayload {
                     random: Random::new(config.provider.secure_random).unwrap(),
                     compression_method: Compression::Null,
                     cipher_suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
@@ -148,7 +146,7 @@ mod tests {
                     session_id: SessionId::empty(),
                     extensions: vec![],
                 }),
-            }),
+            )),
         };
         conn.read_tls(&mut sh.into_wire_bytes().as_slice())
             .unwrap();
@@ -206,9 +204,8 @@ mod tests {
 
         let sh = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ServerHello,
-                payload: HandshakePayload::ServerHello(ServerHelloPayload {
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ServerHello(ServerHelloPayload {
                     random: Random([0u8; 32]),
                     compression_method: Compression::Null,
                     cipher_suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -216,7 +213,7 @@ mod tests {
                     session_id: SessionId::empty(),
                     extensions: vec![ServerExtension::ExtendedMasterSecretAck],
                 }),
-            }),
+            )),
         };
         conn.read_tls(&mut sh.into_wire_bytes().as_slice())
             .unwrap();
@@ -224,12 +221,11 @@ mod tests {
 
         let cert = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::Certificate,
-                payload: HandshakePayload::Certificate(CertificateChain(vec![
-                    CertificateDer::from(&b"does not matter"[..]),
-                ])),
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::Certificate(CertificateChain(vec![CertificateDer::from(
+                    &b"does not matter"[..],
+                )])),
+            )),
         };
         conn.read_tls(&mut cert.into_wire_bytes().as_slice())
             .unwrap();
@@ -237,9 +233,8 @@ mod tests {
 
         let server_kx = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ServerKeyExchange,
-                payload: HandshakePayload::ServerKeyExchange(ServerKeyExchangePayload::Known(
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ServerKeyExchange(ServerKeyExchangePayload::Known(
                     ServerKeyExchange {
                         dss: DigitallySignedStruct::new(
                             SignatureScheme::ECDSA_SHA1_Legacy,
@@ -254,7 +249,7 @@ mod tests {
                         }),
                     },
                 )),
-            }),
+            )),
         };
         conn.read_tls(&mut server_kx.into_wire_bytes().as_slice())
             .unwrap();
@@ -262,10 +257,9 @@ mod tests {
 
         let server_done = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ServerHelloDone,
-                payload: HandshakePayload::ServerHelloDone,
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ServerHelloDone,
+            )),
         };
         conn.read_tls(&mut server_done.into_wire_bytes().as_slice())
             .unwrap();
@@ -386,9 +380,8 @@ mod tests {
 
         let sh = Message {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ServerHello,
-                payload: HandshakePayload::ServerHello(ServerHelloPayload {
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ServerHello(ServerHelloPayload {
                     random: Random([0; 32]),
                     compression_method: Compression::Null,
                     cipher_suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
@@ -399,7 +392,7 @@ mod tests {
                         payload: PayloadU16::new(vec![0xaa; 32]),
                     })],
                 }),
-            }),
+            )),
         };
         conn.read_tls(&mut sh.into_wire_bytes().as_slice())
             .unwrap();
@@ -407,10 +400,9 @@ mod tests {
 
         let ee = Message {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::EncryptedExtensions,
-                payload: HandshakePayload::EncryptedExtensions(encrypted_extensions),
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::EncryptedExtensions(encrypted_extensions),
+            )),
         };
 
         let mut encrypter = fake_server_crypto.server_handshake_encrypter();
@@ -662,11 +654,7 @@ fn client_hello_sent_for_config(config: ClientConfig) -> Result<ClientHelloPaylo
         Message {
             payload:
                 MessagePayload::Handshake {
-                    parsed:
-                        HandshakeMessagePayload {
-                            payload: HandshakePayload::ClientHello(ch),
-                            ..
-                        },
+                    parsed: HandshakeMessagePayload(HandshakePayload::ClientHello(ch)),
                     ..
                 },
             ..

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -280,11 +280,7 @@ impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx<'_> {
     {
         match m.payload {
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::ServerKeyExchange(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::ServerKeyExchange(..)),
                 ..
             } => Box::new(ExpectServerKx {
                 config: self.config,
@@ -300,11 +296,7 @@ impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx<'_> {
             })
             .handle(cx, m),
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::CertificateStatus(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::CertificateStatus(..)),
                 ..
             } => Box::new(ExpectCertificateStatus {
                 config: self.config,
@@ -506,10 +498,9 @@ fn emit_certificate(
 ) {
     let cert = Message {
         version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::handshake(HandshakeMessagePayload {
-            typ: HandshakeType::Certificate,
-            payload: HandshakePayload::Certificate(cert_chain),
-        }),
+        payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::Certificate(
+            cert_chain,
+        ))),
     };
 
     transcript.add_message(&cert);
@@ -536,10 +527,9 @@ fn emit_client_kx(
 
     let ckx = Message {
         version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::handshake(HandshakeMessagePayload {
-            typ: HandshakeType::ClientKeyExchange,
-            payload: HandshakePayload::ClientKeyExchange(pubkey),
-        }),
+        payload: MessagePayload::handshake(HandshakeMessagePayload(
+            HandshakePayload::ClientKeyExchange(pubkey),
+        )),
     };
 
     transcript.add_message(&ckx);
@@ -561,10 +551,9 @@ fn emit_certverify(
 
     let m = Message {
         version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::handshake(HandshakeMessagePayload {
-            typ: HandshakeType::CertificateVerify,
-            payload: HandshakePayload::CertificateVerify(body),
-        }),
+        payload: MessagePayload::handshake(HandshakeMessagePayload(
+            HandshakePayload::CertificateVerify(body),
+        )),
     };
 
     transcript.add_message(&m);
@@ -592,10 +581,9 @@ fn emit_finished(
 
     let f = Message {
         version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::handshake(HandshakeMessagePayload {
-            typ: HandshakeType::Finished,
-            payload: HandshakePayload::Finished(verify_data_payload),
-        }),
+        payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::Finished(
+            verify_data_payload,
+        ))),
     };
 
     transcript.add_message(&f);
@@ -645,10 +633,7 @@ impl State<ClientConnectionData> for ExpectServerDoneOrCertReq<'_> {
         if matches!(
             m.payload,
             MessagePayload::Handshake {
-                parsed: HandshakeMessagePayload {
-                    payload: HandshakePayload::CertificateRequest(_),
-                    ..
-                },
+                parsed: HandshakeMessagePayload(HandshakePayload::CertificateRequest(_)),
                 ..
             }
         ) {
@@ -812,11 +797,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
     {
         match m.payload {
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::ServerHelloDone,
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::ServerHelloDone),
                 ..
             } => {}
             payload => {

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -326,7 +326,7 @@ pub(super) fn fill_in_psk_binder(
     let key_schedule = KeyScheduleEarly::new(suite, resuming.secret());
     let real_binder = key_schedule.resumption_psk_binder_key_and_sign_verify_data(&handshake_hash);
 
-    if let HandshakePayload::ClientHello(ch) = &mut hmp.payload {
+    if let HandshakePayload::ClientHello(ch) = &mut hmp.0 {
         ch.set_psk_binder(real_binder.as_ref());
     };
 
@@ -607,11 +607,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrC
     {
         match m.payload {
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::CertificateTls13(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::CertificateTls13(..)),
                 ..
             } => Box::new(ExpectCertificate {
                 config: self.config,
@@ -626,11 +622,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrC
             })
             .handle(cx, m),
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::CompressedCertificate(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::CompressedCertificate(..)),
                 ..
             } => Box::new(ExpectCompressedCertificate {
                 config: self.config,
@@ -644,11 +636,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrC
             })
             .handle(cx, m),
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::CertificateRequestTls13(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::CertificateRequestTls13(..)),
                 ..
             } => Box::new(ExpectCertificateRequest {
                 config: self.config,
@@ -700,11 +688,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificate {
     {
         match m.payload {
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::CertificateTls13(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::CertificateTls13(..)),
                 ..
             } => Box::new(ExpectCertificate {
                 config: self.config,
@@ -719,11 +703,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificate {
             })
             .handle(cx, m),
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::CompressedCertificate(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::CompressedCertificate(..)),
                 ..
             } => Box::new(ExpectCompressedCertificate {
                 config: self.config,
@@ -773,11 +753,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
     {
         match m.payload {
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::CertificateTls13(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::CertificateTls13(..)),
                 ..
             } => Box::new(ExpectCertificate {
                 config: self.config,
@@ -792,11 +768,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
             })
             .handle(cx, m),
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::CertificateRequestTls13(..),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::CertificateRequestTls13(..)),
                 ..
             } => Box::new(ExpectCertificateRequest {
                 config: self.config,
@@ -1014,10 +986,9 @@ impl State<ClientConnectionData> for ExpectCompressedCertificate {
 
         let m = Message {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::Certificate,
-                payload: HandshakePayload::CertificateTls13(cert_payload.into_owned()),
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::CertificateTls13(cert_payload.into_owned()),
+            )),
         };
 
         Box::new(ExpectCertificate {
@@ -1229,10 +1200,9 @@ fn emit_compressed_certificate_tls13(
         return emit_certificate_tls13(flight, Some(certkey), auth_context);
     };
 
-    flight.add(HandshakeMessagePayload {
-        typ: HandshakeType::CompressedCertificate,
-        payload: HandshakePayload::CompressedCertificate(compressed.compressed_cert_payload()),
-    });
+    flight.add(HandshakeMessagePayload(
+        HandshakePayload::CompressedCertificate(compressed.compressed_cert_payload()),
+    ));
 }
 
 fn emit_certificate_tls13(
@@ -1246,10 +1216,9 @@ fn emit_certificate_tls13(
     let mut cert_payload = CertificatePayloadTls13::new(certs.iter(), None);
     cert_payload.context = PayloadU8::new(auth_context.unwrap_or_default());
 
-    flight.add(HandshakeMessagePayload {
-        typ: HandshakeType::Certificate,
-        payload: HandshakePayload::CertificateTls13(cert_payload),
-    });
+    flight.add(HandshakeMessagePayload(HandshakePayload::CertificateTls13(
+        cert_payload,
+    )));
 }
 
 fn emit_certverify_tls13(
@@ -1262,20 +1231,18 @@ fn emit_certverify_tls13(
     let sig = signer.sign(message.as_ref())?;
     let dss = DigitallySignedStruct::new(scheme, sig);
 
-    flight.add(HandshakeMessagePayload {
-        typ: HandshakeType::CertificateVerify,
-        payload: HandshakePayload::CertificateVerify(dss),
-    });
+    flight.add(HandshakeMessagePayload(
+        HandshakePayload::CertificateVerify(dss),
+    ));
     Ok(())
 }
 
 fn emit_finished_tls13(flight: &mut HandshakeFlightTls13<'_>, verify_data: &crypto::hmac::Tag) {
     let verify_data_payload = Payload::new(verify_data.as_ref());
 
-    flight.add(HandshakeMessagePayload {
-        typ: HandshakeType::Finished,
-        payload: HandshakePayload::Finished(verify_data_payload),
-    });
+    flight.add(HandshakeMessagePayload(HandshakePayload::Finished(
+        verify_data_payload,
+    )));
 }
 
 fn emit_end_of_early_data_tls13(transcript: &mut HandshakeHash, common: &mut CommonState) {
@@ -1285,10 +1252,9 @@ fn emit_end_of_early_data_tls13(transcript: &mut HandshakeHash, common: &mut Com
 
     let m = Message {
         version: ProtocolVersion::TLSv1_3,
-        payload: MessagePayload::handshake(HandshakeMessagePayload {
-            typ: HandshakeType::EndOfEarlyData,
-            payload: HandshakePayload::EndOfEarlyData,
-        }),
+        payload: MessagePayload::handshake(HandshakeMessagePayload(
+            HandshakePayload::EndOfEarlyData,
+        )),
     };
 
     transcript.add_message(&m);
@@ -1575,19 +1541,11 @@ impl State<ClientConnectionData> for ExpectTraffic {
                 .common
                 .take_received_plaintext(payload),
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::NewSessionTicketTls13(new_ticket),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::NewSessionTicketTls13(new_ticket)),
                 ..
             } => self.handle_new_ticket_tls13(cx, &new_ticket)?,
             MessagePayload::Handshake {
-                parsed:
-                    HandshakeMessagePayload {
-                        payload: HandshakePayload::KeyUpdate(key_update),
-                        ..
-                    },
+                parsed: HandshakeMessagePayload(HandshakePayload::KeyUpdate(key_update)),
                 ..
             } => self.handle_key_update(cx.common, &key_update)?,
             payload => {

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -189,7 +189,7 @@ mod tests {
     use super::provider::hash::SHA256;
     use super::*;
     use crate::crypto::hash::Hash;
-    use crate::enums::{HandshakeType, ProtocolVersion};
+    use crate::enums::ProtocolVersion;
     use crate::msgs::base::Payload;
     use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
 
@@ -214,10 +214,9 @@ mod tests {
         // handshake protocol encoding of 0x0e 00 00 00
         let server_hello_done_message = Message {
             version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ServerHelloDone,
-                payload: HandshakePayload::ServerHelloDone,
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ServerHelloDone,
+            )),
         };
 
         let app_data_ignored = Message {

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -158,7 +158,7 @@ impl<C: Cardinality> fmt::Debug for PayloadU16<C> {
 ///
 /// `C` controls the minimum length accepted when decoding.
 #[derive(Clone, Eq, PartialEq)]
-pub struct PayloadU8<C: Cardinality = MaybeEmpty>(pub(crate) Vec<u8>, PhantomData<C>);
+pub(crate) struct PayloadU8<C: Cardinality = MaybeEmpty>(pub(crate) Vec<u8>, PhantomData<C>);
 
 impl<C: Cardinality> PayloadU8<C> {
     pub(crate) fn encode_slice(slice: &[u8], bytes: &mut Vec<u8>) {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -67,7 +67,7 @@ macro_rules! wrapped_payload(
 );
 
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub struct Random(pub(crate) [u8; 32]);
+pub(crate) struct Random(pub(crate) [u8; 32]);
 
 impl fmt::Debug for Random {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -114,7 +114,7 @@ impl From<[u8; 32]> for Random {
 }
 
 #[derive(Copy, Clone)]
-pub struct SessionId {
+pub(crate) struct SessionId {
     len: usize,
     data: [u8; 32],
 }
@@ -164,7 +164,7 @@ impl Codec<'_> for SessionId {
 }
 
 impl SessionId {
-    pub fn random(secure_random: &dyn SecureRandom) -> Result<Self, rand::GetRandomFailed> {
+    pub(crate) fn random(secure_random: &dyn SecureRandom) -> Result<Self, rand::GetRandomFailed> {
         let mut data = [0u8; 32];
         secure_random.fill(&mut data)?;
         Ok(Self { data, len: 32 })
@@ -228,7 +228,7 @@ impl TlsListElement for SignatureScheme {
 }
 
 #[derive(Clone, Debug)]
-pub enum ServerNamePayload<'a> {
+pub(crate) enum ServerNamePayload<'a> {
     /// A successfully decoded value:
     SingleDnsName(DnsName<'a>),
 
@@ -357,7 +357,7 @@ impl HostNamePayload {
 
 wrapped_payload!(
     /// RFC7301: `opaque ProtocolName<1..2^8-1>;`
-    pub struct ProtocolName, PayloadU8<NonEmpty>,
+    pub(crate) struct ProtocolName, PayloadU8<NonEmpty>,
 );
 
 /// RFC7301: `ProtocolName protocol_name_list<2..2^16-1>`
@@ -369,7 +369,7 @@ impl TlsListElement for ProtocolName {
 
 /// RFC7301 encodes a single protocol name as `Vec<ProtocolName>`
 #[derive(Clone, Debug)]
-pub struct SingleProtocolName(ProtocolName);
+pub(crate) struct SingleProtocolName(ProtocolName);
 
 impl SingleProtocolName {
     pub(crate) fn new(bytes: Vec<u8>) -> Self {
@@ -409,14 +409,14 @@ impl AsRef<[u8]> for SingleProtocolName {
 
 // --- TLS 1.3 Key shares ---
 #[derive(Clone, Debug)]
-pub struct KeyShareEntry {
+pub(crate) struct KeyShareEntry {
     pub(crate) group: NamedGroup,
     /// RFC8446: `opaque key_exchange<1..2^16-1>;`
     pub(crate) payload: PayloadU16<NonEmpty>,
 }
 
 impl KeyShareEntry {
-    pub fn new(group: NamedGroup, payload: impl Into<Vec<u8>>) -> Self {
+    pub(crate) fn new(group: NamedGroup, payload: impl Into<Vec<u8>>) -> Self {
         Self {
             group,
             payload: PayloadU16::new(payload.into()),
@@ -489,7 +489,7 @@ impl TlsListElement for PresharedKeyBinder {
 }
 
 #[derive(Clone, Debug)]
-pub struct PresharedKeyOffer {
+pub(crate) struct PresharedKeyOffer {
     pub(crate) identities: Vec<PresharedKeyIdentity>,
     pub(crate) binders: Vec<PresharedKeyBinder>,
 }
@@ -527,7 +527,7 @@ impl TlsListElement for ResponderId {
 }
 
 #[derive(Clone, Debug)]
-pub struct OcspCertificateStatusRequest {
+pub(crate) struct OcspCertificateStatusRequest {
     pub(crate) responder_ids: Vec<ResponderId>,
     pub(crate) extensions: PayloadU16,
 }
@@ -548,7 +548,7 @@ impl Codec<'_> for OcspCertificateStatusRequest {
 }
 
 #[derive(Clone, Debug)]
-pub enum CertificateStatusRequest {
+pub(crate) enum CertificateStatusRequest {
     Ocsp(OcspCertificateStatusRequest),
     Unknown((CertificateStatusType, Payload<'static>)),
 }
@@ -612,7 +612,7 @@ impl TlsListElement for KeyShareEntry {
 ///
 /// RFC8446: `ProtocolVersion versions<2..254>;`
 #[derive(Clone, Copy, Debug, Default)]
-pub struct SupportedProtocolVersions {
+pub(crate) struct SupportedProtocolVersions {
     pub(crate) tls13: bool,
     pub(crate) tls12: bool,
 }
@@ -687,7 +687,7 @@ impl TlsListElement for CertificateCompressionAlgorithm {
 }
 
 #[derive(Clone, Debug)]
-pub enum ClientExtension {
+pub(crate) enum ClientExtension {
     EcPointFormats(Vec<ECPointFormat>),
     NamedGroups(Vec<NamedGroup>),
     SignatureAlgorithms(Vec<SignatureScheme>),
@@ -858,13 +858,13 @@ fn trim_hostname_trailing_dot_for_sni(dns_name: &DnsName<'_>) -> DnsName<'static
 }
 
 #[derive(Clone, Debug)]
-pub enum ClientSessionTicket {
+pub(crate) enum ClientSessionTicket {
     Request,
     Offer(Payload<'static>),
 }
 
 #[derive(Clone, Debug)]
-pub enum ServerExtension {
+pub(crate) enum ServerExtension {
     EcPointFormats(Vec<ECPointFormat>),
     ServerNameAck,
     SessionTicketAck,
@@ -986,13 +986,13 @@ impl ServerExtension {
 }
 
 #[derive(Clone, Debug)]
-pub struct ClientHelloPayload {
-    pub client_version: ProtocolVersion,
-    pub random: Random,
-    pub session_id: SessionId,
-    pub cipher_suites: Vec<CipherSuite>,
-    pub compression_methods: Vec<Compression>,
-    pub extensions: Vec<ClientExtension>,
+pub(crate) struct ClientHelloPayload {
+    pub(crate) client_version: ProtocolVersion,
+    pub(crate) random: Random,
+    pub(crate) session_id: SessionId,
+    pub(crate) cipher_suites: Vec<CipherSuite>,
+    pub(crate) compression_methods: Vec<Compression>,
+    pub(crate) extensions: Vec<ClientExtension>,
 }
 
 impl ClientHelloPayload {
@@ -1082,7 +1082,7 @@ impl ClientHelloPayload {
         }
     }
 
-    pub fn sigalgs_extension(&self) -> Option<&[SignatureScheme]> {
+    pub(crate) fn sigalgs_extension(&self) -> Option<&[SignatureScheme]> {
         let ext = self.find_extension(ExtensionType::SignatureAlgorithms)?;
         match ext {
             ClientExtension::SignatureAlgorithms(req) => Some(req),
@@ -1155,7 +1155,7 @@ impl ClientHelloPayload {
         }
     }
 
-    pub fn keyshare_extension(&self) -> Option<&[KeyShareEntry]> {
+    pub(crate) fn keyshare_extension(&self) -> Option<&[KeyShareEntry]> {
         let ext = self.find_extension(ExtensionType::KeyShare)?;
         match ext {
             ClientExtension::KeyShare(shares) => Some(shares),
@@ -1361,9 +1361,9 @@ impl TlsListElement for HelloRetryExtension {
 }
 
 #[derive(Clone, Debug)]
-pub struct HelloRetryRequest {
+pub(crate) struct HelloRetryRequest {
     pub(crate) legacy_version: ProtocolVersion,
-    pub session_id: SessionId,
+    pub(crate) session_id: SessionId,
     pub(crate) cipher_suite: CipherSuite,
     pub(crate) extensions: Vec<HelloRetryExtension>,
 }
@@ -1417,7 +1417,7 @@ impl HelloRetryRequest {
             .find(|x| x.ext_type() == ext)
     }
 
-    pub fn requested_key_share_group(&self) -> Option<NamedGroup> {
+    pub(crate) fn requested_key_share_group(&self) -> Option<NamedGroup> {
         let ext = self.find_extension(ExtensionType::KeyShare)?;
         match ext {
             HelloRetryExtension::KeyShare(grp) => Some(*grp),
@@ -1484,13 +1484,13 @@ impl HelloRetryRequest {
 }
 
 #[derive(Clone, Debug)]
-pub struct ServerHelloPayload {
-    pub extensions: Vec<ServerExtension>,
+pub(crate) struct ServerHelloPayload {
     pub(crate) legacy_version: ProtocolVersion,
     pub(crate) random: Random,
     pub(crate) session_id: SessionId,
     pub(crate) cipher_suite: CipherSuite,
     pub(crate) compression_method: Compression,
+    pub(crate) extensions: Vec<ServerExtension>,
 }
 
 impl Codec<'_> for ServerHelloPayload {
@@ -1595,7 +1595,7 @@ impl ServerHelloPayload {
 }
 
 #[derive(Clone, Default, Debug)]
-pub struct CertificateChain<'a>(pub Vec<CertificateDer<'a>>);
+pub(crate) struct CertificateChain<'a>(pub(crate) Vec<CertificateDer<'a>>);
 
 impl CertificateChain<'_> {
     pub(crate) fn into_owned(self) -> CertificateChain<'static> {
@@ -1771,7 +1771,7 @@ impl TlsListElement for CertificateEntry<'_> {
 }
 
 #[derive(Debug)]
-pub struct CertificatePayloadTls13<'a> {
+pub(crate) struct CertificatePayloadTls13<'a> {
     pub(crate) context: PayloadU8,
     pub(crate) entries: Vec<CertificateEntry<'a>>,
 }
@@ -2131,20 +2131,20 @@ impl KxDecode<'_> for ServerKeyExchangeParams {
 }
 
 #[derive(Debug)]
-pub struct ServerKeyExchange {
+pub(crate) struct ServerKeyExchange {
     pub(crate) params: ServerKeyExchangeParams,
     pub(crate) dss: DigitallySignedStruct,
 }
 
 impl ServerKeyExchange {
-    pub fn encode(&self, buf: &mut Vec<u8>) {
+    pub(crate) fn encode(&self, buf: &mut Vec<u8>) {
         self.params.encode(buf);
         self.dss.encode(buf);
     }
 }
 
 #[derive(Debug)]
-pub enum ServerKeyExchangePayload {
+pub(crate) enum ServerKeyExchangePayload {
     Known(ServerKeyExchange),
     Unknown(Payload<'static>),
 }
@@ -2317,7 +2317,7 @@ impl TlsListElement for DistinguishedName {
 }
 
 #[derive(Debug)]
-pub struct CertificateRequestPayload {
+pub(crate) struct CertificateRequestPayload {
     pub(crate) certtypes: Vec<ClientCertificateType>,
     pub(crate) sigschemes: Vec<SignatureScheme>,
     pub(crate) canames: Vec<DistinguishedName>,
@@ -2416,7 +2416,7 @@ impl TlsListElement for CertReqExtension {
 }
 
 #[derive(Debug)]
-pub struct CertificateRequestPayloadTls13 {
+pub(crate) struct CertificateRequestPayloadTls13 {
     pub(crate) context: PayloadU8,
     pub(crate) extensions: Vec<CertReqExtension>,
 }
@@ -2474,7 +2474,7 @@ impl CertificateRequestPayloadTls13 {
 
 // -- NewSessionTicket --
 #[derive(Debug)]
-pub struct NewSessionTicketPayload {
+pub(crate) struct NewSessionTicketPayload {
     pub(crate) lifetime_hint: u32,
     // Tickets can be large (KB), so we deserialise this straight
     // into an Arc, so it can be passed directly into the client's
@@ -2556,7 +2556,7 @@ impl TlsListElement for NewSessionTicketExtension {
 }
 
 #[derive(Debug)]
-pub struct NewSessionTicketPayloadTls13 {
+pub(crate) struct NewSessionTicketPayloadTls13 {
     pub(crate) lifetime: u32,
     pub(crate) age_add: u32,
     pub(crate) nonce: PayloadU8,
@@ -2633,7 +2633,7 @@ impl Codec<'_> for NewSessionTicketPayloadTls13 {
 
 /// Only supports OCSP
 #[derive(Debug)]
-pub struct CertificateStatus<'a> {
+pub(crate) struct CertificateStatus<'a> {
     pub(crate) ocsp_response: PayloadU24<'a>,
 }
 
@@ -2677,7 +2677,7 @@ impl<'a> CertificateStatus<'a> {
 // -- RFC8879 compressed certificates
 
 #[derive(Debug)]
-pub struct CompressedCertificatePayload<'a> {
+pub(crate) struct CompressedCertificatePayload<'a> {
     pub(crate) alg: CertificateCompressionAlgorithm,
     pub(crate) uncompressed_len: u32,
     pub(crate) compressed: PayloadU24<'a>,
@@ -2717,7 +2717,7 @@ impl CompressedCertificatePayload<'_> {
 }
 
 #[derive(Debug)]
-pub enum HandshakePayload<'a> {
+pub(crate) enum HandshakePayload<'a> {
     HelloRequest,
     ClientHello(ClientHelloPayload),
     ServerHello(ServerHelloPayload),
@@ -2833,7 +2833,7 @@ impl HandshakePayload<'_> {
 }
 
 #[derive(Debug)]
-pub struct HandshakeMessagePayload<'a>(pub HandshakePayload<'a>);
+pub struct HandshakeMessagePayload<'a>(pub(crate) HandshakePayload<'a>);
 
 impl<'a> Codec<'a> for HandshakeMessagePayload<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
@@ -3214,7 +3214,7 @@ impl TlsListElement for EchConfigExtension {
 ///
 /// [draft-ietf-tls-esni Section 5]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-18.html#section-5>
 #[derive(Clone, Debug)]
-pub enum EncryptedClientHello {
+pub(crate) enum EncryptedClientHello {
     /// A `ECHClientHello` with type [EchClientHelloType::ClientHelloOuter].
     Outer(EncryptedClientHelloOuter),
     /// An empty `ECHClientHello` with type [EchClientHelloType::ClientHelloInner].
@@ -3253,7 +3253,7 @@ impl Codec<'_> for EncryptedClientHello {
 ///
 /// [draft-ietf-tls-esni Section 5]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-18.html#section-5>
 #[derive(Clone, Debug)]
-pub struct EncryptedClientHelloOuter {
+pub(crate) struct EncryptedClientHelloOuter {
     /// The cipher suite used to encrypt ClientHelloInner. Must match a value from
     /// ECHConfigContents.cipher_suites list.
     pub cipher_suite: HpkeSymmetricCipherSuite,
@@ -3289,7 +3289,7 @@ impl Codec<'_> for EncryptedClientHelloOuter {
 ///
 /// [draft-ietf-tls-esni Section 5]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-18.html#section-5>
 #[derive(Clone, Debug)]
-pub struct ServerEncryptedClientHello {
+pub(crate) struct ServerEncryptedClientHello {
     pub(crate) retry_configs: Vec<EchConfigPayload>,
 }
 

--- a/rustls/src/msgs/message/mod.rs
+++ b/rustls/src/msgs/message/mod.rs
@@ -162,7 +162,7 @@ impl Message<'_> {
     pub fn is_handshake_type(&self, hstyp: HandshakeType) -> bool {
         // Bit of a layering violation, but OK.
         if let MessagePayload::Handshake { parsed, .. } = &self.payload {
-            parsed.typ == hstyp
+            parsed.0.handshake_type() == hstyp
         } else {
             false
         }
@@ -181,20 +181,18 @@ impl Message<'_> {
     pub fn build_key_update_notify() -> Self {
         Self {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::KeyUpdate,
-                payload: HandshakePayload::KeyUpdate(KeyUpdateRequest::UpdateNotRequested),
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::KeyUpdate(KeyUpdateRequest::UpdateNotRequested),
+            )),
         }
     }
 
     pub fn build_key_update_request() -> Self {
         Self {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::KeyUpdate,
-                payload: HandshakePayload::KeyUpdate(KeyUpdateRequest::UpdateRequested),
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::KeyUpdate(KeyUpdateRequest::UpdateRequested),
+            )),
         }
     }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1039,8 +1039,7 @@ impl Accepted {
 
     fn client_hello_payload<'a>(message: &'a Message<'_>) -> &'a ClientHelloPayload {
         match &message.payload {
-            crate::msgs::message::MessagePayload::Handshake { parsed, .. } => match &parsed.payload
-            {
+            crate::msgs::message::MessagePayload::Handshake { parsed, .. } => match &parsed.0 {
                 crate::msgs::handshake::HandshakePayload::ClientHello(ch) => ch,
                 _ => unreachable!(),
             },

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -12,9 +12,7 @@ use crate::msgs::handshake::{
     Random, SessionId, SupportedProtocolVersions,
 };
 use crate::msgs::message::{Message, MessagePayload};
-use crate::{
-    CommonState, Error, HandshakeType, PeerIncompatible, PeerMisbehaved, ProtocolVersion, Side,
-};
+use crate::{CommonState, Error, PeerIncompatible, PeerMisbehaved, ProtocolVersion, Side};
 
 #[test]
 fn null_compression_required() {
@@ -51,10 +49,9 @@ fn server_rejects_sni_with_illegal_dns_name() {
 fn test_process_client_hello(hello: ClientHelloPayload) -> Result<(), Error> {
     let m = Message {
         version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::handshake(HandshakeMessagePayload {
-            typ: HandshakeType::ClientHello,
-            payload: HandshakePayload::ClientHello(hello),
-        }),
+        payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::ClientHello(
+            hello,
+        ))),
     };
     super::hs::process_client_hello(
         &m,
@@ -106,10 +103,9 @@ mod tests {
             .retain(|ext| ext.ext_type() != ExtensionType::ExtendedMasterSecret);
         let ch = Message {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ClientHello,
-                payload: HandshakePayload::ClientHello(ch),
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ClientHello(ch),
+            )),
         };
         conn.read_tls(&mut ch.into_wire_bytes().as_slice())
             .unwrap();
@@ -192,10 +188,9 @@ mod tests {
     ) {
         let ch = Message {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ClientHello,
-                payload: HandshakePayload::ClientHello(client_hello),
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ClientHello(client_hello),
+            )),
         };
         conn.read_tls(&mut ch.into_wire_bytes().as_slice())
             .unwrap();
@@ -216,10 +211,9 @@ mod tests {
             ]));
         let ch = Message {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ClientHello,
-                payload: HandshakePayload::ClientHello(ch),
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ClientHello(ch),
+            )),
         };
 
         let mut conn = ServerConnection::new(server_config_for_rpk().into()).unwrap();
@@ -240,10 +234,9 @@ mod tests {
             ]));
         let ch = Message {
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ClientHello,
-                payload: HandshakePayload::ClientHello(ch),
-            }),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ClientHello(ch),
+            )),
         };
 
         let mut conn = ServerConnection::new(server_config_for_rpk().into()).unwrap();

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -347,17 +347,14 @@ mod client_hello {
         ep.process_common(config, cx, ocsp_response, hello, resumedata, extra_exts)?;
         ep.process_tls12(config, hello, using_ems);
 
-        let sh = HandshakeMessagePayload {
-            typ: HandshakeType::ServerHello,
-            payload: HandshakePayload::ServerHello(ServerHelloPayload {
-                legacy_version: ProtocolVersion::TLSv1_2,
-                random: Random::from(randoms.server),
-                session_id,
-                cipher_suite: suite.common.suite,
-                compression_method: Compression::Null,
-                extensions: ep.exts,
-            }),
-        };
+        let sh = HandshakeMessagePayload(HandshakePayload::ServerHello(ServerHelloPayload {
+            legacy_version: ProtocolVersion::TLSv1_2,
+            random: Random::from(randoms.server),
+            session_id,
+            cipher_suite: suite.common.suite,
+            compression_method: Compression::Null,
+            extensions: ep.exts,
+        }));
         trace!("sending server hello {sh:?}");
         flight.add(sh);
 
@@ -368,17 +365,15 @@ mod client_hello {
         flight: &mut HandshakeFlightTls12<'_>,
         cert_chain: &[CertificateDer<'static>],
     ) {
-        flight.add(HandshakeMessagePayload {
-            typ: HandshakeType::Certificate,
-            payload: HandshakePayload::Certificate(CertificateChain(cert_chain.to_vec())),
-        });
+        flight.add(HandshakeMessagePayload(HandshakePayload::Certificate(
+            CertificateChain(cert_chain.to_vec()),
+        )));
     }
 
     fn emit_cert_status(flight: &mut HandshakeFlightTls12<'_>, ocsp: &[u8]) {
-        flight.add(HandshakeMessagePayload {
-            typ: HandshakeType::CertificateStatus,
-            payload: HandshakePayload::CertificateStatus(CertificateStatus::new(ocsp)),
-        });
+        flight.add(HandshakeMessagePayload(
+            HandshakePayload::CertificateStatus(CertificateStatus::new(ocsp)),
+        ));
     }
 
     fn emit_server_kx(
@@ -407,10 +402,9 @@ mod client_hello {
             dss: DigitallySignedStruct::new(sigscheme, sig),
         });
 
-        flight.add(HandshakeMessagePayload {
-            typ: HandshakeType::ServerKeyExchange,
-            payload: HandshakePayload::ServerKeyExchange(skx),
-        });
+        flight.add(HandshakeMessagePayload(
+            HandshakePayload::ServerKeyExchange(skx),
+        ));
         Ok(kx)
     }
 
@@ -440,10 +434,7 @@ mod client_hello {
             canames: names,
         };
 
-        let creq = HandshakeMessagePayload {
-            typ: HandshakeType::CertificateRequest,
-            payload: HandshakePayload::CertificateRequest(cr),
-        };
+        let creq = HandshakeMessagePayload(HandshakePayload::CertificateRequest(cr));
 
         trace!("Sending CertificateRequest {creq:?}");
         flight.add(creq);
@@ -451,10 +442,7 @@ mod client_hello {
     }
 
     fn emit_server_hello_done(flight: &mut HandshakeFlightTls12<'_>) {
-        flight.add(HandshakeMessagePayload {
-            typ: HandshakeType::ServerHelloDone,
-            payload: HandshakePayload::ServerHelloDone,
-        });
+        flight.add(HandshakeMessagePayload(HandshakePayload::ServerHelloDone));
     }
 }
 
@@ -820,13 +808,12 @@ fn emit_ticket(
 
     let m = Message {
         version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::handshake(HandshakeMessagePayload {
-            typ: HandshakeType::NewSessionTicket,
-            payload: HandshakePayload::NewSessionTicket(NewSessionTicketPayload::new(
+        payload: MessagePayload::handshake(HandshakeMessagePayload(
+            HandshakePayload::NewSessionTicket(NewSessionTicketPayload::new(
                 ticket_lifetime,
                 ticket,
             )),
-        }),
+        )),
     };
 
     transcript.add_message(&m);
@@ -854,10 +841,9 @@ fn emit_finished(
 
     let f = Message {
         version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::handshake(HandshakeMessagePayload {
-            typ: HandshakeType::Finished,
-            payload: HandshakePayload::Finished(verify_data_payload),
-        }),
+        payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::Finished(
+            verify_data_payload,
+        ))),
     };
 
     transcript.add_message(&f);


### PR DESCRIPTION
This is quite a big but somewhat uninteresting change.