### PR TITLE
Rework representation of extensions in server messages

### DIFF
--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -325,8 +325,6 @@
     "Server-TooLongSessionID-TLS13": ":BAD_HANDSHAKE_MSG:",
     "Server-TooLongSessionID-TLS12": ":BAD_HANDSHAKE_MSG:",
     "Client-TooLongSessionID": ":BAD_HANDSHAKE_MSG:",
-    "SendUnknownExtensionOnCertificate-TLS13": ":PEER_MISBEHAVIOUR:",
-    "SendDuplicateExtensionsOnCerts-TLS13": ":PEER_MISBEHAVIOUR:",
     "EMS-Forbidden-TLS13": ":PEER_MISBEHAVIOUR:",
     "Unclean-Shutdown": ":CLOSE_WITHOUT_CLOSE_NOTIFY:",
     "SendExtensionOnClientCertificate-TLS13": ":PEER_MISBEHAVIOUR:",

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -382,6 +382,8 @@
     "TrailingDataWithFinished-Client-TLS13": "local error: bad record MAC",
     "TrailingDataWithFinished-Resume-Client-TLS13": "local error: bad record MAC",
     "SkipEarlyData-SecondClientHelloEarlyData-TLS13": "remote error: illegal parameter",
+    "DuplicateExtensionClient-TLS-TLS12": "remote error: illegal parameter",
+    "DuplicateExtensionClient-TLS-TLS13": "remote error: illegal parameter",
     "DuplicateExtensionServer-TLS-TLS12": "remote error: illegal parameter",
     "DuplicateExtensionServer-TLS-TLS13": "remote error: illegal parameter"
   },

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -270,8 +270,6 @@
     "TrailingKeyShareData-TLS13": ":BAD_HANDSHAKE_MSG:",
     "HelloRetryRequestCurveMismatch-TLS13": ":PEER_MISBEHAVIOUR:",
     "HelloRetryRequestVersionMismatch-TLS13": ":INCOMPATIBLE:",
-    "HelloRetryRequest-DuplicateCookie-TLS13": ":PEER_MISBEHAVIOUR:",
-    "HelloRetryRequest-DuplicateCurve-TLS13": ":PEER_MISBEHAVIOUR:",
     "UnknownUnencryptedExtension-Client-TLS13": ":PEER_MISBEHAVIOUR:",
     "UnexpectedUnencryptedExtension-Client-TLS13": ":PEER_MISBEHAVIOUR:",
     "UnofferedExtension-Client-TLS13": ":PEER_MISBEHAVIOUR:",
@@ -386,7 +384,9 @@
     "Downgrade-TLS10-Server": "remote error: protocol version not supported",
     "TrailingDataWithFinished-Client-TLS13": "local error: bad record MAC",
     "TrailingDataWithFinished-Resume-Client-TLS13": "local error: bad record MAC",
-    "SkipEarlyData-SecondClientHelloEarlyData-TLS13": "remote error: illegal parameter"
+    "SkipEarlyData-SecondClientHelloEarlyData-TLS13": "remote error: illegal parameter",
+    "DuplicateExtensionServer-TLS-TLS12": "remote error: illegal parameter",
+    "DuplicateExtensionServer-TLS-TLS13": "remote error: illegal parameter"
   },
   "HalfRTTTickets": 0
 }

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -338,7 +338,6 @@
     "ServerCipherFilter-Ed25519": ":INCOMPATIBLE:",
     "TLS13-OnlyPadding-TLS": ":PEER_MISBEHAVIOUR:",
     "TLS13-EmptyRecords-TLS": ":PEER_MISBEHAVIOUR:",
