### PR TITLE
Fix and defend `limitedclient`

### DIFF
--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -19,7 +19,9 @@ fn main() {
         CryptoProvider {
             cipher_suites: vec![provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256],
             kx_groups: vec![provider::kx_group::X25519],
-            ..provider::default_provider()
+            signature_verification_algorithms: provider::SUPPORTED_SIG_ALGS,
+            secure_random: provider::DEFAULT_SECURE_RANDOM,
+            key_provider: provider::DEFAULT_KEY_PROVIDER,
         }
         .into(),
     )

--- a/examples/tests/limitedclient.rs
+++ b/examples/tests/limitedclient.rs
@@ -1,0 +1,61 @@
+//! Check that `limitedclient` is successful in its goal of not linking in any
+//! AES code.
+//!
+//! We also check `simpleclient` (which includes everything) as a baseline to
+//! detect errors in the test code.
+
+// Don't assume binutils are available everywhere, or that `nm` has a
+// portable interface.
+#![cfg(target_os = "linux")]
+
+use std::process::Command;
+
+#[test]
+fn simpleclient_contains_aes_symbols() {
+    assert!(count_aes_symbols_in_executable(env!("CARGO_BIN_EXE_simpleclient")) > 0);
+}
+
+#[test]
+fn limitedclient_does_not_contain_aes_symbols() {
+    let limitedclient = env!("CARGO_BIN_EXE_limitedclient");
+    if fips_mode(limitedclient) {
+        println!("FIPS mode includes the entirety of the fipsmodule due to dynamic linking");
+        return;
+    }
+    assert_eq!(count_aes_symbols_in_executable(limitedclient), 0);
+}
+
+fn fips_mode(exe: &str) -> bool {
+    symbols_in_executable(exe)
+        .lines()
+        .any(|sym| sym.starts_with("aws_lc_fips_"))
+}
+
+fn count_aes_symbols_in_executable(exe: &str) -> usize {
+    let mut count = 0;
+
+    for sym in symbols_in_executable(exe).lines() {
+        println!("candidate symbol {sym:?}");
+
+        if sym.starts_with("aws_lc_") && sym.ends_with("_EVP_aead_aes_128_gcm_tls13") {
+            println!("found aes symbol {sym:?}");
+            count += 1;
+        }
+    }
+
+    count
+}
+
+fn symbols_in_executable(exe: &str) -> String {
+    let nm_output = dbg!(
+        Command::new("nm")
+            .arg("--defined-only")
+            .arg("--demangle")
+            .arg("--format=just-symbols")
+            .arg(exe)
+    )
+    .output()
+    .expect("nm failed");
+
+    String::from_utf8(nm_output.stdout).expect("nm output not valid utf8")
+}

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -64,6 +64,12 @@ fn default_kx_groups() -> Vec<&'static dyn SupportedKxGroup> {
     }
 }
 
+/// `KeyProvider` impl for aws-lc-rs
+pub static DEFAULT_KEY_PROVIDER: &dyn KeyProvider = &AwsLcRs;
+
+/// `SecureRandom` impl for aws-lc-rs
+pub static DEFAULT_SECURE_RANDOM: &dyn SecureRandom = &AwsLcRs;
+
 #[derive(Debug)]
 struct AwsLcRs;
 
@@ -155,7 +161,7 @@ pub mod cipher_suite {
 
 /// A `WebPkiSupportedAlgorithms` value that reflects webpki's capabilities when
 /// compiled against aws-lc-rs.
-static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+pub static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[
         webpki_algs::ECDSA_P256_SHA256,
         webpki_algs::ECDSA_P256_SHA384,


### PR DESCRIPTION
`limitedclient` is meant to demonstrate how rustls's design scales down, and allows people to make quite small client/servers executables in exchange for limited TLS compatibility. Unfortunately that wasn't defended so broke a while back.