### PR TITLE
Improve compactness of Debug impl for extensions

### DIFF
--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -121,7 +121,7 @@ macro_rules! extension_struct {
     ) => {
         $(#[doc = $comment])*
         #[non_exhaustive]
-        #[derive(Clone, Debug, Default)]
+        #[derive(Clone, Default)]
         $struct_vis struct $struct_name$(<$struct_lt>)* {
             $(
               $(#[$item_attr])*
@@ -293,6 +293,21 @@ macro_rules! extension_struct {
             const ALL_EXTENSIONS: &'static [ExtensionType] = &[
                 $($item_id,)*
             ];
+        }
+
+        impl<'a> core::fmt::Debug for $struct_name$(<$struct_lt>)*  {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let mut ds = f.debug_struct(stringify!($struct_name));
+                $(
+                    if let Some(ext) = &self.$item_slot {
+                        ds.field(stringify!($item_slot), ext);
+                    }
+                )*
+                $($(
+                    ds.field(stringify!($meta_slot), &self.$meta_slot);
+                )+)*
+                ds.finish_non_exhaustive()
+            }
         }
     }
 }


### PR DESCRIPTION
This changes a typical log output from:

```
[2025-07-07T11:12:48Z TRACE rustls::client::hs] We got ServerHello ServerHelloPayload {
        legacy_version: TLSv1_2,
        random: 7788fd3dbfbdc71ccdc498ca9481063b3465aa2cd4ba6dafbbdd2c62c6240305,
        session_id: d0644d0ad008c9ce3c1fc4ac53a27b4e541629e2812dbda296e700e277a8b54b,
        cipher_suite: TLS13_AES_256_GCM_SHA384,
        compression_method: Null,
        extensions: ServerExtensions {
            ec_point_formats: None,
            server_name_ack: None,
            session_ticket_ack: None,
            renegotiation_info: None,
            selected_protocol: None,
            key_share: Some(
                KeyShareEntry {
                    group: X25519,
                    payload: a77c33030bc849e5c28bccc77baab971515180b488d691dca7218eb30dba8e6c,
                },
            ),
            preshared_key: None,
            client_certificate_type: None,
            server_certificate_type: None,
            extended_master_secret_ack: None,
            certificate_status_request_ack: None,
            selected_version: Some(
                TLSv1_3,
            ),
            transport_parameters: None,
            transport_parameters_draft: None,
            early_data_ack: None,
            encrypted_client_hello_ack: None,
            unknown_extensions: {},
        },
    }
```

to

```
[2025-07-07T11:14:27Z TRACE rustls::client::hs] We got ServerHello ServerHelloPayload {
        legacy_version: TLSv1_2,
        random: 99939331b6c6651f8fb629d2c9638af54c58678c23f971779e6e1afe798da72c,
        session_id: 8d40fe95171707857c8316b6fe4b674f7143185fc8ac190024a7a09b536c483f,
        cipher_suite: TLS13_AES_256_GCM_SHA384,
        compression_method: Null,
        extensions: ServerExtensions {
            key_share: KeyShareEntry {
                group: X25519,
                payload: 53465c231a1dd33dc148d5734eb253d8728773826e5a41182ade9a1e11209070,
            },
            selected_version: TLSv1_3,
            unknown_extensions: {},
            ..
        },
    }
```

by eliding mentions of extensions that are not present.