### PR TITLE
Audit public enums for exhaustiveness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,6 +377,15 @@ don't provide additional type safety. Using the
 [newtype idiom](https://doc.rust-lang.org/rust-by-example/generics/new_types.html)
 is one alternative when an abstraction boundary is worth the added complexity.
 
+#### Type exhaustiveness
+
+Public enums should be marked as _either_ `#[non_exhaustive]` or `#[allow(clippy::exhaustive_enums)]`.
+The latter is suitable for enums that are already complete by definition.  For example:
+`enum CoinFlip { Heads, Tails }` is complete.  Err on the side of marking something `#[non_exhaustive]`.
+
+The same applies to structs, with the detail that no manual marking is needed for
+structures with at least one private field.
+
 ## Design and Architecture
 
 Some general concepts about how the library should fit together:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,22 @@ Note that we usually also practice top-down ordering here; where these are in
 conflict, make a choice that you think makes sense. For getters and setters, the
 order should typically mirror the order of the fields in the type definition.
 
+#### Attribute ordering
+
+Order attributes so that documentation appears first, and the attributes with the
+most effect on the meaning and function of the type appear last.  For example:
+
+```rust
+/// Doc comment always first
+#[cfg(feature-gates)]
+#[allow(lint-configuration)]
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct Foo;
+```
+
+Prefer to write `derive`d traits in alphabetical order.
+
 ### Functions
 
 #### Consider avoiding short single-use functions

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -747,6 +747,7 @@ impl server::StoresServerSessions for ServerCacheWithResumptionDelay {
         match &mut ssv {
             ServerSessionValue::Tls12(tls12) => &mut tls12.common,
             ServerSessionValue::Tls13(tls13) => &mut tls13.common,
+            _ => todo!(),
         }
         .creation_time_sec -= self.delay as u64;
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -519,6 +519,7 @@ impl Default for Resumption {
 }
 
 /// What mechanisms to support for resuming a TLS 1.2 session.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Tls12Resumption {
     /// Disable 1.2 resumption.
@@ -1025,6 +1026,7 @@ impl MayEncryptEarlyData<'_> {
 }
 
 /// Errors that may arise when encrypting early (RTT-0) data
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum EarlyDataError {
     /// Cannot encrypt more early data due to imposed limits

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 /// Controls how Encrypted Client Hello (ECH) is used in a client handshake.
+#[non_exhaustive]
 #[derive(Clone, Debug)]
 pub enum EchMode {
     /// ECH is enabled and the ClientHello will be encrypted based on the provided
@@ -277,6 +278,7 @@ impl EchGreaseConfig {
 }
 
 /// An enum representing ECH offer status.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum EchStatus {
     /// ECH was not offered - it is a normal TLS handshake.

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -887,6 +887,7 @@ pub(crate) struct Context<'a, Data> {
 }
 
 /// Side of the connection.
+#[allow(clippy::exhaustive_enums)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Side {
     /// A client initiates the connection.

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -781,6 +781,7 @@ impl CommonState {
 
 /// Describes which sort of handshake happened.
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[non_exhaustive]
 pub enum HandshakeKind {
     /// A full handshake.
     ///

--- a/rustls/src/compress.rs
+++ b/rustls/src/compress.rs
@@ -102,6 +102,7 @@ pub trait CertCompressor: Debug + Send + Sync {
 }
 
 /// A hint for how many resources to dedicate to a compression.
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum CompressionLevel {
     /// This compression is happening interactively during a handshake.

--- a/rustls/src/compress.rs
+++ b/rustls/src/compress.rs
@@ -272,6 +272,7 @@ pub use feat_brotli::{BROTLI_COMPRESSOR, BROTLI_DECOMPRESSOR};
 /// The prospect of being able to reuse a given compression for many connections
 /// means we can afford to spend more time on that compression (by passing
 /// `CompressionLevel::Amortized` to the compressor).
+#[allow(clippy::exhaustive_enums)]
 #[derive(Debug)]
 pub enum CompressionCache {
     /// No caching happens, and compression happens each time using

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -39,6 +39,7 @@ mod connection {
     use crate::vecbuf::ChunkVecBuffer;
 
     /// A client or server connection.
+    #[allow(clippy::exhaustive_enums)]
     #[derive(Debug)]
     pub enum Connection {
         /// A client connection

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -544,6 +544,7 @@ impl<Data> TransmitTlsData<'_, Data> {
 }
 
 /// Errors that may arise when encoding a handshake record
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum EncodeError {
     /// Provided buffer was too small
@@ -575,6 +576,7 @@ impl fmt::Display for EncodeError {
 impl StdError for EncodeError {}
 
 /// Errors that may arise when encrypting application data
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum EncryptError {
     /// Provided buffer was too small

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -763,6 +763,7 @@ impl From<CertificateError> for Error {
 ///
 /// These are usually represented as OID values in the certificate's extension (if present), but
 /// we represent the values that are most relevant to rustls as named enum variants.
+#[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ExtendedKeyPurpose {
     /// Client authentication

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -329,6 +329,7 @@
 #![cfg_attr(not(any(bench, coverage_nightly)), forbid(unstable_features))]
 #![warn(
     clippy::alloc_instead_of_core,
+    clippy::exhaustive_enums,
     clippy::manual_let_else,
     clippy::std_instead_of_core,
     clippy::use_self,

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -10,6 +10,7 @@ use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
 
 /// An externally length'd payload
+#[non_exhaustive]
 #[derive(Clone, Eq, PartialEq)]
 pub enum Payload<'a> {
     Borrowed(&'a [u8]),

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -2894,6 +2894,7 @@ impl Codec<'_> for EchConfigContents {
 }
 
 /// An encrypted client hello (ECH) config.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq)]
 pub enum EchConfigPayload {
     /// A recognized V18 ECH configuration.

--- a/rustls/src/msgs/message/mod.rs
+++ b/rustls/src/msgs/message/mod.rs
@@ -16,6 +16,7 @@ use alloc::vec::Vec;
 pub(crate) use outbound::read_opaque_message_header;
 pub use outbound::{OutboundChunks, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload};
 
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum MessagePayload<'a> {
     Alert(AlertMessagePayload),

--- a/rustls/src/msgs/message/outbound.rs
+++ b/rustls/src/msgs/message/outbound.rs
@@ -37,6 +37,7 @@ impl OutboundPlainMessage<'_> {
 ///
 /// Warning: OutboundChunks does not guarantee that the simplest variant is used.
 /// Multiple can hold non fragmented or empty payloads.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum OutboundChunks<'a> {
     /// A single byte slice. Contrary to `Multiple`, this uses a single pointer indirection

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -299,6 +299,7 @@ static MAX_TICKET_LIFETIME: u32 = 7 * 24 * 60 * 60;
 static MAX_FRESHNESS_SKEW_MS: u32 = 60 * 1000;
 
 // --- Server types ---
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum ServerSessionValue {
     Tls12(Tls12ServerSessionValue),

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -40,6 +40,7 @@ mod connection {
     use crate::vecbuf::ChunkVecBuffer;
 
     /// A QUIC client or server connection.
+    #[allow(clippy::exhaustive_enums)]
     #[derive(Debug)]
     pub enum Connection {
         /// A client connection
@@ -916,6 +917,7 @@ impl Keys {
 /// Once the 1-RTT keys have been exchanged, either side may initiate a key update. Progressive
 /// update keys can be obtained from the [`Secrets`] returned in [`KeyChange::OneRtt`]. Note that
 /// only packet keys are updated by key updates; header protection keys remain the same.
+#[allow(clippy::exhaustive_enums)]
 pub enum KeyChange {
     /// Keys for the handshake space
     Handshake {

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -62,6 +62,7 @@ impl CipherSuiteCommon {
 ///
 /// This type carries both configuration and implementation. Compare with
 /// [`CipherSuite`], which carries solely a cipher suite identifier.
+#[non_exhaustive]
 #[derive(Clone, Copy, PartialEq)]
 pub enum SupportedCipherSuite {
     /// A TLS 1.2 cipher suite


### PR DESCRIPTION
(would like to have written `#[expect()]` here, but our MSRV precludes that.)

fixes #2398