### PR TITLE
crypto: require matching keys for CertifiedKey construction

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -984,7 +984,10 @@ fn make_client_cfg(opts: &Options, key_log: &Arc<KeyLogMemo>) -> Arc<ClientConfi
                     .load_private_key(key)
                     .expect("cannot load private key");
 
-                resolver.set_default(sign::CertifiedKey::new(certs, key), cred)
+                resolver.set_default(
+                    sign::CertifiedKey::new(certs, key).expect("keys match"),
+                    cred,
+                )
             }
 
             for cred in opts.credentials.additional.iter() {
@@ -994,7 +997,10 @@ fn make_client_cfg(opts: &Options, key_log: &Arc<KeyLogMemo>) -> Arc<ClientConfi
                     .load_private_key(key)
                     .expect("cannot load private key");
 
-                resolver.add(sign::CertifiedKey::new(certs, key), cred);
+                resolver.add(
+                    sign::CertifiedKey::new(certs, key).expect("keys match"),
+                    cred,
+                );
             }
 
             cfg.with_client_cert_resolver(Arc::new(resolver))

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -659,7 +659,8 @@ struct ClientCert {
 
 impl ClientCert {
     fn new(mut certkey: sign::CertifiedKey, meta: &Credential) -> Self {
-        let parsed_cert = webpki::EndEntityCert::try_from(certkey.cert.last().unwrap()).unwrap();
+        let parsed_cert =
+            webpki::EndEntityCert::try_from(certkey.cert_chain.last().unwrap()).unwrap();
         let issuer_dn = DistinguishedName::in_sequence(parsed_cert.issuer());
 
         if let Some(scheme) = meta.use_signing_scheme {

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -43,7 +43,7 @@ mod client {
         let server_raw_key = SubjectPublicKeyInfoDer::from_pem_file(server_pub_key)
             .expect("cannot open pub key file");
 
-        let certified_key = Arc::new(CertifiedKey::new(
+        let certified_key = Arc::new(CertifiedKey::new_unchecked(
             vec![client_public_key_as_cert],
             client_private_key,
         ));
@@ -191,7 +191,7 @@ mod server {
             .expect("cannot load public key");
         let server_public_key_as_cert = CertificateDer::from(server_public_key.to_vec());
 
-        let certified_key = Arc::new(CertifiedKey::new(
+        let certified_key = Arc::new(CertifiedKey::new_unchecked(
             vec![server_public_key_as_cert],
             server_private_key,
         ));

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -62,7 +62,7 @@ pub fn server_verifier() -> Arc<dyn ServerCertVerifier> {
 
 pub fn server_cert_resolver() -> Arc<dyn server::ResolvesServerCert> {
     let cert = CertificateDer::from(&include_bytes!("../../test-ca/ecdsa-p256/end.der")[..]);
-    let certified_key = sign::CertifiedKey::new(vec![cert], Arc::new(SigningKey));
+    let certified_key = sign::CertifiedKey::new_unchecked(vec![cert], Arc::new(SigningKey));
     Arc::new(DummyCert(certified_key.into()))
 }
 

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -454,7 +454,7 @@ impl KeyType {
         let private_key = provider
             .key_provider
             .load_private_key(self.get_key())?;
-        Ok(Arc::new(CertifiedKey::new(self.get_chain(), private_key)))
+        Ok(Arc::new(CertifiedKey::new(self.get_chain(), private_key)?))
     }
 
     fn get_crl(&self, role: &str, r#type: &str) -> CertificateRevocationListDer<'static> {

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -424,7 +424,7 @@ impl KeyType {
             .public_key()
             .ok_or(Error::InconsistentKeys(InconsistentKeys::Unknown))?;
         let public_key_as_cert = CertificateDer::from(public_key.to_vec());
-        Ok(Arc::new(CertifiedKey::new(
+        Ok(Arc::new(CertifiedKey::new_unchecked(
             vec![public_key_as_cert],
             private_key,
         )))
@@ -441,7 +441,7 @@ impl KeyType {
             .public_key()
             .ok_or(Error::InconsistentKeys(InconsistentKeys::Unknown))?;
         let public_key_as_cert = CertificateDer::from(public_key.to_vec());
-        Ok(Arc::new(CertifiedKey::new(
+        Ok(Arc::new(CertifiedKey::new_unchecked(
             vec![public_key_as_cert],
             private_key,
         )))

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -475,7 +475,7 @@ mod tests {
                 .as_ref()
                 .to_vec(),
         )];
-        CertifiedKey::new(public_key_as_cert, key)
+        CertifiedKey::new_unchecked(public_key_as_cert, key)
     }
 
     fn client_key() -> PrivateKeyDer<'static> {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -924,7 +924,9 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
         if let Some(client_auth) = &st.client_auth {
             let certs = match client_auth {
                 ClientAuthDetails::Empty { .. } => CertificateChain::default(),
-                ClientAuthDetails::Verify { certkey, .. } => CertificateChain(certkey.cert.clone()),
+                ClientAuthDetails::Verify { certkey, .. } => {
+                    CertificateChain(certkey.cert_chain.clone())
+                }
             };
             emit_certificate(&mut st.transcript, certs, cx.common);
         }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1231,7 +1231,7 @@ fn emit_compressed_certificate_tls13(
     compressor: &dyn compress::CertCompressor,
     config: &ClientConfig,
 ) {
-    let mut cert_payload = CertificatePayloadTls13::new(certkey.cert.iter(), None);
+    let mut cert_payload = CertificatePayloadTls13::new(certkey.cert_chain.iter(), None);
     cert_payload.context = PayloadU8::new(auth_context.clone().unwrap_or_default());
 
     let Ok(compressed) = config
@@ -1252,7 +1252,7 @@ fn emit_certificate_tls13(
     auth_context: Option<Vec<u8>>,
 ) {
     let certs = certkey
-        .map(|ck| ck.cert.as_ref())
+        .map(|ck| ck.cert_chain.as_ref())
         .unwrap_or(&[][..]);
     let mut cert_payload = CertificatePayloadTls13::new(certs.iter(), None);
     cert_payload.context = PayloadU8::new(auth_context.unwrap_or_default());

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -135,6 +135,7 @@ impl ResolvesServerCert for SingleCertAndKey {
 /// certificates.
 ///
 /// [RFC 7250]: https://tools.ietf.org/html/rfc7250
+#[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct CertifiedKey {
     /// The certificate chain or raw public key.

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -139,7 +139,7 @@ impl ResolvesServerCert for SingleCertAndKey {
 #[derive(Clone, Debug)]
 pub struct CertifiedKey {
     /// The certificate chain or raw public key.
-    pub cert: Vec<CertificateDer<'static>>,
+    pub cert_chain: Vec<CertificateDer<'static>>,
 
     /// The certified key.
     pub key: Arc<dyn SigningKey>,
@@ -178,9 +178,9 @@ impl CertifiedKey {
     ///
     /// The cert chain must not be empty. The first certificate in the chain
     /// must be the end-entity certificate.
-    pub fn new(cert: Vec<CertificateDer<'static>>, key: Arc<dyn SigningKey>) -> Self {
+    pub fn new(cert_chain: Vec<CertificateDer<'static>>, key: Arc<dyn SigningKey>) -> Self {
         Self {
-            cert,
+            cert_chain,
             key,
             ocsp: None,
         }
@@ -202,7 +202,7 @@ impl CertifiedKey {
 
     /// The end-entity certificate.
     pub fn end_entity_cert(&self) -> Result<&CertificateDer<'_>, Error> {
-        self.cert
+        self.cert_chain
             .first()
             .ok_or(Error::NoCertificatesPresented)
     }

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -186,6 +186,24 @@ impl CertifiedKey {
         }
     }
 
+    /// Make a new `CertifiedKey` from a raw private key.
+    ///
+    /// Unlike [`CertifiedKey::new()`], this does not check that the end-entity certificate's
+    /// subject key matches `key`'s public key.
+    ///
+    /// This avoids parsing the end-entity certificate, which is useful when using client
+    /// certificates that are not fully standards compliant, but known to usable by the peer.
+    pub fn new_unchecked(
+        cert_chain: Vec<CertificateDer<'static>>,
+        key: Arc<dyn SigningKey>,
+    ) -> Self {
+        Self {
+            cert_chain,
+            key,
+            ocsp: None,
+        }
+    }
+
     /// Verify the consistency of this [`CertifiedKey`]'s public and private keys.
     /// This is done by performing a comparison of SubjectPublicKeyInfo bytes.
     pub fn keys_match(&self) -> Result<(), Error> {

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -100,9 +100,15 @@ pub enum Error {
     /// or too large.
     BadMaxFragmentSize,
 
-    /// Specific failure cases from [`keys_match`] or a [`crate::crypto::signer::SigningKey`] that cannot produce a corresponding public key.
+    /// Specific failure cases from [`CertifiedKey::new()`] or a
+    /// [`crate::crypto::signer::SigningKey`] that cannot produce a corresponding public key.
     ///
-    /// [`keys_match`]: crate::crypto::signer::CertifiedKey::keys_match
+    /// If encountered while building a [`CertifiedKey`], consider if
+    /// [`CertifiedKey::new_unchecked()`] might be appropriate for your use case.
+    ///
+    /// [`CertifiedKey::new()`]: crate::crypto::signer::CertifiedKey::new()
+    /// [`CertifiedKey`]: crate::crypto::signer::CertifiedKey
+    /// [`CertifiedKey::new_unchecked()`]: crate::crypto::signer::CertifiedKey::new_unchecked()
     InconsistentKeys(InconsistentKeys),
 
     /// Any other error.

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -19,7 +19,7 @@ impl ActiveCertifiedKey<'_> {
     /// Get the certificate chain
     #[inline]
     pub(super) fn get_cert(&self) -> &[CertificateDer<'static>] {
-        &self.key.cert
+        &self.key.cert_chain
     }
 
     /// Get the signing key

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -264,7 +264,7 @@ mod tests {
                 .as_ref()
                 .to_vec(),
         )];
-        CertifiedKey::new(public_key_as_cert, key)
+        CertifiedKey::new_unchecked(public_key_as_cert, key)
     }
 
     fn server_key() -> PrivateKeyDer<'static> {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -7465,7 +7465,7 @@ fn test_cert_decompression_by_server_would_result_in_excessively_large_cert() {
         .key_provider
         .load_private_key(KeyType::Rsa2048.get_client_key())
         .unwrap();
-    let big_cert_and_key = sign::CertifiedKey::new(vec![big_cert], key);
+    let big_cert_and_key = sign::CertifiedKey::new_unchecked(vec![big_cert], key);
     client_config.client_auth_cert_resolver =
         Arc::new(sign::SingleCertAndKey::from(big_cert_and_key));
 


### PR DESCRIPTION
One more part of #2119.