### PR TITLE
Fix `complete_io()` for non-blocking IO

### DIFF
--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -969,22 +969,6 @@ pub fn server_name(name: &'static str) -> ServerName<'static> {
     name.try_into().unwrap()
 }
 
-pub struct FailsReads {
-    errkind: io::ErrorKind,
-}
-
-impl FailsReads {
-    pub fn new(errkind: io::ErrorKind) -> Self {
-        Self { errkind }
-    }
-}
-
-impl io::Read for FailsReads {
-    fn read(&mut self, _b: &mut [u8]) -> io::Result<usize> {
-        Err(io::Error::from(self.errkind))
-    }
-}
-
 /// An object that impls `io::Read` and `io::Write` for testing.
 ///
 /// The `reads` and `writes` fields set the behaviour of these trait

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -1,19 +1,17 @@
 #![cfg(feature = "ring")]
 #![allow(clippy::disallowed_types)]
 
-use std::io;
 use std::sync::Arc;
 
 use bencher::{Bencher, benchmark_group, benchmark_main};
 use rustls::ServerConnection;
 use rustls::crypto::ring as provider;
-use rustls_test::{FailsReads, KeyType, make_server_config};
+use rustls_test::{KeyType, TestNonBlockIo, make_server_config};
 
 fn bench_ewouldblock(c: &mut Bencher) {
     let server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
     let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
-    let mut read_ewouldblock = FailsReads::new(io::ErrorKind::WouldBlock);
-    c.iter(|| server.read_tls(&mut read_ewouldblock));
+    c.iter(|| server.read_tls(&mut TestNonBlockIo::default()));
 }
 
 benchmark_group!(benches, bench_ewouldblock);

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -661,9 +661,9 @@ impl<Data> ConnectionCommon<Data> {
             let blocked = blocked_write.zip(blocked_read);
             match (eof, until_handshaked, self.is_handshaking(), blocked) {
                 (_, true, false, _) => return Ok((rdlen, wrlen)),
+                (_, _, _, Some((e, _))) if rdlen == 0 && wrlen == 0 => return Err(e),
                 (_, false, _, _) => return Ok((rdlen, wrlen)),
                 (true, true, true, _) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
-                (_, _, _, Some((e, _))) => return Err(e),
                 _ => {}
             }
         }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2622,6 +2622,99 @@ fn client_complete_io_for_write() {
 }
 
 #[test]
+fn client_complete_io_with_nonblocking_io() {
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+
+    // absolutely no progress writing ClientHello
+    assert_eq!(
+        client
+            .complete_io(&mut TestNonBlockIo::default())
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::WouldBlock
+    );
+
+    // a little progress writing ClientHello
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    assert_eq!(
+        client
+            .complete_io(&mut TestNonBlockIo {
+                writes: vec![1],
+                reads: vec![],
+            })
+            .unwrap(),
+        (0, 1)
+    );
+
+    // complete writing ClientHello
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    assert_eq!(
+        client
+            .complete_io(&mut TestNonBlockIo {
+                writes: vec![4096],
+                reads: vec![],
+            })
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::WouldBlock
+    );
+
+    // complete writing ClientHello, partial read of ServerHello
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (rd, wr) = dbg!(client.complete_io(&mut TestNonBlockIo {
+        writes: vec![4096],
+        reads: vec![vec![ContentType::Handshake.into()]],
+    }))
+    .unwrap();
+    assert_eq!(rd, 1);
+    assert!(wr > 1);
+
+    // data phase:
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    do_handshake(&mut client, &mut server);
+
+    // read
+    assert_eq!(
+        client
+            .complete_io(&mut TestNonBlockIo {
+                reads: vec![vec![ContentType::ApplicationData.into()]],
+                writes: vec![],
+            })
+            .unwrap(),
+        (1, 0)
+    );
+
+    // write
+    client
+        .writer()
+        .write_all(b"hello")
+        .unwrap();
+
+    // no progress
+    assert_eq!(
+        client
+            .complete_io(&mut TestNonBlockIo {
+                reads: vec![],
+                writes: vec![],
+            })
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::WouldBlock
+    );
+
+    // some write progress
+    assert_eq!(
+        client
+            .complete_io(&mut TestNonBlockIo {
+                reads: vec![],
+                writes: vec![1],
+            })
+            .unwrap(),
+        (0, 1)
+    );
+}
+
+#[test]
 fn buffered_client_complete_io_for_write() {
     let provider = provider::default_provider();
     for kt in KeyType::all_for_provider(&provider) {


### PR DESCRIPTION
fixes #2584 re #2559 re #2556

This introduces improved testing of `complete_io()` (tests which demonstrate the lack of progress bug reported in #2584) and then fixes it in two ways. It also fixes a case where the original issue would return `(0, 0)` rather than the desired error.

I don't much like `complete_io()`; it is doing way too much. But this PR is intended to apply cleanly onto rel-0.23, so I'll leave more significant changes to later.