### PR TITLE
Expose `named_groups` extension in `ClientHello`

### DIFF
--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -282,6 +282,7 @@ mod sni_resolver {
                         client_cert_types: None,
                         cipher_suites: &[],
                         certificate_authorities: None,
+                        named_groups: None,
                     })
                     .is_none()
             );
@@ -303,6 +304,7 @@ mod sni_resolver {
                         client_cert_types: None,
                         cipher_suites: &[],
                         certificate_authorities: None,
+                        named_groups: None,
                     })
                     .is_none()
             );

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -417,6 +417,7 @@ impl ExpectClientHello {
                 server_cert_types: client_hello.client_certificate_extension(),
                 cipher_suites: &client_hello.cipher_suites,
                 certificate_authorities,
+                named_groups: client_hello.namedgroups_extension(),
             };
             trace!("Resolving server certificate: {client_hello:#?}");
 


### PR DESCRIPTION
fixes #2484 