### PR TITLE
Remove version selection API

### DIFF
--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -547,9 +547,7 @@ impl ClientSideStepper<'_> {
                 ..params.provider.clone()
             }
             .into(),
-        )
-        .with_safe_default_protocol_versions()
-        .unwrap();
+        );
 
         let mut cfg = match params.auth_key {
             AuthKeySource::KeyType(key_type) => {
@@ -560,12 +558,14 @@ impl ClientSideStepper<'_> {
 
                 cfg.with_root_certificates(root_store)
                     .with_no_client_auth()
+                    .unwrap()
             }
 
             AuthKeySource::FuzzingProvider => cfg
                 .dangerous()
                 .with_custom_certificate_verifier(rustls_fuzzing_provider::server_verifier())
-                .with_no_client_auth(),
+                .with_no_client_auth()
+                .unwrap(),
         };
 
         if resume != ResumptionKind::No {
@@ -636,9 +636,7 @@ impl ServerSideStepper<'_> {
     fn make_config(params: &BenchmarkParams, resume: ResumptionKind) -> Arc<ServerConfig> {
         assert_eq!(params.ciphersuite.version().version(), params.version);
 
-        let cfg = ServerConfig::builder_with_provider(params.provider.clone().into())
-            .with_safe_default_protocol_versions()
-            .unwrap();
+        let cfg = ServerConfig::builder_with_provider(params.provider.clone().into());
 
         let mut cfg = match params.auth_key {
             AuthKeySource::KeyType(key_type) => cfg
@@ -648,7 +646,8 @@ impl ServerSideStepper<'_> {
 
             AuthKeySource::FuzzingProvider => cfg
                 .with_client_cert_verifier(WebPkiClientVerifier::no_client_auth())
-                .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver()),
+                .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
+                .unwrap(),
         };
 
         if resume == ResumptionKind::SessionId {

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -114,11 +114,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     // Construct a rustls client config with a custom provider, and ECH enabled.
-    let mut config =
-        rustls::ClientConfig::builder_with_provider(aws_lc_rs::default_provider().into())
-            .with_ech(ech_mode)?
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
+    let mut config = rustls::ClientConfig::builder_with_provider(
+        aws_lc_rs::default_provider()
+            .with_only_tls13()
+            .into(),
+    )
+    .with_ech(ech_mode)
+    .with_root_certificates(root_store)
+    .with_no_client_auth()?;
 
     // Allow using SSLKEYLOGFILE.
     config.key_log = Arc::new(rustls::KeyLogFile::new());

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -25,10 +25,9 @@ fn main() {
         }
         .into(),
     )
-    .with_protocol_versions(&[&rustls::version::TLS13])
-    .unwrap()
     .with_root_certificates(root_store)
-    .with_no_client_auth();
+    .with_no_client_auth()
+    .unwrap();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -101,7 +101,8 @@ fn main() {
 
     let mut config = rustls::ClientConfig::builder()
         .with_root_certificates(root_store)
-        .with_no_client_auth();
+        .with_no_client_auth()
+        .unwrap();
 
     // Allow using SSLKEYLOGFILE.
     config.key_log = Arc::new(rustls::KeyLogFile::new());

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -18,10 +18,13 @@ fn main() {
     let root_store = RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.into(),
     };
-    let mut config = rustls::ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth()
-        .unwrap();
+
+    let mut config = rustls::ClientConfig::builder_with_provider(
+        rustls::crypto::aws_lc_rs::default_provider().into(),
+    )
+    .with_root_certificates(root_store)
+    .with_no_client_auth()
+    .unwrap();
 
     // Allow using SSLKEYLOGFILE.
     config.key_log = Arc::new(rustls::KeyLogFile::new());

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -20,7 +20,8 @@ fn main() {
     };
     let mut config = rustls::ClientConfig::builder()
         .with_root_certificates(root_store)
-        .with_no_client_auth();
+        .with_no_client_auth()
+        .unwrap();
 
     // Allow using SSLKEYLOGFILE.
     config.key_log = Arc::new(rustls::KeyLogFile::new());

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -460,8 +460,6 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     }
 
     let config = rustls::ClientConfig::builder_with_provider(args.provider().into())
-        .with_safe_default_protocol_versions()
-        .expect("inconsistent cipher-suite/versions selected")
         .with_root_certificates(root_store);
 
     let mut config = match (&args.auth_key, &args.auth_certs) {
@@ -472,7 +470,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
                 .with_client_auth_cert(certs, key)
                 .expect("invalid client auth certs/key")
         }
-        (None, None) => config.with_no_client_auth(),
+        (None, None) => config.with_no_client_auth().unwrap(),
         (_, _) => {
             panic!("must provide --auth-certs and --auth-key together");
         }

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -604,8 +604,6 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
 
     let (versions, provider) = args.provider();
     let mut config = rustls::ServerConfig::builder_with_provider(provider.into())
-        .with_safe_default_protocol_versions()
-        .expect("inconsistent cipher-suites/versions specified")
         .with_client_cert_verifier(client_auth)
         .with_single_cert_with_ocsp(certs, privkey, ocsp)
         .expect("bad certificates/private key");

--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let config = ClientConfig::builder()
         .with_root_certificates(root_store)
-        .with_no_client_auth();
+        .with_no_client_auth()?;
 
     let config = Arc::new(config);
 

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut config = ClientConfig::builder()
         .with_root_certificates(root_store)
-        .with_no_client_auth();
+        .with_no_client_auth()?;
     config.enable_early_data = SEND_EARLY_DATA;
 
     let config = Arc::new(config);

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -12,11 +12,10 @@ fuzz_target!(|data: &[u8]| {
     let _ = env_logger::try_init();
     let config = Arc::new(
         ClientConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .dangerous()
             .with_custom_certificate_verifier(rustls_fuzzing_provider::server_verifier())
-            .with_no_client_auth(),
+            .with_no_client_auth()
+            .unwrap(),
     );
     let hostname = "localhost".try_into().unwrap();
     let mut client = ClientConnection::new(config, hostname).unwrap();

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -21,10 +21,9 @@ fuzz_target!(|data: &[u8]| {
 fn fuzz_buffered_api(data: &[u8]) {
     let config = Arc::new(
         ServerConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_no_client_auth()
-            .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver()),
+            .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
+            .unwrap(),
     );
     let mut stream = io::Cursor::new(data);
     let mut server = ServerConnection::new(config).unwrap();
@@ -60,10 +59,9 @@ fn fuzz_acceptor_api(data: &[u8]) {
 fn fuzz_accepted(stream: &mut dyn io::Read, accepted: Accepted) {
     let mut maybe_server = accepted.into_connection(Arc::new(
         ServerConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_no_client_auth()
-            .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver()),
+            .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
+            .unwrap(),
     ));
 
     if let Ok(conn) = &mut maybe_server {

--- a/fuzz/fuzzers/unbuffered.rs
+++ b/fuzz/fuzzers/unbuffered.rs
@@ -20,11 +20,10 @@ fuzz_target!(|data: &[u8]| {
 
 fn client(data: &mut [u8]) {
     let config = ClientConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .dangerous()
         .with_custom_certificate_verifier(rustls_fuzzing_provider::server_verifier())
-        .with_no_client_auth();
+        .with_no_client_auth()
+        .unwrap();
     let conn =
         UnbufferedClientConnection::new(config.into(), "localhost".try_into().unwrap()).unwrap();
     fuzz_unbuffered(data, ClientServer::Client(conn));
@@ -32,10 +31,9 @@ fn client(data: &mut [u8]) {
 
 fn server(data: &mut [u8]) {
     let config = ServerConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_no_client_auth()
-        .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver());
+        .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
+        .unwrap();
     let conn = UnbufferedServerConnection::new(config.into()).unwrap();
     fuzz_unbuffered(data, ClientServer::Server(conn));
 }

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -149,10 +149,9 @@ fn client_config_with_ffdhe_kx() -> ClientConfig {
             .with_only_tls13()
             .into(),
     )
-    .with_safe_default_protocol_versions()
-    .unwrap()
     .with_root_certificates(root_ca())
     .with_no_client_auth()
+    .unwrap()
 }
 
 // TLS 1.2 requires stripping leading zeros of the shared secret,
@@ -210,8 +209,6 @@ fn ffdhe_provider() -> CryptoProvider {
 
 fn server_config_with_ffdhe_kx(provider: CryptoProvider) -> ServerConfig {
     ServerConfig::builder_with_provider(provider.into())
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_no_client_auth()
         .with_single_cert(load_certs(), load_private_key())
         .unwrap()

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -55,6 +55,7 @@ mod client {
             .with_client_cert_resolver(Arc::new(AlwaysResolvesClientRawPublicKeys::new(
                 certified_key,
             )))
+            .unwrap()
     }
 
     /// Run the client and connect to the server at the specified port.
@@ -200,6 +201,7 @@ mod server {
         ServerConfig::builder()
             .with_client_cert_verifier(client_cert_verifier)
             .with_cert_resolver(server_cert_resolver)
+            .unwrap()
     }
 
     /// Run the server at the specified port and accept a connection from the client.

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -13,10 +13,9 @@ fn main() {
 
     let config =
         rustls::ClientConfig::builder_with_provider(rustls_provider_example::provider().into())
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_root_certificates(root_store)
-            .with_no_client_auth();
+            .with_no_client_auth()
+            .unwrap();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();

--- a/provider-example/examples/server.rs
+++ b/provider-example/examples/server.rs
@@ -93,8 +93,6 @@ impl TestPki {
     fn server_config(self) -> Arc<ServerConfig> {
         let mut server_config =
             ServerConfig::builder_with_provider(rustls_provider_example::provider().into())
-                .with_safe_default_protocol_versions()
-                .unwrap()
                 .with_no_client_auth()
                 .with_single_cert(vec![self.server_cert_der], self.server_key_der)
                 .unwrap();

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -813,8 +813,6 @@ impl Parameters {
         };
 
         let mut cfg = ServerConfig::builder_with_provider(provider)
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_client_cert_verifier(client_auth)
             .with_single_cert(
                 self.proto.key_type.get_chain(),
@@ -853,8 +851,6 @@ impl Parameters {
             }
             .into(),
         )
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_root_certificates(root_store);
 
         let mut cfg = match self.client_auth {
@@ -864,7 +860,7 @@ impl Parameters {
                     self.proto.key_type.get_client_key(),
                 )
                 .unwrap(),
-            ClientAuth::No => cfg.with_no_client_auth(),
+            ClientAuth::No => cfg.with_no_client_auth().unwrap(),
         };
 
         cfg.resumption = match self.resume {

--- a/rustls-fuzzing-provider/tests/smoke.rs
+++ b/rustls-fuzzing-provider/tests/smoke.rs
@@ -75,18 +75,16 @@ fn test_version(provider: CryptoProvider) -> Transcript {
     let _ = env_logger::try_init();
 
     let server_config = ServerConfig::builder_with_provider(provider.clone().into())
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_no_client_auth()
-        .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver());
+        .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
+        .unwrap();
     let mut server = ServerConnection::new(server_config.into()).unwrap();
 
     let client_config = ClientConfig::builder_with_provider(provider.into())
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .dangerous()
         .with_custom_certificate_verifier(rustls_fuzzing_provider::server_verifier())
-        .with_no_client_auth();
+        .with_no_client_auth()
+        .unwrap();
     let hostname = "localhost".try_into().unwrap();
     let mut client = ClientConnection::new(client_config.into(), hostname).unwrap();
     server

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -481,16 +481,12 @@ pub fn server_config_builder(
     provider: &CryptoProvider,
 ) -> rustls::ConfigBuilder<ServerConfig, rustls::WantsVerifier> {
     ServerConfig::builder_with_provider(provider.clone().into())
-        .with_safe_default_protocol_versions()
-        .unwrap()
 }
 
 pub fn client_config_builder(
     provider: &CryptoProvider,
 ) -> rustls::ConfigBuilder<ClientConfig, rustls::WantsVerifier> {
     ClientConfig::builder_with_provider(provider.clone().into())
-        .with_safe_default_protocol_versions()
-        .unwrap()
 }
 
 pub fn finish_server_config(
@@ -519,9 +515,7 @@ pub fn make_server_config_with_kx_groups(
                 ..provider.clone()
             }
             .into(),
-        )
-        .with_safe_default_protocol_versions()
-        .unwrap(),
+        ),
     )
 }
 
@@ -600,6 +594,7 @@ pub fn make_server_config_with_raw_key_support(
     server_config_builder(provider)
         .with_client_cert_verifier(Arc::new(client_verifier))
         .with_cert_resolver(server_cert_resolver)
+        .unwrap()
 }
 
 pub fn make_client_config_with_raw_key_support(
@@ -616,6 +611,7 @@ pub fn make_client_config_with_raw_key_support(
         .dangerous()
         .with_custom_certificate_verifier(server_verifier)
         .with_client_cert_resolver(client_cert_resolver)
+        .unwrap()
 }
 
 pub fn finish_client_config(
@@ -630,6 +626,7 @@ pub fn finish_client_config(
     config
         .with_root_certificates(root_store)
         .with_no_client_auth()
+        .unwrap()
 }
 
 pub fn finish_client_config_with_creds(
@@ -662,9 +659,7 @@ pub fn make_client_config_with_kx_groups(
             ..provider.clone()
         }
         .into(),
-    )
-    .with_safe_default_protocol_versions()
-    .unwrap();
+    );
     finish_client_config(kt, builder)
 }
 
@@ -680,6 +675,7 @@ pub fn make_client_config_with_verifier(
         .dangerous()
         .with_custom_certificate_verifier(verifier_builder.build().unwrap())
         .with_no_client_auth()
+        .unwrap()
 }
 
 pub fn webpki_client_verifier_builder(

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -1,12 +1,10 @@
 use alloc::format;
-use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 
 use crate::client::EchMode;
 use crate::crypto::CryptoProvider;
 use crate::error::Error;
-use crate::msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS;
 use crate::sync::Arc;
 use crate::time_provider::TimeProvider;
 use crate::versions;
@@ -221,38 +219,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
             return Err(Error::General("no usable cipher suites configured".into()));
         }
 
-        if self.provider.kx_groups.is_empty() {
-            return Err(Error::General("no kx groups configured".into()));
-        }
-
-        // verifying cipher suites have matching kx groups
-        let mut supported_kx_algos = Vec::with_capacity(ALL_KEY_EXCHANGE_ALGORITHMS.len());
-        for group in self.provider.kx_groups.iter() {
-            let kx = group.name().key_exchange_algorithm();
-            if !supported_kx_algos.contains(&kx) {
-                supported_kx_algos.push(kx);
-            }
-            // Small optimization. We don't need to go over other key exchange groups
-            // if we already cover all supported key exchange algorithms
-            if supported_kx_algos.len() == ALL_KEY_EXCHANGE_ALGORITHMS.len() {
-                break;
-            }
-        }
-
-        for cs in self.provider.cipher_suites.iter() {
-            let cs_kx = cs.key_exchange_algorithms();
-            if cs_kx
-                .iter()
-                .any(|kx| supported_kx_algos.contains(kx))
-            {
-                continue;
-            }
-            let suite_name = cs.common().suite;
-            return Err(Error::General(alloc::format!(
-                "Ciphersuite {suite_name:?} requires {cs_kx:?} key exchange, but no {cs_kx:?}-compatible \
-                key exchange groups were present in `CryptoProvider`'s `kx_groups` field",
-            )));
-        }
+        self.provider.consistency_check()?;
 
         Ok(ConfigBuilder {
             state: WantsVerifier {

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -52,10 +52,9 @@ mod tests {
                 .with_only_tls13()
                 .into(),
         )
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_root_certificates(roots())
-        .with_no_client_auth();
+        .with_no_client_auth()
+        .unwrap();
         config.resumption = Resumption::in_memory_sessions(128)
             .tls12_resumption(Tls12Resumption::SessionIdOrTickets);
         let ch = client_hello_sent_for_config(config).unwrap();
@@ -70,10 +69,9 @@ mod tests {
                     .with_only_tls13()
                     .into(),
             )
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_root_certificates(roots())
-            .with_no_client_auth(),
+            .with_no_client_auth()
+            .unwrap(),
         )
         .unwrap();
         assert!(
@@ -89,10 +87,9 @@ mod tests {
             super::provider::default_provider().with_only_tls13(),
         ] {
             let config = ClientConfig::builder_with_provider(provider.into())
-                .with_safe_default_protocol_versions()
-                .unwrap()
                 .with_root_certificates(roots())
-                .with_no_client_auth();
+                .with_no_client_auth()
+                .unwrap();
             let ch = client_hello_sent_for_config(config).unwrap();
             assert!(
                 !ch.extensions
@@ -109,10 +106,9 @@ mod tests {
     fn test_client_rejects_hrr_with_varied_session_id() {
         let config =
             ClientConfig::builder_with_provider(super::provider::default_provider().into())
-                .with_safe_default_protocol_versions()
-                .unwrap()
                 .with_root_certificates(roots())
-                .with_no_client_auth();
+                .with_no_client_auth()
+                .unwrap();
         let mut conn =
             ClientConnection::new(config.into(), ServerName::try_from("localhost").unwrap())
                 .unwrap();
@@ -147,10 +143,9 @@ mod tests {
     fn test_client_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
         let mut config =
             ClientConfig::builder_with_provider(super::provider::default_provider().into())
-                .with_safe_default_protocol_versions()
-                .unwrap()
                 .with_root_certificates(roots())
-                .with_no_client_auth();
+                .with_no_client_auth()
+                .unwrap();
         if config.provider.fips() {
             assert!(config.require_ems);
         } else {
@@ -199,11 +194,10 @@ mod tests {
         ] {
             let client_hello = client_hello_sent_for_config(
                 ClientConfig::builder_with_provider(provider.into())
-                    .with_safe_default_protocol_versions()
-                    .unwrap()
                     .dangerous()
                     .with_custom_certificate_verifier(Arc::new(cas_sending_server_verifier.clone()))
-                    .with_no_client_auth(),
+                    .with_no_client_auth()
+                    .unwrap(),
             )
             .unwrap();
             assert_eq!(
@@ -221,11 +215,10 @@ mod tests {
     fn test_client_with_custom_verifier_can_accept_ecdsa_sha1_signatures() {
         let verifier = Arc::new(ExpectSha1EcdsaVerifier::default());
         let config = ClientConfig::builder_with_provider(x25519_provider().into())
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .dangerous()
             .with_custom_certificate_verifier(verifier.clone())
-            .with_no_client_auth();
+            .with_no_client_auth()
+            .unwrap();
 
         let mut conn =
             ClientConnection::new(config.into(), ServerName::try_from("localhost").unwrap())
@@ -465,13 +458,12 @@ mod tests {
                 .with_only_tls13()
                 .into(),
         )
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(ServerVerifierRequiringRpk))
         .with_client_cert_resolver(Arc::new(AlwaysResolvesClientRawPublicKeys::new(Arc::new(
             client_certified_key(),
-        ))));
+        ))))
+        .unwrap();
         config.key_log = key_log;
         config
     }
@@ -658,10 +650,9 @@ mod tests {
 fn hybrid_kx_component_share_offered_if_supported_separately() {
     let ch = client_hello_sent_for_config(
         ClientConfig::builder_with_provider(crate::crypto::aws_lc_rs::default_provider().into())
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_root_certificates(roots())
-            .with_no_client_auth(),
+            .with_no_client_auth()
+            .unwrap(),
     )
     .unwrap();
 
@@ -685,10 +676,9 @@ fn hybrid_kx_component_share_not_offered_unless_supported_separately() {
     };
     let ch = client_hello_sent_for_config(
         ClientConfig::builder_with_provider(provider.into())
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_root_certificates(roots())
-            .with_no_client_auth(),
+            .with_no_client_auth()
+            .unwrap(),
     )
     .unwrap();
 

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -754,10 +754,9 @@ impl From<Vec<u8>> for SharedSecret {
 /// let config = rustls::ClientConfig::builder_with_provider(
 ///         rustls::crypto::default_fips_provider().into()
 ///     )
-///     .with_safe_default_protocol_versions()
-///     .unwrap()
 ///     .with_root_certificates(root_store)
-///     .with_no_client_auth();
+///     .with_no_client_auth()
+///     .unwrap();
 /// # }
 /// ```
 #[cfg(all(feature = "aws-lc-rs", any(feature = "fips", docsrs)))]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -164,7 +164,8 @@
 //! # let root_store: rustls::RootCertStore = panic!();
 //! let config = rustls::ClientConfig::builder()
 //!     .with_root_certificates(root_store)
-//!     .with_no_client_auth();
+//!     .with_no_client_auth()
+//!     .unwrap();
 //! # }
 //! ```
 //!
@@ -184,7 +185,8 @@
 //! # );
 //! # let config = rustls::ClientConfig::builder()
 //! #     .with_root_certificates(root_store)
-//! #     .with_no_client_auth();
+//! #     .with_no_client_auth()
+//! #     .unwrap();
 //! let rc_config = Arc::new(config);
 //! let example_com = "example.com".try_into().unwrap();
 //! let mut client = rustls::ClientConnection::new(rc_config, example_com);
@@ -511,7 +513,7 @@ pub mod unbuffered {
 }
 
 // The public interface is:
-pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier, WantsVersions};
+pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier};
 pub use crate::common_state::{CommonState, HandshakeKind, IoState, Side};
 #[cfg(feature = "std")]
 pub use crate::conn::{Connection, Reader, Writer};

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -82,8 +82,6 @@ mod tests {
     fn test_server_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
         let provider = super::provider::default_provider().with_only_tls12();
         let mut config = ServerConfig::builder_with_provider(provider.into())
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_no_client_auth()
             .with_single_cert(server_cert(), server_key())
             .unwrap();
@@ -123,8 +121,6 @@ mod tests {
                 .with_only_tls12()
                 .into(),
         )
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_no_client_auth()
         .with_single_cert(server_cert(), server_key())
         .unwrap();
@@ -146,8 +142,6 @@ mod tests {
                 .with_only_tls12()
                 .into(),
         )
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_no_client_auth()
         .with_single_cert(server_cert(), server_key())
         .unwrap();
@@ -170,8 +164,6 @@ mod tests {
                 .with_only_tls12()
                 .into(),
         )
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_no_client_auth()
         .with_single_cert(server_cert(), server_key())
         .unwrap();
@@ -253,12 +245,11 @@ mod tests {
             ..super::provider::default_provider()
         };
         ServerConfig::builder_with_provider(x25519_provider.with_only_tls12().into())
-            .with_safe_default_protocol_versions()
-            .unwrap()
             .with_no_client_auth()
             .with_cert_resolver(Arc::new(AlwaysResolvesServerRawPublicKeys::new(Arc::new(
                 server_certified_key(),
             ))))
+            .unwrap()
     }
 
     fn server_certified_key() -> CertifiedKey {

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use crate::enums::ProtocolVersion;
 
 /// A TLS protocol version supported by rustls.
@@ -91,50 +89,4 @@ pub struct Tls12Version {
 pub struct Tls13Version {
     pub(crate) client: &'static dyn crate::client::Tls13Handler,
     pub(crate) server: &'static dyn crate::server::Tls13Handler,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct EnabledVersions {
-    tls12: Option<&'static SupportedProtocolVersion>,
-    tls13: Option<&'static SupportedProtocolVersion>,
-}
-
-impl fmt::Debug for EnabledVersions {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut list = &mut f.debug_list();
-        if let Some(v) = self.tls12 {
-            list = list.entry(v);
-        }
-        if let Some(v) = self.tls13 {
-            list = list.entry(v);
-        }
-        list.finish()
-    }
-}
-
-impl EnabledVersions {
-    pub(crate) fn new(versions: &[&'static SupportedProtocolVersion]) -> Self {
-        let mut ev = Self {
-            tls12: None,
-            tls13: None,
-        };
-
-        for v in versions {
-            match v.version() {
-                ProtocolVersion::TLSv1_2 => ev.tls12 = Some(v),
-                ProtocolVersion::TLSv1_3 => ev.tls13 = Some(v),
-                _ => {}
-            }
-        }
-
-        ev
-    }
-
-    pub(crate) fn contains(&self, version: ProtocolVersion) -> bool {
-        match version {
-            ProtocolVersion::TLSv1_2 => self.tls12.is_some(),
-            ProtocolVersion::TLSv1_3 => self.tls13.is_some(),
-            _ => false,
-        }
-    }
 }

--- a/rustls/tests/api_ffdhe.rs
+++ b/rustls/tests/api_ffdhe.rs
@@ -21,7 +21,8 @@ fn config_builder_for_client_rejects_cipher_suites_without_compatible_kx_groups(
     };
 
     let build_err = ClientConfig::builder_with_provider(bad_crypto_provider.into())
-        .with_safe_default_protocol_versions()
+        .with_root_certificates(get_client_root_store(KeyType::EcdsaP256))
+        .with_no_client_auth()
         .unwrap_err()
         .to_string();
 
@@ -55,15 +56,11 @@ fn ffdhe_ciphersuite() {
         });
         let client_config = finish_client_config(
             KeyType::Rsa2048,
-            rustls::ClientConfig::builder_with_provider(provider.clone())
-                .with_safe_default_protocol_versions()
-                .unwrap(),
+            rustls::ClientConfig::builder_with_provider(provider.clone()),
         );
         let server_config = finish_server_config(
             KeyType::Rsa2048,
-            rustls::ServerConfig::builder_with_provider(provider)
-                .with_safe_default_protocol_versions()
-                .unwrap(),
+            rustls::ServerConfig::builder_with_provider(provider),
         );
         do_suite_and_kx_test(
             client_config,
@@ -91,9 +88,7 @@ fn server_avoids_dhe_cipher_suites_when_client_has_no_known_dhe_in_groups_ext() 
                 ..provider::default_provider()
             }
             .into(),
-        )
-        .with_safe_default_protocol_versions()
-        .unwrap(),
+        ),
     );
 
     let server_config = finish_server_config(
@@ -108,9 +103,7 @@ fn server_avoids_dhe_cipher_suites_when_client_has_no_known_dhe_in_groups_ext() 
                 ..provider::default_provider()
             }
             .into(),
-        )
-        .with_safe_default_protocol_versions()
-        .unwrap(),
+        ),
     );
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -146,9 +139,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
                 ..provider::default_provider()
             }
             .into(),
-        )
-        .with_safe_default_protocol_versions()
-        .unwrap(),
+        ),
     )
     .into();
 
@@ -234,9 +225,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
         };
         let client_config = finish_client_config(
             KeyType::Rsa2048,
-            rustls::ClientConfig::builder_with_provider(provider.into())
-                .with_safe_default_protocol_versions()
-                .unwrap(),
+            rustls::ClientConfig::builder_with_provider(provider.into()),
         )
         .into();
 

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -13,16 +13,12 @@ pub fn server_config_builder(
     provider: &CryptoProvider,
 ) -> rustls::ConfigBuilder<ServerConfig, rustls::WantsVerifier> {
     rustls::ServerConfig::builder_with_provider(provider.clone().into())
-        .with_safe_default_protocol_versions()
-        .unwrap()
 }
 
 pub fn client_config_builder(
     provider: &CryptoProvider,
 ) -> rustls::ConfigBuilder<ClientConfig, rustls::WantsVerifier> {
     rustls::ClientConfig::builder_with_provider(provider.clone().into())
-        .with_safe_default_protocol_versions()
-        .unwrap()
 }
 
 pub fn webpki_client_verifier_builder(

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -190,7 +190,8 @@ fn client_can_request_certain_trusted_cas() {
     let server_config = Arc::new(
         server_config_builder(&provider)
             .with_no_client_auth()
-            .with_cert_resolver(Arc::new(cert_resolver.clone())),
+            .with_cert_resolver(Arc::new(cert_resolver.clone()))
+            .unwrap(),
     );
 
     let mut cas_unaware_error_count = 0;
@@ -219,7 +220,8 @@ fn client_can_request_certain_trusted_cas() {
         let cas_sending_client_config = client_config_builder(&provider)
             .dangerous()
             .with_custom_certificate_verifier(cas_sending_server_verifier)
-            .with_no_client_auth();
+            .with_no_client_auth()
+            .unwrap();
 
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(cas_sending_client_config), &server_config);
@@ -228,7 +230,8 @@ fn client_can_request_certain_trusted_cas() {
         let cas_unaware_client_config = client_config_builder(&provider)
             .dangerous()
             .with_custom_certificate_verifier(server_verifier)
-            .with_no_client_auth();
+            .with_no_client_auth()
+            .unwrap();
 
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(cas_unaware_client_config), &server_config);

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -751,9 +751,7 @@ fn refresh_traffic_keys_automatically() {
         KeyType::Rsa2048,
         ClientConfig::builder_with_provider(aes_128_gcm_with_1024_confidentiality_limit(
             provider::default_provider(),
-        ))
-        .with_safe_default_protocol_versions()
-        .unwrap(),
+        )),
     );
 
     let server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
@@ -828,9 +826,7 @@ fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
 
     let client_config = finish_client_config(
         KeyType::Ed25519,
-        ClientConfig::builder_with_provider(provider)
-            .with_safe_default_protocol_versions()
-            .unwrap(),
+        ClientConfig::builder_with_provider(provider),
     );
 
     let server_config = make_server_config(KeyType::Ed25519, &provider::default_provider());
@@ -907,13 +903,12 @@ fn tls13_packed_handshake() {
     let client_config = ClientConfig::builder_with_provider(unsafe_plaintext_crypto_provider(
         provider::default_provider(),
     ))
-    .with_safe_default_protocol_versions()
-    .unwrap()
     .dangerous()
     .with_custom_certificate_verifier(Arc::new(MockServerVerifier::rejects_certificate(
         CertificateError::UnknownIssuer.into(),
     )))
-    .with_no_client_auth();
+    .with_no_client_auth()
+    .unwrap();
 
     let mut client =
         UnbufferedClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
@@ -1554,8 +1549,6 @@ fn test_secret_extraction_enabled() {
             }
             .into(),
         )
-        .with_safe_default_protocol_versions()
-        .unwrap()
         .with_no_client_auth()
         .with_single_cert(kt.get_chain(), kt.get_key())
         .unwrap();


### PR DESCRIPTION
This removes the version selection parts of the config builder API: `.with_protocol_versions()`, `.with_safe_default_protocol_versions()`, etc.

A further step towards #1659.