### PR TITLE
Turn `SupportedProtocolVersion`s into capabilities and eliminate `tls12` crate feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,12 +89,12 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; aws-lc-rs)
-        run: cargo test --no-default-features --features aws-lc-rs,tls12,log,std --all-targets
+        run: cargo test --no-default-features --features aws-lc-rs,log,std --all-targets
         env:
           RUST_BACKTRACE: 1
 
       - name: cargo test (release; fips)
-        run: cargo test --release --no-default-features --features fips,tls12,log,std --all-targets
+        run: cargo test --release --no-default-features --features fips,log,std --all-targets
         env:
           RUST_BACKTRACE: 1
 
@@ -172,16 +172,16 @@ jobs:
         run: cargo test --locked --no-default-features
         working-directory: rustls
 
-      - name: cargo test (debug; no default features; tls12)
-        run: cargo test --locked --no-default-features --features tls12,std
+      - name: cargo test (debug; no default features; std)
+        run: cargo test --locked --no-default-features --features std
         working-directory: rustls
 
-      - name: cargo test (debug; no default features; aws-lc-rs,tls12)
-        run: cargo test --no-default-features --features aws-lc-rs,tls12,std
+      - name: cargo test (debug; no default features; std+aws-lc-rs)
+        run: cargo test --no-default-features --features aws-lc-rs,std
         working-directory: rustls
 
-      - name: cargo test (debug; no default features; fips,tls12)
-        run: cargo test --no-default-features --features fips,tls12,std
+      - name: cargo test (debug; no default features; std+fips)
+        run: cargo test --no-default-features --features fips,std
         working-directory: rustls
 
       - name: cargo test (release; no run)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: cargo doc
         # keep features in sync with Cargo.toml `[package.metadata.docs.rs]` section
-        run: cargo doc --locked --features aws-lc-rs,brotli,custom-provider,hashbrown,log,ring,std,tls12,zlib --no-deps --package rustls
+        run: cargo doc --locked --features aws-lc-rs,brotli,custom-provider,hashbrown,log,ring,std,zlib --no-deps --package rustls
         env:
           RUSTDOCFLAGS: -Dwarnings --cfg=docsrs --html-after-content tag.html
 

--- a/admin/coverage
+++ b/admin/coverage
@@ -7,8 +7,8 @@ cargo llvm-cov clean --workspace
 
 cargo build --locked --all-targets --all-features
 cargo test --locked --all-features
-cargo test -p rustls --locked --no-default-features --features tls12,log,aws-lc-rs,fips,std
-cargo test -p rustls --locked --no-default-features --features tls12,log,ring,std
+cargo test -p rustls --locked --no-default-features --features log,aws-lc-rs,fips,std
+cargo test -p rustls --locked --no-default-features --features log,ring,std
 
 # ensure both zlib and brotli are tested, irrespective of their order
 cargo test --locked $(admin/all-features-except zlib rustls)

--- a/bogo/Cargo.toml
+++ b/bogo/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 base64 = { workspace = true }
 env_logger = { workspace = true }
 nix = { version = "0.30", default-features = false, features = ["signal"] }
