### PR TITLE
Draft: Generalize API for extensible non-X.509 support

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -41,13 +41,10 @@ use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::handshake::EchConfigPayload;
 use rustls::internal::msgs::persist::ServerSessionValue;
 use rustls::pki_types::pem::PemObject;
-use rustls::pki_types::{CertificateDer, EchConfigListBytes, PrivateKeyDer, ServerName, UnixTime};
-use rustls::server::danger::{ClientIdVerified, ClientCertVerifier};
 use rustls::pki_types::{
     CertificateDer, EchConfigListBytes, PrivateKeyDer, ServerName, SubjectPublicKeyInfoDer,
     UnixTime,
 };
-use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::server::danger::{ClientCertVerifier, ClientIdVerified};
 use rustls::server::{
     CertificateType, ClientHello, ProducesTickets, ServerConfig, ServerConnection,
@@ -1203,9 +1200,9 @@ fn handle_err(opts: &Options, err: Error) -> ! {
             quit(":CANNOT_PARSE_LEAF_CERT:")
         }
         Error::InvalidCertificate(CertificateError::BadSignature) => quit(":BAD_SIGNATURE:"),
-        Error::InvalidCertificate(CertificateError::UnsupportedSignatureAlgorithm) => {
-            quit(":WRONG_SIGNATURE_TYPE:")
-        }
+        Error::InvalidCertificate(CertificateError::UnsupportedSignatureAlgorithmContext {
+            ..
+        }) => quit(":WRONG_SIGNATURE_TYPE:"),
         Error::InvalidCertificate(CertificateError::InvalidOcspResponse) => {
             // note: only use is in this file.
             quit(":OCSP_CB_ERROR:")

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -365,8 +365,8 @@ mod danger {
             _server_name: &ServerName<'_>,
             _ocsp: &[u8],
             _now: UnixTime,
-        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        ) -> Result<rustls::client::danger::ServerIdVerified, rustls::Error> {
+            Ok(rustls::client::danger::ServerIdVerified::assertion())
         }
 
         fn verify_tls12_signature(
@@ -495,7 +495,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     if args.insecure {
         config
             .dangerous()
-            .set_certificate_verifier(Arc::new(danger::NoCertificateVerification::new(
+            .certificate_verifier(Arc::new(danger::NoCertificateVerification::new(
                 provider::default_provider(),
             )));
     }

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -495,7 +495,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     if args.insecure {
         config
             .dangerous()
-            .certificate_verifier(Arc::new(danger::NoCertificateVerification::new(
+            .set_certificate_verifier(Arc::new(danger::NoCertificateVerification::new(
                 provider::default_provider(),
             )));
     }

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -124,10 +124,6 @@ mod client {
         fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
             self.supported_algs.supported_schemes()
         }
-
-        fn request_ocsp_response(&self) -> bool {
-            false
-        }
     }
 }
 

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -156,8 +156,8 @@ use crate::{ClientConfig, ServerConfig};
 /// [`ServerConfig::builder_with_provider()`]: crate::ServerConfig::builder_with_provider()
 /// [`ConfigBuilder<ClientConfig, WantsVerifier>`]: struct.ConfigBuilder.html#impl-3
 /// [`ConfigBuilder<ServerConfig, WantsVerifier>`]: struct.ConfigBuilder.html#impl-6
-/// [`WantsClientCert`]: crate::client::WantsClientCert
-/// [`WantsServerCert`]: crate::server::WantsServerCert
+/// [`WantsClientCert`]: crate::client::WantsClientIdentity
+/// [`WantsServerCert`]: crate::server::WantsServerIdentity
 /// [`CryptoProvider::get_default`]: crate::crypto::CryptoProvider::get_default
 /// [`DangerousClientConfigBuilder::with_custom_certificate_verifier`]: crate::client::danger::DangerousClientConfigBuilder::with_custom_certificate_verifier
 #[derive(Clone)]

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -96,7 +96,7 @@ pub(super) mod danger {
 
     use crate::client::WantsClientIdentity;
     use crate::sync::Arc;
-    use crate::verify::{ServerCertVerifierCompat, ServerRpkVerifierCompat};
+    use crate::verify::{ServerCertVerifierCompat, ServerRpkVerifierWrapper};
     use crate::{ClientConfig, ConfigBuilder, WantsVerifier, verify};
 
     /// Accessor for dangerous configuration options.
@@ -120,7 +120,7 @@ pub(super) mod danger {
             self,
             verifier: Arc<dyn verify::ServerRpkVerifier>,
         ) -> ConfigBuilder<ClientConfig, WantsClientIdentity> {
-            self.with_custom_identity_verifier(Arc::new(ServerRpkVerifierCompat::from(verifier)))
+            self.with_custom_identity_verifier(Arc::new(ServerRpkVerifierWrapper::from(verifier)))
         }
 
         /// Set a custom certificate verifier.

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+
 use pki_types::{CertificateDer, PrivateKeyDer};
 
 use super::client_conn::{
@@ -11,7 +12,7 @@ use crate::error::Error;
 use crate::key_log::NoKeyLog;
 use crate::sign::{CertifiedKey, SingleCertAndKey};
 use crate::sync::Arc;
-use crate::verify::{ServerCertVerifier, ServerCertVerifierCompat};
+use crate::verify::ServerCertVerifierCompat;
 use crate::versions::TLS13;
 use crate::webpki::{self, WebPkiServerVerifier};
 use crate::{WantsVersions, compress, verify, versions};
@@ -70,7 +71,6 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
         self,
         verifier: Arc<WebPkiServerVerifier>,
     ) -> ConfigBuilder<ClientConfig, WantsClientIdentity> {
-        let verifier: Arc<dyn ServerCertVerifier> = verifier;
         ConfigBuilder {
             state: WantsClientIdentity {
                 versions: self.state.versions,

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -641,7 +641,7 @@ pub(super) mod danger {
     use crate::sync::Arc;
     use crate::verify::{
         ServerCertVerifier, ServerCertVerifierCompat, ServerIdVerifier, ServerRpkVerifier,
-        ServerRpkVerifierCompat,
+        ServerRpkVerifierWrapper,
     };
 
     /// Accessor for dangerous configuration options.
@@ -653,17 +653,17 @@ pub(super) mod danger {
 
     impl DangerousClientConfig<'_> {
         /// Overrides the default `ServerIdVerifier` with something else.
-        pub fn certificate_verifier(&mut self, verifier: Arc<dyn ServerCertVerifier>) {
-            self.identity_verifier(Arc::new(ServerCertVerifierCompat::from(verifier)))
+        pub fn set_certificate_verifier(&mut self, verifier: Arc<dyn ServerCertVerifier>) {
+            self.set_identity_verifier(Arc::new(ServerCertVerifierCompat::from(verifier)))
         }
 
         /// Overrides the default `ServerIdVerifier` with something else.
-        pub fn rpk_verifier(&mut self, verifier: Arc<dyn ServerRpkVerifier>) {
-            self.identity_verifier(Arc::new(ServerRpkVerifierCompat::from(verifier)))
+        pub fn set_rpk_verifier(&mut self, verifier: Arc<dyn ServerRpkVerifier>) {
+            self.set_identity_verifier(Arc::new(ServerRpkVerifierWrapper::from(verifier)))
         }
 
         /// Overrides the default `ServerIdVerifier` with something else.
-        pub fn identity_verifier(&mut self, verifier: Arc<dyn ServerIdVerifier>) {
+        pub fn set_identity_verifier(&mut self, verifier: Arc<dyn ServerIdVerifier>) {
             self.cfg.verifier = verifier;
         }
     }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -6,6 +6,8 @@ use crate::builder::ConfigBuilder;
 use crate::client::{EchMode, EchStatus};
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
+#[cfg(doc)]
+use crate::crypto;
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
 use crate::enums::{CertificateType, CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
@@ -21,8 +23,6 @@ use crate::time_provider::DefaultTimeProvider;
 use crate::time_provider::TimeProvider;
 use crate::unbuffered::{EncryptError, TransmitTlsData};
 use crate::{DistinguishedName, KeyLog, WantsVersions, compress, sign, verify, versions};
-#[cfg(doc)]
-use crate::{DistinguishedName, crypto};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -1,13 +1,12 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use crate::client::ResolvesClientIdentity;
+use super::ResolvesClientIdentity;
 use crate::enums::CertificateType;
 use crate::identity::SigningIdentity;
 use crate::log::{debug, trace};
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::handshake::{CertificateChain, DistinguishedName, ProtocolName, ServerExtensions};
-use crate::sync::Arc;
 use crate::{SignatureScheme, compress, sign};
 
 #[derive(Debug)]
@@ -91,7 +90,7 @@ pub(super) enum ClientAuthDetails {
 
 impl ClientAuthDetails {
     pub(super) fn resolve(
-        resolver: &Arc<dyn ResolvesClientIdentity>,
+        resolver: &dyn ResolvesClientIdentity,
         certificate_type: CertificateType,
         canames: Option<&[DistinguishedName]>,
         sigschemes: &[SignatureScheme],

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -165,9 +165,7 @@ impl EchConfig {
         EchState::new(
             self,
             server_name.clone(),
-            config
-                .client_auth_cert_resolver
-                .has_certs(),
+            config.client_auth_id_resolver.enabled(),
             config.provider.secure_random,
             config.enable_sni,
         )

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -248,8 +248,7 @@ mod tests {
     use super::NoClientSessionStorage;
     use super::provider::cipher_suite;
     use crate::client::danger::{
-        HandshakeSignatureValid, ServerCertVerifier, ServerCertVerifierCompat, ServerIdVerified,
-        ServerIdVerifier,
+        HandshakeSignatureValid, ServerCertVerifier, ServerIdVerified, ServerIdVerifier,
     };
     use crate::client::{ClientSessionStore, ResolvesClientCert};
     use crate::msgs::base::PayloadU16;
@@ -269,8 +268,9 @@ mod tests {
         let name = ServerName::try_from("example.com").unwrap();
         let now = UnixTime::now();
         let server_cert_verifier: Arc<dyn ServerCertVerifier> = Arc::new(DummyServerCertVerifier);
-        let server_id_verifier: Arc<dyn ServerIdVerifier> =
-            Arc::new(ServerCertVerifierCompat::from(server_cert_verifier));
+        let server_id_verifier: Arc<dyn ServerIdVerifier> = Arc::new(
+            crate::verify::ServerCertVerifierCompat::from(server_cert_verifier),
+        );
         let drcc: Arc<dyn ResolvesClientCert> = Arc::new(DummyResolvesClientCert);
         let resolves_client_cert: Arc<dyn crate::client::ResolvesClientIdentity> = Arc::new(
             crate::client::client_conn::ResolvesClientCertCompat::from(drcc),

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -650,7 +650,7 @@ pub(super) fn process_server_cert_type_extension(
     config: &ClientConfig,
     server_cert_extension: Option<&CertificateType>,
 ) -> Result<(), Error> {
-    // X.509 is implied of no extension present
+    // X.509 is implied if no extension present
     let accepted = server_cert_extension
         .map(|c| c)
         .unwrap_or(&CertificateType::X509);

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -569,10 +569,6 @@ mod tests {
         fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
             vec![SignatureScheme::RSA_PKCS1_SHA1]
         }
-
-        fn request_ocsp_response(&self) -> bool {
-            false
-        }
     }
 
     #[derive(Debug)]

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -920,7 +920,9 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
         if let Some(client_auth) = &st.client_auth {
             let id = match client_auth {
                 ClientAuthDetails::Empty { .. } => CertificateChain::default().into(),
-                ClientAuthDetails::Verify { signing_id: id_key, .. } => id_key.id().clone(),
+                ClientAuthDetails::Verify {
+                    signing_id: id_key, ..
+                } => id_key.id().clone(),
             };
             // We only support certificates in TLS 1.2
             if let Some(certs) = id.as_certificates() {

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+
 use pki_types::CertificateDer;
 
 use crate::conn::kernel::KernelState;

--- a/rustls/src/compress.rs
+++ b/rustls/src/compress.rs
@@ -42,7 +42,7 @@ use std::sync::Mutex;
 use crate::enums::CertificateCompressionAlgorithm;
 use crate::msgs::base::{Payload, PayloadU24};
 use crate::msgs::codec::Codec;
-use crate::msgs::handshake::{CertificatePayloadTls13, CompressedCertificatePayload};
+use crate::msgs::handshake::{IdentityPayloadTls13, CompressedCertificatePayload};
 use crate::sync::Arc;
 
 /// Returns the supported `CertDecompressor` implementations enabled
@@ -320,7 +320,7 @@ impl CompressionCache {
     pub(crate) fn compression_for(
         &self,
         compressor: &dyn CertCompressor,
-        original: &CertificatePayloadTls13<'_>,
+        original: &IdentityPayloadTls13<'_>,
     ) -> Result<Arc<CompressionCacheEntry>, CompressionFailed> {
         match self {
             Self::Disabled => Self::uncached_compression(compressor, original),
@@ -334,7 +334,7 @@ impl CompressionCache {
     fn compression_for_impl(
         &self,
         compressor: &dyn CertCompressor,
-        original: &CertificatePayloadTls13<'_>,
+        original: &IdentityPayloadTls13<'_>,
     ) -> Result<Arc<CompressionCacheEntry>, CompressionFailed> {
         let (max_size, entries) = match self {
             Self::Enabled(CompressionCacheInner { size, entries }) => (*size, entries),
@@ -391,7 +391,7 @@ impl CompressionCache {
     /// Compress `original` using `compressor` at `Interactive` level.
     fn uncached_compression(
         compressor: &dyn CertCompressor,
-        original: &CertificatePayloadTls13<'_>,
+        original: &IdentityPayloadTls13<'_>,
     ) -> Result<Arc<CompressionCacheEntry>, CompressionFailed> {
         let algorithm = compressor.algorithm();
         let encoding = original.get_encoding();
@@ -446,9 +446,11 @@ impl CompressionCacheEntry {
 
 #[cfg(all(test, any(feature = "brotli", feature = "zlib")))]
 mod tests {
-    use super::*;
-    use crate::identity::{IntoOwned, TlsIdentity};
     use std::{println, vec};
+
+    use super::*;
+
+    use crate::identity::{IntoOwned, TlsIdentity};
 
     #[test]
     #[cfg(feature = "zlib")]
@@ -537,22 +539,22 @@ mod tests {
 
         let cert = CertificateDer::from(vec![1]);
 
-        let cert1 = CertificatePayloadTls13::from(
+        let cert1 = IdentityPayloadTls13::from(
             X509Identity::new([cert.clone()].into_iter(), b"1".as_slice())
                 .to_wire_format()
                 .into_owned(),
         );
-        let cert2 = CertificatePayloadTls13::from(
+        let cert2 = IdentityPayloadTls13::from(
             X509Identity::new([cert.clone()].into_iter(), b"2".as_slice())
                 .to_wire_format()
                 .into_owned(),
         );
-        let cert3 = CertificatePayloadTls13::from(
+        let cert3 = IdentityPayloadTls13::from(
             X509Identity::new([cert.clone()].into_iter(), b"3".as_slice())
                 .to_wire_format()
                 .into_owned(),
         );
-        let cert4 = CertificatePayloadTls13::from(
+        let cert4 = IdentityPayloadTls13::from(
             X509Identity::new([cert.clone()].into_iter(), b"4".as_slice())
                 .to_wire_format()
                 .into_owned(),

--- a/rustls/src/compress.rs
+++ b/rustls/src/compress.rs
@@ -446,9 +446,9 @@ impl CompressionCacheEntry {
 
 #[cfg(all(test, any(feature = "brotli", feature = "zlib")))]
 mod tests {
-    use std::{println, vec};
-
     use super::*;
+    use crate::identity::{IntoOwned, TlsIdentity};
+    use std::{println, vec};
 
     #[test]
     #[cfg(feature = "zlib")]
@@ -528,6 +528,7 @@ mod tests {
     #[test]
     #[cfg(all(feature = "brotli", feature = "zlib"))]
     fn test_cache_evicts_lru() {
+        use crate::identity::X509Identity;
         use core::sync::atomic::{AtomicBool, Ordering};
 
         use pki_types::CertificateDer;
@@ -536,10 +537,26 @@ mod tests {
 
         let cert = CertificateDer::from(vec![1]);
 
-        let cert1 = CertificatePayloadTls13::new([&cert].into_iter(), Some(b"1"));
-        let cert2 = CertificatePayloadTls13::new([&cert].into_iter(), Some(b"2"));
-        let cert3 = CertificatePayloadTls13::new([&cert].into_iter(), Some(b"3"));
-        let cert4 = CertificatePayloadTls13::new([&cert].into_iter(), Some(b"4"));
+        let cert1 = CertificatePayloadTls13::from(
+            X509Identity::new([cert.clone()].into_iter(), b"1".as_slice())
+                .to_wire_format()
+                .into_owned(),
+        );
+        let cert2 = CertificatePayloadTls13::from(
+            X509Identity::new([cert.clone()].into_iter(), b"2".as_slice())
+                .to_wire_format()
+                .into_owned(),
+        );
+        let cert3 = CertificatePayloadTls13::from(
+            X509Identity::new([cert.clone()].into_iter(), b"3".as_slice())
+                .to_wire_format()
+                .into_owned(),
+        );
+        let cert4 = CertificatePayloadTls13::from(
+            X509Identity::new([cert.clone()].into_iter(), b"4".as_slice())
+                .to_wire_format()
+                .into_owned(),
+        );
 
         // insert zlib (1), (2), (3), (4)
 

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -272,7 +272,6 @@ impl IdentitySigner for KeyPair {
     }
 }
 
-#[cfg_attr(not(any(feature = "aws_lc_rs", feature = "ring")), allow(dead_code))]
 #[cfg_attr(not(any(feature = "aws-lc-rs", feature = "ring")), allow(dead_code))]
 pub(crate) fn public_key_to_spki(
     alg_id: &AlgorithmIdentifier,

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -1,3 +1,11 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::any::Any;
+use core::fmt::Debug;
+use core::ops::Deref;
+
+use pki_types::{AlgorithmIdentifier, CertificateDer, PrivateKeyDer, SubjectPublicKeyInfoDer};
+
 use super::CryptoProvider;
 use crate::client::ResolvesClientCert;
 use crate::enums::{SignatureAlgorithm, SignatureScheme};
@@ -6,12 +14,6 @@ use crate::identity::{IdentitySigner, TlsIdentity, X509Identity};
 use crate::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
 use crate::sync::Arc;
 use crate::x509;
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use core::fmt::Debug;
-use pki_types::{AlgorithmIdentifier, CertificateDer, PrivateKeyDer, SubjectPublicKeyInfoDer};
-use std::any::Any;
-use std::ops::Deref;
 
 /// An abstract signing key.
 ///

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -584,6 +584,9 @@ enum_builder! {
     pub enum CertificateType {
         X509 => 0x00,
         RawPublicKey => 0x02,
+        
+        !Ranges:
+          Custom => 224..=255,
     }
 }
 

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -50,6 +50,9 @@ pub enum Error {
     /// The certificate verifier doesn't support the given type of name.
     UnsupportedNameType,
 
+    /// The specified identity type is not supported.
+    UnsupportedIdentityType,
+
     /// We couldn't decrypt a message.  This is invariably fatal.
     DecryptError,
 
@@ -988,6 +991,7 @@ impl fmt::Display for Error {
             }
             Self::NoCertificatesPresented => write!(f, "peer sent no certificates"),
             Self::UnsupportedNameType => write!(f, "presented server name type wasn't supported"),
+            Self::UnsupportedIdentityType => write!(f, "specified identity type wasn't supported"),
             Self::DecryptError => write!(f, "cannot decrypt peer's message"),
             Self::InvalidEncryptedClientHello(err) => {
                 write!(f, "encrypted client hello failure: {err:?}")

--- a/rustls/src/identity.rs
+++ b/rustls/src/identity.rs
@@ -1,0 +1,213 @@
+use crate::enums::CertificateType;
+use crate::msgs::base::{Payload, PayloadU8};
+use crate::msgs::handshake;
+use crate::msgs::handshake::{
+    CertificateChain, CertificatePayloadTls13, CertificateStatus, IdentityEntry,
+};
+use crate::sign::{CertifiedKey, SigningKey};
+use crate::sync::Arc;
+use core::fmt::Debug;
+use pki_types::{CertificateDer, SubjectPublicKeyInfoDer};
+use std::any::Any;
+use std::prelude::rust_2015::{Box, Vec};
+use std::{iter, vec};
+
+#[derive(Debug, Clone)]
+pub struct Identity(Arc<dyn TlsIdentity>);
+
+impl Default for Identity {
+    fn default() -> Self {
+        X509Identity::new([], None::<&[u8]>).into()
+    }
+}
+
+impl Identity {
+    pub fn as_certificates(&self) -> Option<&[CertificateDer<'static>]> {
+        self.as_any()
+            .downcast_ref::<X509Identity>()
+            .map(|cd| cd.cert_chain.as_ref())
+    }
+
+    pub fn as_public_key(&self) -> Option<&SubjectPublicKeyInfoDer<'static>> {
+        self.as_any()
+            .downcast_ref::<SubjectPublicKeyInfoDer<'static>>()
+    }
+
+    pub fn as_any(&self) -> &dyn Any {
+        self.0.as_any()
+    }
+
+    pub fn certificate_type(&self) -> CertificateType {
+        self.0.certificate_type()
+    }
+
+    pub(crate) fn to_wire_format(&self) -> TlsIdentityEntries<'_> {
+        self.0.to_wire_format()
+    }
+}
+
+pub type TlsIdentityEntries<'a> = Vec<IdentityEntry<'a>>;
+
+impl<'a> From<TlsIdentityEntries<'a>> for CertificatePayloadTls13<'a> {
+    fn from(value: TlsIdentityEntries<'a>) -> Self {
+        Self {
+            context: PayloadU8::empty(),
+            entries: value,
+        }
+    }
+}
+
+impl<'a> From<CertificatePayloadTls13<'a>> for TlsIdentityEntries<'a> {
+    fn from(value: CertificatePayloadTls13<'a>) -> Self {
+        value.entries
+    }
+}
+
+pub(crate) trait IntoOwned {
+    type R<'a>;
+    fn into_owned(self) -> Self::R<'static>;
+}
+
+impl IntoOwned for TlsIdentityEntries<'_> {
+    type R<'a> = TlsIdentityEntries<'a>;
+
+    fn into_owned(self) -> Self::R<'static> {
+        self.into_iter()
+            .map(|e| e.into_owned())
+            .collect()
+    }
+}
+
+impl From<CertificateChain<'static>> for Identity {
+    fn from(value: CertificateChain<'static>) -> Self {
+        X509Identity::new(value.0, None::<&[u8]>).into()
+    }
+}
+
+impl<T: TlsIdentity + 'static> From<T> for Identity {
+    fn from(value: T) -> Self {
+        Self(Arc::new(value))
+    }
+}
+
+pub trait TlsIdentity: Debug + Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+    fn certificate_type(&self) -> CertificateType;
+    fn to_wire_format(&self) -> TlsIdentityEntries<'_>;
+}
+
+#[derive(Debug)]
+pub(crate) struct X509Identity {
+    pub(crate) cert_chain: CertificateChain<'static>,
+    pub(crate) ocsp_response: Vec<u8>,
+}
+
+impl X509Identity {
+    pub(crate) fn new<'a>(
+        cert_chain: impl IntoIterator<Item = CertificateDer<'a>>,
+        ocsp_response: impl Into<Payload<'a>>,
+    ) -> Self {
+        Self {
+            cert_chain: CertificateChain::from_certs(cert_chain.into_iter()).into_owned(),
+            ocsp_response: ocsp_response.into().into_vec(),
+        }
+    }
+}
+
+impl TlsIdentity for X509Identity {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn certificate_type(&self) -> CertificateType {
+        CertificateType::X509
+    }
+
+    fn to_wire_format(&self) -> TlsIdentityEntries<'_> {
+        self.cert_chain
+            .iter()
+            // zip certificate iterator with `ocsp_response` followed by
+            // an infinite-length iterator of `None`.
+            .zip(
+                [&self.ocsp_response]
+                    .into_iter()
+                    .filter_map(|o| {
+                        let mut exts = handshake::CertificateExtensions::default();
+                        if !o.is_empty() {
+                            exts.status = Some(CertificateStatus::new(o));
+                            let mut out = Vec::new();
+                            exts.encode_payload(&mut out);
+                            Some(Some(out))
+                        } else {
+                            None
+                        }
+                    })
+                    .chain(iter::repeat(None)),
+            )
+            .map(|(cert, ocsp)| {
+                if let Some(ocsp) = ocsp {
+                    IdentityEntry::new_with_extensions(cert.as_ref(), ocsp)
+                } else {
+                    IdentityEntry::new(cert.as_ref())
+                }
+            })
+            .collect()
+    }
+}
+
+impl TlsIdentity for SubjectPublicKeyInfoDer<'static> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn certificate_type(&self) -> CertificateType {
+        CertificateType::RawPublicKey
+    }
+
+    fn to_wire_format(&self) -> TlsIdentityEntries<'_> {
+        vec![IdentityEntry::new(self.as_ref())]
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SigningIdentity(Arc<dyn IdentitySigner>, Identity);
+
+impl SigningIdentity {
+    pub fn id(&self) -> &Identity {
+        &self.1
+    }
+
+    pub(crate) fn signing_key(&self) -> &dyn SigningKey {
+        self.0.signing_key()
+    }
+
+    pub(crate) fn as_certified_key(&self) -> Option<&CertifiedKey> {
+        self.as_any()
+            .downcast_ref::<CertifiedKey>()
+    }
+
+    pub fn as_any(&self) -> &dyn Any {
+        self.0.as_any()
+    }
+}
+
+impl<T: IdentitySigner + 'static> From<T> for SigningIdentity {
+    fn from(value: T) -> Self {
+        Arc::new(value).into()
+    }
+}
+
+impl<T: IdentitySigner + 'static> From<Arc<T>> for SigningIdentity {
+    fn from(value: Arc<T>) -> Self {
+        let id: Arc<dyn TlsIdentity> = Arc::from(value.id());
+        Self(value, Identity(id))
+    }
+}
+
+pub trait IdentitySigner: Debug + Send + Sync {
+    fn id(&self) -> Box<dyn TlsIdentity>;
+
+    fn signing_key(&self) -> &dyn SigningKey;
+
+    fn as_any(&self) -> &dyn Any;
+}

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -593,9 +593,8 @@ pub mod client {
         pub use super::builder::danger::DangerousClientConfigBuilder;
         pub use super::client_conn::danger::DangerousClientConfig;
         pub use crate::verify::{
-            HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
-            ServerCertVerifierCompat, ServerIdVerified, ServerIdVerifier, ServerRpkVerifier,
-            ServerRpkVerifierCompat,
+            HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdVerified,
+            ServerIdVerifier, ServerRpkVerifier,
         };
     }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -645,7 +645,6 @@ pub mod server {
 
     /// Dangerous configuration that should be audited and used with extreme care.
     pub mod danger {
-        pub use crate::msgs::handshake::IdentityEntry;
         pub use crate::verify::{
             ClientCertVerified, ClientCertVerifier, ClientIdVerified, ClientIdVerifier,
             ClientRpkVerifier,

--- a/rustls/src/manual/howto.rs
+++ b/rustls/src/manual/howto.rs
@@ -31,7 +31,7 @@ For a complete example of implementing a custom [`sign::SigningKey`][signing_key
 [sign_method]: crate::crypto::signer::Signer::sign
 [certified_key]: crate::crypto::signer::CertifiedKey
 [cert_using_sni]: crate::server::ResolvesServerCertUsingSni
-[cert_resolver]: crate::ServerConfig::cert_resolver
+[cert_resolver]: crate::ServerConfig::certificate_resolver
 [rustls-cng-signer]: https://github.com/rustls/rustls-cng/blob/dev/src/signer.rs
 
 [^1]: For PKCS#8 it does not support password encryption -- there's not a meaningful threat

--- a/rustls/src/manual/howto.rs
+++ b/rustls/src/manual/howto.rs
@@ -31,7 +31,7 @@ For a complete example of implementing a custom [`sign::SigningKey`][signing_key
 [sign_method]: crate::crypto::signer::Signer::sign
 [certified_key]: crate::crypto::signer::CertifiedKey
 [cert_using_sni]: crate::server::ResolvesServerCertUsingSni
-[cert_resolver]: crate::ServerConfig::certificate_resolver
+[cert_resolver]: crate::ServerConfig::set_certificate_resolver
 [rustls-cng-signer]: https://github.com/rustls/rustls-cng/blob/dev/src/signer.rs
 
 [^1]: For PKCS#8 it does not support password encryption -- there's not a meaningful threat

--- a/rustls/src/manual/howto.rs
+++ b/rustls/src/manual/howto.rs
@@ -31,7 +31,7 @@ For a complete example of implementing a custom [`sign::SigningKey`][signing_key
 [sign_method]: crate::crypto::signer::Signer::sign
 [certified_key]: crate::crypto::signer::CertifiedKey
 [cert_using_sni]: crate::server::ResolvesServerCertUsingSni
-[cert_resolver]: crate::ServerConfig::set_certificate_resolver
+[cert_resolver]: crate::ServerConfig::cert_resolver
 [rustls-cng-signer]: https://github.com/rustls/rustls-cng/blob/dev/src/signer.rs
 
 [^1]: For PKCS#8 it does not support password encryption -- there's not a meaningful threat

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
+
 use pki_types::{CertificateDer, SubjectPublicKeyInfoDer};
 use zeroize::Zeroize;
 

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -2,7 +2,6 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 use pki_types::{CertificateDer, SubjectPublicKeyInfoDer};
-use std::ops::Deref;
 use zeroize::Zeroize;
 
 use crate::error::InvalidMessage;
@@ -47,20 +46,6 @@ impl<'a> Payload<'a> {
 
     pub fn read(r: &mut Reader<'a>) -> Self {
         Self::Borrowed(r.rest())
-    }
-}
-
-impl<'a> AsRef<[u8]> for Payload<'a> {
-    fn as_ref(&self) -> &[u8] {
-        self.bytes()
-    }
-}
-
-impl<'a> Deref for Payload<'a> {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        self.bytes()
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1720,9 +1720,9 @@ pub struct IdentityEntry<'a> {
 
 impl<'a> Codec<'a> for IdentityEntry<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        codec::u24(self.payload.len() as u32).encode(bytes);
+        codec::u24(self.payload.bytes().len() as u32).encode(bytes);
         self.payload.encode(bytes);
-        (self.extensions.len() as u16).encode(bytes);
+        (self.extensions.bytes().len() as u16).encode(bytes);
         self.extensions.encode(bytes);
     }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 use alloc::collections::BTreeSet;
-#[cfg(feature = "logging")]
+#[cfg(feature = "log")]
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -9,8 +9,8 @@ use super::enums::{
     ClientCertificateType, Compression, ECCurveType, ExtensionType, KeyUpdateRequest, NamedGroup,
 };
 use super::handshake::{
-    CertificateChain, IdentityEntry, CertificateExtensions, CertificatePayloadTls13,
-    CertificateRequestExtensions, CertificateRequestPayload, CertificateRequestPayloadTls13,
+    CertificateChain, IdentityEntry, CertificateExtensions, IdentityPayloadTls13,
+    CertificateRequestExtensions, CertificateRequestPayload, IdentityRequestPayloadTls13,
     CertificateStatus, CertificateStatusRequest, ClientExtensions, ClientHelloPayload,
     ClientSessionTicket, CompressedCertificatePayload, DistinguishedName, EcParameters,
     EncryptedClientHello, HandshakeMessagePayload, HandshakePayload, HelloRetryRequest,
@@ -951,8 +951,8 @@ fn all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload<'static>> {
     ]
 }
 
-fn sample_certificate_payload_tls13() -> CertificatePayloadTls13<'static> {
-    CertificatePayloadTls13 {
+fn sample_certificate_payload_tls13() -> IdentityPayloadTls13<'static> {
+    IdentityPayloadTls13 {
         context: PayloadU8::new(vec![1, 2, 3]),
         entries: vec![IdentityEntry {
             payload: Payload::Owned(vec![3, 4, 5].into()),
@@ -1012,8 +1012,8 @@ fn sample_certificate_request_payload() -> CertificateRequestPayload {
     }
 }
 
-fn sample_certificate_request_payload_tls13() -> CertificateRequestPayloadTls13 {
-    CertificateRequestPayloadTls13 {
+fn sample_certificate_request_payload_tls13() -> IdentityRequestPayloadTls13 {
+    IdentityRequestPayloadTls13 {
         context: PayloadU8::new(vec![1, 2, 3]),
         extensions: CertificateRequestExtensions {
             signature_algorithms: Some(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -9,7 +9,7 @@ use super::enums::{
     ClientCertificateType, Compression, ECCurveType, ExtensionType, KeyUpdateRequest, NamedGroup,
 };
 use super::handshake::{
-    CertificateChain, CertificateEntry, CertificateExtensions, CertificatePayloadTls13,
+    CertificateChain, IdentityEntry, CertificateExtensions, CertificatePayloadTls13,
     CertificateRequestExtensions, CertificateRequestPayload, CertificateRequestPayloadTls13,
     CertificateStatus, CertificateStatusRequest, ClientExtensions, ClientHelloPayload,
     ClientSessionTicket, CompressedCertificatePayload, DistinguishedName, EcParameters,
@@ -954,13 +954,16 @@ fn all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload<'static>> {
 fn sample_certificate_payload_tls13() -> CertificatePayloadTls13<'static> {
     CertificatePayloadTls13 {
         context: PayloadU8::new(vec![1, 2, 3]),
-        entries: vec![CertificateEntry {
-            cert: CertificateDer::from(vec![3, 4, 5]),
-            extensions: CertificateExtensions {
-                status: Some(CertificateStatus {
-                    ocsp_response: PayloadU24(Payload::new(vec![1, 2, 3])),
-                }),
-            },
+        entries: vec![IdentityEntry {
+            payload: Payload::Owned(vec![3, 4, 5].into()),
+            extensions: Payload::Owned(
+                CertificateExtensions {
+                    status: Some(CertificateStatus {
+                        ocsp_response: PayloadU24(Payload::new(vec![1, 2, 3])),
+                    }),
+                }
+                .get_encoding(),
+            ),
         }],
     }
 }

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -18,6 +18,14 @@ macro_rules! enum_builder {
               ),*
               $(,)?
           )?
+          $(
+              !Ranges:
+              $(
+                  $(#[doc = $enum_comment_nd:literal])*
+                  $enum_var_range:ident => $start_val:literal ..= $end_val:literal
+              ),*
+              $(,)?
+          )?
         }
     ) => {
         $(#[doc = $comment])*
@@ -33,6 +41,13 @@ macro_rules! enum_builder {
                 $(
                     $(#[doc = $enum_comment_nd])*
                     $enum_var_nd
+                ),*
+            )?
+            $(
+                ,
+                $(
+                    $(#[doc = $enum_comment_nd])*
+                    $enum_var_range($uint)
                 ),*
             )?
             ,Unknown($uint)
@@ -51,6 +66,7 @@ macro_rules! enum_builder {
                 match self {
                     $( $enum_name::$enum_var => Some(stringify!($enum_var))),*
                     $(, $( $enum_name::$enum_var_nd => Some(stringify!($enum_var_nd))),* )?
+                    $(, $( $enum_name::$enum_var_range(_) => Some(stringify!($enum_var_range))),* )?
                     ,$enum_name::Unknown(_) => None,
                 }
             }
@@ -72,10 +88,12 @@ macro_rules! enum_builder {
         }
 
         impl From<$uint> for $enum_name {
+            #[allow(unused_comparisons)]
             fn from(x: $uint) -> Self {
                 match x {
                     $($enum_val => $enum_name::$enum_var),*
                     $(, $($enum_val_nd => $enum_name::$enum_var_nd),* )?
+                    $(, $(x if x >= $start_val && x <= $end_val => $enum_name::$enum_var_range(x)),* )?
                     , x => $enum_name::Unknown(x),
                 }
             }
@@ -86,6 +104,7 @@ macro_rules! enum_builder {
                 match value {
                     $( $enum_name::$enum_var => $enum_val),*
                     $(, $( $enum_name::$enum_var_nd => $enum_val_nd),* )?
+                    $(, $( $enum_name::$enum_var_range(x) => x),* )?
                     ,$enum_name::Unknown(x) => x
                 }
             }
@@ -95,6 +114,7 @@ macro_rules! enum_builder {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 match self {
                     $( $enum_name::$enum_var => f.write_str(stringify!($enum_var)), )*
+                    $( $($enum_name::$enum_var_range(x) =>  write!(f, "{}(0x{:x?})", stringify!($enum_var_range), x),)* )?
                     _ => write!(f, "{}(0x{:x?})", stringify!($enum_name), <$uint>::from(*self)),
                 }
             }

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -21,7 +21,7 @@ macro_rules! enum_builder {
           $(
               !Ranges:
               $(
-                  $(#[doc = $enum_comment_nd:literal])*
+                  $(#[doc = $enum_comment_range:literal])*
                   $enum_var_range:ident => $start_val:literal ..= $end_val:literal
               ),*
               $(,)?
@@ -46,7 +46,7 @@ macro_rules! enum_builder {
             $(
                 ,
                 $(
-                    $(#[doc = $enum_comment_nd])*
+                    $(#[doc = $enum_comment_range])*
                     $enum_var_range($uint)
                 ),*
             )?

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -1,3 +1,9 @@
+use alloc::vec::Vec;
+use core::cmp;
+
+use pki_types::{DnsName, UnixTime};
+use zeroize::Zeroizing;
+
 use crate::client::ResolvesClientIdentity;
 use crate::enums::{CertificateType, CipherSuite, ProtocolVersion};
 use crate::error::InvalidMessage;
@@ -12,10 +18,6 @@ use crate::sync::{Arc, Weak};
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
 use crate::verify::ServerIdVerifier;
-use alloc::vec::Vec;
-use core::cmp;
-use pki_types::{DnsName, UnixTime};
-use zeroize::Zeroizing;
 
 pub(crate) struct Retrieved<T> {
     pub(crate) value: T,

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -1,7 +1,7 @@
 use crate::client::ResolvesClientIdentity;
 use crate::enums::{CertificateType, CipherSuite, ProtocolVersion};
 use crate::error::InvalidMessage;
-use crate::identity::{Identity, TlsIdentityEntries, IntoOwned};
+use crate::identity::{Identity, IntoOwned, TlsIdentityEntries};
 use crate::msgs::base::{MaybeEmpty, PayloadU8, PayloadU16};
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::handshake::ProtocolName;

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -166,27 +166,23 @@ impl server::ProducesTickets for NeverProducesTickets {
     }
 }
 
-/// An exemplar `ResolvesServerCert` implementation that always resolves to a single
+/// An exemplar `ResolvesServerRpk` implementation that always resolves to a single
 /// [RFC 7250] raw public key.
 ///
 /// [RFC 7250]: https://tools.ietf.org/html/rfc7250
 #[derive(Clone, Debug)]
-pub struct AlwaysResolvesServerRawPublicKeys(Arc<sign::CertifiedKey>);
+pub struct AlwaysResolvesServerRawPublicKeys(Arc<sign::KeyPair>);
 
 impl AlwaysResolvesServerRawPublicKeys {
     /// Create a new `AlwaysResolvesServerRawPublicKeys` instance.
-    pub fn new(certified_key: Arc<sign::CertifiedKey>) -> Self {
+    pub fn new(certified_key: Arc<sign::KeyPair>) -> Self {
         Self(certified_key)
     }
 }
 
-impl server::ResolvesServerCert for AlwaysResolvesServerRawPublicKeys {
-    fn resolve(&self, _client_hello: &ClientHello<'_>) -> Option<Arc<sign::CertifiedKey>> {
+impl server::ResolvesServerRpk for AlwaysResolvesServerRawPublicKeys {
+    fn resolve(&self, _client_hello: &ClientHello<'_>) -> Option<Arc<sign::KeyPair>> {
         Some(self.0.clone())
-    }
-
-    fn only_raw_public_keys(&self) -> bool {
-        true
     }
 }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -115,7 +115,7 @@ pub trait ProducesTickets: Debug + Send + Sync {
 pub trait ResolvesServerIdentity: Debug + Send + Sync {
     fn resolve(
         &self,
-        client_hello: ClientHello<'_>,
+        client_hello: &ClientHello<'_>,
         negotiated_certificate_type: CertificateType,
     ) -> Option<SigningIdentity>;
 
@@ -170,7 +170,7 @@ impl<T: ResolvesServerCert + 'static> From<T> for ResolvesServerCertCompat {
 impl ResolvesServerIdentity for ResolvesServerCertCompat {
     fn resolve(
         &self,
-        client_hello: ClientHello<'_>,
+        client_hello: &ClientHello<'_>,
         negotiated_certificate_type: CertificateType,
     ) -> Option<SigningIdentity> {
         if negotiated_certificate_type != CertificateType::X509 {
@@ -187,7 +187,7 @@ impl ResolvesServerIdentity for ResolvesServerCertCompat {
 }
 
 pub trait ResolvesServerRpk: Debug + Send + Sync {
-    fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<sign::KeyPair>>;
+    fn resolve(&self, client_hello: &ClientHello<'_>) -> Option<Arc<sign::KeyPair>>;
 }
 
 #[derive(Debug)]
@@ -214,7 +214,7 @@ impl<T: ResolvesServerRpk + 'static> From<T> for ResolvesServerRpkWrapper {
 impl ResolvesServerIdentity for ResolvesServerRpkWrapper {
     fn resolve(
         &self,
-        client_hello: ClientHello<'_>,
+        client_hello: &ClientHello<'_>,
         negotiated_certificate_type: CertificateType,
     ) -> Option<SigningIdentity> {
         if negotiated_certificate_type != CertificateType::RawPublicKey {

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -650,11 +650,11 @@ impl ServerConfig {
             .ok_or(Error::FailedToGetCurrentTime)
     }
 
-    pub fn certificate_resolver(&mut self, resolver: Arc<dyn ResolvesServerCert>) {
+    pub fn set_certificate_resolver(&mut self, resolver: Arc<dyn ResolvesServerCert>) {
         self.id_resolver = Arc::new(ResolvesServerCertCompat::from(resolver));
     }
 
-    pub fn rpk_resolver(&mut self, resolver: Arc<dyn ResolvesServerRpk>) {
+    pub fn set_rpk_resolver(&mut self, resolver: Arc<dyn ResolvesServerRpk>) {
         self.id_resolver = Arc::new(ResolvesServerRpkWrapper::from(resolver));
     }
 }

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -254,15 +254,12 @@ mod tests {
     }
 
     fn server_key_pair() -> KeyPair {
-        let private_key = super::provider::default_provider()
+        let key = super::provider::default_provider()
             .key_provider
             .load_private_key(server_key())
             .unwrap();
-        let public_key = private_key
-            .public_key()
-            .unwrap()
-            .into_owned();
-        KeyPair::new(public_key, private_key)
+        let public_key = key.public_key().unwrap().into_owned();
+        KeyPair::new(public_key, key)
             .ok()
             .unwrap()
     }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -436,6 +436,7 @@ mod client_hello {
         let names = config
             .verifier
             .root_hint_subjects()
+            .unwrap_or_default()
             .to_vec();
 
         let cr = CertificateRequestPayload {
@@ -508,8 +509,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
                 None
             }
             false => {
-                let client_id =
-                    Identity::from(X509Identity::new(cert_chain.0, None::<&[u8]>));
+                let client_id = Identity::from(X509Identity::new(cert_chain.0, None::<&[u8]>));
 
                 let now = self.config.current_time()?;
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -730,14 +730,10 @@ mod client_hello {
                             .collect(),
                     ),
                 },
-                authority_names: match config
+                authority_names: config
                     .verifier
                     .root_hint_subjects()
-                    .as_ref()
-                {
-                    [] => None,
-                    authorities => Some(authorities.to_vec()),
-                },
+                    .map(|dn| dn.to_vec()),
             },
         };
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1061,7 +1061,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
         if certp
             .entries
             .iter()
-            .any(|e| !e.extensions.is_empty())
+            .any(|e| !e.extensions.bytes().is_empty())
         {
             return Err(PeerMisbehaved::UnsolicitedCertExtension.into());
         }

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -201,8 +201,12 @@ pub trait ServerIdVerifier: Debug + Send + Sync {
     fn supported_certificate_types(&self) -> &[CertificateType];
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme>;
 
-    fn root_hint_subjects(&self) -> Option<&[DistinguishedName]> {
+    fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>> {
         None
+    }
+
+    fn request_ocsp_response(&self) -> bool {
+        false
     }
 }
 
@@ -316,8 +320,12 @@ impl ServerIdVerifier for ServerCertVerifierCompat {
         self.0.supported_verify_schemes()
     }
 
-    fn root_hint_subjects(&self) -> Option<&[DistinguishedName]> {
+    fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>> {
         self.0.root_hint_subjects()
+    }
+
+    fn request_ocsp_response(&self) -> bool {
+        self.0.request_ocsp_response()
     }
 }
 
@@ -338,7 +346,7 @@ pub trait ServerRpkVerifier: Debug + Send + Sync {
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme>;
 
-    fn root_hint_subjects(&self) -> Option<&[DistinguishedName]> {
+    fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>> {
         None
     }
 }
@@ -432,7 +440,7 @@ impl ServerIdVerifier for ServerRpkVerifierWrapper {
         self.0.supported_verify_schemes()
     }
 
-    fn root_hint_subjects(&self) -> Option<&[DistinguishedName]> {
+    fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>> {
         self.0.root_hint_subjects()
     }
 }
@@ -452,7 +460,7 @@ pub trait ClientIdVerifier: Debug + Send + Sync {
     }
 
     fn supported_certificate_types(&self) -> &[CertificateType];
-    fn root_hint_subjects(&self) -> Option<&[DistinguishedName]>;
+    fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>>;
 
     fn parse_tls13_payload(
         &self,
@@ -519,7 +527,7 @@ impl ClientIdVerifier for ClientCertVerifierCompat {
         &[CertificateType::X509]
     }
 
-    fn root_hint_subjects(&self) -> Option<&[DistinguishedName]> {
+    fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>> {
         let hints = self.0.root_hint_subjects();
         if hints.is_empty() { None } else { Some(hints) }
     }
@@ -577,8 +585,8 @@ pub trait ClientRpkVerifier: Debug + Send + Sync {
         self.offer_client_auth()
     }
 
-    fn root_hint_subjects(&self) -> &[DistinguishedName] {
-        &[]
+    fn root_hint_subjects(&self) -> Arc<[DistinguishedName]> {
+        Arc::default()
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme>;
@@ -631,7 +639,7 @@ impl ClientIdVerifier for ClientRpkVerifierWrapper {
         &[CertificateType::RawPublicKey]
     }
 
-    fn root_hint_subjects(&self) -> Option<&[DistinguishedName]> {
+    fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>> {
         let hints = self.0.root_hint_subjects();
         if hints.is_empty() { None } else { Some(hints) }
     }

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -13,7 +13,7 @@ use crate::crypto::{CryptoProvider, WebPkiSupportedAlgorithms};
 use crate::server::ServerConfig;
 use crate::sync::Arc;
 use crate::verify::{
-    ClientCertVerified, ClientCertVerifier, DigitallySignedStruct, HandshakeSignatureValid,
+    ClientIdVerified, ClientCertVerifier, DigitallySignedStruct, HandshakeSignatureValid,
     NoClientAuth,
 };
 use crate::webpki::parse_crls;
@@ -362,7 +362,7 @@ impl ClientCertVerifier for WebPkiClientVerifier {
         end_entity: &CertificateDer<'_>,
         intermediates: &[CertificateDer<'_>],
         now: UnixTime,
-    ) -> Result<ClientCertVerified, Error> {
+    ) -> Result<ClientIdVerified, Error> {
         let cert = ParsedCertificate::try_from(end_entity)?;
 
         let crl_refs = self.crls.iter().collect::<Vec<_>>();
@@ -393,7 +393,7 @@ impl ClientCertVerifier for WebPkiClientVerifier {
                 None,
             )
             .map_err(pki_error)
-            .map(|_| ClientCertVerified::assertion())
+            .map(|_| ClientIdVerified::assertion())
     }
 
     fn verify_tls12_signature(

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -6,7 +6,7 @@ use webpki::{CertRevocationList, ExpirationPolicy, RevocationCheckDepth, Unknown
 use crate::crypto::{CryptoProvider, WebPkiSupportedAlgorithms};
 use crate::sync::Arc;
 use crate::verify::{
-    DigitallySignedStruct, HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
+    DigitallySignedStruct, HandshakeSignatureValid, ServerIdVerified, ServerCertVerifier,
 };
 use crate::webpki::verify::{
     ParsedCertificate, verify_server_cert_signed_by_trust_anchor_impl, verify_tls12_signature,
@@ -235,7 +235,7 @@ impl ServerCertVerifier for WebPkiServerVerifier {
         server_name: &ServerName<'_>,
         _ocsp_response: &[u8],
         now: UnixTime,
-    ) -> Result<ServerCertVerified, Error> {
+    ) -> Result<ServerIdVerified, Error> {
         let cert = ParsedCertificate::try_from(end_entity)?;
 
         let crl_refs = self.crls.iter().collect::<Vec<_>>();
@@ -269,7 +269,7 @@ impl ServerCertVerifier for WebPkiServerVerifier {
         )?;
 
         verify_server_name(&cert, server_name)?;
-        Ok(ServerCertVerified::assertion())
+        Ok(ServerIdVerified::assertion())
     }
 
     fn verify_tls12_signature(

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -237,7 +237,7 @@ mod test_custom_identity {
                 ));
             }
             let entry = payload.into_iter().next().unwrap();
-            Ok(CustomIdentity::try_from(entry.payload.as_ref())
+            Ok(CustomIdentity::try_from(entry.payload.bytes())
                 .map_err(|_| Error::UnsupportedIdentityType)?
                 .into())
         }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -7855,8 +7855,8 @@ fn test_cert_decompression_by_server_would_result_in_excessively_large_cert() {
         .load_private_key(KeyType::Rsa2048.get_client_key())
         .unwrap();
     let big_cert_and_key = sign::CertifiedKey::new(vec![big_cert], key);
-    client_config.client_auth_id_resolver =
-        Arc::new(sign::SingleCertAndKey::from(big_cert_and_key));
+    client_config
+        .client_auth_certificate_resolver(Arc::new(sign::SingleCertAndKey::from(big_cert_and_key)));
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     assert_eq!(

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -12,23 +12,23 @@ use common::{
     make_client_config_with_versions_with_auth, make_pair_for_arc_configs, server_config_builder,
     server_name,
 };
-use rustls::server::danger::ClientCertVerified;
+use rustls::server::danger::ClientIdVerified;
 use rustls::{
     AlertDescription, ClientConnection, Error, InvalidMessage, ServerConfig, ServerConnection,
 };
 
 // Client is authorized!
-fn ver_ok() -> Result<ClientCertVerified, Error> {
-    Ok(ClientCertVerified::assertion())
+fn ver_ok() -> Result<ClientIdVerified, Error> {
+    Ok(ClientIdVerified::assertion())
 }
 
 // Use when we shouldn't even attempt verification
-fn ver_unreachable() -> Result<ClientCertVerified, Error> {
+fn ver_unreachable() -> Result<ClientIdVerified, Error> {
     unreachable!()
 }
 
 // Verifier that returns an error that we can expect
-fn ver_err() -> Result<ClientCertVerified, Error> {
+fn ver_err() -> Result<ClientIdVerified, Error> {
     Err(Error::General("test err".to_string()))
 }
 

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -13,7 +13,7 @@ use common::{
 };
 use pki_types::{CertificateDer, ServerName};
 use rustls::client::WebPkiServerVerifier;
-use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::client::danger::{HandshakeSignatureValid, ServerIdVerified, ServerCertVerifier};
 use rustls::server::{ClientHello, ResolvesServerCert};
 use rustls::sign::CertifiedKey;
 use rustls::{
@@ -35,7 +35,7 @@ fn client_can_override_certificate_verification() {
             let mut client_config = make_client_config_with_versions(*kt, &[version], &provider);
             client_config
                 .dangerous()
-                .set_certificate_verifier(verifier.clone());
+                .certificate_verifier(verifier.clone());
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -58,7 +58,7 @@ fn client_can_override_certificate_verification_and_reject_certificate() {
             let mut client_config = make_client_config_with_versions(*kt, &[version], &provider);
             client_config
                 .dangerous()
-                .set_certificate_verifier(verifier.clone());
+                .certificate_verifier(verifier.clone());
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -89,7 +89,7 @@ fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
 
         client_config
             .dangerous()
-            .set_certificate_verifier(verifier);
+            .certificate_verifier(verifier);
 
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -123,7 +123,7 @@ fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
 
         client_config
             .dangerous()
-            .set_certificate_verifier(verifier);
+            .certificate_verifier(verifier);
 
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -154,7 +154,7 @@ fn client_can_override_certificate_verification_and_offer_no_signature_schemes()
             let mut client_config = make_client_config_with_versions(*kt, &[version], &provider);
             client_config
                 .dangerous()
-                .set_certificate_verifier(verifier.clone());
+                .certificate_verifier(verifier.clone());
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -299,7 +299,7 @@ impl ServerCertVerifier for ServerCertVerifierWithCasExt {
         server_name: &ServerName<'_>,
         ocsp_response: &[u8],
         now: pki_types::UnixTime,
-    ) -> Result<ServerCertVerified, Error> {
+    ) -> Result<ServerIdVerified, Error> {
         self.verifier
             .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
     }
@@ -330,10 +330,6 @@ impl ServerCertVerifier for ServerCertVerifierWithCasExt {
 
     fn request_ocsp_response(&self) -> bool {
         self.verifier.request_ocsp_response()
-    }
-
-    fn requires_raw_public_keys(&self) -> bool {
-        self.verifier.requires_raw_public_keys()
     }
 
     fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>> {

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -35,7 +35,7 @@ fn client_can_override_certificate_verification() {
             let mut client_config = make_client_config_with_versions(*kt, &[version], &provider);
             client_config
                 .dangerous()
-                .certificate_verifier(verifier.clone());
+                .set_certificate_verifier(verifier.clone());
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -58,7 +58,7 @@ fn client_can_override_certificate_verification_and_reject_certificate() {
             let mut client_config = make_client_config_with_versions(*kt, &[version], &provider);
             client_config
                 .dangerous()
-                .certificate_verifier(verifier.clone());
+                .set_certificate_verifier(verifier.clone());
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -89,7 +89,7 @@ fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
 
         client_config
             .dangerous()
-            .certificate_verifier(verifier);
+            .set_certificate_verifier(verifier);
 
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -123,7 +123,7 @@ fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
 
         client_config
             .dangerous()
-            .certificate_verifier(verifier);
+            .set_certificate_verifier(verifier);
 
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -154,7 +154,7 @@ fn client_can_override_certificate_verification_and_offer_no_signature_schemes()
             let mut client_config = make_client_config_with_versions(*kt, &[version], &provider);
             client_config
                 .dangerous()
-                .certificate_verifier(verifier.clone());
+                .set_certificate_verifier(verifier.clone());
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);


### PR DESCRIPTION
### What

This draft PR introduces an approach for cleaner, more extensible support of non-X.509 identity schemes, such as Raw Public Keys. The focus is on a long-term design that better represents the realities of modern TLS. It also solves issue #2258.

### Why

Historically, TLS and X.509 certificates were tightly coupled, both by convention and implementation. However, the TLS protocol has been evolving towards a more flexible design. RFC 7250 added support for `Raw Public Keys` (RPK) to TLS 1.2, and RFC 8446 (TLS 1.3) went further by making `certificate_type` negotiation a standard part of the handshake.

The specification is extensible, currently allowing:
*   X.509 (certificate type id `0`)
*   RPK (certificate type id `2`)
*   Custom/private schemes (certificate type id range `224-255`)

*(Note: OpenPGP, which used certificate type id `19`, was specified in RFC 6091, but its support was removed in RFC 8446 due to a lack of adoption.)*

Rustls' initial RPK support (PR #2062) minimized changes to the public API by reusing existing types (`CertificateDer` to hold RPKs) and traits (`CertVerifier`). This required adding specialized methods like `requires_raw_public_keys` and hardcoded logic to the handshake to differentiate between schemes.

While this approach reduced the scope of the PR and preserved backward compatibility, it limits how cleanly Rustls can support schemes beyond X.509, as highlighted in discussions #2258 and #2266. The `CertVerifier` traits, designed exclusively for X.509, now have potentially invalid states and are awkward to use for other identity types.

Furthermore, the current design does not scale to support future schemes and does *not* support custom/private types at all. For me, enabling custom schemes is the primary motivation for this PR.

### How

1.  **Introduced `Identity` Abstraction:** This PR introduces a new `TlsIdentity` trait to decouple the API from X.509 certificates. Implementations for X.509 and RPK are included. A peer's identity is accessible via `peer_identity()`, while `peer_certificates()` is kept for backward compatibility. Convenience methods like `Identity::as_certificates` and `Identity::as_public_key` are provided, with `Identity::as_any` available for custom types.

2.  **New Verifier/Resolver Traits:** New, scheme-neutral traits have been introduced: `ServerIdVerifier`, `ClientIdVerifier`, `ResolvesServerIdentity`, and `ResolvesClientIdentity`. Implementations are only required for new or custom schemes. This PR includes implementations for X.509 (wrapping the existing `CertVerifier` traits for compatibility) and new, purpose-built `RpkVerifier`/`RpkResolver` traits for RPK users.

3.  **Dynamic Handshake Logic:** Hardcoded handshake logic has been replaced with a dynamic approach that delegates negotiation to the new verifier/resolver traits. X.509-specific code has been moved into its respective trait implementation, making the main code paths identity-scheme neutral.

4.  **Support for Custom Types:** The `CertificateType` enum was extended to support the custom/private use range (224-255). Basic range support was added to the `enum_builder`.

5.  **Terminology Update:** Throughout the codebase, `certificate`/`cert` has been replaced with `identity`/`id` where appropriate to reflect the new abstractions.

### Impact

The changes are necessarily invasive but establish a foundation for long-term API evolution. The number of changed LOC is substantial, though many are simple renames.

#### Code Changes

The most meaningful changes are in:
*   `identity.rs`: Contains the main `Identity` type,  the `TlsIdentity` & `IdentitySigner` traits and their respective implementations.
*   `verify.rs`: Adds the new `ServerIdVerifier` & `ClientIdVerifier` traits, compatibility wrappers for X.509, and the new `ServerRpkVerifier` & `ClientRpkVerifier` traits.
*   `server_conn.rs` & `client_conn.rs`:  Adds new identity resolvers and public setters for using non-X.509 schemes.
*   `common_state.rs`: Adds the `peer_identity()` method and fields to store the negotiated certificate types.
*   Handshake logic: Updated to use the new dynamic negotiation. The changes are mostly related to TLS 1.3, TLS 1.2 remains limited to X.509 certificate support.
*   `builder.rs`: Adds `with_*_rpk_resolver` and `with_*_identity_resolver` methods to supplement existing ones.

#### Performance

Performance should be unaffected. Any significant regression should be considered a bug.

#### Backward Compatibility

Although the changes are substantial, care has been taken to minimize breakage.

1.  **RPK Users:** This is a breaking change. Users must migrate to the new, purpose-built RPK traits (e.g., `ClientRpkVerifier` instead of `ClientCertVerifier`) and use the new `with_rpk_*` configuration methods. The peer's key should be accessed via `peer_identity().as_public_key()`. These changes result in a cleaner, more correct API for RPK usage.

2.  **Direct Config Field Access:** For users who directly access the public `ClientConfig::client_auth_cert_resolver` or `ServerConfig::cert_resolver` fields, 100% backward compatibility cannot be maintained, as these fields have been renamed and re-typed. Affected users must use the similarly named methods instead (e.g. change from `config.cert_resolver = X;` to `config.cert_resolver(X);`.
 *Note: Users who rely on the builder methods are **not** affected.*

Overall, this has been an interesting endeavor. I believe these changes are needed in one form or another. Looking forward to everyone's feedback and opinions.