### PR TITLE
Correct calculation of ServerHello ECH confirmation

### DIFF
--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -180,9 +180,21 @@ pub(super) fn handle_server_hello(
 
     // If we have ECH state, check that the server accepted our offer.
     if let Some(ech_state) = ech_state {
+        let Message {
+            payload:
+                MessagePayload::Handshake {
+                    encoded: server_hello_encoded,
+                    ..
+                },
+            ..
+        } = &server_hello_msg
+        else {
+            unreachable!("ServerHello is a handshake message");
+        };
         cx.data.ech_status = match ech_state.confirm_acceptance(
             &mut key_schedule,
             server_hello,
+            server_hello_encoded,
             suite.common.hash_provider,
         )? {
             // The server accepted our ECH offer, so complete the inner transcript with the


### PR DESCRIPTION
This was another case where we were relying on the ability to round-trip received messages.  That assumption as abandoned in 692f981446. This meant that we calculated the ECH confirmation based on a different extension ordering than the one the server sent, which meant it didn't match.

bogo and the cloudflare test server continued to work, as they just happened to choose the same extension ordering as us.  But OpenSSL didn't.