-rustls = { path = "../rustls", features = ["aws-lc-rs", "ring", "tls12"] }
+rustls = { path = "../rustls", features = ["aws-lc-rs", "ring"] }
 webpki = { workspace = true }
 
 [features]

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -539,7 +539,7 @@ struct ClientSideStepper<'a> {
 
 impl ClientSideStepper<'_> {
     fn make_config(params: &BenchmarkParams, resume: ResumptionKind) -> Arc<ClientConfig> {
-        assert_eq!(params.ciphersuite.version(), params.version);
+        assert_eq!(params.ciphersuite.version(), *params.version);
 
         let cfg = ClientConfig::builder_with_provider(
             CryptoProvider {
@@ -634,7 +634,7 @@ struct ServerSideStepper<'a> {
 
 impl ServerSideStepper<'_> {
     fn make_config(params: &BenchmarkParams, resume: ResumptionKind) -> Arc<ServerConfig> {
-        assert_eq!(params.ciphersuite.version(), params.version);
+        assert_eq!(params.ciphersuite.version(), *params.version);
 
         let cfg = ServerConfig::builder_with_provider(params.provider.clone().into())
             .with_protocol_versions(&[params.version])

--- a/examples/tests/limitedclient.rs
+++ b/examples/tests/limitedclient.rs
@@ -16,6 +16,11 @@ fn simpleclient_contains_aes_symbols() {
 }
 
 #[test]
+fn simpleclient_contains_tls12_code() {
+    assert!(count_tls12_client_symbols_in_executable(env!("CARGO_BIN_EXE_simpleclient")) > 0);
+}
+
+#[test]
 fn limitedclient_does_not_contain_aes_symbols() {
     let limitedclient = env!("CARGO_BIN_EXE_limitedclient");
     if fips_mode(limitedclient) {
@@ -23,6 +28,14 @@ fn limitedclient_does_not_contain_aes_symbols() {
         return;
     }
     assert_eq!(count_aes_symbols_in_executable(limitedclient), 0);
+}
+
+#[test]
+fn limitedclient_does_not_contain_tls12_code() {
+    assert_eq!(
+        count_tls12_client_symbols_in_executable(env!("CARGO_BIN_EXE_limitedclient")),
+        0
+    );
 }
 
 fn fips_mode(exe: &str) -> bool {
@@ -39,6 +52,21 @@ fn count_aes_symbols_in_executable(exe: &str) -> usize {
 
         if sym.starts_with("aws_lc_") && sym.ends_with("_EVP_aead_aes_128_gcm_tls13") {
             println!("found aes symbol {sym:?}");
+            count += 1;
+        }
+    }
+
+    count
+}
+
+fn count_tls12_client_symbols_in_executable(exe: &str) -> usize {
+    let mut count = 0;
+
+    for sym in symbols_in_executable(exe).lines() {
+        println!("candidate symbol {sym:?}");
+
+        if sym.contains("rustls::client::tls12") && !sym.contains("core::fmt::Debug") {
+            println!("found tls12 symbol {sym:?}");
             count += 1;
         }
     }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 env_logger = "0.11"
 libfuzzer-sys = "0.4"
-rustls = { path = "../rustls", default-features = false, features = ["std", "tls12", "custom-provider"] }
+rustls = { path = "../rustls", default-features = false, features = ["std", "custom-provider"] }
 rustls-fuzzing-provider = { path = "../rustls-fuzzing-provider" }
 
 # Prevent this from interfering with workspaces

--- a/provider-example/Cargo.toml
+++ b/provider-example/Cargo.toml
@@ -17,7 +17,7 @@ hpke-rs-rust-crypto = { workspace = true }
 p256 = { workspace = true }
 pkcs8 = { workspace = true }
 rand_core = { workspace = true }
-rustls = { path = "../rustls", default-features = false, features = ["log", "tls12"] }
+rustls = { path = "../rustls", default-features = false, features = ["log"] }
 rsa = { workspace = true }
 sha2 = { workspace = true }
 signature = { workspace = true }

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -82,6 +82,7 @@ pub static TLS13_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
             hash_provider: &hash::Sha256,
             confidentiality_limit: u64::MAX,
         },
+        protocol_version: rustls::version::TLS13_VERSION,
         hkdf_provider: &rustls::crypto::tls13::HkdfUsingHmac(&hmac::Sha256Hmac),
         aead_alg: &aead::Chacha20Poly1305,
         quic: None,

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -94,6 +94,7 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherS
             hash_provider: &hash::Sha256,
             confidentiality_limit: u64::MAX,
         },
+        protocol_version: rustls::version::TLS12_VERSION,
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: &[
             rustls::SignatureScheme::RSA_PSS_SHA256,

--- a/rustls-fuzzing-provider/Cargo.toml
+++ b/rustls-fuzzing-provider/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-rustls = { path = "../rustls", default-features = false, features = ["log", "std", "tls12"] }
+rustls = { path = "../rustls", default-features = false, features = ["log", "std"] }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -120,6 +120,7 @@ pub static TLS_FUZZING_SUITE: SupportedCipherSuite =
             hash_provider: &Hash,
             confidentiality_limit: u64::MAX,
         },
+        protocol_version: rustls::version::TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: &[SIGNATURE_SCHEME],
         prf_provider: &tls12::PrfUsingHmac(&Hmac),

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -108,6 +108,7 @@ pub static TLS13_FUZZING_SUITE: SupportedCipherSuite =
             hash_provider: &Hash,
             confidentiality_limit: u64::MAX,
         },
+        protocol_version: rustls::version::TLS13_VERSION,
         hkdf_provider: &tls13::HkdfUsingHmac(&Hmac),
         aead_alg: &Aead,
         quic: None,

--- a/rustls-test/Cargo.toml
+++ b/rustls-test/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-rustls = { path = "../rustls", default-features = false, features = ["std", "tls12"] }
+rustls = { path = "../rustls", default-features = false, features = ["std"] }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -14,7 +14,7 @@ autotests = false
 exclude = ["src/testdata", "tests/**"]
 
 [features]
-default = ["log", "std", "tls12"]
+default = ["log", "std"]
 
 aws-lc-rs = ["dep:aws-lc-rs", "webpki/aws-lc-rs", "aws-lc-rs/aws-lc-sys", "aws-lc-rs/prebuilt-nasm"]
 brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
@@ -23,7 +23,6 @@ fips = ["aws-lc-rs", "aws-lc-rs?/fips", "webpki/aws-lc-rs-fips"]
 log = ["dep:log"]
 ring = ["dep:ring", "webpki/ring"]
 std = ["webpki/std", "pki-types/std", "once_cell/std"]
-tls12 = []
 zlib = ["dep:zlib-rs"]
 
 [dependencies]
@@ -74,7 +73,6 @@ path = "tests/runners/api.rs"
 [[test]]
 name = "api_ffdhe"
 path = "tests/runners/api_ffdhe.rs"
-required-features = ["tls12"]
 
 [[test]]
 name = "bogo"
@@ -106,7 +104,7 @@ path = "tests/runners/unbuffered.rs"
 
 [package.metadata.docs.rs]
 # all non-default features except fips (cannot build on docs.rs environment)
-features = ["aws-lc-rs", "brotli", "custom-provider", "hashbrown", "log", "ring", "std", "tls12", "zlib"]
+features = ["aws-lc-rs", "brotli", "custom-provider", "hashbrown", "log", "ring", "std", "zlib"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo_check_external_types]

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -211,7 +211,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
     ) -> Result<ConfigBuilder<S, WantsVerifier>, Error> {
         let mut any_usable_suite = false;
         for suite in &self.provider.cipher_suites {
-            if versions.contains(&suite.version()) {
+            if versions.contains(&&suite.version()) {
                 any_usable_suite = true;
                 break;
             }

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -279,13 +279,10 @@ pub struct WantsVerifier {
 ///
 /// [`ClientConfig`]: crate::ClientConfig
 /// [`ServerConfig`]: crate::ServerConfig
-pub trait ConfigSide: sealed::Sealed {}
+pub trait ConfigSide: crate::sealed::Sealed {}
 
 impl ConfigSide for crate::ClientConfig {}
 impl ConfigSide for crate::ServerConfig {}
 
-mod sealed {
-    pub trait Sealed {}
-    impl Sealed for crate::ClientConfig {}
-    impl Sealed for crate::ServerConfig {}
-}
+impl crate::sealed::Sealed for crate::ClientConfig {}
+impl crate::sealed::Sealed for crate::ServerConfig {}

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -174,7 +174,6 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             key_log: Arc::new(NoKeyLog {}),
             enable_secret_extraction: false,
             enable_early_data: false,
-            #[cfg(feature = "tls12")]
             require_ems: cfg!(feature = "fips"),
             time_provider: self.time_provider,
             cert_compressors: compress::default_cert_compressors().to_vec(),

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -233,7 +233,6 @@ pub struct ClientConfig {
     ///
     /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
     /// [FIPS 140-3 IG.pdf]: https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf
-    #[cfg(feature = "tls12")]
     pub require_ems: bool,
 
     /// Provides the current system time
@@ -372,12 +371,7 @@ impl ClientConfig {
     /// is concerned only with cryptography, whereas this _also_ covers TLS-level
     /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
     pub fn fips(&self) -> bool {
-        let mut is_fips = self.provider.fips();
-
-        #[cfg(feature = "tls12")]
-        {
-            is_fips = is_fips && self.require_ems
-        }
+        let mut is_fips = self.provider.fips() && self.require_ems;
 
         if let Some(ech_mode) = &self.ech_mode {
             is_fips = is_fips && ech_mode.fips();

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -410,7 +410,7 @@ impl ClientConfig {
                 .provider
                 .cipher_suites
                 .iter()
-                .any(|cs| cs.version().version == v)
+                .any(|cs| cs.version().version() == v)
     }
 
     #[cfg(feature = "std")]

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -48,7 +48,6 @@ mod cache {
         kx_hint: Option<NamedGroup>,
 
         // Zero or one TLS1.2 sessions.
-        #[cfg(feature = "tls12")]
         tls12: Option<persist::Tls12ClientSessionValue>,
 
         // Up to MAX_TLS13_TICKETS_PER_SERVER TLS1.3 tickets, oldest first.
@@ -59,7 +58,6 @@ mod cache {
         fn default() -> Self {
             Self {
                 kx_hint: None,
-                #[cfg(feature = "tls12")]
                 tls12: None,
                 tls13: VecDeque::with_capacity(MAX_TLS13_TICKETS_PER_SERVER),
             }
@@ -119,7 +117,6 @@ mod cache {
             _server_name: ServerName<'static>,
             _value: persist::Tls12ClientSessionValue,
         ) {
-            #[cfg(feature = "tls12")]
             self.servers
                 .lock()
                 .unwrap()
@@ -132,10 +129,6 @@ mod cache {
             &self,
             _server_name: &ServerName<'_>,
         ) -> Option<persist::Tls12ClientSessionValue> {
-            #[cfg(not(feature = "tls12"))]
-            return None;
-
-            #[cfg(feature = "tls12")]
             self.servers
                 .lock()
                 .unwrap()
@@ -144,7 +137,6 @@ mod cache {
         }
 
         fn remove_tls12_session(&self, _server_name: &ServerName<'static>) {
-            #[cfg(feature = "tls12")]
             self.servers
                 .lock()
                 .unwrap()
@@ -257,9 +249,7 @@ mod tests {
     use crate::client::{ClientSessionStore, ResolvesClientCert};
     use crate::msgs::base::PayloadU16;
     use crate::msgs::enums::NamedGroup;
-    use crate::msgs::handshake::CertificateChain;
-    #[cfg(feature = "tls12")]
-    use crate::msgs::handshake::SessionId;
+    use crate::msgs::handshake::{CertificateChain, SessionId};
     use crate::msgs::persist::Tls13ClientSessionValue;
     use crate::pki_types::CertificateDer;
     use crate::suites::SupportedCipherSuite;
@@ -277,7 +267,6 @@ mod tests {
         c.set_kx_hint(name.clone(), NamedGroup::X25519);
         assert_eq!(None, c.kx_hint(&name));
 
-        #[cfg(feature = "tls12")]
         {
             use crate::msgs::persist::Tls12ClientSessionValue;
             let SupportedCipherSuite::Tls12(tls12_suite) =

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -6,8 +6,6 @@ use core::ops::Deref;
 
 use pki_types::ServerName;
 
-#[cfg(feature = "tls12")]
-use super::tls12;
 use super::{ResolvesClientCert, Tls12Resumption};
 use crate::SupportedCipherSuite;
 #[cfg(feature = "log")]
@@ -65,7 +63,7 @@ struct ExpectServerHelloOrHelloRetryRequest {
     extra_exts: ClientExtensionsInput<'static>,
 }
 
-pub(super) struct ClientHelloInput {
+pub(crate) struct ClientHelloInput {
     pub(super) config: Arc<ClientConfig>,
     pub(super) resuming: Option<persist::Retrieved<ClientSessionValue>>,
     pub(super) random: Random,
@@ -822,15 +820,18 @@ impl State<ClientConnectionData> for ExpectServerHello {
                 )
             }
             #[cfg(feature = "tls12")]
-            SupportedCipherSuite::Tls12(suite) => tls12::handle_server_hello(
-                cx,
-                server_hello,
-                randoms,
-                suite,
-                transcript,
-                tls13_supported,
-                self.input,
-            ),
+            SupportedCipherSuite::Tls12(suite) => suite
+                .protocol_version
+                .client
+                .handle_server_hello(
+                    cx,
+                    server_hello,
+                    randoms,
+                    suite,
+                    transcript,
+                    tls13_supported,
+                    self.input,
+                ),
         }
     }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -771,7 +771,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
                 )
             })?;
 
-        if version != suite.version().version {
+        if version != suite.version().version() {
             return Err({
                 cx.common.send_fatal_alert(
                     AlertDescription::IllegalParameter,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -804,8 +804,10 @@ impl State<ClientConnectionData> for ExpectServerHello {
         // For TLS1.3, start message encryption using
         // handshake_traffic_secret.
         match suite {
-            SupportedCipherSuite::Tls13(suite) => {
-                tls13::handle_server_hello(
+            SupportedCipherSuite::Tls13(suite) => suite
+                .protocol_version
+                .client
+                .handle_server_hello(
                     cx,
                     server_hello,
                     randoms,
@@ -817,8 +819,8 @@ impl State<ClientConnectionData> for ExpectServerHello {
                     &m,
                     self.ech_state,
                     self.input,
-                )
-            }
+                ),
+
             #[cfg(feature = "tls12")]
             SupportedCipherSuite::Tls12(suite) => suite
                 .protocol_version

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -822,12 +822,15 @@ impl State<ClientConnectionData> for ExpectServerHello {
                 )
             }
             #[cfg(feature = "tls12")]
-            SupportedCipherSuite::Tls12(suite) => tls12::CompleteServerHelloHandling {
+            SupportedCipherSuite::Tls12(suite) => tls12::handle_server_hello(
+                cx,
+                server_hello,
                 randoms,
+                suite,
                 transcript,
-                input: self.input,
-            }
-            .handle_server_hello(cx, suite, server_hello, tls13_supported),
+                tls13_supported,
+                self.input,
+            ),
         }
     }
 

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -134,7 +134,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "tls12")]
     #[test]
     fn test_client_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
         let mut config =
@@ -208,7 +207,6 @@ mod tests {
     }
 
     /// Regression test for <https://github.com/seanmonstar/reqwest/issues/2191>
-    #[cfg(feature = "tls12")]
     #[test]
     fn test_client_with_custom_verifier_can_accept_ecdsa_sha1_signatures() {
         let verifier = Arc::new(ExpectSha1EcdsaVerifier::default());

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -232,7 +232,7 @@ struct ExpectCertificate {
     randoms: ConnectionRandoms,
     using_ems: bool,
     transcript: HandshakeHash,
-    pub(super) suite: &'static Tls12CipherSuite,
+    suite: &'static Tls12CipherSuite,
     may_send_cert_status: bool,
     must_issue_new_ticket: bool,
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -4,7 +4,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use pki_types::ServerName;
-pub(super) use server_hello::CompleteServerHelloHandling;
+pub(super) use server_hello::handle_server_hello;
 use subtle::ConstantTimeEq;
 
 use super::client_conn::ClientConnectionData;
@@ -41,186 +41,176 @@ mod server_hello {
     use crate::client::hs::{ClientHelloInput, ClientSessionValue};
     use crate::msgs::handshake::ServerHelloPayload;
 
-    pub(in crate::client) struct CompleteServerHelloHandling {
-        pub(in crate::client) randoms: ConnectionRandoms,
-        pub(in crate::client) transcript: HandshakeHash,
-        pub(in crate::client) input: ClientHelloInput,
-    }
+    pub(in crate::client) fn handle_server_hello(
+        cx: &mut ClientContext<'_>,
+        server_hello: &ServerHelloPayload,
+        mut randoms: ConnectionRandoms,
+        suite: &'static Tls12CipherSuite,
+        transcript: HandshakeHash,
+        tls13_supported: bool,
+        input: ClientHelloInput,
+    ) -> hs::NextStateOrError<'static> {
+        randoms
+            .server
+            .clone_from_slice(&server_hello.random.0[..]);
 
-    impl CompleteServerHelloHandling {
-        pub(in crate::client) fn handle_server_hello(
-            mut self,
-            cx: &mut ClientContext<'_>,
-            suite: &'static Tls12CipherSuite,
-            server_hello: &ServerHelloPayload,
-            tls13_supported: bool,
-        ) -> hs::NextStateOrError<'static> {
-            self.randoms
-                .server
-                .clone_from_slice(&server_hello.random.0[..]);
-
-            // Look for TLS1.3 downgrade signal in server random
-            // both the server random and TLS12_DOWNGRADE_SENTINEL are
-            // public values and don't require constant time comparison
-            let has_downgrade_marker = self.randoms.server[24..] == tls12::DOWNGRADE_SENTINEL;
-            if tls13_supported && has_downgrade_marker {
-                return Err({
-                    cx.common.send_fatal_alert(
-                        AlertDescription::IllegalParameter,
-                        PeerMisbehaved::AttemptedDowngradeToTls12WhenTls13IsSupported,
-                    )
-                });
-            }
-
-            // If we didn't have an input session to resume, and we sent a session ID,
-            // that implies we sent a TLS 1.3 legacy_session_id for compatibility purposes.
-            // In this instance since we're now continuing a TLS 1.2 handshake the server
-            // should not have echoed it back: it's a randomly generated session ID it couldn't
-            // have known.
-            if self.input.resuming.is_none()
-                && !self.input.session_id.is_empty()
-                && self.input.session_id == server_hello.session_id
-            {
-                return Err({
-                    cx.common.send_fatal_alert(
-                        AlertDescription::IllegalParameter,
-                        PeerMisbehaved::ServerEchoedCompatibilitySessionId,
-                    )
-                });
-            }
-
-            let ClientHelloInput {
-                config,
-                server_name,
-                ..
-            } = self.input;
-
-            let resuming_session = self
-                .input
-                .resuming
-                .and_then(|resuming| match resuming.value {
-                    ClientSessionValue::Tls12(inner) => Some(inner),
-                    ClientSessionValue::Tls13(_) => None,
-                });
-
-            // Doing EMS?
-            let using_ems = server_hello
-                .extended_master_secret_ack
-                .is_some();
-            if config.require_ems && !using_ems {
-                return Err({
-                    cx.common.send_fatal_alert(
-                        AlertDescription::HandshakeFailure,
-                        PeerIncompatible::ExtendedMasterSecretExtensionRequired,
-                    )
-                });
-            }
-
-            // Might the server send a ticket?
-            let must_issue_new_ticket = if server_hello
-                .session_ticket_ack
-                .is_some()
-            {
-                debug!("Server supports tickets");
-                true
-            } else {
-                false
-            };
-
-            // Might the server send a CertificateStatus between Certificate and
-            // ServerKeyExchange?
-            let may_send_cert_status = server_hello
-                .certificate_status_request_ack
-                .is_some();
-            if may_send_cert_status {
-                debug!("Server may staple OCSP response");
-            }
-
-            // See if we're successfully resuming.
-            if let Some(resuming) = resuming_session {
-                if resuming.session_id == server_hello.session_id {
-                    debug!("Server agreed to resume");
-
-                    // Is the server telling lies about the ciphersuite?
-                    if resuming.suite() != suite {
-                        return Err(PeerMisbehaved::ResumptionOfferedWithVariedCipherSuite.into());
-                    }
-
-                    // And about EMS support?
-                    if resuming.extended_ms() != using_ems {
-                        return Err(PeerMisbehaved::ResumptionOfferedWithVariedEms.into());
-                    }
-
-                    let secrets = ConnectionSecrets::new_resume(
-                        self.randoms,
-                        suite,
-                        resuming.master_secret(),
-                    );
-                    config.key_log.log(
-                        "CLIENT_RANDOM",
-                        &secrets.randoms.client,
-                        secrets.master_secret(),
-                    );
-                    cx.common
-                        .start_encryption_tls12(&secrets, Side::Client);
-
-                    // Since we're resuming, we verified the certificate and
-                    // proof of possession in the prior session.
-                    cx.common.peer_certificates = Some(
-                        resuming
-                            .server_cert_chain()
-                            .clone()
-                            .into_owned(),
-                    );
-                    cx.common.handshake_kind = Some(HandshakeKind::Resumed);
-                    let cert_verified = verify::ServerCertVerified::assertion();
-                    let sig_verified = verify::HandshakeSignatureValid::assertion();
-
-                    return if must_issue_new_ticket {
-                        Ok(Box::new(ExpectNewTicket {
-                            config,
-                            secrets,
-                            resuming_session: Some(resuming),
-                            session_id: server_hello.session_id,
-                            server_name,
-                            using_ems,
-                            transcript: self.transcript,
-                            resuming: true,
-                            cert_verified,
-                            sig_verified,
-                        }))
-                    } else {
-                        Ok(Box::new(ExpectCcs {
-                            config,
-                            secrets,
-                            resuming_session: Some(resuming),
-                            session_id: server_hello.session_id,
-                            server_name,
-                            using_ems,
-                            transcript: self.transcript,
-                            ticket: None,
-                            resuming: true,
-                            cert_verified,
-                            sig_verified,
-                        }))
-                    };
-                }
-            }
-
-            cx.common.handshake_kind = Some(HandshakeKind::Full);
-            Ok(Box::new(ExpectCertificate {
-                config,
-                resuming_session: None,
-                session_id: server_hello.session_id,
-                server_name,
-                randoms: self.randoms,
-                using_ems,
-                transcript: self.transcript,
-                suite,
-                may_send_cert_status,
-                must_issue_new_ticket,
-            }))
+        // Look for TLS1.3 downgrade signal in server random
+        // both the server random and TLS12_DOWNGRADE_SENTINEL are
+        // public values and don't require constant time comparison
+        let has_downgrade_marker = randoms.server[24..] == tls12::DOWNGRADE_SENTINEL;
+        if tls13_supported && has_downgrade_marker {
+            return Err({
+                cx.common.send_fatal_alert(
+                    AlertDescription::IllegalParameter,
+                    PeerMisbehaved::AttemptedDowngradeToTls12WhenTls13IsSupported,
+                )
+            });
         }
+
+        // If we didn't have an input session to resume, and we sent a session ID,
+        // that implies we sent a TLS 1.3 legacy_session_id for compatibility purposes.
+        // In this instance since we're now continuing a TLS 1.2 handshake the server
+        // should not have echoed it back: it's a randomly generated session ID it couldn't
+        // have known.
+        if input.resuming.is_none()
+            && !input.session_id.is_empty()
+            && input.session_id == server_hello.session_id
+        {
+            return Err({
+                cx.common.send_fatal_alert(
+                    AlertDescription::IllegalParameter,
+                    PeerMisbehaved::ServerEchoedCompatibilitySessionId,
+                )
+            });
+        }
+
+        let ClientHelloInput {
+            config,
+            server_name,
+            ..
+        } = input;
+
+        let resuming_session = input
+            .resuming
+            .and_then(|resuming| match resuming.value {
+                ClientSessionValue::Tls12(inner) => Some(inner),
+                ClientSessionValue::Tls13(_) => None,
+            });
+
+        // Doing EMS?
+        let using_ems = server_hello
+            .extended_master_secret_ack
+            .is_some();
+        if config.require_ems && !using_ems {
+            return Err({
+                cx.common.send_fatal_alert(
+                    AlertDescription::HandshakeFailure,
+                    PeerIncompatible::ExtendedMasterSecretExtensionRequired,
+                )
+            });
+        }
+
+        // Might the server send a ticket?
+        let must_issue_new_ticket = if server_hello
+            .session_ticket_ack
+            .is_some()
+        {
+            debug!("Server supports tickets");
+            true
+        } else {
+            false
+        };
+
+        // Might the server send a CertificateStatus between Certificate and
+        // ServerKeyExchange?
+        let may_send_cert_status = server_hello
+            .certificate_status_request_ack
+            .is_some();
+        if may_send_cert_status {
+            debug!("Server may staple OCSP response");
+        }
+
+        // See if we're successfully resuming.
+        if let Some(resuming) = resuming_session {
+            if resuming.session_id == server_hello.session_id {
+                debug!("Server agreed to resume");
+
+                // Is the server telling lies about the ciphersuite?
+                if resuming.suite() != suite {
+                    return Err(PeerMisbehaved::ResumptionOfferedWithVariedCipherSuite.into());
+                }
+
+                // And about EMS support?
+                if resuming.extended_ms() != using_ems {
+                    return Err(PeerMisbehaved::ResumptionOfferedWithVariedEms.into());
+                }
+
+                let secrets =
+                    ConnectionSecrets::new_resume(randoms, suite, resuming.master_secret());
+                config.key_log.log(
+                    "CLIENT_RANDOM",
+                    &secrets.randoms.client,
+                    secrets.master_secret(),
+                );
+                cx.common
+                    .start_encryption_tls12(&secrets, Side::Client);
+
+                // Since we're resuming, we verified the certificate and
+                // proof of possession in the prior session.
+                cx.common.peer_certificates = Some(
+                    resuming
+                        .server_cert_chain()
+                        .clone()
+                        .into_owned(),
+                );
+                cx.common.handshake_kind = Some(HandshakeKind::Resumed);
+                let cert_verified = verify::ServerCertVerified::assertion();
+                let sig_verified = verify::HandshakeSignatureValid::assertion();
+
+                return if must_issue_new_ticket {
+                    Ok(Box::new(ExpectNewTicket {
+                        config,
+                        secrets,
+                        resuming_session: Some(resuming),
+                        session_id: server_hello.session_id,
+                        server_name,
+                        using_ems,
+                        transcript,
+                        resuming: true,
+                        cert_verified,
+                        sig_verified,
+                    }))
+                } else {
+                    Ok(Box::new(ExpectCcs {
+                        config,
+                        secrets,
+                        resuming_session: Some(resuming),
+                        session_id: server_hello.session_id,
+                        server_name,
+                        using_ems,
+                        transcript,
+                        ticket: None,
+                        resuming: true,
+                        cert_verified,
+                        sig_verified,
+                    }))
+                };
+            }
+        }
+
+        cx.common.handshake_kind = Some(HandshakeKind::Full);
+        Ok(Box::new(ExpectCertificate {
+            config,
+            resuming_session: None,
+            session_id: server_hello.session_id,
+            server_name,
+            randoms,
+            using_ems,
+            transcript,
+            suite,
+            may_send_cert_status,
+            must_issue_new_ticket,
+        }))
     }
 }
 

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -21,7 +21,6 @@ use crate::msgs::message::{
 };
 use crate::record_layer::PreEncryptAction;
 use crate::suites::{PartiallyExtractedSecrets, SupportedCipherSuite};
-#[cfg(feature = "tls12")]
 use crate::tls12::ConnectionSecrets;
 use crate::unbuffered::{EncryptError, InsufficientSizeError};
 use crate::vecbuf::ChunkVecBuffer;
@@ -485,7 +484,6 @@ impl CommonState {
             .append(bytes.into_vec());
     }
 
-    #[cfg(feature = "tls12")]
     pub(crate) fn start_encryption_tls12(&mut self, secrets: &ConnectionSecrets, side: Side) {
         let (dec, enc) = secrets.make_cipher_pair(side);
         self.record_layer
@@ -1043,7 +1041,6 @@ impl<'a, const TLS13: bool> HandshakeFlight<'a, TLS13> {
     }
 }
 
-#[cfg(feature = "tls12")]
 pub(crate) type HandshakeFlightTls12<'a> = HandshakeFlight<'a, false>;
 pub(crate) type HandshakeFlightTls13<'a> = HandshakeFlight<'a, true>;
 

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -34,7 +34,6 @@ pub(crate) mod kx;
 pub(crate) mod quic;
 #[cfg(feature = "std")]
 pub(crate) mod ticketer;
-#[cfg(feature = "tls12")]
 pub(crate) mod tls12;
 pub(crate) mod tls13;
 
@@ -111,17 +110,13 @@ pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     #[cfg(not(feature = "fips"))]
     tls13::TLS13_CHACHA20_POLY1305_SHA256,
     // TLS1.2 suites
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(all(feature = "tls12", not(feature = "fips")))]
+    #[cfg(not(feature = "fips"))]
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(all(feature = "tls12", not(feature = "fips")))]
+    #[cfg(not(feature = "fips"))]
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
@@ -132,23 +127,16 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     tls13::TLS13_AES_128_GCM_SHA256,
     tls13::TLS13_CHACHA20_POLY1305_SHA256,
     // TLS1.2 suites
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
 /// All defined cipher suites supported by aws-lc-rs appear in this module.
 pub mod cipher_suite {
-    #[cfg(feature = "tls12")]
     pub use super::tls12::{
         TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
         TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -17,7 +17,7 @@ use crate::msgs::message::{
 };
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls12::Tls12CipherSuite;
-use crate::version::TLS12;
+use crate::version::{TLS12, TLS12_VERSION};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256.
 pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
@@ -27,6 +27,7 @@ pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             hash_provider: &super::hash::SHA256,
             confidentiality_limit: u64::MAX,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
         aead_alg: &ChaCha20Poly1305,
@@ -41,6 +42,7 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             hash_provider: &super::hash::SHA256,
             confidentiality_limit: u64::MAX,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
         aead_alg: &ChaCha20Poly1305,
@@ -55,6 +57,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             hash_provider: &super::hash::SHA256,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
         aead_alg: &AES128_GCM,
@@ -69,6 +72,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             hash_provider: &super::hash::SHA384,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
         aead_alg: &AES256_GCM,
@@ -83,6 +87,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             hash_provider: &super::hash::SHA256,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
         aead_alg: &AES128_GCM,
@@ -97,6 +102,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             hash_provider: &super::hash::SHA384,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
         aead_alg: &AES256_GCM,

--- a/rustls/src/crypto/aws_lc_rs/tls13.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls13.rs
@@ -16,6 +16,7 @@ use crate::msgs::message::{
 };
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls13::Tls13CipherSuite;
+use crate::version::TLS13_VERSION;
 
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256
 pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
@@ -28,6 +29,7 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
         // ref: <https://www.ietf.org/archive/id/draft-irtf-cfrg-aead-limits-08.html#section-5.2.1>
         confidentiality_limit: u64::MAX,
     },
+    protocol_version: TLS13_VERSION,
     hkdf_provider: &AwsLcHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
     aead_alg: &Chacha20Poly1305Aead(AeadAlgorithm(&aead::CHACHA20_POLY1305)),
     quic: Some(&super::quic::KeyBuilder {
@@ -48,6 +50,7 @@ pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
             hash_provider: &super::hash::SHA384,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS13_VERSION,
         hkdf_provider: &AwsLcHkdf(hkdf::HKDF_SHA384, hmac::HMAC_SHA384),
         aead_alg: &Aes256GcmAead(AeadAlgorithm(&aead::AES_256_GCM)),
         quic: Some(&super::quic::KeyBuilder {
@@ -70,6 +73,7 @@ pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13C
         hash_provider: &super::hash::SHA256,
         confidentiality_limit: 1 << 24,
     },
+    protocol_version: TLS13_VERSION,
     hkdf_provider: &AwsLcHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
     aead_alg: &Aes128GcmAead(AeadAlgorithm(&aead::AES_128_GCM)),
     quic: Some(&super::quic::KeyBuilder {

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -179,13 +179,11 @@ pub struct Iv([u8; NONCE_LEN]);
 
 impl Iv {
     /// Create a new `Iv` from a byte array, of precisely `NONCE_LEN` bytes.
-    #[cfg(feature = "tls12")]
     pub fn new(value: [u8; NONCE_LEN]) -> Self {
         Self(value)
     }
 
     /// Create a new `Iv` from a byte slice, of precisely `NONCE_LEN` bytes.
-    #[cfg(feature = "tls12")]
     pub fn copy(value: &[u8]) -> Self {
         debug_assert_eq!(value.len(), NONCE_LEN);
         let mut iv = Self::new(Default::default());
@@ -280,7 +278,6 @@ pub struct AeadKey {
 }
 
 impl AeadKey {
-    #[cfg(feature = "tls12")]
     pub(crate) fn new(buf: &[u8]) -> Self {
         debug_assert!(buf.len() <= Self::MAX_LEN);
         let mut key = Self::from([0u8; Self::MAX_LEN]);

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 use pki_types::PrivateKeyDer;
 use zeroize::Zeroize;
 
-#[cfg(all(doc, feature = "tls12"))]
+#[cfg(doc)]
 use crate::Tls12CipherSuite;
 use crate::msgs::ffdhe_groups::FfdheGroup;
 use crate::sign::SigningKey;
@@ -39,7 +39,6 @@ pub mod hash;
 pub mod hmac;
 
 /// Cryptography specific to TLS1.2.
-#[cfg(feature = "tls12")]
 pub mod tls12;
 
 /// Cryptography specific to TLS1.3.

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -466,7 +466,7 @@ pub trait ActiveKeyExchange: Send + Sync {
         peer_pub_key: &[u8],
         tls_version: &SupportedProtocolVersion,
     ) -> Result<SharedSecret, Error> {
-        if tls_version.version != ProtocolVersion::TLSv1_2 {
+        if tls_version.version() != ProtocolVersion::TLSv1_2 {
             return self.complete(peer_pub_key);
         }
 

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -15,13 +15,11 @@ use crate::webpki::WebPkiSupportedAlgorithms;
 pub mod sign;
 
 pub(crate) mod hash;
-#[cfg(any(test, feature = "tls12"))]
 pub(crate) mod hmac;
 pub(crate) mod kx;
 pub(crate) mod quic;
 #[cfg(feature = "std")]
 pub(crate) mod ticketer;
-#[cfg(feature = "tls12")]
 pub(crate) mod tls12;
 pub(crate) mod tls13;
 
@@ -74,23 +72,16 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     tls13::TLS13_AES_128_GCM_SHA256,
     tls13::TLS13_CHACHA20_POLY1305_SHA256,
     // TLS1.2 suites
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
 /// All defined cipher suites supported by *ring* appear in this module.
 pub mod cipher_suite {
-    #[cfg(feature = "tls12")]
     pub use super::tls12::{
         TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
         TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -15,6 +15,7 @@ use crate::msgs::message::{
 };
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls12::Tls12CipherSuite;
+use crate::version::TLS12_VERSION;
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256.
 pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
@@ -24,6 +25,7 @@ pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             hash_provider: &super::hash::SHA256,
             confidentiality_limit: u64::MAX,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
         aead_alg: &ChaCha20Poly1305,
@@ -38,6 +40,7 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             hash_provider: &super::hash::SHA256,
             confidentiality_limit: u64::MAX,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
         aead_alg: &ChaCha20Poly1305,
@@ -52,6 +55,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             hash_provider: &super::hash::SHA256,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
         aead_alg: &AES128_GCM,
@@ -66,6 +70,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             hash_provider: &super::hash::SHA384,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_RSA_SCHEMES,
         aead_alg: &AES256_GCM,
@@ -80,6 +85,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             hash_provider: &super::hash::SHA256,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
         aead_alg: &AES128_GCM,
@@ -94,6 +100,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             hash_provider: &super::hash::SHA384,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS12_VERSION,
         kx: KeyExchangeAlgorithm::ECDHE,
         sign: TLS12_ECDSA_SCHEMES,
         aead_alg: &AES256_GCM,

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -15,6 +15,7 @@ use crate::msgs::message::{
 };
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
 use crate::tls13::Tls13CipherSuite;
+use crate::version::TLS13_VERSION;
 
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256
 pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
@@ -27,6 +28,7 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
         // ref: <https://www.ietf.org/archive/id/draft-irtf-cfrg-aead-limits-08.html#section-5.2.1>
         confidentiality_limit: u64::MAX,
     },
+    protocol_version: TLS13_VERSION,
     hkdf_provider: &RingHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
     aead_alg: &Chacha20Poly1305Aead(AeadAlgorithm(&aead::CHACHA20_POLY1305)),
     quic: Some(&super::quic::KeyBuilder {
@@ -47,6 +49,7 @@ pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
             hash_provider: &super::hash::SHA384,
             confidentiality_limit: 1 << 24,
         },
+        protocol_version: TLS13_VERSION,
         hkdf_provider: &RingHkdf(hkdf::HKDF_SHA384, hmac::HMAC_SHA384),
         aead_alg: &Aes256GcmAead(AeadAlgorithm(&aead::AES_256_GCM)),
         quic: Some(&super::quic::KeyBuilder {
@@ -69,6 +72,7 @@ pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13C
         hash_provider: &super::hash::SHA256,
         confidentiality_limit: 1 << 24,
     },
+    protocol_version: TLS13_VERSION,
     hkdf_provider: &RingHkdf(hkdf::HKDF_SHA256, hmac::HMAC_SHA256),
     aead_alg: &Aes128GcmAead(AeadAlgorithm(&aead::AES_128_GCM)),
     quic: Some(&super::quic::KeyBuilder {

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -162,7 +162,6 @@ impl HandshakeHash {
     /// Takes this object's buffer containing all handshake messages
     /// so far.  This method only works once; it resets the buffer
     /// to empty.
-    #[cfg(feature = "tls12")]
     pub(crate) fn take_handshake_buf(&mut self) -> Option<Vec<u8>> {
         self.client_auth.take()
     }
@@ -256,7 +255,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "tls12")]
     #[test]
     fn buffers_correctly() {
         let mut hhb = HandshakeHashBuffer::new();

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -642,6 +642,8 @@ pub mod server {
     pub mod danger {
         pub use crate::verify::{ClientCertVerified, ClientCertVerifier};
     }
+
+    pub(crate) use tls12::{TLS12_HANDLER, Tls12Handler};
 }
 
 pub use server::ServerConfig;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -644,6 +644,7 @@ pub mod server {
     }
 
     pub(crate) use tls12::{TLS12_HANDLER, Tls12Handler};
+    pub(crate) use tls13::{TLS13_HANDLER, Tls13Handler};
 }
 
 pub use server::ServerConfig;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -695,3 +695,7 @@ mod hash_map {
     #[cfg(all(not(feature = "std"), feature = "hashbrown"))]
     pub(crate) use hashbrown::hash_map::Entry;
 }
+
+mod sealed {
+    pub trait Sealed {}
+}

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -592,6 +592,8 @@ pub mod client {
         pub use crate::verify::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
     }
 
+    pub(crate) use tls12::{TLS12_HANDLER, Tls12Handler};
+
     pub use crate::msgs::persist::{Tls12ClientSessionValue, Tls13ClientSessionValue};
     pub use crate::webpki::{
         ServerCertVerifierBuilder, VerifierBuilderError, WebPkiServerVerifier,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -303,12 +303,6 @@
 //! - `custom-provider`: disables implicit use of built-in providers (`aws-lc-rs` or `ring`). This forces
 //!   applications to manually install one, for instance, when using a custom `CryptoProvider`.
 //!
-//! - `tls12` (enabled by default): enable support for TLS version 1.2. Note that, due to the
-//!   additive nature of Cargo features and because it is enabled by default, other crates
-//!   in your dependency graph could re-enable it for your application. If you want to disable
-//!   TLS 1.2 for security reasons, consider explicitly enabling TLS 1.3 only in the config
-//!   builder API.
-//!
 //! - `log` (enabled by default): make the rustls crate depend on the `log` crate.
 //!   rustls outputs interesting protocol-level messages at `trace!` and `debug!` level,
 //!   and protocol-level errors at `warn!` and `error!` level.  The log messages do not
@@ -425,7 +419,6 @@ mod rand;
 mod record_layer;
 #[cfg(feature = "std")]
 mod stream;
-#[cfg(feature = "tls12")]
 mod tls12;
 mod tls13;
 mod vecbuf;
@@ -552,7 +545,6 @@ pub use crate::suites::{
 };
 #[cfg(feature = "std")]
 pub use crate::ticketer::TicketRotator;
-#[cfg(feature = "tls12")]
 pub use crate::tls12::Tls12CipherSuite;
 pub use crate::tls13::Tls13CipherSuite;
 pub use crate::verify::DigitallySignedStruct;
@@ -569,7 +561,6 @@ pub mod client {
     mod hs;
     #[cfg(test)]
     mod test;
-    #[cfg(feature = "tls12")]
     mod tls12;
     mod tls13;
 
@@ -615,7 +606,6 @@ pub mod server {
     mod server_conn;
     #[cfg(test)]
     mod test;
-    #[cfg(feature = "tls12")]
     mod tls12;
     mod tls13;
 
@@ -655,9 +645,9 @@ pub use server::ServerConnection;
 ///
 /// ALL_VERSIONS is a provided as an array of all of these values.
 pub mod version {
-    #[cfg(feature = "tls12")]
-    pub use crate::versions::TLS12;
-    pub use crate::versions::{TLS12_VERSION, TLS13, TLS13_VERSION, Tls12Version, Tls13Version};
+    pub use crate::versions::{
+        TLS12, TLS12_VERSION, TLS13, TLS13_VERSION, Tls12Version, Tls13Version,
+    };
 }
 
 /// Re-exports the contents of the [rustls-pki-types](https://docs.rs/rustls-pki-types) crate for easy access

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -651,7 +651,7 @@ pub use server::ServerConnection;
 pub mod version {
     #[cfg(feature = "tls12")]
     pub use crate::versions::TLS12;
-    pub use crate::versions::TLS13;
+    pub use crate::versions::{TLS12_VERSION, TLS13, TLS13_VERSION, Tls12Version, Tls13Version};
 }
 
 /// Re-exports the contents of the [rustls-pki-types](https://docs.rs/rustls-pki-types) crate for easy access

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -593,6 +593,7 @@ pub mod client {
     }
 
     pub(crate) use tls12::{TLS12_HANDLER, Tls12Handler};
+    pub(crate) use tls13::{TLS13_HANDLER, Tls13Handler};
 
     pub use crate::msgs::persist::{Tls12ClientSessionValue, Tls13ClientSessionValue};
     pub use crate::webpki::{

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -83,7 +83,6 @@ fn accepts_short_session_id() {
     let sess = SessionId::read(&mut rd).unwrap();
     println!("{sess:?}");
 
-    #[cfg(feature = "tls12")]
     assert!(!sess.is_empty());
     assert_ne!(sess, SessionId::empty());
     assert!(!rd.any_left());
@@ -96,7 +95,6 @@ fn accepts_empty_session_id() {
     let sess = SessionId::read(&mut rd).unwrap();
     println!("{sess:?}");
 
-    #[cfg(feature = "tls12")]
     assert!(sess.is_empty());
     assert_eq!(sess, SessionId::empty());
     assert!(!rd.any_left());

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -9,11 +9,8 @@ use crate::enums::{CipherSuite, ProtocolVersion};
 use crate::error::InvalidMessage;
 use crate::msgs::base::{MaybeEmpty, PayloadU8, PayloadU16};
 use crate::msgs::codec::{Codec, Reader};
-#[cfg(feature = "tls12")]
-use crate::msgs::handshake::SessionId;
-use crate::msgs::handshake::{CertificateChain, ProtocolName};
+use crate::msgs::handshake::{CertificateChain, ProtocolName, SessionId};
 use crate::sync::{Arc, Weak};
-#[cfg(feature = "tls12")]
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
 use crate::verify::ServerCertVerifier;
@@ -152,20 +149,14 @@ impl core::ops::Deref for Tls13ClientSessionValue {
 
 #[derive(Debug, Clone)]
 pub struct Tls12ClientSessionValue {
-    #[cfg(feature = "tls12")]
     suite: &'static Tls12CipherSuite,
-    #[cfg(feature = "tls12")]
     pub(crate) session_id: SessionId,
-    #[cfg(feature = "tls12")]
     master_secret: Zeroizing<[u8; 48]>,
-    #[cfg(feature = "tls12")]
     extended_ms: bool,
     #[doc(hidden)]
-    #[cfg(feature = "tls12")]
     pub(crate) common: ClientSessionCommon,
 }
 
-#[cfg(feature = "tls12")]
 impl Tls12ClientSessionValue {
     pub(crate) fn new(
         suite: &'static Tls12CipherSuite,
@@ -218,7 +209,6 @@ impl Tls12ClientSessionValue {
     }
 }
 
-#[cfg(feature = "tls12")]
 impl core::ops::Deref for Tls12ClientSessionValue {
     type Target = ClientSessionCommon;
 
@@ -339,7 +329,6 @@ pub struct Tls12ServerSessionValue {
 }
 
 impl Tls12ServerSessionValue {
-    #[cfg(feature = "tls12")]
     pub(crate) fn new(
         common: CommonServerSessionValue,
         master_secret: &[u8; 48],

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -116,7 +116,6 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             max_early_data_size: 0,
             send_half_rtt_data: false,
             send_tls13_tickets: 2,
-            #[cfg(feature = "tls12")]
             require_ems: cfg!(feature = "fips"),
             time_provider: self.time_provider,
             cert_compressors: compress::default_cert_compressors().to_vec(),

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -3,7 +3,7 @@ use pki_types::CertificateDer;
 use crate::sign;
 
 /// ActiveCertifiedKey wraps [`sign::CertifiedKey`] and tracks OSCP state in a single handshake.
-pub(super) struct ActiveCertifiedKey<'a> {
+pub(crate) struct ActiveCertifiedKey<'a> {
     key: &'a sign::CertifiedKey,
     ocsp: Option<&'a [u8]>,
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -502,25 +502,28 @@ impl ExpectClientHello {
                 sig_schemes,
             ),
             #[cfg(feature = "tls12")]
-            SupportedCipherSuite::Tls12(suite) => tls12::handle_client_hello(
-                tls12::CompleteClientHelloHandling {
-                    config: self.config,
-                    transcript,
-                    session_id: self.session_id,
-                    suite,
-                    using_ems: self.using_ems,
-                    randoms,
-                    send_ticket: self.send_tickets > 0,
-                    extra_exts: self.extra_exts,
-                },
-                cx,
-                certkey,
-                m,
-                client_hello,
-                skxg,
-                sig_schemes,
-                tls13_enabled,
-            ),
+            SupportedCipherSuite::Tls12(suite) => suite
+                .protocol_version
+                .server
+                .handle_client_hello(
+                    tls12::CompleteClientHelloHandling {
+                        config: self.config,
+                        transcript,
+                        session_id: self.session_id,
+                        suite,
+                        using_ems: self.using_ems,
+                        randoms,
+                        send_ticket: self.send_tickets > 0,
+                        extra_exts: self.extra_exts,
+                    },
+                    cx,
+                    certkey,
+                    m,
+                    client_hello,
+                    skxg,
+                    sig_schemes,
+                    tls13_enabled,
+                ),
         }
     }
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -495,17 +495,17 @@ impl ExpectClientHello {
             }
             .handle_client_hello(cx, certkey, m, client_hello, skxg, sig_schemes),
             #[cfg(feature = "tls12")]
-            SupportedCipherSuite::Tls12(suite) => tls12::CompleteClientHelloHandling {
-                config: self.config,
-                transcript,
-                session_id: self.session_id,
-                suite,
-                using_ems: self.using_ems,
-                randoms,
-                send_ticket: self.send_tickets > 0,
-                extra_exts: self.extra_exts,
-            }
-            .handle_client_hello(
+            SupportedCipherSuite::Tls12(suite) => tls12::handle_client_hello(
+                tls12::CompleteClientHelloHandling {
+                    config: self.config,
+                    transcript,
+                    session_id: self.session_id,
+                    suite,
+                    using_ems: self.using_ems,
+                    randoms,
+                    send_ticket: self.send_tickets > 0,
+                    extra_exts: self.extra_exts,
+                },
                 cx,
                 certkey,
                 m,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -5,7 +5,6 @@ use alloc::vec::Vec;
 use pki_types::DnsName;
 
 use super::server_conn::ServerConnectionData;
-#[cfg(feature = "tls12")]
 use super::tls12;
 use crate::common_state::{KxState, Protocol, State};
 use crate::conn::ConnectionRandoms;
@@ -18,11 +17,9 @@ use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
 use crate::log::{debug, trace};
 use crate::msgs::enums::{Compression, ExtensionType, NamedGroup};
-#[cfg(feature = "tls12")]
-use crate::msgs::handshake::SessionId;
 use crate::msgs::handshake::{
     ClientHelloPayload, HandshakePayload, KeyExchangeAlgorithm, ProtocolName, Random,
-    ServerExtensions, ServerExtensionsInput, ServerNamePayload, SingleProtocolName,
+    ServerExtensions, ServerExtensionsInput, ServerNamePayload, SessionId, SingleProtocolName,
     TransportParameters,
 };
 use crate::msgs::message::{Message, MessagePayload};
@@ -58,7 +55,6 @@ pub(super) fn can_resume(
 pub(super) struct ExtensionProcessing {
     // extensions to reply with
     pub(super) extensions: Box<ServerExtensions<'static>>,
-    #[cfg(feature = "tls12")]
     pub(super) send_ticket: bool,
 }
 
@@ -75,7 +71,6 @@ impl ExtensionProcessing {
 
         Self {
             extensions,
-            #[cfg(feature = "tls12")]
             send_ticket: false,
         }
     }
@@ -170,7 +165,6 @@ impl ExtensionProcessing {
         Ok(())
     }
 
-    #[cfg(feature = "tls12")]
     pub(super) fn process_tls12(
         &mut self,
         config: &ServerConfig,
@@ -296,9 +290,7 @@ pub(super) struct ExpectClientHello {
     pub(super) config: Arc<ServerConfig>,
     pub(super) extra_exts: ServerExtensionsInput<'static>,
     pub(super) transcript: HandshakeHashOrBuffer,
-    #[cfg(feature = "tls12")]
     pub(super) session_id: SessionId,
-    #[cfg(feature = "tls12")]
     pub(super) using_ems: bool,
     pub(super) done_retry: bool,
     pub(super) send_tickets: usize,
@@ -319,9 +311,7 @@ impl ExpectClientHello {
             config,
             extra_exts,
             transcript: HandshakeHashOrBuffer::Buffer(transcript_buffer),
-            #[cfg(feature = "tls12")]
             session_id: SessionId::empty(),
-            #[cfg(feature = "tls12")]
             using_ems: false,
             done_retry: false,
             send_tickets: 0,
@@ -504,7 +494,6 @@ impl ExpectClientHello {
                     skxg,
                     sig_schemes,
                 ),
-            #[cfg(feature = "tls12")]
             SupportedCipherSuite::Tls12(suite) => suite
                 .protocol_version
                 .server

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -484,23 +484,26 @@ impl ExpectClientHello {
             Random::new(self.config.provider.secure_random)?,
         );
         match suite {
-            SupportedCipherSuite::Tls13(suite) => tls13::handle_client_hello(
-                tls13::CompleteClientHelloHandling {
-                    config: self.config,
-                    transcript,
-                    suite,
-                    randoms,
-                    done_retry: self.done_retry,
-                    send_tickets: self.send_tickets,
-                    extra_exts: self.extra_exts,
-                },
-                cx,
-                certkey,
-                m,
-                client_hello,
-                skxg,
-                sig_schemes,
-            ),
+            SupportedCipherSuite::Tls13(suite) => suite
+                .protocol_version
+                .server
+                .handle_client_hello(
+                    tls13::CompleteClientHelloHandling {
+                        config: self.config,
+                        transcript,
+                        suite,
+                        randoms,
+                        done_retry: self.done_retry,
+                        send_tickets: self.send_tickets,
+                        extra_exts: self.extra_exts,
+                    },
+                    cx,
+                    certkey,
+                    m,
+                    client_hello,
+                    skxg,
+                    sig_schemes,
+                ),
             #[cfg(feature = "tls12")]
             SupportedCipherSuite::Tls12(suite) => suite
                 .protocol_version

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -484,16 +484,23 @@ impl ExpectClientHello {
             Random::new(self.config.provider.secure_random)?,
         );
         match suite {
-            SupportedCipherSuite::Tls13(suite) => tls13::CompleteClientHelloHandling {
-                config: self.config,
-                transcript,
-                suite,
-                randoms,
-                done_retry: self.done_retry,
-                send_tickets: self.send_tickets,
-                extra_exts: self.extra_exts,
-            }
-            .handle_client_hello(cx, certkey, m, client_hello, skxg, sig_schemes),
+            SupportedCipherSuite::Tls13(suite) => tls13::handle_client_hello(
+                tls13::CompleteClientHelloHandling {
+                    config: self.config,
+                    transcript,
+                    suite,
+                    randoms,
+                    done_retry: self.done_retry,
+                    send_tickets: self.send_tickets,
+                    extra_exts: self.extra_exts,
+                },
+                cx,
+                certkey,
+                m,
+                client_hello,
+                skxg,
+                sig_schemes,
+            ),
             #[cfg(feature = "tls12")]
             SupportedCipherSuite::Tls12(suite) => tls12::handle_client_hello(
                 tls12::CompleteClientHelloHandling {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -592,7 +592,7 @@ impl ExpectClientHello {
                 // Reduce our supported ciphersuites by the certified key's algorithm.
                 suite.usable_for_signature_algorithm(sig_key_algorithm)
                 // And version
-                && suite.version().version == selected_version
+                && suite.version().version() == selected_version
                 // And protocol
                 && suite.usable_for_protocol(protocol)
                 // And support one of key exchange groups

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -408,7 +408,6 @@ pub struct ServerConfig {
     ///
     /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
     /// [FIPS 140-3 IG.pdf]: https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf
-    #[cfg(feature = "tls12")]
     pub require_ems: bool,
 
     /// Provides the current system time
@@ -536,15 +535,7 @@ impl ServerConfig {
     /// is concerned only with cryptography, whereas this _also_ covers TLS-level
     /// configuration that NIST recommends.
     pub fn fips(&self) -> bool {
-        #[cfg(feature = "tls12")]
-        {
-            self.provider.fips() && self.require_ems
-        }
-
-        #[cfg(not(feature = "tls12"))]
-        {
-            self.provider.fips()
-        }
+        self.provider.fips() && self.require_ems
     }
 
     /// Return the crypto provider used to construct this client configuration.

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -561,7 +561,7 @@ impl ServerConfig {
                 .provider
                 .cipher_suites
                 .iter()
-                .any(|cs| cs.version().version == v)
+                .any(|cs| cs.version().version() == v)
     }
 
     #[cfg(feature = "std")]

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -78,7 +78,6 @@ mod tests {
     use crate::sync::Arc;
     use crate::{CipherSuiteCommon, SupportedCipherSuite, Tls12CipherSuite, version};
 
-    #[cfg(feature = "tls12")]
     #[test]
     fn test_server_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
         let provider = super::provider::default_provider();
@@ -117,7 +116,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "tls12")]
     #[test]
     fn server_picks_ffdhe_group_when_clienthello_has_no_ffdhe_group_in_groups_ext() {
         let config = ServerConfig::builder_with_provider(ffdhe_provider().into())
@@ -137,7 +135,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "tls12")]
     #[test]
     fn server_picks_ffdhe_group_when_clienthello_has_no_groups_ext() {
         let config = ServerConfig::builder_with_provider(ffdhe_provider().into())
@@ -158,7 +155,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "tls12")]
     #[test]
     fn server_accepts_client_with_no_ecpoints_extension_and_only_ffdhe_cipher_suites() {
         let config = ServerConfig::builder_with_provider(ffdhe_provider().into())

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -167,9 +167,7 @@ mod client_hello {
                 let next = Box::new(hs::ExpectClientHello {
                     config: cch.config,
                     transcript: HandshakeHashOrBuffer::Hash(cch.transcript),
-                    #[cfg(feature = "tls12")]
                     session_id: SessionId::empty(),
-                    #[cfg(feature = "tls12")]
                     using_ems: false,
                     done_retry: true,
                     send_tickets: cch.send_tickets,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -2,7 +2,8 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 
-pub(super) use client_hello::{CompleteClientHelloHandling, handle_client_hello};
+pub(super) use client_hello::CompleteClientHelloHandling;
+pub(crate) use client_hello::{TLS13_HANDLER, Tls13Handler};
 use pki_types::{CertificateDer, UnixTime};
 use subtle::ConstantTimeEq;
 
@@ -38,6 +39,8 @@ use crate::tls13::{
 use crate::{ConnectionTrafficSecrets, compress, rand, verify};
 
 mod client_hello {
+    use core::fmt;
+
     use super::*;
     use crate::compress::CertCompressor;
     use crate::crypto::SupportedKxGroup;
@@ -50,6 +53,7 @@ mod client_hello {
         ClientHelloPayload, HelloRetryRequest, HelloRetryRequestExtensions, KeyShareEntry, Random,
         ServerExtensions, ServerExtensionsInput, ServerHelloPayload, SessionId,
     };
+    use crate::sealed::Sealed;
     use crate::server::common::ActiveCertifiedKey;
     use crate::sign;
     use crate::tls13::key_schedule::{
@@ -57,322 +61,351 @@ mod client_hello {
     };
     use crate::verify::DigitallySignedStruct;
 
-    pub(in crate::server) fn handle_client_hello(
-        mut cch: CompleteClientHelloHandling,
-        cx: &mut ServerContext<'_>,
-        server_key: ActiveCertifiedKey<'_>,
-        chm: &Message<'_>,
-        client_hello: &ClientHelloPayload,
-        selected_kxg: &'static dyn SupportedKxGroup,
-        mut sigschemes_ext: Vec<SignatureScheme>,
-    ) -> hs::NextStateOrError<'static> {
-        if client_hello.compression_methods.len() != 1 {
-            return Err(cx.common.send_fatal_alert(
-                AlertDescription::IllegalParameter,
-                PeerMisbehaved::OfferedIncorrectCompressions,
-            ));
-        }
+    pub(crate) static TLS13_HANDLER: &'static dyn Tls13Handler = &Handler;
 
-        sigschemes_ext.retain(SignatureScheme::supported_in_tls13);
+    #[derive(Debug)]
+    struct Handler;
 
-        let shares_ext = client_hello
-            .key_shares
-            .as_ref()
-            .ok_or_else(|| {
-                cx.common.send_fatal_alert(
-                    AlertDescription::HandshakeFailure,
-                    PeerIncompatible::KeyShareExtensionRequired,
-                )
-            })?;
-
-        if client_hello.has_keyshare_extension_with_duplicates() {
-            return Err(cx.common.send_fatal_alert(
-                AlertDescription::IllegalParameter,
-                PeerMisbehaved::OfferedDuplicateKeyShares,
-            ));
-        }
-
-        if client_hello.has_certificate_compression_extension_with_duplicates() {
-            return Err(cx.common.send_fatal_alert(
-                AlertDescription::IllegalParameter,
-                PeerMisbehaved::OfferedDuplicateCertificateCompressions,
-            ));
-        }
-
-        let cert_compressor = client_hello
-            .certificate_compression_algorithms
-            .as_ref()
-            .and_then(|offered|
-                // prefer server order when choosing a compression: the client's
-                // extension here does not denote any preference.
-                cch.config
-                    .cert_compressors
-                    .iter()
-                    .find(|compressor| offered.contains(&compressor.algorithm()))
-                    .cloned());
-
-        let early_data_requested = client_hello
-            .early_data_request
-            .is_some();
-
-        // EarlyData extension is illegal in second ClientHello
-        if cch.done_retry && early_data_requested {
-            return Err({
-                cx.common.send_fatal_alert(
-                    AlertDescription::IllegalParameter,
-                    PeerMisbehaved::EarlyDataAttemptedInSecondClientHello,
-                )
-            });
-        }
-
-        // See if there is a KeyShare for the selected kx group.
-        let chosen_share_and_kxg = shares_ext.iter().find_map(|share| {
-            (share.group == selected_kxg.name()).then_some((share, selected_kxg))
-        });
-
-        let Some(chosen_share_and_kxg) = chosen_share_and_kxg else {
-            // We don't have a suitable key share.  Send a HelloRetryRequest
-            // for the mutually_preferred_group.
-            cch.transcript.add_message(chm);
-
-            if cch.done_retry {
+    impl Tls13Handler for Handler {
+        fn handle_client_hello(
+            &self,
+            mut cch: CompleteClientHelloHandling,
+            cx: &mut ServerContext<'_>,
+            server_key: ActiveCertifiedKey<'_>,
+            chm: &Message<'_>,
+            client_hello: &ClientHelloPayload,
+            selected_kxg: &'static dyn SupportedKxGroup,
+            mut sigschemes_ext: Vec<SignatureScheme>,
+        ) -> hs::NextStateOrError<'static> {
+            if client_hello.compression_methods.len() != 1 {
                 return Err(cx.common.send_fatal_alert(
                     AlertDescription::IllegalParameter,
-                    PeerMisbehaved::RefusedToFollowHelloRetryRequest,
+                    PeerMisbehaved::OfferedIncorrectCompressions,
                 ));
             }
 
-            emit_hello_retry_request(
-                &mut cch.transcript,
-                cch.suite,
-                client_hello.session_id,
-                cx.common,
-                selected_kxg.name(),
-            );
-            emit_fake_ccs(cx.common);
+            sigschemes_ext.retain(SignatureScheme::supported_in_tls13);
 
-            let skip_early_data = max_early_data_size(cch.config.max_early_data_size);
+            let shares_ext = client_hello
+                .key_shares
+                .as_ref()
+                .ok_or_else(|| {
+                    cx.common.send_fatal_alert(
+                        AlertDescription::HandshakeFailure,
+                        PeerIncompatible::KeyShareExtensionRequired,
+                    )
+                })?;
 
-            let next = Box::new(hs::ExpectClientHello {
-                config: cch.config,
-                transcript: HandshakeHashOrBuffer::Hash(cch.transcript),
-                #[cfg(feature = "tls12")]
-                session_id: SessionId::empty(),
-                #[cfg(feature = "tls12")]
-                using_ems: false,
-                done_retry: true,
-                send_tickets: cch.send_tickets,
-                extra_exts: cch.extra_exts,
+            if client_hello.has_keyshare_extension_with_duplicates() {
+                return Err(cx.common.send_fatal_alert(
+                    AlertDescription::IllegalParameter,
+                    PeerMisbehaved::OfferedDuplicateKeyShares,
+                ));
+            }
+
+            if client_hello.has_certificate_compression_extension_with_duplicates() {
+                return Err(cx.common.send_fatal_alert(
+                    AlertDescription::IllegalParameter,
+                    PeerMisbehaved::OfferedDuplicateCertificateCompressions,
+                ));
+            }
+
+            let cert_compressor = client_hello
+                .certificate_compression_algorithms
+                .as_ref()
+                .and_then(|offered|
+                    // prefer server order when choosing a compression: the client's
+                    // extension here does not denote any preference.
+                    cch.config
+                        .cert_compressors
+                        .iter()
+                        .find(|compressor| offered.contains(&compressor.algorithm()))
+                        .cloned());
+
+            let early_data_requested = client_hello
+                .early_data_request
+                .is_some();
+
+            // EarlyData extension is illegal in second ClientHello
+            if cch.done_retry && early_data_requested {
+                return Err({
+                    cx.common.send_fatal_alert(
+                        AlertDescription::IllegalParameter,
+                        PeerMisbehaved::EarlyDataAttemptedInSecondClientHello,
+                    )
+                });
+            }
+
+            // See if there is a KeyShare for the selected kx group.
+            let chosen_share_and_kxg = shares_ext.iter().find_map(|share| {
+                (share.group == selected_kxg.name()).then_some((share, selected_kxg))
             });
 
-            return if early_data_requested {
-                Ok(Box::new(ExpectAndSkipRejectedEarlyData {
-                    skip_data_left: skip_early_data,
-                    next,
-                }))
-            } else {
-                Ok(next)
-            };
-        };
+            let Some(chosen_share_and_kxg) = chosen_share_and_kxg else {
+                // We don't have a suitable key share.  Send a HelloRetryRequest
+                // for the mutually_preferred_group.
+                cch.transcript.add_message(chm);
 
-        let mut chosen_psk_index = None;
-        let mut resumedata = None;
-
-        if let Some(psk_offer) = &client_hello.preshared_key_offer {
-            // "A client MUST provide a "psk_key_exchange_modes" extension if it
-            //  offers a "pre_shared_key" extension. If clients offer
-            //  "pre_shared_key" without a "psk_key_exchange_modes" extension,
-            //  servers MUST abort the handshake." - RFC8446 4.2.9
-            if client_hello
-                .preshared_key_modes
-                .is_none()
-            {
-                return Err(cx.common.send_fatal_alert(
-                    AlertDescription::MissingExtension,
-                    PeerMisbehaved::MissingPskModesExtension,
-                ));
-            }
-
-            if psk_offer.binders.is_empty() {
-                return Err(cx.common.send_fatal_alert(
-                    AlertDescription::DecodeError,
-                    PeerMisbehaved::MissingBinderInPskExtension,
-                ));
-            }
-
-            if psk_offer.binders.len() != psk_offer.identities.len() {
-                return Err(cx.common.send_fatal_alert(
-                    AlertDescription::IllegalParameter,
-                    PeerMisbehaved::PskExtensionWithMismatchedIdsAndBinders,
-                ));
-            }
-
-            let now = cch.config.current_time()?;
-
-            for (i, psk_id) in psk_offer.identities.iter().enumerate() {
-                let maybe_resume_data = cch
-                    .attempt_tls13_ticket_decryption(&psk_id.identity.0)
-                    .map(|resumedata| resumedata.set_freshness(psk_id.obfuscated_ticket_age, now))
-                    .filter(|resumedata| {
-                        hs::can_resume(cch.suite.into(), &cx.data.sni, &resumedata.common)
-                    });
-
-                let Some(resume) = maybe_resume_data else {
-                    continue;
-                };
-
-                if !cch.check_binder(
-                    cch.suite,
-                    chm,
-                    &resume.secret.0,
-                    psk_offer.binders[i].as_ref(),
-                ) {
+                if cch.done_retry {
                     return Err(cx.common.send_fatal_alert(
-                        AlertDescription::DecryptError,
-                        PeerMisbehaved::IncorrectBinder,
+                        AlertDescription::IllegalParameter,
+                        PeerMisbehaved::RefusedToFollowHelloRetryRequest,
                     ));
                 }
 
-                chosen_psk_index = Some(i);
-                resumedata = Some(resume);
-                break;
-            }
-        }
-
-        if !client_hello
-            .preshared_key_modes
-            .as_ref()
-            .map(|offer| offer.psk_dhe)
-            .unwrap_or_default()
-        {
-            debug!("Client unwilling to resume, PSK_DHE_KE not offered");
-            cch.send_tickets = 0;
-            chosen_psk_index = None;
-            resumedata = None;
-        } else {
-            cch.send_tickets = cch.config.send_tls13_tickets;
-        }
-
-        if let Some(resume) = &resumedata {
-            cx.data.received_resumption_data = Some(resume.common.application_data.0.clone());
-            cx.common
-                .peer_certificates
-                .clone_from(&resume.common.client_cert_chain);
-        }
-
-        let full_handshake = resumedata.is_none();
-        cch.transcript.add_message(chm);
-        let key_schedule = emit_server_hello(
-            &mut cch.transcript,
-            &cch.randoms,
-            cch.suite,
-            cx,
-            &client_hello.session_id,
-            chosen_share_and_kxg,
-            chosen_psk_index,
-            resumedata
-                .as_ref()
-                .map(|x| &x.secret.0[..]),
-            &cch.config,
-        )?;
-        if !cch.done_retry {
-            emit_fake_ccs(cx.common);
-        }
-
-        if full_handshake {
-            cx.common
-                .handshake_kind
-                .get_or_insert(HandshakeKind::Full);
-        } else {
-            cx.common.handshake_kind = Some(HandshakeKind::Resumed);
-        }
-
-        let mut ocsp_response = server_key.get_ocsp();
-        let mut flight = HandshakeFlightTls13::new(&mut cch.transcript);
-        let doing_early_data = emit_encrypted_extensions(
-            &mut flight,
-            cch.suite,
-            cx,
-            &mut ocsp_response,
-            client_hello,
-            resumedata.as_ref(),
-            cch.extra_exts,
-            &cch.config,
-        )?;
-
-        let doing_client_auth = if full_handshake {
-            let client_auth = emit_certificate_req_tls13(&mut flight, &cch.config)?;
-
-            if let Some(compressor) = cert_compressor {
-                emit_compressed_certificate_tls13(
-                    &mut flight,
-                    &cch.config,
-                    server_key.get_cert(),
-                    ocsp_response,
-                    compressor,
-                );
-            } else {
-                emit_certificate_tls13(&mut flight, server_key.get_cert(), ocsp_response);
-            }
-            emit_certificate_verify_tls13(
-                &mut flight,
-                cx.common,
-                server_key.get_key(),
-                &sigschemes_ext,
-            )?;
-            client_auth
-        } else {
-            false
-        };
-
-        // If we're not doing early data, then the next messages we receive
-        // are encrypted with the handshake keys.
-        match doing_early_data {
-            EarlyDataDecision::Disabled => {
-                key_schedule.set_handshake_decrypter(None, cx.common);
-                cx.data.early_data.reject();
-            }
-            EarlyDataDecision::RequestedButRejected => {
-                debug!(
-                    "Client requested early_data, but not accepted: switching to handshake keys with trial decryption"
-                );
-                key_schedule.set_handshake_decrypter(
-                    Some(max_early_data_size(cch.config.max_early_data_size)),
+                emit_hello_retry_request(
+                    &mut cch.transcript,
+                    cch.suite,
+                    client_hello.session_id,
                     cx.common,
+                    selected_kxg.name(),
                 );
-                cx.data.early_data.reject();
+                emit_fake_ccs(cx.common);
+
+                let skip_early_data = max_early_data_size(cch.config.max_early_data_size);
+
+                let next = Box::new(hs::ExpectClientHello {
+                    config: cch.config,
+                    transcript: HandshakeHashOrBuffer::Hash(cch.transcript),
+                    #[cfg(feature = "tls12")]
+                    session_id: SessionId::empty(),
+                    #[cfg(feature = "tls12")]
+                    using_ems: false,
+                    done_retry: true,
+                    send_tickets: cch.send_tickets,
+                    extra_exts: cch.extra_exts,
+                });
+
+                return if early_data_requested {
+                    Ok(Box::new(ExpectAndSkipRejectedEarlyData {
+                        skip_data_left: skip_early_data,
+                        next,
+                    }))
+                } else {
+                    Ok(next)
+                };
+            };
+
+            let mut chosen_psk_index = None;
+            let mut resumedata = None;
+
+            if let Some(psk_offer) = &client_hello.preshared_key_offer {
+                // "A client MUST provide a "psk_key_exchange_modes" extension if it
+                //  offers a "pre_shared_key" extension. If clients offer
+                //  "pre_shared_key" without a "psk_key_exchange_modes" extension,
+                //  servers MUST abort the handshake." - RFC8446 4.2.9
+                if client_hello
+                    .preshared_key_modes
+                    .is_none()
+                {
+                    return Err(cx.common.send_fatal_alert(
+                        AlertDescription::MissingExtension,
+                        PeerMisbehaved::MissingPskModesExtension,
+                    ));
+                }
+
+                if psk_offer.binders.is_empty() {
+                    return Err(cx.common.send_fatal_alert(
+                        AlertDescription::DecodeError,
+                        PeerMisbehaved::MissingBinderInPskExtension,
+                    ));
+                }
+
+                if psk_offer.binders.len() != psk_offer.identities.len() {
+                    return Err(cx.common.send_fatal_alert(
+                        AlertDescription::IllegalParameter,
+                        PeerMisbehaved::PskExtensionWithMismatchedIdsAndBinders,
+                    ));
+                }
+
+                let now = cch.config.current_time()?;
+
+                for (i, psk_id) in psk_offer.identities.iter().enumerate() {
+                    let maybe_resume_data = cch
+                        .attempt_tls13_ticket_decryption(&psk_id.identity.0)
+                        .map(|resumedata| {
+                            resumedata.set_freshness(psk_id.obfuscated_ticket_age, now)
+                        })
+                        .filter(|resumedata| {
+                            hs::can_resume(cch.suite.into(), &cx.data.sni, &resumedata.common)
+                        });
+
+                    let Some(resume) = maybe_resume_data else {
+                        continue;
+                    };
+
+                    if !cch.check_binder(
+                        cch.suite,
+                        chm,
+                        &resume.secret.0,
+                        psk_offer.binders[i].as_ref(),
+                    ) {
+                        return Err(cx.common.send_fatal_alert(
+                            AlertDescription::DecryptError,
+                            PeerMisbehaved::IncorrectBinder,
+                        ));
+                    }
+
+                    chosen_psk_index = Some(i);
+                    resumedata = Some(resume);
+                    break;
+                }
             }
-            EarlyDataDecision::Accepted => {
-                cx.data
-                    .early_data
-                    .accept(cch.config.max_early_data_size as usize);
+
+            if !client_hello
+                .preshared_key_modes
+                .as_ref()
+                .map(|offer| offer.psk_dhe)
+                .unwrap_or_default()
+            {
+                debug!("Client unwilling to resume, PSK_DHE_KE not offered");
+                cch.send_tickets = 0;
+                chosen_psk_index = None;
+                resumedata = None;
+            } else {
+                cch.send_tickets = cch.config.send_tls13_tickets;
             }
-        }
 
-        cx.common.check_aligned_handshake()?;
-        let key_schedule_traffic =
-            emit_finished_tls13(flight, &cch.randoms, cx, key_schedule, &cch.config);
+            if let Some(resume) = &resumedata {
+                cx.data.received_resumption_data = Some(resume.common.application_data.0.clone());
+                cx.common
+                    .peer_certificates
+                    .clone_from(&resume.common.client_cert_chain);
+            }
 
-        if !doing_client_auth && cch.config.send_half_rtt_data {
-            // Application data can be sent immediately after Finished, in one
-            // flight.  However, if client auth is enabled, we don't want to send
-            // application data to an unauthenticated peer.
-            cx.common
-                .start_outgoing_traffic(&mut cx.sendable_plaintext);
-        }
+            let full_handshake = resumedata.is_none();
+            cch.transcript.add_message(chm);
+            let key_schedule = emit_server_hello(
+                &mut cch.transcript,
+                &cch.randoms,
+                cch.suite,
+                cx,
+                &client_hello.session_id,
+                chosen_share_and_kxg,
+                chosen_psk_index,
+                resumedata
+                    .as_ref()
+                    .map(|x| &x.secret.0[..]),
+                &cch.config,
+            )?;
+            if !cch.done_retry {
+                emit_fake_ccs(cx.common);
+            }
 
-        if doing_client_auth {
-            if cch.config.cert_decompressors.is_empty() {
-                Ok(Box::new(ExpectCertificate {
+            if full_handshake {
+                cx.common
+                    .handshake_kind
+                    .get_or_insert(HandshakeKind::Full);
+            } else {
+                cx.common.handshake_kind = Some(HandshakeKind::Resumed);
+            }
+
+            let mut ocsp_response = server_key.get_ocsp();
+            let mut flight = HandshakeFlightTls13::new(&mut cch.transcript);
+            let doing_early_data = emit_encrypted_extensions(
+                &mut flight,
+                cch.suite,
+                cx,
+                &mut ocsp_response,
+                client_hello,
+                resumedata.as_ref(),
+                cch.extra_exts,
+                &cch.config,
+            )?;
+
+            let doing_client_auth = if full_handshake {
+                let client_auth = emit_certificate_req_tls13(&mut flight, &cch.config)?;
+
+                if let Some(compressor) = cert_compressor {
+                    emit_compressed_certificate_tls13(
+                        &mut flight,
+                        &cch.config,
+                        server_key.get_cert(),
+                        ocsp_response,
+                        compressor,
+                    );
+                } else {
+                    emit_certificate_tls13(&mut flight, server_key.get_cert(), ocsp_response);
+                }
+                emit_certificate_verify_tls13(
+                    &mut flight,
+                    cx.common,
+                    server_key.get_key(),
+                    &sigschemes_ext,
+                )?;
+                client_auth
+            } else {
+                false
+            };
+
+            // If we're not doing early data, then the next messages we receive
+            // are encrypted with the handshake keys.
+            match doing_early_data {
+                EarlyDataDecision::Disabled => {
+                    key_schedule.set_handshake_decrypter(None, cx.common);
+                    cx.data.early_data.reject();
+                }
+                EarlyDataDecision::RequestedButRejected => {
+                    debug!(
+                        "Client requested early_data, but not accepted: switching to handshake keys with trial decryption"
+                    );
+                    key_schedule.set_handshake_decrypter(
+                        Some(max_early_data_size(cch.config.max_early_data_size)),
+                        cx.common,
+                    );
+                    cx.data.early_data.reject();
+                }
+                EarlyDataDecision::Accepted => {
+                    cx.data
+                        .early_data
+                        .accept(cch.config.max_early_data_size as usize);
+                }
+            }
+
+            cx.common.check_aligned_handshake()?;
+            let key_schedule_traffic =
+                emit_finished_tls13(flight, &cch.randoms, cx, key_schedule, &cch.config);
+
+            if !doing_client_auth && cch.config.send_half_rtt_data {
+                // Application data can be sent immediately after Finished, in one
+                // flight.  However, if client auth is enabled, we don't want to send
+                // application data to an unauthenticated peer.
+                cx.common
+                    .start_outgoing_traffic(&mut cx.sendable_plaintext);
+            }
+
+            if doing_client_auth {
+                if cch.config.cert_decompressors.is_empty() {
+                    Ok(Box::new(ExpectCertificate {
+                        config: cch.config,
+                        transcript: cch.transcript,
+                        suite: cch.suite,
+                        key_schedule: key_schedule_traffic,
+                        send_tickets: cch.send_tickets,
+                        message_already_in_transcript: false,
+                    }))
+                } else {
+                    Ok(Box::new(ExpectCertificateOrCompressedCertificate {
+                        config: cch.config,
+                        transcript: cch.transcript,
+                        suite: cch.suite,
+                        key_schedule: key_schedule_traffic,
+                        send_tickets: cch.send_tickets,
+                    }))
+                }
+            } else if doing_early_data == EarlyDataDecision::Accepted && !cx.common.is_quic() {
+                // Not used for QUIC: RFC 9001 §8.3: Clients MUST NOT send the EndOfEarlyData
+                // message. A server MUST treat receipt of a CRYPTO frame in a 0-RTT packet as a
+                // connection error of type PROTOCOL_VIOLATION.
+                Ok(Box::new(ExpectEarlyData {
                     config: cch.config,
                     transcript: cch.transcript,
                     suite: cch.suite,
                     key_schedule: key_schedule_traffic,
                     send_tickets: cch.send_tickets,
-                    message_already_in_transcript: false,
                 }))
             } else {
-                Ok(Box::new(ExpectCertificateOrCompressedCertificate {
+                Ok(Box::new(ExpectFinished {
                     config: cch.config,
                     transcript: cch.transcript,
                     suite: cch.suite,
@@ -380,26 +413,22 @@ mod client_hello {
                     send_tickets: cch.send_tickets,
                 }))
             }
-        } else if doing_early_data == EarlyDataDecision::Accepted && !cx.common.is_quic() {
-            // Not used for QUIC: RFC 9001 §8.3: Clients MUST NOT send the EndOfEarlyData
-            // message. A server MUST treat receipt of a CRYPTO frame in a 0-RTT packet as a
-            // connection error of type PROTOCOL_VIOLATION.
-            Ok(Box::new(ExpectEarlyData {
-                config: cch.config,
-                transcript: cch.transcript,
-                suite: cch.suite,
-                key_schedule: key_schedule_traffic,
-                send_tickets: cch.send_tickets,
-            }))
-        } else {
-            Ok(Box::new(ExpectFinished {
-                config: cch.config,
-                transcript: cch.transcript,
-                suite: cch.suite,
-                key_schedule: key_schedule_traffic,
-                send_tickets: cch.send_tickets,
-            }))
         }
+    }
+
+    impl Sealed for Handler {}
+
+    pub(crate) trait Tls13Handler: fmt::Debug + Sealed + Send + Sync {
+        fn handle_client_hello(
+            &self,
+            cch: CompleteClientHelloHandling,
+            cx: &mut ServerContext<'_>,
+            server_key: ActiveCertifiedKey<'_>,
+            chm: &Message<'_>,
+            client_hello: &ClientHelloPayload,
+            selected_kxg: &'static dyn SupportedKxGroup,
+            sigschemes_ext: Vec<SignatureScheme>,
+        ) -> hs::NextStateOrError<'static>;
     }
 
     #[derive(PartialEq)]
@@ -409,7 +438,7 @@ mod client_hello {
         Accepted,
     }
 
-    pub(in crate::server) struct CompleteClientHelloHandling {
+    pub(crate) struct CompleteClientHelloHandling {
         pub(in crate::server) config: Arc<ServerConfig>,
         pub(in crate::server) transcript: HandshakeHash,
         pub(in crate::server) suite: &'static Tls13CipherSuite,

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -8,9 +8,7 @@ use crate::msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS;
 #[cfg(feature = "tls12")]
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
-#[cfg(feature = "tls12")]
-use crate::versions::TLS12;
-use crate::versions::{SupportedProtocolVersion, TLS13};
+use crate::versions::SupportedProtocolVersion;
 
 /// Common state for cipher suites (both for TLS 1.2 and TLS 1.3)
 #[allow(clippy::exhaustive_structs)]
@@ -102,11 +100,11 @@ impl SupportedCipherSuite {
     }
 
     /// Return supported protocol version for the cipher suite.
-    pub fn version(&self) -> &'static SupportedProtocolVersion {
+    pub fn version(&self) -> SupportedProtocolVersion {
         match self {
             #[cfg(feature = "tls12")]
-            Self::Tls12(_) => &TLS12,
-            Self::Tls13(_) => &TLS13,
+            Self::Tls12(suite) => SupportedProtocolVersion::TLS12(suite.protocol_version),
+            Self::Tls13(suite) => SupportedProtocolVersion::TLS13(suite.protocol_version),
         }
     }
 

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -5,7 +5,6 @@ use crate::crypto::cipher::{AeadKey, Iv};
 use crate::crypto::{self, KeyExchangeAlgorithm};
 use crate::enums::{CipherSuite, SignatureAlgorithm, SignatureScheme};
 use crate::msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS;
-#[cfg(feature = "tls12")]
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
 use crate::versions::SupportedProtocolVersion;
@@ -65,7 +64,6 @@ impl CipherSuiteCommon {
 #[derive(Clone, Copy, PartialEq)]
 pub enum SupportedCipherSuite {
     /// A TLS 1.2 cipher suite
-    #[cfg(feature = "tls12")]
     Tls12(&'static Tls12CipherSuite),
     /// A TLS 1.3 cipher suite
     Tls13(&'static Tls13CipherSuite),
@@ -84,7 +82,6 @@ impl SupportedCipherSuite {
 
     pub(crate) fn common(&self) -> &CipherSuiteCommon {
         match self {
-            #[cfg(feature = "tls12")]
             Self::Tls12(inner) => &inner.common,
             Self::Tls13(inner) => &inner.common,
         }
@@ -93,7 +90,6 @@ impl SupportedCipherSuite {
     /// Return the inner `Tls13CipherSuite` for this suite, if it is a TLS1.3 suite.
     pub fn tls13(&self) -> Option<&'static Tls13CipherSuite> {
         match self {
-            #[cfg(feature = "tls12")]
             Self::Tls12(_) => None,
             Self::Tls13(inner) => Some(inner),
         }
@@ -102,7 +98,6 @@ impl SupportedCipherSuite {
     /// Return supported protocol version for the cipher suite.
     pub fn version(&self) -> SupportedProtocolVersion {
         match self {
-            #[cfg(feature = "tls12")]
             Self::Tls12(suite) => SupportedProtocolVersion::TLS12(suite.protocol_version),
             Self::Tls13(suite) => SupportedProtocolVersion::TLS13(suite.protocol_version),
         }
@@ -113,7 +108,6 @@ impl SupportedCipherSuite {
     pub fn usable_for_signature_algorithm(&self, _sig_alg: SignatureAlgorithm) -> bool {
         match self {
             Self::Tls13(_) => true, // no constraint expressed by ciphersuite (e.g., TLS1.3)
-            #[cfg(feature = "tls12")]
             Self::Tls12(inner) => inner
                 .sign
                 .iter()
@@ -138,7 +132,6 @@ impl SupportedCipherSuite {
     /// Return `true` if this is backed by a FIPS-approved implementation.
     pub fn fips(&self) -> bool {
         match self {
-            #[cfg(feature = "tls12")]
             Self::Tls12(cs) => cs.fips(),
             Self::Tls13(cs) => cs.fips(),
         }
@@ -150,7 +143,6 @@ impl SupportedCipherSuite {
     /// support one or the other.
     pub(crate) fn key_exchange_algorithms(&self) -> &[KeyExchangeAlgorithm] {
         match self {
-            #[cfg(feature = "tls12")]
             Self::Tls12(tls12) => core::slice::from_ref(&tls12.kx),
             Self::Tls13(_) => ALL_KEY_EXCHANGE_ALGORITHMS,
         }
@@ -162,7 +154,6 @@ impl SupportedCipherSuite {
     /// support only one.
     pub(crate) fn usable_for_kx_algorithm(&self, _kxa: KeyExchangeAlgorithm) -> bool {
         match self {
-            #[cfg(feature = "tls12")]
             Self::Tls12(tls12) => tls12.kx == _kxa,
             Self::Tls13(_) => true,
         }

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -15,12 +15,25 @@ use crate::error::{Error, InvalidMessage};
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::handshake::{KeyExchangeAlgorithm, KxDecode};
 use crate::suites::{CipherSuiteCommon, PartiallyExtractedSecrets, SupportedCipherSuite};
+use crate::version::Tls12Version;
 
 /// A TLS 1.2 cipher suite supported by rustls.
 #[allow(clippy::exhaustive_structs)]
 pub struct Tls12CipherSuite {
     /// Common cipher suite fields.
     pub common: CipherSuiteCommon,
+
+    /// The associated protocol version.
+    ///
+    /// This field should have the value [`rustls::version::TLS12_VERSION`].
+    ///
+    /// This value contains references to the TLS1.2 protocol handling code.
+    /// This means that a program that does not contain any `Tls12CipherSuite`
+    /// values also does not contain any reference to the TLS1.2 protocol handling
+    /// code, and the linker can remove it.
+    ///
+    /// [`rustls::version::TLS12_VERSION`]: crate::version::TLS12_VERSION
+    pub protocol_version: &'static Tls12Version,
 
     /// How to compute the TLS1.2 PRF for the suite's hash function.
     ///

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -3,6 +3,7 @@ use core::fmt;
 use crate::crypto;
 use crate::crypto::hash;
 use crate::suites::{CipherSuiteCommon, SupportedCipherSuite};
+use crate::version::Tls13Version;
 
 pub(crate) mod key_schedule;
 
@@ -11,6 +12,18 @@ pub(crate) mod key_schedule;
 pub struct Tls13CipherSuite {
     /// Common cipher suite fields.
     pub common: CipherSuiteCommon,
+
+    /// The associated protocol version.
+    ///
+    /// This field should have the value [`rustls::version::TLS13_VERSION`].
+    ///
+    /// This value contains references to the TLS1.3 protocol handling code.
+    /// This means that a program that does not contain any `Tls13CipherSuite`
+    /// values also does not contain any reference to the TLS1.3 protocol handling
+    /// code, and the linker can remove it.
+    ///
+    /// [`rustls::version::TLS13_VERSION`]: crate::version::TLS13_VERSION
+    pub protocol_version: &'static Tls13Version,
 
     /// How to complete HKDF with the suite's hash function.
     ///
@@ -49,6 +62,7 @@ impl Tls13CipherSuite {
     pub fn fips(&self) -> bool {
         let Self {
             common,
+            protocol_version: _,
             hkdf_provider,
             aead_alg,
             quic,

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -75,6 +75,7 @@ pub static TLS12_VERSION: &Tls12Version = &Tls12Version {
 /// can be removed by the linker.
 pub static TLS13_VERSION: &Tls13Version = &Tls13Version {
     client: crate::client::TLS13_HANDLER,
+    server: crate::server::TLS13_HANDLER,
 };
 
 /// Internal data for handling the TLS1.2 protocol.
@@ -94,6 +95,7 @@ pub struct Tls12Version {
 #[derive(Debug)]
 pub struct Tls13Version {
     pub(crate) client: &'static dyn crate::client::Tls13Handler,
+    pub(crate) server: &'static dyn crate::server::Tls13Handler,
 }
 
 #[derive(Clone, Copy)]

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -65,6 +65,7 @@ pub static DEFAULT_VERSIONS: &[&SupportedProtocolVersion] = ALL_VERSIONS;
 /// can be removed by the linker.
 pub static TLS12_VERSION: &Tls12Version = &Tls12Version {
     client: crate::client::TLS12_HANDLER,
+    server: crate::server::TLS12_HANDLER,
 };
 
 /// Internal data for handling the TLS1.3 protocol.
@@ -83,6 +84,7 @@ pub static TLS13_VERSION: &Tls13Version = &Tls13Version {
 #[derive(Debug)]
 pub struct Tls12Version {
     pub(crate) client: &'static dyn crate::client::Tls12Handler,
+    pub(crate) server: &'static dyn crate::server::Tls12Handler,
 }
 
 /// Internal data for handling the TLS1.3 protocol.

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -72,7 +72,9 @@ pub static TLS12_VERSION: &Tls12Version = &Tls12Version {
 /// This value refers to TLS1.3 protocol handling code.  This means
 /// that if your program does not refer to this value, all that code
 /// can be removed by the linker.
-pub static TLS13_VERSION: &Tls13Version = &Tls13Version {};
+pub static TLS13_VERSION: &Tls13Version = &Tls13Version {
+    client: crate::client::TLS13_HANDLER,
+};
 
 /// Internal data for handling the TLS1.2 protocol.
 ///
@@ -88,7 +90,9 @@ pub struct Tls12Version {
 /// There is one value of this type.  It is `TLS13_VERSION`.
 #[non_exhaustive]
 #[derive(Debug)]
-pub struct Tls13Version {}
+pub struct Tls13Version {
+    pub(crate) client: &'static dyn crate::client::Tls13Handler,
+}
 
 #[derive(Clone, Copy)]
 pub(crate) struct EnabledVersions {

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -38,18 +38,13 @@ impl PartialEq for SupportedProtocolVersion {
 impl Eq for SupportedProtocolVersion {}
 
 /// TLS1.2
-#[cfg(feature = "tls12")]
 pub static TLS12: SupportedProtocolVersion = SupportedProtocolVersion::TLS12(TLS12_VERSION);
 
 /// TLS1.3
 pub static TLS13: SupportedProtocolVersion = SupportedProtocolVersion::TLS13(TLS13_VERSION);
 
 /// A list of all the protocol versions supported by rustls.
-pub static ALL_VERSIONS: &[&SupportedProtocolVersion] = &[
-    &TLS13,
-    #[cfg(feature = "tls12")]
-    &TLS12,
-];
+pub static ALL_VERSIONS: &[&SupportedProtocolVersion] = &[&TLS13, &TLS12];
 
 /// The version configuration that an application should use by default.
 ///
@@ -100,7 +95,6 @@ pub struct Tls13Version {
 
 #[derive(Clone, Copy)]
 pub(crate) struct EnabledVersions {
-    #[cfg(feature = "tls12")]
     tls12: Option<&'static SupportedProtocolVersion>,
     tls13: Option<&'static SupportedProtocolVersion>,
 }
@@ -108,7 +102,6 @@ pub(crate) struct EnabledVersions {
 impl fmt::Debug for EnabledVersions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut list = &mut f.debug_list();
-        #[cfg(feature = "tls12")]
         if let Some(v) = self.tls12 {
             list = list.entry(v);
         }
@@ -122,14 +115,12 @@ impl fmt::Debug for EnabledVersions {
 impl EnabledVersions {
     pub(crate) fn new(versions: &[&'static SupportedProtocolVersion]) -> Self {
         let mut ev = Self {
-            #[cfg(feature = "tls12")]
             tls12: None,
             tls13: None,
         };
 
         for v in versions {
             match v.version() {
-                #[cfg(feature = "tls12")]
                 ProtocolVersion::TLSv1_2 => ev.tls12 = Some(v),
                 ProtocolVersion::TLSv1_3 => ev.tls13 = Some(v),
                 _ => {}
@@ -141,7 +132,6 @@ impl EnabledVersions {
 
     pub(crate) fn contains(&self, version: ProtocolVersion) -> bool {
         match version {
-            #[cfg(feature = "tls12")]
             ProtocolVersion::TLSv1_2 => self.tls12.is_some(),
             ProtocolVersion::TLSv1_3 => self.tls13.is_some(),
             _ => false,

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -63,7 +63,9 @@ pub static DEFAULT_VERSIONS: &[&SupportedProtocolVersion] = ALL_VERSIONS;
 /// This value refers to TLS1.2 protocol handling code.  This means
 /// that if your program does not refer to this value, all that code
 /// can be removed by the linker.
-pub static TLS12_VERSION: &Tls12Version = &Tls12Version {};
+pub static TLS12_VERSION: &Tls12Version = &Tls12Version {
+    client: crate::client::TLS12_HANDLER,
+};
 
 /// Internal data for handling the TLS1.3 protocol.
 ///
@@ -77,7 +79,9 @@ pub static TLS13_VERSION: &Tls13Version = &Tls13Version {};
 /// There is one value of this type.  It is `TLS12_VERSION`.
 #[non_exhaustive]
 #[derive(Debug)]
-pub struct Tls12Version {}
+pub struct Tls12Version {
+    pub(crate) client: &'static dyn crate::client::Tls12Handler,
+}
 
 /// Internal data for handling the TLS1.3 protocol.
 ///

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6414,7 +6414,6 @@ fn test_secret_extraction_enabled() {
         #[cfg(not(feature = "fips"))]
         cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
     ] {
-        let version = suite.version();
         println!("Testing suite {:?}", suite.suite().as_str());
 
         // Only offer the cipher suite (and protocol version) that we're testing
@@ -6425,7 +6424,7 @@ fn test_secret_extraction_enabled() {
             }
             .into(),
         )
-        .with_protocol_versions(&[version])
+        .with_safe_default_protocol_versions()
         .unwrap()
         .with_no_client_auth()
         .with_single_cert(kt.get_chain(), kt.get_key())

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -303,7 +303,6 @@ fn versions() {
     version_test(&[], &[], Some(ProtocolVersion::TLSv1_3));
 
     // client default, server 1.2 -> 1.2
-    #[cfg(feature = "tls12")]
     version_test(
         &[],
         &[&rustls::version::TLS12],
@@ -311,7 +310,6 @@ fn versions() {
     );
 
     // client 1.2, server default -> 1.2
-    #[cfg(feature = "tls12")]
     version_test(
         &[&rustls::version::TLS12],
         &[],
@@ -319,15 +317,12 @@ fn versions() {
     );
 
     // client 1.2, server 1.3 -> fail
-    #[cfg(feature = "tls12")]
     version_test(&[&rustls::version::TLS12], &[&rustls::version::TLS13], None);
 
     // client 1.3, server 1.2 -> fail
-    #[cfg(feature = "tls12")]
     version_test(&[&rustls::version::TLS13], &[&rustls::version::TLS12], None);
 
     // client 1.3, server 1.2+1.3 -> 1.3
-    #[cfg(feature = "tls12")]
     version_test(
         &[&rustls::version::TLS13],
         &[&rustls::version::TLS12, &rustls::version::TLS13],
@@ -335,7 +330,6 @@ fn versions() {
     );
 
     // client 1.2+1.3, server 1.2 -> 1.2
-    #[cfg(feature = "tls12")]
     version_test(
         &[&rustls::version::TLS13, &rustls::version::TLS12],
         &[&rustls::version::TLS12],
@@ -399,7 +393,6 @@ fn config_builder_for_client_rejects_empty_cipher_suites() {
     );
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn config_builder_for_client_rejects_incompatible_cipher_suites() {
     assert_eq!(
@@ -448,7 +441,6 @@ fn config_builder_for_server_rejects_empty_cipher_suites() {
     );
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn config_builder_for_server_rejects_incompatible_cipher_suites() {
     assert_eq!(
@@ -1307,7 +1299,6 @@ fn client_trims_terminating_dot() {
     }
 }
 
-#[cfg(feature = "tls12")]
 fn check_sigalgs_reduced_by_ciphersuite(
     kt: KeyType,
     suite: CipherSuite,
@@ -1342,7 +1333,6 @@ fn check_sigalgs_reduced_by_ciphersuite(
     assert!(err.is_err());
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn server_cert_resolve_reduces_sigalgs_for_rsa_ciphersuite() {
     check_sigalgs_reduced_by_ciphersuite(
@@ -1359,7 +1349,6 @@ fn server_cert_resolve_reduces_sigalgs_for_rsa_ciphersuite() {
     );
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn server_cert_resolve_reduces_sigalgs_for_ecdsa_ciphersuite() {
     check_sigalgs_reduced_by_ciphersuite(
@@ -3570,7 +3559,6 @@ fn do_exporter_test(client_config: ClientConfig, server_config: ServerConfig) {
     assert_eq!(client_secret.to_vec(), server_secret.to_vec());
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn test_tls12_exporter() {
     let provider = provider::default_provider();
@@ -3673,25 +3661,21 @@ fn test_ciphersuites() -> Vec<(
             KeyType::Rsa2048,
             CipherSuite::TLS13_AES_128_GCM_SHA256,
         ),
-        #[cfg(feature = "tls12")]
         (
             &rustls::version::TLS12,
             KeyType::EcdsaP384,
             CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
         ),
-        #[cfg(feature = "tls12")]
         (
             &rustls::version::TLS12,
             KeyType::EcdsaP384,
             CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
         ),
-        #[cfg(feature = "tls12")]
         (
             &rustls::version::TLS12,
             KeyType::Rsa2048,
             CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
         ),
-        #[cfg(feature = "tls12")]
         (
             &rustls::version::TLS12,
             KeyType::Rsa2048,
@@ -3706,13 +3690,11 @@ fn test_ciphersuites() -> Vec<(
                 KeyType::Rsa2048,
                 CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
             ),
-            #[cfg(feature = "tls12")]
             (
                 &rustls::version::TLS12,
                 KeyType::EcdsaP256,
                 CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
             ),
-            #[cfg(feature = "tls12")]
             (
                 &rustls::version::TLS12,
                 KeyType::Rsa2048,
@@ -3898,7 +3880,6 @@ impl KeyLog for KeyLogToVec {
     }
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn key_log_for_tls12() {
     let client_key_log = Arc::new(KeyLogToVec::new("client"));
@@ -4333,12 +4314,10 @@ impl ClientStorage {
         self.alter_max_early_data_size = Some((expected, altered));
     }
 
-    #[cfg(feature = "tls12")]
     fn ops(&self) -> Vec<ClientStorageOp> {
         self.ops.lock().unwrap().clone()
     }
 
-    #[cfg(feature = "tls12")]
     fn ops_and_reset(&self) -> Vec<ClientStorageOp> {
         std::mem::take(&mut self.ops.lock().unwrap())
     }
@@ -5131,7 +5110,6 @@ mod test_quic {
         }
     }
 
-    #[cfg(feature = "tls12")]
     #[test]
     fn test_quic_no_tls13_error() {
         let provider = provider::default_provider();
@@ -5559,7 +5537,6 @@ fn exercise_all_key_exchange_methods() {
     }
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn test_client_sends_helloretryrequest() {
     let provider = provider::default_provider();
@@ -5681,7 +5658,6 @@ fn test_client_sends_helloretryrequest() {
     ));
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn test_client_attempts_to_use_unsupported_kx_group() {
     // common to both client configs
@@ -5738,7 +5714,6 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     ));
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn test_client_sends_share_for_less_preferred_group() {
     // this is a test for the case described in:
@@ -5806,7 +5781,6 @@ fn test_client_sends_share_for_less_preferred_group() {
     );
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn test_tls13_client_resumption_does_not_reuse_tickets() {
     let shared_storage = Arc::new(ClientStorage::new());
@@ -6140,7 +6114,6 @@ fn test_client_rejects_illegal_tls13_ccs() {
 }
 
 /// https://github.com/rustls/rustls/issues/797
-#[cfg(feature = "tls12")]
 #[test]
 fn test_client_tls12_no_resume_after_server_downgrade() {
     let provider = provider::default_provider();
@@ -6391,7 +6364,6 @@ fn test_no_warning_logging_during_successful_sessions() {
 }
 
 /// Test that secrets can be extracted and used for encryption/decryption.
-#[cfg(feature = "tls12")]
 #[test]
 fn test_secret_extraction_enabled() {
     // Normally, secret extraction would be used to configure kTLS (TLS offload
@@ -6547,7 +6519,6 @@ fn test_secret_extract_produces_correct_variant() {
 
 /// Test that secrets cannot be extracted unless explicitly enabled, and until
 /// the handshake is done.
-#[cfg(feature = "tls12")]
 #[test]
 fn test_secret_extraction_disabled_or_too_early() {
     let kt = KeyType::Rsa2048;
@@ -6839,7 +6810,6 @@ fn test_client_construction_requires_66_bytes_of_random_material() {
         .expect("check how much random material ClientConnection::new consumes");
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message() {
     fn inject_corrupt_finished_message(msg: &mut Message) -> Altered {
@@ -7588,7 +7558,6 @@ fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
     );
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
     let provider = provider::default_provider();
@@ -7657,7 +7626,6 @@ fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
     );
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn test_illegal_client_renegotiation_attempt_during_tls12_handshake() {
     let provider = provider::default_provider();
@@ -7812,7 +7780,6 @@ fn test_automatic_refresh_traffic_keys() {
     assert_eq!(transferred, KEY_UPDATE_SIZE + encrypted_size(message.len()));
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
     let provider = aes_128_gcm_with_1024_confidentiality_limit(provider::default_provider());

--- a/rustls/tests/api_ffdhe.rs
+++ b/rustls/tests/api_ffdhe.rs
@@ -62,7 +62,7 @@ fn ffdhe_ciphersuite() {
             server_config,
             expected_cipher_suite,
             NamedGroup::FFDHE2048,
-            expected_protocol.version,
+            expected_protocol.version(),
         );
     }
 }
@@ -238,7 +238,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
                 .suite(),
             expected_cipher_suite
         );
-        assert_eq!(server.protocol_version(), Some(protocol_version.version));
+        assert_eq!(server.protocol_version(), Some(protocol_version.version()));
         assert_eq!(
             server
                 .negotiated_key_exchange_group()

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -76,7 +76,6 @@ fn client_can_override_certificate_verification_and_reject_certificate() {
     }
 }
 
-#[cfg(feature = "tls12")]
 #[test]
 fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
     let provider = provider::default_provider();

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1540,7 +1540,6 @@ fn test_secret_extraction_enabled() {
         #[cfg(not(feature = "fips"))]
         cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
     ] {
-        let version = suite.version();
         println!("Testing suite {:?}", suite.suite().as_str());
 
         // Only offer the cipher suite (and protocol version) that we're testing
@@ -1551,7 +1550,7 @@ fn test_secret_extraction_enabled() {
             }
             .into(),
         )
-        .with_protocol_versions(&[version])
+        .with_safe_default_protocol_versions()
         .unwrap()
         .with_no_client_auth()
         .with_single_cert(kt.get_chain(), kt.get_key())

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1733,7 +1733,6 @@ fn kernel_key_updates_tls13() {
 }
 
 #[test]
-#[cfg(feature = "tls12")]
 fn kernel_key_updates_tls12() {
     use rustls::version::TLS12;
 


### PR DESCRIPTION
This fixes #224 . I've manually verified this works using `limitedclient`, but as noted on [#2401](https://github.com/rustls/rustls/issues/2401#issuecomment-3083716092) this doesn't work as-is because the call to `aws_lc_rs::default_provider()` links in all the cipher suites anyway.

```
$ nm -C target/debug/limitedclient | grep rustls::client::tls13 | wc -l
87
$ nm -C target/debug/limitedclient | grep rustls::client::tls12 | wc -l
0
```
(in other words, none of the TLS1.2 handshake machinery exists in a program that only uses TLS1.3)

Note the naming of `rustls::version::TLS12_VERSION` is janky but temporary: after this I want to eliminate `SupportedProtocolVersion` and all the config builder steps to do with version configuration will fall away. During that `rustls::version::TLS12_VERSION` will become `rustls::version::TLS12` (etc.)

After _that_ `SupportedCipherSuite` will disappear in the course of addressing #1659.  Instead, someone configures a set of `Tls12CipherSuite`s and `Tls13CipherSuite`s, and their program references `rustls::version::TLS12`/`rustls::version::TLS13` only via these.