### PR TITLE
Memoise computation of empty hash

### DIFF
--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::upper_case_acronyms)]
 #![allow(non_camel_case_types)]
-use crate::crypto::KeyExchangeAlgorithm;
+use crate::crypto::{KeyExchangeAlgorithm, hash};
 use crate::msgs::codec::{Codec, Reader};
 
 enum_builder! {
@@ -16,6 +16,32 @@ enum_builder! {
         SHA256 => 0x04,
         SHA384 => 0x05,
         SHA512 => 0x06,
+    }
+}
+
+impl HashAlgorithm {
+    /// Returns the hash of the empty input.
+    ///
+    /// This returns `None` for some hash algorithms, so the caller
+    /// should be prepared to do the computation themselves in this case.
+    pub(crate) fn hash_for_empty_input(&self) -> Option<hash::Output> {
+        match self {
+            Self::SHA256 => Some(hash::Output::new(
+                b"\xe3\xb0\xc4\x42\x98\xfc\x1c\x14\
+                  \x9a\xfb\xf4\xc8\x99\x6f\xb9\x24\
+                  \x27\xae\x41\xe4\x64\x9b\x93\x4c\
+                  \xa4\x95\x99\x1b\x78\x52\xb8\x55",
+            )),
+            Self::SHA384 => Some(hash::Output::new(
+                b"\x38\xb0\x60\xa7\x51\xac\x96\x38\
+                  \x4c\xd9\x32\x7e\xb1\xb1\xe3\x6a\
+                  \x21\xfd\xb7\x11\x14\xbe\x07\x43\
+                  \x4c\x0c\xc7\xbf\x63\xf6\xe1\xda\
+                  \x27\x4e\xde\xbf\xe7\x6f\x65\xfb\
+                  \xd5\x1a\xd2\xf1\x48\x98\xb9\x5b",
+            )),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
For a small, common set of `HashAlgorithm`s, we now just inherently know their `hash::Output` for the empty input. This value is used in the TLS1.3 key schedule.