### PR TITLE
bogo: enable client certificate selection tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ dependencies = [
  "nix",
  "rustls",
  "rustls-post-quantum",
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/bogo/Cargo.toml
+++ b/bogo/Cargo.toml
@@ -10,6 +10,7 @@ env_logger = { workspace = true }
 nix = { version = "0.30", default-features = false, features = ["signal"] }
 rustls = { path = "../rustls", features = ["aws_lc_rs", "ring", "tls12"] }
 rustls-post-quantum = { path = "../rustls-post-quantum", optional = true }
+webpki = { workspace = true }
 
 [features]
 default = []

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -1,11 +1,11 @@
 {
   "DisabledTests": {
-    "SendV2ClientHello-*": "only support TLS1.2",
-    "*SSL3*": "",
-    "*TLS1-*": "",
-    "*-TLS1": "",
-    "*TLS11-*": "",
-    "*-TLS11": "",
+    "SendV2ClientHello-*": "we only support >=TLS1.2",
+    "*SSL3*": "we only support >=TLS1.2",
+    "*TLS1-*": "we only support >=TLS1.2",
+    "*-TLS1": "we only support >=TLS1.2",
+    "*TLS11-*": "we only support >=TLS1.2",
+    "*-TLS11": "we only support >=TLS1.2",
     "ConflictingVersionNegotiation": "expects to negotiate TLS1.1",
     "CertificateSelection-*": "TODO",
     "SendFallbackSCSV": "fallback scsv not implemented",

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -6,7 +6,7 @@
     "*-TLS1": "",
     "*TLS11-*": "",
     "*-TLS11": "",
-    "ConflictingVersionNegotiation": "",
+    "ConflictingVersionNegotiation": "expects to negotiate TLS1.1",
     "CertificateSelection-*": "TODO",
     "SendFallbackSCSV": "fallback scsv not implemented",
     "ECDSAKeyUsage-*": "TODO: we don't do anything with key usages",

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -6,8 +6,11 @@
     "*-TLS1": "we only support >=TLS1.2",
     "*TLS11-*": "we only support >=TLS1.2",
     "*-TLS11": "we only support >=TLS1.2",
+    "CertificateSelection-*TrustAnchorIDs-*": "no support for trust anchor IDs draft",
+    "CertificateSelection-*ClientCertificateTypes-*": "no support for CertificateRequest::certificate_types",
+    "CertificateSelection-Client-SignatureAlgorithmECDSACurve-TLS-TLS12": "ResolvesClientCert does not receive protocol version",
+    "CertificateSelection-Server-*": "TODO certificate selection for servers",
     "ConflictingVersionNegotiation": "expects to negotiate TLS1.1",
-    "CertificateSelection-*": "TODO",
     "SendFallbackSCSV": "fallback scsv not implemented",
     "ECDSAKeyUsage-*": "TODO: we don't do anything with key usages",
     "CheckRecordVersion-*": "we don't look at record version",
@@ -384,7 +387,17 @@
     "DuplicateExtensionClient-TLS-TLS12": "remote error: illegal parameter",
     "DuplicateExtensionClient-TLS-TLS13": "remote error: illegal parameter",
     "DuplicateExtensionServer-TLS-TLS12": "remote error: illegal parameter",
-    "DuplicateExtensionServer-TLS-TLS13": "remote error: illegal parameter"
+    "DuplicateExtensionServer-TLS-TLS13": "remote error: illegal parameter",
+    "_": "no alerts sent for the following tests... (artificial error created in the shim)",
+    "CertificateSelection-Client-CheckIssuer-MatchNone-TLS-TLS12": "",
+    "CertificateSelection-Client-CheckIssuer-MatchNone-TLS-TLS13": "",
+    "CertificateSelection-Client-CheckIssuerFallback-MatchNone-TLS-TLS12": "",
+    "CertificateSelection-Client-CheckIssuerFallback-MatchNone-TLS-TLS13": "",
+    "CertificateSelection-Client-SignatureAlgorithm-MatchNone-TLS-TLS12": "",
+    "CertificateSelection-Client-SignatureAlgorithm-MatchNone-TLS-TLS13": "",
+    "CertificateSelection-Client-SignatureAlgorithmECDSACurve-MatchNone-TLS-TLS13": "",
+    "CertificateSelection-Client-SignatureAlgorithmKeyPrefs-MatchNone-TLS-TLS12": "",
+    "CertificateSelection-Client-SignatureAlgorithmKeyPrefs-MatchNone-TLS-TLS13": ""
   },
   "HalfRTTTickets": 0
 }


### PR DESCRIPTION
This enables most `CertificateSelection-Client-*` tests, which demonstrates the extent to which the `ResolvesClientCert` trait is good or not.

This PR also does some minor fiddling in config.json.in, with the eventual goal of making the order of `DisabledTests` irrelevent, and therefore being able to sort the sections of this file.