### PR TITLE
Prepare 0.23.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.30"
+version = "0.23.31"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.30"
+version = "0.23.31"
 dependencies = [
  "log",
  "once_cell",

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -967,22 +967,6 @@ pub fn server_name(name: &'static str) -> ServerName<'static> {
     name.try_into().unwrap()
 }
 
-pub struct FailsReads {
-    errkind: io::ErrorKind,
-}
-
-impl FailsReads {
-    pub fn new(errkind: io::ErrorKind) -> Self {
-        Self { errkind }
-    }
-}
-
-impl io::Read for FailsReads {
-    fn read(&mut self, _b: &mut [u8]) -> io::Result<usize> {
-        Err(io::Error::from(self.errkind))
-    }
-}
-
 /// An object that impls `io::Read` and `io::Write` for testing.
 ///
 /// The `reads` and `writes` fields set the behaviour of these trait

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -983,6 +983,70 @@ impl io::Read for FailsReads {
     }
 }
 
+/// An object that impls `io::Read` and `io::Write` for testing.
+///
+/// The `reads` and `writes` fields set the behaviour of these trait
+/// implementations.  They return the `WouldBlock` error if not otherwise
+/// configured -- `TestNonBlockIo::default()` does this permanently.
+///
+/// This object panics on drop if the configured expected reads/writes
+/// didn't take place.
+#[derive(Debug, Default)]
+pub struct TestNonBlockIo {
+    /// Each `write()` call is satisfied by inspecting this field.
+    ///
+    /// If it is empty, `WouldBlock` is returned.  Otherwise the write is
+    /// satisfied by popping a value and returning it (reduced by the size
+    /// of the write buffer, if needed).
+    pub writes: Vec<usize>,
+
+    /// Each `read()` call is satisfied by inspecting this field.
+    ///
+    /// If it is empty, `WouldBlock` is returned.  Otherwise the read is
+    /// satisfied by popping a value and copying it into the output
+    /// buffer.  Each value must be no longer than the buffer for that
+    /// call.
+    pub reads: Vec<Vec<u8>>,
+}
+
+impl io::Read for TestNonBlockIo {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        println!("read {:?}", buf.len());
+        match self.reads.pop() {
+            None => Err(io::ErrorKind::WouldBlock.into()),
+            Some(data) => {
+                assert!(data.len() <= buf.len());
+                let take = core::cmp::min(data.len(), buf.len());
+                buf[..take].clone_from_slice(&data[..take]);
+                Ok(take)
+            }
+        }
+    }
+}
+
+impl io::Write for TestNonBlockIo {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        println!("write {:?}", buf.len());
+        match self.writes.pop() {
+            None => Err(io::ErrorKind::WouldBlock.into()),
+            Some(n) => Ok(core::cmp::min(n, buf.len())),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        println!("flush");
+        Ok(())
+    }
+}
+
+impl Drop for TestNonBlockIo {
+    fn drop(&mut self) {
+        // ensure the object was exhausted as expected
+        assert!(self.reads.is_empty());
+        assert!(self.writes.is_empty());
+    }
+}
+
 pub fn do_suite_and_kx_test(
     client_config: ClientConfig,
     server_config: ServerConfig,

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.30"
+version = "0.23.31"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -1,19 +1,17 @@
 #![cfg(feature = "ring")]
 #![allow(clippy::disallowed_types)]
 
-use std::io;
 use std::sync::Arc;
 
 use bencher::{Bencher, benchmark_group, benchmark_main};
 use rustls::ServerConnection;
 use rustls::crypto::ring as provider;
-use rustls_test::{FailsReads, KeyType, make_server_config};
+use rustls_test::{KeyType, TestNonBlockIo, make_server_config};
 
 fn bench_ewouldblock(c: &mut Bencher) {
     let server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
     let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
-    let mut read_ewouldblock = FailsReads::new(io::ErrorKind::WouldBlock);
-    c.iter(|| server.read_tls(&mut read_ewouldblock));
+    c.iter(|| server.read_tls(&mut TestNonBlockIo::default()));
 }
 
 benchmark_group!(benches, bench_ewouldblock);

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -638,6 +638,15 @@ impl<Data> ConnectionCommon<Data> {
                 return Ok((rdlen, wrlen));
             }
 
+            // If we want to write, but are WouldBlocked by the underlying IO, *and*
+            // have no desire to read; that is everything.
+            if let (Some(_), false) = (&blocked_write, self.wants_read()) {
+                return match wrlen {
+                    0 => Err(blocked_write.unwrap()),
+                    _ => Ok((rdlen, wrlen)),
+                };
+            }
+
             while !eof && self.wants_read() {
                 let read_size = match self.read_tls(io) {
                     Ok(0) => {
@@ -667,6 +676,15 @@ impl<Data> ConnectionCommon<Data> {
                 let _ignored = io.flush();
                 return Err(io::Error::new(io::ErrorKind::InvalidData, e));
             };
+
+            // If we want to read, but are WouldBlocked by the underlying IO, *and*
+            // have no desire to write; that is everything.
+            if let (Some(_), false) = (&blocked_read, self.wants_write()) {
+                return match rdlen {
+                    0 => Err(blocked_read.unwrap()),
+                    _ => Ok((rdlen, wrlen)),
+                };
+            }
 
             // if we're doing IO until handshaked, and we believe we've finished handshaking,
             // but process_new_packets() has queued TLS data to send, loop around again to write

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -696,9 +696,9 @@ impl<Data> ConnectionCommon<Data> {
             let blocked = blocked_write.zip(blocked_read);
             match (eof, until_handshaked, self.is_handshaking(), blocked) {
                 (_, true, false, _) => return Ok((rdlen, wrlen)),
+                (_, _, _, Some((e, _))) if rdlen == 0 && wrlen == 0 => return Err(e),
                 (_, false, _, _) => return Ok((rdlen, wrlen)),
                 (true, true, true, _) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
-                (_, _, _, Some((e, _))) => return Err(e),
                 _ => {}
             }
         }


### PR DESCRIPTION
Cherry picks of:

- [ ] #2586 
- [ ] #2583 (not yet on main, but I'd like this to be in 0.23.31 to simplify versioning of the next benchmarks I do)

Release notes:

* Fixes #2584 -- `complete_io()` not making progress when used with non-blocking IO.  This was a regression in 0.23.30 (now yanked).

