### PR TITLE
Fix clippy warning on sometimes-unused constant

### DIFF
--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -107,6 +107,7 @@ impl TicketRotator {
         self.state.read().ok()
     }
 
+    #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
     pub(crate) const SIX_HOURS: u32 = 6 * 60 * 60;
 }
 


### PR DESCRIPTION
Slipped in with previous commit -- cc8766bb829d2a3b6107b3d172b5625d20ab0ec7