### PR TITLE
Clarify the ambiguous process-level CryptoProvider error

### DIFF
--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -246,7 +246,11 @@ impl CryptoProvider {
         }
 
         let provider = Self::from_crate_features()
-            .expect("no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point");
+            .expect(r###"
+Could not automatically determine the process-level CryptoProvider from Rustls crate features.
+Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
+See the documentation of the CryptoProvider type for more information.
+            "###);
         // Ignore the error resulting from us losing a race, and accept the outcome.
         let _ = provider.install_default();
         Self::get_default().unwrap()


### PR DESCRIPTION
I have personally hit this error after adding a new dependency that enabled the `ring` feature without me realizing.
I think the instruction of the error, to call `CryptoProvider::install_default()`, does not help the user understand why this error suddenly appeared.

Yesterday I saw this [reddit thread](https://www.reddit.com/r/rust/comments/1lyekqv/rustls_ring_and_awslcrs/) hit the same problem, so lets fix this. I'm open to different wording than I came up with, I'm not an expert on this crate.