### PR TITLE
Make `SigningKey::public_key()` mandatory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -960,6 +961,7 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -2117,6 +2119,15 @@ checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64",
  "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ clap = { version = "4.3.21", features = ["derive", "env"] }
 crabgrind = "=0.1.9" # compatible with valgrind package on GHA ubuntu-latest
 criterion = "0.6"
 der = "0.7"
-ecdsa = "0.16.8"
+ecdsa = { version = "0.16.8", features = ["pem"] }
 env_logger = "0.11"
 fxhash = "0.2.1"
 hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"] }

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -41,7 +41,10 @@ use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::handshake::EchConfigPayload;
 use rustls::internal::msgs::persist::ServerSessionValue;
 use rustls::pki_types::pem::PemObject;
-use rustls::pki_types::{CertificateDer, EchConfigListBytes, PrivateKeyDer, ServerName, UnixTime};
+use rustls::pki_types::{
+    CertificateDer, EchConfigListBytes, PrivateKeyDer, ServerName, SubjectPublicKeyInfoDer,
+    UnixTime,
+};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::server::{
     ClientHello, ProducesTickets, ServerConfig, ServerConnection, WebPkiClientVerifier,
@@ -479,6 +482,11 @@ impl sign::SigningKey for FixedSignatureSchemeSigningKey {
             self.key.choose_scheme(&[])
         }
     }
+
+    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
+        self.key.public_key()
+    }
+
     fn algorithm(&self) -> SignatureAlgorithm {
         self.key.algorithm()
     }

--- a/provider-example/src/sign.rs
+++ b/provider-example/src/sign.rs
@@ -2,8 +2,8 @@ use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-use pkcs8::DecodePrivateKey;
-use rustls::pki_types::PrivateKeyDer;
+use pkcs8::{DecodePrivateKey, EncodePublicKey};
+use rustls::pki_types::{PrivateKeyDer, SubjectPublicKeyInfoDer};
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
 use signature::{RandomizedSigner, SignatureEncoding};
@@ -37,6 +37,16 @@ impl SigningKey for EcdsaSigningKeyP256 {
         } else {
             None
         }
+    }
+
+    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
+        Some(SubjectPublicKeyInfoDer::from(
+            self.key
+                .verifying_key()
+                .to_public_key_der()
+                .ok()?
+                .into_vec(),
+        ))
     }
 
     fn algorithm(&self) -> SignatureAlgorithm {

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -28,7 +28,7 @@ use rustls::crypto::{
 };
 use rustls::pki_types::{
     AlgorithmIdentifier, CertificateDer, InvalidSignature, PrivateKeyDer,
-    SignatureVerificationAlgorithm, alg_id,
+    SignatureVerificationAlgorithm, SubjectPublicKeyInfoDer, alg_id,
 };
 use rustls::server::ProducesTickets;
 use rustls::{
@@ -476,6 +476,10 @@ impl sign::SigningKey for SigningKey {
             true => Some(Box::new(Self)),
             false => None,
         }
+    }
+
+    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
+        None
     }
 
     fn algorithm(&self) -> SignatureAlgorithm {

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -63,11 +63,11 @@ pub trait SigningKey: Debug + Send + Sync {
     /// using the chosen scheme.
     fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>>;
 
-    /// Get the RFC 5280-compliant SubjectPublicKeyInfo (SPKI) of this [`SigningKey`] if available.
-    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
-        // Opt-out by default
-        None
-    }
+    /// Get the RFC 5280-compliant SubjectPublicKeyInfo (SPKI) of this [`SigningKey`].
+    ///
+    /// If an implementation does not have the ability to derive this,
+    /// it can return `None`.
+    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>>;
 
     /// What kind of key we have.
     fn algorithm(&self) -> SignatureAlgorithm;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{fmt, mem};
 
-use pki_types::{CertificateDer, IpAddr, ServerName, UnixTime};
+use pki_types::{CertificateDer, IpAddr, ServerName, SubjectPublicKeyInfoDer, UnixTime};
 use rustls::client::{ResolvesClientCert, Resumption, verify_server_cert_signed_by_trust_anchor};
 use rustls::crypto::{ActiveKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup};
 use rustls::internal::msgs::base::Payload;
@@ -3516,6 +3516,10 @@ struct SigningKeyNoneSpki;
 impl sign::SigningKey for SigningKeyNoneSpki {
     fn choose_scheme(&self, _offered: &[SignatureScheme]) -> Option<Box<dyn sign::Signer>> {
         unimplemented!("Not meant to be called during tests")
+    }
+
+    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
+        None
     }
 
     fn algorithm(&self) -> rustls::SignatureAlgorithm {


### PR DESCRIPTION
Retain the ability to opt-out, but this must now be done explicitly.

re #2119 