### PR TITLE
Fix docs link errors

### DIFF
--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -426,8 +426,8 @@ impl<'c, 'i> ReadEarlyData<'c, 'i, ServerConnectionData> {
 pub struct AppDataRecord<'i> {
     /// Number of additional bytes to discard
     ///
-    /// This number MUST be added to the value of [`UnbufferedStatus.discard`] *prior* to the
-    /// discard operation. See [`UnbufferedStatus.discard`] for more details
+    /// This number MUST be added to the value of [`UnbufferedStatus::discard`] *prior* to the
+    /// discard operation. See [`UnbufferedStatus::discard`] for more details
     pub discard: usize,
 
     /// The payload of the app-data record

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -961,7 +961,7 @@ impl From<EncryptedClientHelloError> for Error {
 
 /// The server rejected the request to enable Encrypted Client Hello (ECH)
 ///
-/// If [`RejectedEch.can_retry()`] is true, then you may use this with
+/// If [`RejectedEch::can_retry()`] is true, then you may use this with
 /// [`crate::client::EchConfig::for_retry()`] to build a new `EchConfig` for a fresh client
 /// connection that will use a compatible ECH configuration provided by the server for a retry.
 #[non_exhaustive]

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -26,7 +26,7 @@ pub struct CipherSuiteCommon {
     ///
     /// This is to be set on the assumption that messages are maximally sized --
     /// each is 2<sup>14</sup> bytes. It **does not** consider confidentiality limits for
-    /// QUIC connections - see the [`quic::KeyBuilder.confidentiality_limit`] field for
+    /// QUIC connections - see the [`quic::PacketKey::confidentiality_limit`] field for
     /// this context.
     ///
     /// For AES-GCM implementations, this should be set to 2<sup>24</sup> to limit attack
@@ -41,6 +41,7 @@ pub struct CipherSuiteCommon {
     /// ```
     /// [AEBounds]: https://eprint.iacr.org/2024/051.pdf
     /// [draft-irtf-aead-limits-08]: https://www.ietf.org/archive/id/draft-irtf-cfrg-aead-limits-08.html#section-5.1.1
+    /// [`quic::PacketKey::confidentiality_limit`]: crate::quic::PacketKey::confidentiality_limit
     ///
     /// For chacha20-poly1305 implementations, this should be set to `u64::MAX`:
     /// see <https://www.ietf.org/archive/id/draft-irtf-cfrg-aead-limits-08.html#section-5.2.1>

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -80,9 +80,10 @@ pub trait ServerCertVerifier: Debug + Send + Sync {
     ///
     /// Note that none of the certificates have been parsed yet, so it is the responsibility of
     /// the implementer to handle invalid data. It is recommended that the implementer returns
-    /// [`Error::InvalidCertificate(CertificateError::BadEncoding)`] when these cases are encountered.
+    /// [`Error::InvalidCertificate`] containing [`CertificateError::BadEncoding`] when these cases are encountered.
     ///
     /// [Certificate]: https://datatracker.ietf.org/doc/html/rfc8446#section-4.4.2
+    /// [`CertificateError::BadEncoding`]: crate::error::CertificateError::BadEncoding
     fn verify_server_cert(
         &self,
         end_entity: &CertificateDer<'_>,


### PR DESCRIPTION
Nightly seems to have grown improved internal link checking (see https://github.com/rustls/rustls/actions/runs/16717516382/job/47314050195) which finds new issues addressed in this PR.

These are actual real issues in published docs (see https://docs.rs/rustls/latest/rustls/unbuffered/struct.AppDataRecord.html#structfield.discard for an example) so I'll cherry pick this.