-    "TLS13-DuplicateTicketEarlyDataSupport": ":PEER_MISBEHAVIOUR:",
     "SupportedVersionSelection-TLS12": ":PEER_MISBEHAVIOUR:",
     "HelloRetryRequest-CipherChange-TLS13": ":PEER_MISBEHAVIOUR:",
     "CurveTest-Client-Compressed-P-256-TLS12": ":PEER_MISBEHAVIOUR:",

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -927,7 +927,8 @@ fn handle_err(opts: &Options, err: Error) -> ! {
         Error::InvalidMessage(InvalidMessage::DuplicateExtension(_)) => {
             quit(":DUPLICATE_EXTENSION:")
         }
-        Error::InvalidMessage(InvalidMessage::UnknownHelloRetryRequestExtension) => {
+        Error::InvalidMessage(InvalidMessage::UnknownHelloRetryRequestExtension)
+        | Error::InvalidMessage(InvalidMessage::UnknownCertificateExtension) => {
             quit(":UNEXPECTED_EXTENSION:")
         }
         Error::InvalidMessage(InvalidMessage::UnexpectedMessage(_)) => quit(":GARBAGE:"),

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -927,6 +927,9 @@ fn handle_err(opts: &Options, err: Error) -> ! {
         Error::InvalidMessage(InvalidMessage::DuplicateExtension(_)) => {
             quit(":DUPLICATE_EXTENSION:")
         }
+        Error::InvalidMessage(InvalidMessage::UnknownHelloRetryRequestExtension) => {
+            quit(":UNEXPECTED_EXTENSION:")
+        }
         Error::InvalidMessage(InvalidMessage::UnexpectedMessage(_)) => quit(":GARBAGE:"),
         Error::InvalidMessage(InvalidMessage::PreSharedKeyIsNotFinalExtension) => {
             quit(":PRE_SHARED_KEY_MUST_BE_LAST:")

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -480,12 +480,12 @@ impl EchState {
         common: &mut CommonState,
     ) -> Result<bool, Error> {
         // The client checks for the "encrypted_client_hello" extension.
-        let ech_conf = match hrr.ech() {
+        let ech_conf = match &hrr.encrypted_client_hello {
             // If none is found, the server has implicitly rejected ECH.
             None => return Ok(false),
             // Otherwise, if it has a length other than 8, the client aborts the
             // handshake with a "decode_error" alert.
-            Some(ech_conf) if ech_conf.len() != 8 => {
+            Some(ech_conf) if ech_conf.bytes().len() != 8 => {
                 return Err({
                     common.send_fatal_alert(
                         AlertDescription::DecodeError,
@@ -510,7 +510,7 @@ impl EchState {
             confirmation_transcript.current_hash(),
         );
 
-        match ConstantTimeEq::ct_eq(derived.as_ref(), ech_conf).into() {
+        match ConstantTimeEq::ct_eq(derived.as_ref(), ech_conf.bytes()).into() {
             true => {
                 trace!("ECH accepted by server in hello retry request");
                 Ok(true)

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -335,7 +335,7 @@ fn emit_client_hello_for_retry(
         let mut shares = vec![KeyShareEntry::new(key_share.group(), key_share.pub_key())];
 
         if !retryreq
-            .map(|rr| rr.requested_key_share_group().is_some())
+            .map(|rr| rr.key_share.is_some())
             .unwrap_or_default()
         {
             // Only for the initial client hello, or a HRR that does not specify a kx group,
@@ -358,7 +358,7 @@ fn emit_client_hello_for_retry(
         exts.key_shares = Some(shares);
     }
 
-    if let Some(cookie) = retryreq.and_then(HelloRetryRequest::cookie) {
+    if let Some(cookie) = retryreq.and_then(|hrr| hrr.cookie.as_ref()) {
         exts.cookie = Some(cookie.clone());
     }
 
@@ -958,9 +958,6 @@ impl ExpectServerHelloOrHelloRetryRequest {
 
         cx.common.check_aligned_handshake()?;
 
-        let cookie = hrr.cookie();
-        let req_group = hrr.requested_key_share_group();
-
         // We always send a key share when TLS 1.3 is enabled.
         let offered_key_share = self.next.offered_key_share.unwrap();
 
@@ -968,7 +965,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         // retry of a group we already sent.
         let config = &self.next.input.config;
 
-        if let (None, Some(req_group)) = (cookie, req_group) {
+        if let (None, Some(req_group)) = (&hrr.cookie, hrr.key_share) {
             let offered_hybrid = offered_key_share
                 .hybrid_component()
                 .and_then(|(group_name, _)| {
@@ -987,7 +984,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         }
 
         // Or has an empty cookie.
-        if let Some(cookie) = cookie {
+        if let Some(cookie) = &hrr.cookie {
             if cookie.0.is_empty() {
                 return Err({
                     cx.common.send_fatal_alert(
@@ -998,26 +995,8 @@ impl ExpectServerHelloOrHelloRetryRequest {
             }
         }
 
-        // Or has something unrecognised
-        if hrr.has_unknown_extension() {
-            return Err(cx.common.send_fatal_alert(
-                AlertDescription::UnsupportedExtension,
-                PeerIncompatible::ServerSentHelloRetryRequestWithUnknownExtension,
-            ));
-        }
-
-        // Or has the same extensions more than once
-        if hrr.has_duplicate_extension() {
-            return Err({
-                cx.common.send_fatal_alert(
-                    AlertDescription::IllegalParameter,
-                    PeerMisbehaved::DuplicateHelloRetryRequestExtensions,
-                )
-            });
-        }
-
         // Or asks us to change nothing.
-        if cookie.is_none() && req_group.is_none() {
+        if hrr.cookie.is_none() && hrr.key_share.is_none() {
             return Err({
                 cx.common.send_fatal_alert(
                     AlertDescription::IllegalParameter,
@@ -1049,7 +1028,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         }
 
         // Or asks us to talk a protocol we didn't offer, or doesn't support HRR at all.
-        match hrr.supported_versions() {
+        match hrr.supported_versions {
             Some(ProtocolVersion::TLSv1_3) => {
                 cx.common.negotiated_version = Some(ProtocolVersion::TLSv1_3);
             }
@@ -1074,7 +1053,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         };
 
         // Or offers ECH related extensions when we didn't offer ECH.
-        if cx.data.ech_status == EchStatus::NotOffered && hrr.ech().is_some() {
+        if cx.data.ech_status == EchStatus::NotOffered && hrr.encrypted_client_hello.is_some() {
             return Err({
                 cx.common.send_fatal_alert(
                     AlertDescription::UnsupportedExtension,
@@ -1122,7 +1101,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
             cx.data.early_data.rejected();
         }
 
-        let key_share = match req_group {
+        let key_share = match hrr.key_share {
             Some(group) if group != offered_key_share.group() => {
                 let Some(skxg) = config.find_kx_group(group, ProtocolVersion::TLSv1_3) else {
                     return Err(cx.common.send_fatal_alert(

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -12,8 +12,8 @@ use crate::msgs::base::PayloadU16;
 use crate::msgs::codec::Reader;
 use crate::msgs::enums::{Compression, NamedGroup};
 use crate::msgs::handshake::{
-    ClientHelloPayload, HandshakeMessagePayload, HandshakePayload, HelloRetryExtension,
-    HelloRetryRequest, Random, ServerHelloPayload, SessionId,
+    ClientHelloPayload, HandshakeMessagePayload, HandshakePayload, HelloRetryRequest, Random,
+    ServerHelloPayload, SessionId,
 };
 use crate::msgs::message::{Message, MessagePayload, OutboundOpaqueMessage};
 use crate::sync::Arc;
@@ -31,8 +31,9 @@ mod tests {
     use crate::msgs::base::PayloadU8;
     use crate::msgs::enums::ECCurveType;
     use crate::msgs::handshake::{
-        CertificateChain, EcParameters, KeyShareEntry, ServerEcdhParams, ServerExtension,
-        ServerKeyExchange, ServerKeyExchangeParams, ServerKeyExchangePayload,
+        CertificateChain, EcParameters, HelloRetryRequestExtensions, KeyShareEntry,
+        ServerEcdhParams, ServerExtension, ServerKeyExchange, ServerKeyExchangeParams,
+        ServerKeyExchangePayload,
     };
     use crate::msgs::message::PlainMessage;
     use crate::pki_types::pem::PemObject;
@@ -117,9 +118,10 @@ mod tests {
                     cipher_suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
                     legacy_version: ProtocolVersion::TLSv1_2,
                     session_id: SessionId::empty(),
-                    extensions: vec![HelloRetryExtension::Cookie(PayloadU16::new(vec![
-                        1, 2, 3, 4,
-                    ]))],
+                    extensions: HelloRetryRequestExtensions {
+                        cookie: Some(PayloadU16::new(vec![1, 2, 3, 4])),
+                        ..HelloRetryRequestExtensions::default()
+                    },
                 }),
             )),
         };

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1060,14 +1060,6 @@ impl State<ClientConnectionData> for ExpectCertificate {
             ));
         }
 
-        if cert_chain.any_entry_has_duplicate_extension()
-            || cert_chain.any_entry_has_unknown_extension()
-        {
-            return Err(cx.common.send_fatal_alert(
-                AlertDescription::UnsupportedExtension,
-                PeerMisbehaved::BadCertChainExtensions,
-            ));
-        }
         let end_entity_ocsp = cert_chain.end_entity_ocsp().to_vec();
         let server_cert = ServerCertDetails::new(
             cert_chain

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -29,9 +29,9 @@ use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{ExtensionType, KeyUpdateRequest};
 use crate::msgs::handshake::{
     CERTIFICATE_MAX_SIZE_LIMIT, CertificatePayloadTls13, ClientExtensions, EchConfigPayload,
-    HandshakeMessagePayload, HandshakePayload, HasServerExtensions, KeyShareEntry,
-    NewSessionTicketPayloadTls13, PresharedKeyBinder, PresharedKeyIdentity, PresharedKeyOffer,
-    ServerExtension, ServerHelloPayload,
+    HandshakeMessagePayload, HandshakePayload, KeyShareEntry, NewSessionTicketPayloadTls13,
+    PresharedKeyBinder, PresharedKeyIdentity, PresharedKeyOffer, ServerExtensions,
+    ServerHelloPayload,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -85,7 +85,8 @@ pub(super) fn handle_server_hello(
     validate_server_hello(cx.common, server_hello)?;
 
     let their_key_share = server_hello
-        .key_share()
+        .key_share
+        .as_ref()
         .ok_or_else(|| {
             cx.common.send_fatal_alert(
                 AlertDescription::MissingExtension,
@@ -101,7 +102,7 @@ pub(super) fn handle_server_hello(
             )
         })?;
 
-    let key_schedule_pre_handshake = match (server_hello.psk_index(), early_data_key_schedule) {
+    let key_schedule_pre_handshake = match (server_hello.preshared_key, early_data_key_schedule) {
         (Some(selected_psk), Some(early_key_schedule)) => {
             match &resuming_session {
                 Some(resuming) => {
@@ -269,13 +270,11 @@ fn validate_server_hello(
     common: &mut CommonState,
     server_hello: &ServerHelloPayload,
 ) -> Result<(), Error> {
-    for ext in &server_hello.extensions {
-        if !ALLOWED_PLAINTEXT_EXTS.contains(&ext.ext_type()) {
-            return Err(common.send_fatal_alert(
-                AlertDescription::UnsupportedExtension,
-                PeerMisbehaved::UnexpectedCleartextExtension,
-            ));
-        }
+    if !server_hello.only_contains(ALLOWED_PLAINTEXT_EXTS) {
+        return Err(common.send_fatal_alert(
+            AlertDescription::UnsupportedExtension,
+            PeerMisbehaved::UnexpectedCleartextExtension,
+        ));
     }
 
     Ok(())
@@ -427,15 +426,8 @@ pub(super) fn emit_fake_ccs(sent_tls13_fake_ccs: &mut bool, common: &mut CommonS
 fn validate_encrypted_extensions(
     common: &mut CommonState,
     hello: &ClientHelloDetails,
-    exts: &Vec<ServerExtension>,
+    exts: &ServerExtensions<'_>,
 ) -> Result<(), Error> {
-    if exts.has_duplicate_extension() {
-        return Err(common.send_fatal_alert(
-            AlertDescription::DecodeError,
-            PeerMisbehaved::DuplicateEncryptedExtensions,
-        ));
-    }
-
     if hello.server_sent_unsolicited_extensions(exts, &[]) {
         return Err(common.send_fatal_alert(
             AlertDescription::UnsupportedExtension,
@@ -443,15 +435,11 @@ fn validate_encrypted_extensions(
         ));
     }
 
-    for ext in exts {
-        if ALLOWED_PLAINTEXT_EXTS.contains(&ext.ext_type())
-            || DISALLOWED_TLS13_EXTS.contains(&ext.ext_type())
-        {
-            return Err(common.send_fatal_alert(
-                AlertDescription::UnsupportedExtension,
-                PeerMisbehaved::DisallowedEncryptedExtension,
-            ));
-        }
+    if exts.contains_any(ALLOWED_PLAINTEXT_EXTS) || exts.contains_any(DISALLOWED_TLS13_EXTS) {
+        return Err(common.send_fatal_alert(
+            AlertDescription::UnsupportedExtension,
+            PeerMisbehaved::DisallowedEncryptedExtension,
+        ));
     }
 
     Ok(())
@@ -486,11 +474,25 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
         self.transcript.add_message(&m);
 
         validate_encrypted_extensions(cx.common, &self.hello, exts)?;
-        hs::process_alpn_protocol(cx.common, &self.hello.alpn_protocols, exts.alpn_protocol())?;
-        hs::process_client_cert_type_extension(cx.common, &self.config, exts.client_cert_type())?;
-        hs::process_server_cert_type_extension(cx.common, &self.config, exts.server_cert_type())?;
+        hs::process_alpn_protocol(
+            cx.common,
+            &self.hello.alpn_protocols,
+            exts.selected_protocol
+                .as_ref()
+                .map(|protocol| protocol.as_ref()),
+        )?;
+        hs::process_client_cert_type_extension(
+            cx.common,
+            &self.config,
+            exts.client_certificate_type.as_ref(),
+        )?;
+        hs::process_server_cert_type_extension(
+            cx.common,
+            &self.config,
+            exts.server_certificate_type.as_ref(),
+        )?;
 
-        let ech_retry_configs = match (cx.data.ech_status, exts.server_ech_extension()) {
+        let ech_retry_configs = match (cx.data.ech_status, &exts.encrypted_client_hello_ack) {
             // If we didn't offer ECH, or ECH was accepted, but the server sent an ECH encrypted
             // extension with retry configs, we must error.
             (EchStatus::NotOffered | EchStatus::Accepted, Some(_)) => {
@@ -502,14 +504,20 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
             // If we offered ECH, and it was rejected, store the retry configs (if any) from
             // the server's ECH extension. We will return them in an error produced at the end
             // of the handshake.
-            (EchStatus::Rejected, ext) => ext.map(|ext| ext.retry_configs.to_vec()),
+            (EchStatus::Rejected, ext) => ext
+                .as_ref()
+                .map(|ext| ext.retry_configs.to_vec()),
             _ => None,
         };
 
         // QUIC transport parameters
         if cx.common.is_quic() {
-            match exts.quic_params_extension() {
-                Some(params) => cx.common.quic.params = Some(params),
+            match exts
+                .transport_parameters
+                .as_ref()
+                .or(exts.transport_parameters_draft.as_ref())
+            {
+                Some(params) => cx.common.quic.params = Some(params.clone().into_vec()),
                 None => {
                     return Err(cx
                         .common
@@ -522,11 +530,12 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
             Some(resuming_session) => {
                 let was_early_traffic = cx.common.early_traffic;
                 if was_early_traffic {
-                    if exts.early_data_extension_offered() {
-                        cx.data.early_data.accepted();
-                    } else {
-                        cx.data.early_data.rejected();
-                        cx.common.early_traffic = false;
+                    match exts.early_data_ack {
+                        Some(()) => cx.data.early_data.accepted(),
+                        None => {
+                            cx.data.early_data.rejected();
+                            cx.common.early_traffic = false;
+                        }
                     }
                 }
 
@@ -561,7 +570,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
                 }))
             }
             _ => {
-                if exts.early_data_extension_offered() {
+                if exts.early_data_ack.is_some() {
                     return Err(PeerMisbehaved::EarlyDataExtensionWithoutResumption.into());
                 }
                 cx.common

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1442,10 +1442,6 @@ impl ExpectTraffic {
         cx: &mut KernelContext<'_>,
         nst: &NewSessionTicketPayloadTls13,
     ) -> Result<(), Error> {
-        if nst.has_duplicate_extension() {
-            return Err(PeerMisbehaved::DuplicateNewSessionTicketExtensions.into());
-        }
-
         let handshake_hash = self.transcript.current_hash();
         let secret = ResumptionSecret::new(&self.key_schedule, &handshake_hash)
             .derive_ticket_psk(&nst.nonce.0);
@@ -1465,12 +1461,13 @@ impl ExpectTraffic {
             now,
             nst.lifetime,
             nst.age_add,
-            nst.max_early_data_size()
+            nst.extensions
+                .max_early_data_size
                 .unwrap_or_default(),
         );
 
         if cx.is_quic() {
-            if let Some(sz) = nst.max_early_data_size() {
+            if let Some(sz) = nst.extensions.max_early_data_size {
                 if sz != 0 && sz != 0xffff_ffff {
                     return Err(PeerMisbehaved::InvalidMaxEarlyDataSize.into());
                 }
@@ -1491,13 +1488,6 @@ impl ExpectTraffic {
         cx: &mut ClientContext<'_>,
         nst: &NewSessionTicketPayloadTls13,
     ) -> Result<(), Error> {
-        if nst.has_duplicate_extension() {
-            return Err(cx.common.send_fatal_alert(
-                AlertDescription::IllegalParameter,
-                PeerMisbehaved::DuplicateNewSessionTicketExtensions,
-            ));
-        }
-
         let mut kcx = KernelContext {
             peer_certificates: cx.common.peer_certificates.as_ref(),
             protocol: cx.common.protocol,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -852,10 +852,11 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             ));
         }
 
-        let no_sigschemes = Vec::new();
         let compat_sigschemes = certreq
-            .sigalgs_extension()
-            .unwrap_or(&no_sigschemes)
+            .extensions
+            .signature_algorithms
+            .as_deref()
+            .unwrap_or_default()
             .iter()
             .cloned()
             .filter(SignatureScheme::supported_in_tls13)
@@ -869,7 +870,9 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
         }
 
         let compat_compressor = certreq
-            .certificate_compression_extension()
+            .extensions
+            .certificate_compression_algorithms
+            .as_deref()
             .and_then(|offered| {
                 self.config
                     .cert_compressors
@@ -882,7 +885,10 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             self.config
                 .client_auth_cert_resolver
                 .as_ref(),
-            certreq.authorities_extension(),
+            certreq
+                .extensions
+                .authority_names
+                .as_deref(),
             &compat_sigschemes,
             Some(certreq.context.0.clone()),
             compat_compressor,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -142,7 +142,6 @@ impl From<InconsistentKeys> for Error {
 /// A corrupt TLS message payload that resulted in an error.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
-
 pub enum InvalidMessage {
     /// A certificate payload exceeded rustls's 64KB limit
     CertificatePayloadTooLarge,
@@ -198,6 +197,8 @@ pub enum InvalidMessage {
     DuplicateExtension(u16),
     /// A peer sent a message with a PSK offer extension in wrong position
     PreSharedKeyIsNotFinalExtension,
+    /// A server sent a HelloRetryRequest with an unknown extension
+    UnknownHelloRetryRequestExtension,
 }
 
 impl From<InvalidMessage> for Error {
@@ -211,6 +212,8 @@ impl From<InvalidMessage> for AlertDescription {
     fn from(e: InvalidMessage) -> Self {
         match e {
             InvalidMessage::PreSharedKeyIsNotFinalExtension => Self::IllegalParameter,
+            InvalidMessage::DuplicateExtension(_) => Self::IllegalParameter,
+            InvalidMessage::UnknownHelloRetryRequestExtension => Self::UnsupportedExtension,
             _ => Self::DecodeError,
         }
     }

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -199,6 +199,8 @@ pub enum InvalidMessage {
     PreSharedKeyIsNotFinalExtension,
     /// A server sent a HelloRetryRequest with an unknown extension
     UnknownHelloRetryRequestExtension,
+    /// The peer sent a TLS1.3 Certificate with an unknown extension
+    UnknownCertificateExtension,
 }
 
 impl From<InvalidMessage> for Error {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2259,77 +2259,57 @@ impl Codec<'_> for CertificateRequestPayload {
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum CertReqExtension {
-    SignatureAlgorithms(Vec<SignatureScheme>),
-    AuthorityNames(Vec<DistinguishedName>),
-    CertificateCompressionAlgorithms(Vec<CertificateCompressionAlgorithm>),
-    Unknown(UnknownExtension),
-}
+extension_struct! {
+    pub(crate) struct CertificateRequestExtensions {
+        ExtensionType::SignatureAlgorithms =>
+            pub(crate) signature_algorithms: Option<Vec<SignatureScheme>>,
 
-impl CertReqExtension {
-    pub(crate) fn ext_type(&self) -> ExtensionType {
-        match self {
-            Self::SignatureAlgorithms(_) => ExtensionType::SignatureAlgorithms,
-            Self::AuthorityNames(_) => ExtensionType::CertificateAuthorities,
-            Self::CertificateCompressionAlgorithms(_) => ExtensionType::CompressCertificate,
-            Self::Unknown(r) => r.typ,
-        }
+        ExtensionType::CertificateAuthorities =>
+            pub(crate) authority_names: Option<Vec<DistinguishedName>>,
+
+        ExtensionType::CompressCertificate =>
+            pub(crate) certificate_compression_algorithms: Option<Vec<CertificateCompressionAlgorithm>>,
     }
 }
 
-impl Codec<'_> for CertReqExtension {
+impl Codec<'_> for CertificateRequestExtensions {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.ext_type().encode(bytes);
+        let extensions = LengthPrefixedBuffer::new(ListLength::U16, bytes);
 
-        let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
-        match self {
-            Self::SignatureAlgorithms(r) => r.encode(nested.buf),
-            Self::AuthorityNames(r) => r.encode(nested.buf),
-            Self::CertificateCompressionAlgorithms(r) => r.encode(nested.buf),
-            Self::Unknown(r) => r.encode(nested.buf),
+        for ext in Self::ALL_EXTENSIONS {
+            self.encode_one(*ext, extensions.buf);
         }
     }
 
     fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
-        let typ = ExtensionType::read(r)?;
-        let len = u16::read(r)? as usize;
+        let mut out = Self::default();
+
+        let mut checker = DuplicateExtensionChecker::new();
+
+        let len = usize::from(u16::read(r)?);
         let mut sub = r.sub(len)?;
 
-        let ext = match typ {
-            ExtensionType::SignatureAlgorithms => {
-                let schemes = Vec::read(&mut sub)?;
-                if schemes.is_empty() {
-                    return Err(InvalidMessage::NoSignatureSchemes);
-                }
-                Self::SignatureAlgorithms(schemes)
-            }
-            ExtensionType::CertificateAuthorities => {
-                let cas = Vec::read(&mut sub)?;
-                if cas.is_empty() {
-                    return Err(InvalidMessage::IllegalEmptyList("DistinguishedNames"));
-                }
-                Self::AuthorityNames(cas)
-            }
-            ExtensionType::CompressCertificate => {
-                Self::CertificateCompressionAlgorithms(Vec::read(&mut sub)?)
-            }
-            _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
-        };
+        while sub.any_left() {
+            out.read_one(&mut sub, |unknown| checker.check(unknown))?;
+        }
 
-        sub.expect_empty("CertReqExtension")
-            .map(|_| ext)
+        if out
+            .signature_algorithms
+            .as_ref()
+            .map(|algs| algs.is_empty())
+            .unwrap_or_default()
+        {
+            return Err(InvalidMessage::NoSignatureSchemes);
+        }
+
+        Ok(out)
     }
-}
-
-impl TlsListElement for CertReqExtension {
-    const SIZE_LEN: ListLength = ListLength::U16;
 }
 
 #[derive(Debug)]
 pub(crate) struct CertificateRequestPayloadTls13 {
     pub(crate) context: PayloadU8,
-    pub(crate) extensions: Vec<CertReqExtension>,
+    pub(crate) extensions: CertificateRequestExtensions,
 }
 
 impl Codec<'_> for CertificateRequestPayloadTls13 {
@@ -2340,46 +2320,12 @@ impl Codec<'_> for CertificateRequestPayloadTls13 {
 
     fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
         let context = PayloadU8::read(r)?;
-        let extensions = Vec::read(r)?;
+        let extensions = CertificateRequestExtensions::read(r)?;
 
         Ok(Self {
             context,
             extensions,
         })
-    }
-}
-
-impl CertificateRequestPayloadTls13 {
-    pub(crate) fn find_extension(&self, ext: ExtensionType) -> Option<&CertReqExtension> {
-        self.extensions
-            .iter()
-            .find(|x| x.ext_type() == ext)
-    }
-
-    pub(crate) fn sigalgs_extension(&self) -> Option<&[SignatureScheme]> {
-        let ext = self.find_extension(ExtensionType::SignatureAlgorithms)?;
-        match ext {
-            CertReqExtension::SignatureAlgorithms(sa) => Some(sa),
-            _ => None,
-        }
-    }
-
-    pub(crate) fn authorities_extension(&self) -> Option<&[DistinguishedName]> {
-        let ext = self.find_extension(ExtensionType::CertificateAuthorities)?;
-        match ext {
-            CertReqExtension::AuthorityNames(an) => Some(an),
-            _ => None,
-        }
-    }
-
-    pub(crate) fn certificate_compression_extension(
-        &self,
-    ) -> Option<&[CertificateCompressionAlgorithm]> {
-        let ext = self.find_extension(ExtensionType::CompressCertificate)?;
-        match ext {
-            CertReqExtension::CertificateCompressionAlgorithms(comps) => Some(comps),
-            _ => None,
-        }
     }
 }
 

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -268,6 +268,27 @@ macro_rules! extension_struct {
                 true
             }
 
+            /// Return true if any extension named in `exts` is present.
+            #[allow(dead_code)]
+            pub(crate) fn contains_any(&self, exts: &[ExtensionType]) -> bool {
+                for e in exts {
+                    if self.contains(*e) {
+                        return true;
+                    }
+                }
+                false
+            }
+
+            fn contains(&self, e: ExtensionType) -> bool {
+                match e {
+                    $(
+
+                        $item_id => self.$item_slot.is_some(),
+                    )*
+                    _ => false,
+                }
+            }
+
             /// Every `ExtensionType` this structure may encode/decode.
             const ALL_EXTENSIONS: &'static [ExtensionType] = &[
                 $($item_id,)*

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -213,6 +213,7 @@ macro_rules! extension_struct {
             }
 
             /// Return a list of extensions whose items are `Some`
+            #[allow(dead_code)]
             pub(crate) fn collect_used(&self) -> Vec<ExtensionType> {
                 let mut r = Vec::with_capacity(Self::ALL_EXTENSIONS.len());
 
@@ -228,6 +229,7 @@ macro_rules! extension_struct {
             /// Clone the value of the extension identified by `typ` from `source` to `self`.
             ///
             /// Does nothing if `typ` is not an extension handled by this object.
+            #[allow(dead_code)]
             pub(crate) fn clone_one(
                 &mut self,
                 source: &Self,
@@ -242,6 +244,7 @@ macro_rules! extension_struct {
             }
 
             /// Remove the extension identified by `typ` from `self`.
+            #[allow(dead_code)]
             pub(crate) fn clear(&mut self, typ: ExtensionType) {
                 match typ {
                     $(

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -254,6 +254,20 @@ macro_rules! extension_struct {
                 }
             }
 
+            /// Return true if all present extensions are named in `allowed`
+            #[allow(dead_code)]
+            pub(crate) fn only_contains(&self, allowed: &[ExtensionType]) -> bool {
+                $(
+                    if let Some(_) = &self.$item_slot {
+                        if !allowed.contains(&$item_id) {
+                            return false;
+                        }
+                    }
+                )*
+
+                true
+            }
+
             /// Every `ExtensionType` this structure may encode/decode.
             const ALL_EXTENSIONS: &'static [ExtensionType] = &[
                 $($item_id,)*

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -47,7 +47,7 @@ mod client_hello {
     use crate::msgs::enums::{Compression, NamedGroup, PskKeyExchangeMode};
     use crate::msgs::handshake::{
         CertReqExtension, CertificatePayloadTls13, CertificateRequestPayloadTls13,
-        ClientHelloPayload, HelloRetryExtension, HelloRetryRequest, KeyShareEntry, Random,
+        ClientHelloPayload, HelloRetryRequest, HelloRetryRequestExtensions, KeyShareEntry, Random,
         ServerExtension, ServerHelloPayload, SessionId,
     };
     use crate::server::common::ActiveCertifiedKey;
@@ -587,19 +587,16 @@ mod client_hello {
         common: &mut CommonState,
         group: NamedGroup,
     ) {
-        let mut req = HelloRetryRequest {
+        let req = HelloRetryRequest {
             legacy_version: ProtocolVersion::TLSv1_2,
             session_id,
             cipher_suite: suite.common.suite,
-            extensions: Vec::new(),
+            extensions: HelloRetryRequestExtensions {
+                key_share: Some(group),
+                supported_versions: Some(ProtocolVersion::TLSv1_3),
+                ..Default::default()
+            },
         };
-
-        req.extensions
-            .push(HelloRetryExtension::KeyShare(group));
-        req.extensions
-            .push(HelloRetryExtension::SupportedVersions(
-                ProtocolVersion::TLSv1_3,
-            ));
 
         let m = Message {
             version: ProtocolVersion::TLSv1_2,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1051,7 +1051,11 @@ impl State<ServerConnectionData> for ExpectCertificate {
 
         // We don't send any CertificateRequest extensions, so any extensions
         // here are illegal.
-        if certp.any_entry_has_extension() {
+        if certp
+            .entries
+            .iter()
+            .any(|e| !e.extensions.only_contains(&[]))
+        {
             return Err(PeerMisbehaved::UnsolicitedCertExtension.into());
         }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -22,7 +22,7 @@ use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::KeyUpdateRequest;
 use crate::msgs::handshake::{
     CERTIFICATE_MAX_SIZE_LIMIT, CertificateChain, CertificatePayloadTls13, HandshakeMessagePayload,
-    HandshakePayload, NewSessionTicketExtension, NewSessionTicketPayloadTls13,
+    HandshakePayload, NewSessionTicketPayloadTls13,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -1300,11 +1300,7 @@ impl ExpectFinished {
 
         if config.max_early_data_size > 0 {
             if !stateless {
-                payload
-                    .exts
-                    .push(NewSessionTicketExtension::EarlyData(
-                        config.max_early_data_size,
-                    ));
+                payload.extensions.max_early_data_size = Some(config.max_early_data_size);
             } else {
                 // We implement RFC8446 section 8.1: by enforcing that 0-RTT is
                 // only possible if using stateful resumption


### PR DESCRIPTION
This follows on from #2502, and applies similar changes to messages sent by TLS servers.

See #1475 for more background and prior discussion.