### PR TITLE
Track 1.89 lint changes

### DIFF
--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -232,7 +232,7 @@ impl TestPki {
         &self,
         serials: Vec<rcgen::SerialNumber>,
         next_update_seconds: u64,
-    ) -> CertificateRevocationListDer {
+    ) -> CertificateRevocationListDer<'static> {
         // In a real use-case you would want to set this to the current date/time.
         let now = rcgen::date_time_ymd(2023, 1, 1);
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2141,7 +2141,7 @@ fn client_flush_does_nothing() {
     assert!(matches!(client.writer().flush(), Ok(())));
 }
 
-#[allow(clippy::no_effect)]
+#[allow(clippy::unnecessary_operation)]
 #[test]
 fn server_is_send_and_sync() {
     let (_, server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
@@ -2149,7 +2149,7 @@ fn server_is_send_and_sync() {
     &server as &dyn Sync;
 }
 
-#[allow(clippy::no_effect)]
+#[allow(clippy::unnecessary_operation)]
 #[test]
 fn client_is_send_and_sync() {
     let (client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
@@ -3570,7 +3570,7 @@ impl sign::SigningKey for SigningKeyNoneSpki {
 struct SigningKeySomeSpki;
 
 impl sign::SigningKey for SigningKeySomeSpki {
-    fn public_key(&self) -> Option<pki_types::SubjectPublicKeyInfoDer> {
+    fn public_key(&self) -> Option<pki_types::SubjectPublicKeyInfoDer<'_>> {
         let chain = KeyType::Rsa2048.get_chain();
         let cert = ParsedCertificate::try_from(chain.first().unwrap()).unwrap();
         Some(


### PR DESCRIPTION
One instance of the new 1.89 `mismatched_lifetime_syntaxes` lint.

Also `clippy::no_effect` has become `clippy::unnecessary_operation` for the case we are allowing.