### PR TITLE
0.23: cherry-pick of fixes to `complete_io()` with non-blocking transport

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -587,9 +587,8 @@ impl<Data> ConnectionCommon<Data> {
     ///   once.
     ///
     /// The return value is the number of bytes read from and written
-    /// to `io`, respectively.
-    ///
-    /// This function will block if `io` blocks.
+    /// to `io`, respectively. Once both `read()` and `write()` yield `WouldBlock`,
+    /// this function will propagate the error.
     ///
     /// Errors from TLS record handling (i.e., from [`process_new_packets`])
     /// are wrapped in an `io::ErrorKind::InvalidData`-kind error.
@@ -608,8 +607,8 @@ impl<Data> ConnectionCommon<Data> {
         let mut eof = false;
         let mut wrlen = 0;
         let mut rdlen = 0;
-
         loop {
+            let (mut blocked_write, mut blocked_read) = (None, None);
             let until_handshaked = self.is_handshaking();
 
             if !self.wants_write() && !self.wants_read() {
@@ -618,15 +617,22 @@ impl<Data> ConnectionCommon<Data> {
             }
 
             while self.wants_write() {
-                match self.write_tls(io)? {
-                    0 => {
+                match self.write_tls(io) {
+                    Ok(0) => {
                         io.flush()?;
                         return Ok((rdlen, wrlen)); // EOF.
                     }
-                    n => wrlen += n,
+                    Ok(n) => wrlen += n,
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                        blocked_write = Some(err);
+                        break;
+                    }
+                    Err(err) => return Err(err),
                 }
             }
-            io.flush()?;
+            if wrlen > 0 {
+                io.flush()?;
+            }
 
             if !until_handshaked && wrlen > 0 {
                 return Ok((rdlen, wrlen));
@@ -641,6 +647,10 @@ impl<Data> ConnectionCommon<Data> {
                     Ok(n) => {
                         rdlen += n;
                         Some(n)
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                        blocked_read = Some(err);
+                        break;
                     }
                     Err(err) if err.kind() == io::ErrorKind::Interrupted => None, // nothing to do
                     Err(err) => return Err(err),
@@ -665,11 +675,13 @@ impl<Data> ConnectionCommon<Data> {
                 continue;
             }
 
-            match (eof, until_handshaked, self.is_handshaking()) {
-                (_, true, false) => return Ok((rdlen, wrlen)),
-                (_, false, _) => return Ok((rdlen, wrlen)),
-                (true, true, true) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
-                (..) => {}
+            let blocked = blocked_write.zip(blocked_read);
+            match (eof, until_handshaked, self.is_handshaking(), blocked) {
+                (_, true, false, _) => return Ok((rdlen, wrlen)),
+                (_, false, _, _) => return Ok((rdlen, wrlen)),
+                (true, true, true, _) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
+                (_, _, _, Some((e, _))) => return Err(e),
+                _ => {}
             }
         }
     }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -650,17 +650,12 @@ impl<Data> ConnectionCommon<Data> {
                 }
             }
 
-            match self.process_new_packets() {
-                Ok(_) => {}
-                Err(e) => {
-                    // In case we have an alert to send describing this error,
-                    // try a last-gasp write -- but don't predate the primary
-                    // error.
-                    let _ignored = self.write_tls(io);
-                    let _ignored = io.flush();
-
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, e));
-                }
+            if let Err(e) = self.process_new_packets() {
+                // In case we have an alert to send describing this error, try a last-gasp
+                // write -- but don't predate the primary error.
+                let _ignored = self.write_tls(io);
+                let _ignored = io.flush();
+                return Err(io::Error::new(io::ErrorKind::InvalidData, e));
             };
 
             // if we're doing IO until handshaked, and we believe we've finished handshaking,

--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -6,6 +6,8 @@ use crate::conn::{ConnectionCommon, SideData};
 /// This type implements `io::Read` and `io::Write`, encapsulating
 /// a Connection `C` and an underlying transport `T`, such as a socket.
 ///
+/// Relies on [`ConnectionCommon::complete_io()`] to perform the necessary I/O.
+///
 /// This allows you to use a rustls Connection like a normal stream.
 #[derive(Debug)]
 pub struct Stream<'a, C: 'a + ?Sized, T: 'a + Read + Write + ?Sized> {
@@ -153,8 +155,9 @@ where
 }
 
 /// This type implements `io::Read` and `io::Write`, encapsulating
-/// and owning a Connection `C` and an underlying blocking transport
-/// `T`, such as a socket.
+/// and owning a Connection `C` and an underlying transport `T`, such as a socket.
+///
+/// Relies on [`ConnectionCommon::complete_io()`] to perform the necessary I/O.
 ///
 /// This allows you to use a rustls Connection like a normal stream.
 #[derive(Debug)]


### PR DESCRIPTION
Cherry pick of #2559