### PR TITLE
add `From<Arc<CertifiedKey>>` for `SingleCertAndKey`

### DIFF
--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -101,6 +101,12 @@ impl From<CertifiedKey> for SingleCertAndKey {
     }
 }
 
+impl From<Arc<CertifiedKey>> for SingleCertAndKey {
+    fn from(certified_key: Arc<CertifiedKey>) -> Self {
+        Self(certified_key)
+    }
+}
+
 impl ResolvesClientCert for SingleCertAndKey {
     fn resolve(
         &self,


### PR DESCRIPTION
For my use case, the `Arc<CertifiedKey>` is shared between the client and server certificate resolver.
This commit avoid cloning the `CertifiedKey`