### PR TITLE
Delete unusable no-std ticketer code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,9 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+      - name: cargo build (debug; no-std)
+        run: cargo build --locked --lib -p rustls $(admin/all-features-except std,brotli,read_buf rustls)
+
       - name: cargo build (debug; rustls-provider-example)
         run: cargo build --locked -p rustls-provider-example
 

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod hmac;
 pub(crate) mod kx;
 #[path = "../ring/quic.rs"]
 pub(crate) mod quic;
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(feature = "std")]
 pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
 pub(crate) mod tls12;
@@ -262,7 +262,7 @@ pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[
     kx_group::MLKEM768,
 ];
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(feature = "std")]
 pub use ticketer::Ticketer;
 
 /// Compatibility shims between ring 0.16.x and 0.17.x API

--- a/rustls/src/crypto/aws_lc_rs/ticketer.rs
+++ b/rustls/src/crypto/aws_lc_rs/ticketer.rs
@@ -38,24 +38,6 @@ impl Ticketer {
             make_ticket_generator,
         )?))
     }
-
-    /// Make the recommended `Ticketer`.  This produces tickets
-    /// with a 12 hour life and randomly generated keys.
-    ///
-    /// The `Ticketer` uses the [RFC 5077 §4] "Recommended Ticket Construction",
-    /// using AES 256 for encryption and HMAC-SHA256 for ciphertext authentication.
-    ///
-    /// [RFC 5077 §4]: https://www.rfc-editor.org/rfc/rfc5077#section-4
-    #[cfg(not(feature = "std"))]
-    pub fn new<M: crate::lock::MakeMutex>(
-        time_provider: &'static dyn TimeProvider,
-    ) -> Result<Arc<dyn ProducesTickets>, Error> {
-        Ok(Arc::new(crate::ticketer::TicketSwitcher::new::<M>(
-            6 * 60 * 60,
-            make_ticket_generator,
-            time_provider,
-        )?))
-    }
 }
 
 fn make_ticket_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> {

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod hash;
 pub(crate) mod hmac;
 pub(crate) mod kx;
 pub(crate) mod quic;
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(feature = "std")]
 pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
 pub(crate) mod tls12;
@@ -177,7 +177,7 @@ pub static DEFAULT_KX_GROUPS: &[&dyn SupportedKxGroup] = ALL_KX_GROUPS;
 pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] =
     &[kx_group::X25519, kx_group::SECP256R1, kx_group::SECP384R1];
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(feature = "std")]
 pub use ticketer::Ticketer;
 
 /// Compatibility shims between ring 0.16.x and 0.17.x API

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -31,21 +31,6 @@ impl Ticketer {
             make_ticket_generator,
         )?))
     }
-
-    /// Make the recommended `Ticketer`.  This produces tickets
-    /// with a 12 hour life and randomly generated keys.
-    ///
-    /// The encryption mechanism used is Chacha20Poly1305.
-    #[cfg(not(feature = "std"))]
-    pub fn new<M: crate::lock::MakeMutex>(
-        time_provider: &'static dyn TimeProvider,
-    ) -> Result<Arc<dyn ProducesTickets>, Error> {
-        Ok(Arc::new(crate::ticketer::TicketSwitcher::new::<M>(
-            6 * 60 * 60,
-            make_ticket_generator,
-            time_provider,
-        )?))
-    }
 }
 
 fn make_ticket_generator() -> Result<Box<dyn ProducesTickets>, GetRandomFailed> {


### PR DESCRIPTION
This code didn't compile since its introduction in 0.23.5:

```shell
$ cargo check --lib --no-default-features --features hashbrown,ring,aws-lc-rs
error[E0405]: cannot find trait `TimeProvider` in this scope
  --> rustls/src/crypto/ring/ticketer.rs:41:37
   |
41 |         time_provider: &'static dyn TimeProvider,
   |                                     ^^^^^^^^^^^^ not found in this scope
   |
help: consider importing this trait
   |
1  + use crate::time_provider::TimeProvider;
   |

error[E0405]: cannot find trait `TimeProvider` in this scope
  --> rustls/src/crypto/aws_lc_rs/ticketer.rs:51:37
   |
51 |         time_provider: &'static dyn TimeProvider,
   |                                     ^^^^^^^^^^^^ not found in this scope
   |
help: consider importing this trait
   |
1  + use crate::time_provider::TimeProvider;
   |
```

Therefore we can conclude deleting it is not a breaking change, and affects no users.