### PR TITLE
Split cipher suite configuration in `CryptoProvider` by version

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -312,7 +312,8 @@ impl SelectedProvider {
                 // version of `aws_lc_rs::default_provider()`
                 CryptoProvider {
                     kx_groups: aws_lc_rs::DEFAULT_KX_GROUPS.to_vec(),
-                    cipher_suites: aws_lc_rs::ALL_CIPHER_SUITES.to_vec(),
+                    tls12_cipher_suites: aws_lc_rs::ALL_TLS12_CIPHER_SUITES.to_vec(),
+                    tls13_cipher_suites: aws_lc_rs::ALL_TLS13_CIPHER_SUITES.to_vec(),
                     ..aws_lc_rs::default_provider()
                 }
             }

--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -83,14 +83,14 @@ impl ResumptionKind {
 /// Parameters associated to a benchmark
 #[derive(Clone, Debug)]
 pub struct BenchmarkParams {
-    /// Which `CryptoProvider` to test
-    pub provider: rustls::crypto::CryptoProvider,
+    /// Which `CryptoProvider` to test.
+    ///
+    /// The choice of cipher suite is baked into this.
+    pub provider: Arc<rustls::crypto::CryptoProvider>,
     /// How to make a suitable [`rustls::server::ProducesTickets`].
     pub ticketer: &'static fn() -> Arc<dyn rustls::server::ProducesTickets>,
     /// Where to get keys for server auth
     pub auth_key: AuthKeySource,
-    /// Cipher suite
-    pub ciphersuite: rustls::SupportedCipherSuite,
     /// TLS version
     pub version: rustls::ProtocolVersion,
     /// A user-facing label that identifies these params
@@ -100,10 +100,9 @@ pub struct BenchmarkParams {
 impl BenchmarkParams {
     /// Create a new set of benchmark params
     pub const fn new(
-        provider: rustls::crypto::CryptoProvider,
+        provider: Arc<rustls::crypto::CryptoProvider>,
         ticketer: &'static fn() -> Arc<dyn rustls::server::ProducesTickets>,
         auth_key: AuthKeySource,
-        ciphersuite: rustls::SupportedCipherSuite,
         version: rustls::ProtocolVersion,
         label: String,
     ) -> Self {
@@ -111,7 +110,6 @@ impl BenchmarkParams {
             provider,
             ticketer,
             auth_key,
-            ciphersuite,
             version,
             label,
         }

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -17,7 +17,8 @@ fn main() {
 
     let config = rustls::ClientConfig::builder_with_provider(
         CryptoProvider {
-            cipher_suites: vec![provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256],
+            tls12_cipher_suites: vec![],
+            tls13_cipher_suites: vec![provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256],
             kx_groups: vec![provider::kx_group::X25519],
             signature_verification_algorithms: provider::SUPPORTED_SIG_ALGS,
             secure_random: provider::DEFAULT_SECURE_RANDOM,

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -319,9 +319,16 @@ fn find_key_exchange(name: &str) -> &'static dyn SupportedKxGroup {
 fn filter_suites(mut provider: CryptoProvider, suites: &[String]) -> CryptoProvider {
     // first, check `suites` all name known suites, and will have some effect
     let known_suites = provider
-        .cipher_suites
+        .tls12_cipher_suites
         .iter()
-        .map(|cs| format!("{:?}", cs.suite()).to_lowercase())
+        .map(|cs| cs.common.suite)
+        .chain(
+            provider
+                .tls13_cipher_suites
+                .iter()
+                .map(|cs| cs.common.suite),
+        )
+        .map(|cs| format!("{:?}", cs).to_lowercase())
         .collect::<Vec<String>>();
 
     for s in suites {
@@ -331,12 +338,22 @@ fn filter_suites(mut provider: CryptoProvider, suites: &[String]) -> CryptoProvi
     }
 
     // now discard non-named suites
-    provider.cipher_suites.retain(|cs| {
-        let name = format!("{:?}", cs.suite()).to_lowercase();
-        suites
-            .iter()
-            .any(|s| s.to_lowercase() == name)
-    });
+    provider
+        .tls12_cipher_suites
+        .retain(|cs| {
+            let name = format!("{:?}", cs.common.suite).to_lowercase();
+            suites
+                .iter()
+                .any(|s| s.to_lowercase() == name)
+        });
+    provider
+        .tls13_cipher_suites
+        .retain(|cs| {
+            let name = format!("{:?}", cs.common.suite).to_lowercase();
+            suites
+                .iter()
+                .any(|s| s.to_lowercase() == name)
+        });
 
     provider
 }

--- a/openssl-tests/src/ffdhe.rs
+++ b/openssl-tests/src/ffdhe.rs
@@ -4,11 +4,7 @@ use rustls::crypto::{
     aws_lc_rs as provider,
 };
 use rustls::ffdhe_groups::FfdheGroup;
-use rustls::{CipherSuite, NamedGroup, SupportedCipherSuite, Tls12CipherSuite};
-
-/// The (test-only) TLS1.2 ciphersuite TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
-pub(crate) static TLS_DHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&TLS12_DHE_RSA_WITH_AES_128_GCM_SHA256);
+use rustls::{CipherSuite, NamedGroup, Tls12CipherSuite};
 
 #[derive(Debug)]
 pub(crate) struct FfdheKxGroup(pub NamedGroup, pub FfdheGroup<'static>);
@@ -46,18 +42,14 @@ impl SupportedKxGroup for FfdheKxGroup {
     }
 }
 
-static TLS12_DHE_RSA_WITH_AES_128_GCM_SHA256: Tls12CipherSuite =
-    match &provider::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
-        SupportedCipherSuite::Tls12(original) => Tls12CipherSuite {
-            common: CipherSuiteCommon {
-                suite: CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
-                ..original.common
-            },
-            kx: KeyExchangeAlgorithm::DHE,
-            ..**original
-        },
-        _ => unreachable!(),
-    };
+pub(crate) static TLS_DHE_RSA_WITH_AES_128_GCM_SHA256: Tls12CipherSuite = Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+        ..provider::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.common
+    },
+    kx: KeyExchangeAlgorithm::DHE,
+    ..*provider::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+};
 
 struct ActiveFfdheKx {
     x_pub: Vec<u8>,

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -195,10 +195,8 @@ fn load_private_key() -> PrivateKeyDer<'static> {
 
 fn ffdhe_provider() -> CryptoProvider {
     CryptoProvider {
-        cipher_suites: vec![
-            ffdhe::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
-            provider::cipher_suite::TLS13_AES_128_GCM_SHA256,
-        ],
+        tls12_cipher_suites: vec![&ffdhe::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256],
+        tls13_cipher_suites: vec![provider::cipher_suite::TLS13_AES_128_GCM_SHA256],
         kx_groups: vec![&FfdheKxGroup(
             rustls::NamedGroup::FFDHE2048,
             rustls::ffdhe_groups::FFDHE2048,

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -33,7 +33,8 @@ mod verify;
 
 pub fn provider() -> CryptoProvider {
     CryptoProvider {
-        cipher_suites: ALL_CIPHER_SUITES.to_vec(),
+        tls12_cipher_suites: ALL_TLS12_CIPHER_SUITES.to_vec(),
+        tls13_cipher_suites: ALL_TLS13_CIPHER_SUITES.to_vec(),
         kx_groups: kx::ALL_KX_GROUPS.to_vec(),
         signature_verification_algorithms: verify::ALGORITHMS,
         secure_random: &Provider,
@@ -70,26 +71,25 @@ impl rustls::crypto::KeyProvider for Provider {
     }
 }
 
-static ALL_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[
-    TLS13_CHACHA20_POLY1305_SHA256,
-    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-];
+static ALL_TLS12_CIPHER_SUITES: &[&rustls::Tls12CipherSuite] =
+    &[TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256];
 
-pub static TLS13_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
-    rustls::SupportedCipherSuite::Tls13(&rustls::Tls13CipherSuite {
-        common: rustls::crypto::CipherSuiteCommon {
-            suite: rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
-            hash_provider: &hash::Sha256,
-            confidentiality_limit: u64::MAX,
-        },
-        protocol_version: rustls::version::TLS13_VERSION,
-        hkdf_provider: &rustls::crypto::tls13::HkdfUsingHmac(&hmac::Sha256Hmac),
-        aead_alg: &aead::Chacha20Poly1305,
-        quic: None,
-    });
+static ALL_TLS13_CIPHER_SUITES: &[&rustls::Tls13CipherSuite] = &[TLS13_CHACHA20_POLY1305_SHA256];
 
-pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
-    rustls::SupportedCipherSuite::Tls12(&rustls::Tls12CipherSuite {
+pub static TLS13_CHACHA20_POLY1305_SHA256: &rustls::Tls13CipherSuite = &rustls::Tls13CipherSuite {
+    common: rustls::crypto::CipherSuiteCommon {
+        suite: rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
+        hash_provider: &hash::Sha256,
+        confidentiality_limit: u64::MAX,
+    },
+    protocol_version: rustls::version::TLS13_VERSION,
+    hkdf_provider: &rustls::crypto::tls13::HkdfUsingHmac(&hmac::Sha256Hmac),
+    aead_alg: &aead::Chacha20Poly1305,
+    quic: None,
+};
+
+pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: &rustls::Tls12CipherSuite =
+    &rustls::Tls12CipherSuite {
         common: rustls::crypto::CipherSuiteCommon {
             suite: rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
             hash_provider: &hash::Sha256,
@@ -103,4 +103,4 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherS
         ],
         prf_provider: &rustls::crypto::tls12::PrfUsingHmac(&hmac::Sha256Hmac),
         aead_alg: &aead::Chacha20Poly1305,
-    });
+    };

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -33,14 +33,15 @@ use rustls::pki_types::{
 use rustls::server::ProducesTickets;
 use rustls::{
     CipherSuite, ConnectionTrafficSecrets, ContentType, Error, NamedGroup, PeerMisbehaved,
-    ProtocolVersion, RootCertStore, SignatureAlgorithm, SignatureScheme, SupportedCipherSuite,
-    Tls12CipherSuite, Tls13CipherSuite, crypto, server, sign,
+    ProtocolVersion, RootCertStore, SignatureAlgorithm, SignatureScheme, Tls12CipherSuite,
+    Tls13CipherSuite, crypto, server, sign,
 };
 
 /// This is a `CryptoProvider` that provides NO SECURITY and is for fuzzing only.
 pub fn provider() -> crypto::CryptoProvider {
     crypto::CryptoProvider {
-        cipher_suites: vec![TLS13_FUZZING_SUITE, TLS_FUZZING_SUITE],
+        tls12_cipher_suites: vec![TLS_FUZZING_SUITE],
+        tls13_cipher_suites: vec![TLS13_FUZZING_SUITE],
         kx_groups: vec![&KeyExchangeGroup],
         signature_verification_algorithms: VERIFY_ALGORITHMS,
         secure_random: &Provider,
@@ -101,32 +102,30 @@ impl crypto::KeyProvider for Provider {
     }
 }
 
-pub static TLS13_FUZZING_SUITE: SupportedCipherSuite =
-    SupportedCipherSuite::Tls13(&Tls13CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::Unknown(0xff13),
-            hash_provider: &Hash,
-            confidentiality_limit: u64::MAX,
-        },
-        protocol_version: rustls::version::TLS13_VERSION,
-        hkdf_provider: &tls13::HkdfUsingHmac(&Hmac),
-        aead_alg: &Aead,
-        quic: None,
-    });
+pub static TLS13_FUZZING_SUITE: &Tls13CipherSuite = &Tls13CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::Unknown(0xff13),
+        hash_provider: &Hash,
+        confidentiality_limit: u64::MAX,
+    },
+    protocol_version: rustls::version::TLS13_VERSION,
+    hkdf_provider: &tls13::HkdfUsingHmac(&Hmac),
+    aead_alg: &Aead,
+    quic: None,
+};
 
-pub static TLS_FUZZING_SUITE: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::Unknown(0xff12),
-            hash_provider: &Hash,
-            confidentiality_limit: u64::MAX,
-        },
-        protocol_version: rustls::version::TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: &[SIGNATURE_SCHEME],
-        prf_provider: &tls12::PrfUsingHmac(&Hmac),
-        aead_alg: &Aead,
-    });
+pub static TLS_FUZZING_SUITE: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::Unknown(0xff12),
+        hash_provider: &Hash,
+        confidentiality_limit: u64::MAX,
+    },
+    protocol_version: rustls::version::TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: &[SIGNATURE_SCHEME],
+    prf_provider: &tls12::PrfUsingHmac(&Hmac),
+    aead_alg: &Aead,
+};
 
 #[derive(Debug, Default)]
 pub struct Ticketer;

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -161,8 +161,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
         if self.state.client_ech_mode.is_some() {
             if !self
                 .provider
-                .cipher_suites
-                .iter()
+                .iter_cipher_suites()
                 .any(|cs| cs.version().version() == ProtocolVersion::TLSv1_3)
             {
                 return Err(Error::General("ECH requires TLS1.3 support".into()));
@@ -170,8 +169,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
 
             if self
                 .provider
-                .cipher_suites
-                .iter()
+                .iter_cipher_suites()
                 .any(|cs| cs.version().version() == ProtocolVersion::TLSv1_2)
             {
                 return Err(Error::General("ECH forbids TLS1.2 support".into()));

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -358,24 +358,20 @@ impl ClientConfig {
     /// also configured.
     pub(crate) fn supports_version(&self, v: ProtocolVersion) -> bool {
         self.provider
-            .cipher_suites
-            .iter()
+            .iter_cipher_suites()
             .any(|cs| cs.version().version() == v)
     }
 
     #[cfg(feature = "std")]
     pub(crate) fn supports_protocol(&self, proto: Protocol) -> bool {
         self.provider
-            .cipher_suites
-            .iter()
+            .iter_cipher_suites()
             .any(|cs| cs.usable_for_protocol(proto))
     }
 
     pub(super) fn find_cipher_suite(&self, suite: CipherSuite) -> Option<SupportedCipherSuite> {
         self.provider
-            .cipher_suites
-            .iter()
-            .copied()
+            .iter_cipher_suites()
             .find(|&scs| scs.suite() == suite)
     }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -353,13 +353,8 @@ impl ClientConfig {
         self.supports_version(ProtocolVersion::TLSv1_3)
     }
 
-    /// We support a given TLS version if it's quoted in the configured
-    /// versions *and* at least one ciphersuite for this version is
-    /// also configured.
     pub(crate) fn supports_version(&self, v: ProtocolVersion) -> bool {
-        self.provider
-            .iter_cipher_suites()
-            .any(|cs| cs.version().version() == v)
+        self.provider.supports_version(v)
     }
 
     #[cfg(feature = "std")]

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -252,7 +252,6 @@ mod tests {
     use crate::msgs::handshake::{CertificateChain, SessionId};
     use crate::msgs::persist::Tls13ClientSessionValue;
     use crate::pki_types::CertificateDer;
-    use crate::suites::SupportedCipherSuite;
     use crate::sync::Arc;
     use crate::{DigitallySignedStruct, Error, SignatureScheme, sign};
 
@@ -269,16 +268,11 @@ mod tests {
 
         {
             use crate::msgs::persist::Tls12ClientSessionValue;
-            let SupportedCipherSuite::Tls12(tls12_suite) =
-                cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-            else {
-                unreachable!()
-            };
 
             c.set_tls12_session(
                 name.clone(),
                 Tls12ClientSessionValue::new(
-                    tls12_suite,
+                    cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
                     SessionId::empty(),
                     Arc::new(PayloadU16::empty()),
                     &[0u8; 48],
@@ -294,14 +288,10 @@ mod tests {
             c.remove_tls12_session(&name);
         }
 
-        let SupportedCipherSuite::Tls13(tls13_suite) = cipher_suite::TLS13_AES_256_GCM_SHA384
-        else {
-            unreachable!();
-        };
         c.insert_tls13_ticket(
             name.clone(),
             Tls13ClientSessionValue::new(
-                tls13_suite,
+                cipher_suite::TLS13_AES_256_GCM_SHA384,
                 Arc::new(PayloadU16::empty()),
                 &[],
                 CertificateChain::default(),

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -360,8 +360,7 @@ fn emit_client_hello_for_retry(
 
     let mut cipher_suites: Vec<_> = config
         .provider
-        .cipher_suites
-        .iter()
+        .iter_cipher_suites()
         .filter_map(|cs| match cs.usable_for_protocol(cx.common.protocol) {
             true => Some(cs.suite()),
             false => None,

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -609,9 +609,7 @@ mod tests {
         }
 
         fn server_handshake_encrypter(&self) -> Box<dyn MessageEncrypter> {
-            let cipher_suite = super::provider::cipher_suite::TLS13_AES_128_GCM_SHA256
-                .tls13()
-                .unwrap();
+            let cipher_suite = super::provider::cipher_suite::TLS13_AES_128_GCM_SHA256;
 
             let secret = self
                 .server_handshake_secret

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -31,7 +31,7 @@ use crate::msgs::handshake::{
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 use crate::sign::Signer;
-use crate::suites::{PartiallyExtractedSecrets, SupportedCipherSuite};
+use crate::suites::PartiallyExtractedSecrets;
 use crate::sync::Arc;
 use crate::tls12::{self, ConnectionSecrets, Tls12CipherSuite};
 use crate::verify::{self, DigitallySignedStruct};
@@ -915,9 +915,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
 
             // Check the signature is compatible with the ciphersuite.
             let sig = &st.server_kx.kx_sig;
-            if !SupportedCipherSuite::from(suite)
-                .usable_for_signature_algorithm(sig.scheme.algorithm())
-            {
+            if !suite.usable_for_signature_algorithm(sig.scheme.algorithm()) {
                 warn!(
                     "peer signed kx with wrong algorithm (got {:?} expect {:?})",
                     sig.scheme.algorithm(),

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -15,99 +15,93 @@ use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
 use crate::msgs::message::{
     InboundPlainMessage, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload,
 };
-use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
+use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets};
 use crate::tls12::Tls12CipherSuite;
 use crate::version::{TLS12, TLS12_VERSION};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256.
-pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-            hash_provider: &super::hash::SHA256,
-            confidentiality_limit: u64::MAX,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_ECDSA_SCHEMES,
-        aead_alg: &ChaCha20Poly1305,
-        prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
-    });
+pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: u64::MAX,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_ECDSA_SCHEMES,
+    aead_alg: &ChaCha20Poly1305,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-            hash_provider: &super::hash::SHA256,
-            confidentiality_limit: u64::MAX,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_RSA_SCHEMES,
-        aead_alg: &ChaCha20Poly1305,
-        prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
-    });
+pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: u64::MAX,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_RSA_SCHEMES,
+    aead_alg: &ChaCha20Poly1305,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-            hash_provider: &super::hash::SHA256,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_RSA_SCHEMES,
-        aead_alg: &AES128_GCM,
-        prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
-    });
+pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_RSA_SCHEMES,
+    aead_alg: &AES128_GCM,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-            hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_RSA_SCHEMES,
-        aead_alg: &AES256_GCM,
-        prf_provider: &Tls12Prf(&tls_prf::P_SHA384),
-    });
+pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        hash_provider: &super::hash::SHA384,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_RSA_SCHEMES,
+    aead_alg: &AES256_GCM,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA384),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            hash_provider: &super::hash::SHA256,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_ECDSA_SCHEMES,
-        aead_alg: &AES128_GCM,
-        prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
-    });
+pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_ECDSA_SCHEMES,
+    aead_alg: &AES128_GCM,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-            hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_ECDSA_SCHEMES,
-        aead_alg: &AES256_GCM,
-        prf_provider: &Tls12Prf(&tls_prf::P_SHA384),
-    });
+pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        hash_provider: &super::hash::SHA384,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_ECDSA_SCHEMES,
+    aead_alg: &AES256_GCM,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA384),
+};
 
 static TLS12_ECDSA_SCHEMES: &[SignatureScheme] = &[
     SignatureScheme::ED25519,

--- a/rustls/src/crypto/aws_lc_rs/tls13.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls13.rs
@@ -14,15 +14,12 @@ use crate::error::Error;
 use crate::msgs::message::{
     InboundPlainMessage, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload,
 };
-use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
+use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets};
 use crate::tls13::Tls13CipherSuite;
 use crate::version::TLS13_VERSION;
 
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256
-pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls13(TLS13_CHACHA20_POLY1305_SHA256_INTERNAL);
-
-pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13CipherSuite {
+pub static TLS13_CHACHA20_POLY1305_SHA256: &Tls13CipherSuite = &Tls13CipherSuite {
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
         hash_provider: &super::hash::SHA256,
@@ -43,31 +40,27 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
 };
 
 /// The TLS1.3 ciphersuite TLS_AES_256_GCM_SHA384
-pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
-    SupportedCipherSuite::Tls13(&Tls13CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
-            hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS13_VERSION,
-        hkdf_provider: &AwsLcHkdf(hkdf::HKDF_SHA384, hmac::HMAC_SHA384),
-        aead_alg: &Aes256GcmAead(AeadAlgorithm(&aead::AES_256_GCM)),
-        quic: Some(&super::quic::KeyBuilder {
-            packet_alg: &aead::AES_256_GCM,
-            header_alg: &aead::quic::AES_256,
-            // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.1>
-            confidentiality_limit: 1 << 23,
-            // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.2>
-            integrity_limit: 1 << 52,
-        }),
-    });
+pub static TLS13_AES_256_GCM_SHA384: &Tls13CipherSuite = &Tls13CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
+        hash_provider: &super::hash::SHA384,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS13_VERSION,
+    hkdf_provider: &AwsLcHkdf(hkdf::HKDF_SHA384, hmac::HMAC_SHA384),
+    aead_alg: &Aes256GcmAead(AeadAlgorithm(&aead::AES_256_GCM)),
+    quic: Some(&super::quic::KeyBuilder {
+        packet_alg: &aead::AES_256_GCM,
+        header_alg: &aead::quic::AES_256,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.1>
+        confidentiality_limit: 1 << 23,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.2>
+        integrity_limit: 1 << 52,
+    }),
+};
 
 /// The TLS1.3 ciphersuite TLS_AES_128_GCM_SHA256
-pub static TLS13_AES_128_GCM_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls13(TLS13_AES_128_GCM_SHA256_INTERNAL);
-
-pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13CipherSuite {
+pub static TLS13_AES_128_GCM_SHA256: &Tls13CipherSuite = &Tls13CipherSuite {
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
         hash_provider: &super::hash::SHA256,

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -404,6 +404,16 @@ See the documentation of the CryptoProvider type for more information.
                     .map(SupportedCipherSuite::Tls12),
             )
     }
+
+    /// We support a given TLS version if at least one ciphersuite for the version
+    /// is available.
+    pub(crate) fn supports_version(&self, v: ProtocolVersion) -> bool {
+        match v {
+            ProtocolVersion::TLSv1_2 => !self.tls12_cipher_suites.is_empty(),
+            ProtocolVersion::TLSv1_3 => !self.tls13_cipher_suites.is_empty(),
+            _ => false,
+        }
+    }
 }
 
 /// A source of cryptographically secure randomness.

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -374,18 +374,15 @@ See the documentation of the CryptoProvider type for more information.
             }
         }
 
-        for cs in self.iter_cipher_suites() {
-            let cs_kx = cs.key_exchange_algorithms();
-            if cs_kx
-                .iter()
-                .any(|kx| supported_kx_algos.contains(kx))
-            {
+        for cs in &self.tls12_cipher_suites {
+            if supported_kx_algos.contains(&cs.kx) {
                 continue;
             }
-            let suite_name = cs.common().suite;
+            let suite_name = cs.common.suite;
             return Err(Error::General(alloc::format!(
-                "Ciphersuite {suite_name:?} requires {cs_kx:?} key exchange, but no {cs_kx:?}-compatible \
+                "TLS1.2 cipher suite {suite_name:?} requires {0:?} key exchange, but no {0:?}-compatible \
                 key exchange groups were present in `CryptoProvider`'s `kx_groups` field",
+                cs.kx,
             )));
         }
 

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -348,7 +348,11 @@ See the documentation of the CryptoProvider type for more information.
     }
 
     pub(crate) fn consistency_check(&self) -> Result<(), Error> {
-        if self.cipher_suites.is_empty() {
+        if self
+            .iter_cipher_suites()
+            .next()
+            .is_none()
+        {
             return Err(Error::General("no cipher suites configured".into()));
         }
 
@@ -370,7 +374,7 @@ See the documentation of the CryptoProvider type for more information.
             }
         }
 
-        for cs in self.cipher_suites.iter() {
+        for cs in self.iter_cipher_suites() {
             let cs_kx = cs.key_exchange_algorithms();
             if cs_kx
                 .iter()
@@ -386,6 +390,12 @@ See the documentation of the CryptoProvider type for more information.
         }
 
         Ok(())
+    }
+
+    pub(crate) fn iter_cipher_suites(
+        &self,
+    ) -> impl Iterator<Item = suites::SupportedCipherSuite> + '_ {
+        self.cipher_suites.iter().cloned()
     }
 }
 

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -2,14 +2,13 @@ use pki_types::PrivateKeyDer;
 pub(crate) use ring as ring_like;
 use webpki::ring as webpki_algs;
 
-use crate::Error;
 use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom, SupportedKxGroup};
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
-use crate::suites::SupportedCipherSuite;
 use crate::sync::Arc;
 use crate::webpki::WebPkiSupportedAlgorithms;
+use crate::{Error, Tls12CipherSuite, Tls13CipherSuite};
 
 /// Using software keys for authentication.
 pub mod sign;
@@ -28,7 +27,8 @@ pub(crate) mod tls13;
 /// [*ring*]: https://github.com/briansmith/ring
 pub fn default_provider() -> CryptoProvider {
     CryptoProvider {
-        cipher_suites: DEFAULT_CIPHER_SUITES.to_vec(),
+        tls12_cipher_suites: DEFAULT_TLS12_CIPHER_SUITES.to_vec(),
+        tls13_cipher_suites: DEFAULT_TLS13_CIPHER_SUITES.to_vec(),
         kx_groups: DEFAULT_KX_GROUPS.to_vec(),
         signature_verification_algorithms: SUPPORTED_SIG_ALGS,
         secure_random: &Ring,
@@ -59,25 +59,33 @@ impl KeyProvider for Ring {
     }
 }
 
-/// The cipher suite configuration that an application should use by default.
+/// The TLS1.2 cipher suite configuration that an application should use by default.
 ///
-/// This will be [`ALL_CIPHER_SUITES`] sans any supported cipher suites that
+/// This will be [`ALL_TLS12_CIPHER_SUITES`] sans any supported cipher suites that
 /// shouldn't be enabled by most applications.
-pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = ALL_CIPHER_SUITES;
+pub static DEFAULT_TLS12_CIPHER_SUITES: &[&Tls12CipherSuite] = ALL_TLS12_CIPHER_SUITES;
 
-/// A list of all the cipher suites supported by the rustls *ring* provider.
-pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
-    // TLS1.3 suites
-    tls13::TLS13_AES_256_GCM_SHA384,
-    tls13::TLS13_AES_128_GCM_SHA256,
-    tls13::TLS13_CHACHA20_POLY1305_SHA256,
-    // TLS1.2 suites
+/// A list of all the TLS1.2 cipher suites supported by the rustls *ring* provider.
+pub static ALL_TLS12_CIPHER_SUITES: &[&Tls12CipherSuite] = &[
     tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
     tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+];
+
+/// The TLS1.3 cipher suite configuration that an application should use by default.
+///
+/// This will be [`ALL_TLS13_CIPHER_SUITES`] sans any supported cipher suites that
+/// shouldn't be enabled by most applications.
+pub static DEFAULT_TLS13_CIPHER_SUITES: &[&Tls13CipherSuite] = ALL_TLS13_CIPHER_SUITES;
+
+/// A list of all the TLS1.3 cipher suites supported by the rustls *ring* provider.
+pub static ALL_TLS13_CIPHER_SUITES: &[&Tls13CipherSuite] = &[
+    tls13::TLS13_AES_256_GCM_SHA384,
+    tls13::TLS13_AES_128_GCM_SHA256,
+    tls13::TLS13_CHACHA20_POLY1305_SHA256,
 ];
 
 /// All defined cipher suites supported by *ring* appear in this module.

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -224,9 +224,7 @@ impl quic::Algorithm for KeyBuilder {
 mod tests {
     use std::dbg;
 
-    use super::provider::tls13::{
-        TLS13_AES_128_GCM_SHA256_INTERNAL, TLS13_CHACHA20_POLY1305_SHA256_INTERNAL,
-    };
+    use super::provider::tls13::{TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256};
     use crate::common_state::Side;
     use crate::crypto::tls13::OkmBlock;
     use crate::quic::*;
@@ -243,10 +241,10 @@ mod tests {
         let builder = KeyBuilder::new(
             &secret,
             version,
-            TLS13_CHACHA20_POLY1305_SHA256_INTERNAL
+            TLS13_CHACHA20_POLY1305_SHA256
                 .quic
                 .unwrap(),
-            TLS13_CHACHA20_POLY1305_SHA256_INTERNAL.hkdf_provider,
+            TLS13_CHACHA20_POLY1305_SHA256.hkdf_provider,
         );
         let packet = builder.packet_key();
         let hpk = builder.header_protection_key();
@@ -317,10 +315,8 @@ mod tests {
                     0x4e, 0xb1, 0xe4, 0x38, 0xd8, 0x55,
                 ][..],
             ),
-            TLS13_AES_128_GCM_SHA256_INTERNAL,
-            TLS13_AES_128_GCM_SHA256_INTERNAL
-                .quic
-                .unwrap(),
+            TLS13_AES_128_GCM_SHA256,
+            TLS13_AES_128_GCM_SHA256.quic.unwrap(),
             Side::Client,
             Version::V1,
         );
@@ -366,10 +362,8 @@ mod tests {
         let icid = [0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08];
         let server = Keys::initial(
             Version::V2,
-            TLS13_AES_128_GCM_SHA256_INTERNAL,
-            TLS13_AES_128_GCM_SHA256_INTERNAL
-                .quic
-                .unwrap(),
+            TLS13_AES_128_GCM_SHA256,
+            TLS13_AES_128_GCM_SHA256.quic.unwrap(),
             &icid,
             Side::Server,
         );
@@ -447,10 +441,8 @@ mod tests {
         let builder = KeyBuilder::new(
             &secret,
             Version::V1,
-            TLS13_AES_128_GCM_SHA256_INTERNAL
-                .quic
-                .unwrap(),
-            TLS13_AES_128_GCM_SHA256_INTERNAL.hkdf_provider,
+            TLS13_AES_128_GCM_SHA256.quic.unwrap(),
+            TLS13_AES_128_GCM_SHA256.hkdf_provider,
         );
 
         let packet = builder.packet_key();
@@ -482,10 +474,8 @@ mod tests {
         let builder = KeyBuilder::new(
             &secret,
             Version::V1,
-            TLS13_AES_128_GCM_SHA256_INTERNAL
-                .quic
-                .unwrap(),
-            TLS13_AES_128_GCM_SHA256_INTERNAL.hkdf_provider,
+            TLS13_AES_128_GCM_SHA256.quic.unwrap(),
+            TLS13_AES_128_GCM_SHA256.hkdf_provider,
         );
         let packet = builder.packet_key();
 

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -13,99 +13,93 @@ use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
 use crate::msgs::message::{
     InboundPlainMessage, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload,
 };
-use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
+use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets};
 use crate::tls12::Tls12CipherSuite;
 use crate::version::TLS12_VERSION;
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256.
-pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-            hash_provider: &super::hash::SHA256,
-            confidentiality_limit: u64::MAX,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_ECDSA_SCHEMES,
-        aead_alg: &ChaCha20Poly1305,
-        prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
-    });
+pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: u64::MAX,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_ECDSA_SCHEMES,
+    aead_alg: &ChaCha20Poly1305,
+    prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-            hash_provider: &super::hash::SHA256,
-            confidentiality_limit: u64::MAX,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_RSA_SCHEMES,
-        aead_alg: &ChaCha20Poly1305,
-        prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
-    });
+pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: u64::MAX,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_RSA_SCHEMES,
+    aead_alg: &ChaCha20Poly1305,
+    prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-            hash_provider: &super::hash::SHA256,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_RSA_SCHEMES,
-        aead_alg: &AES128_GCM,
-        prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
-    });
+pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_RSA_SCHEMES,
+    aead_alg: &AES128_GCM,
+    prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-            hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_RSA_SCHEMES,
-        aead_alg: &AES256_GCM,
-        prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA384),
-    });
+pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        hash_provider: &super::hash::SHA384,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_RSA_SCHEMES,
+    aead_alg: &AES256_GCM,
+    prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA384),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            hash_provider: &super::hash::SHA256,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_ECDSA_SCHEMES,
-        aead_alg: &AES128_GCM,
-        prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
-    });
+pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_ECDSA_SCHEMES,
+    aead_alg: &AES128_GCM,
+    prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
+};
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
-    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-            hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS12_VERSION,
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_ECDSA_SCHEMES,
-        aead_alg: &AES256_GCM,
-        prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA384),
-    });
+pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: &Tls12CipherSuite = &Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        hash_provider: &super::hash::SHA384,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS12_VERSION,
+    kx: KeyExchangeAlgorithm::ECDHE,
+    sign: TLS12_ECDSA_SCHEMES,
+    aead_alg: &AES256_GCM,
+    prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA384),
+};
 
 static TLS12_ECDSA_SCHEMES: &[SignatureScheme] = &[
     SignatureScheme::ED25519,

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -13,15 +13,12 @@ use crate::error::Error;
 use crate::msgs::message::{
     InboundPlainMessage, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload,
 };
-use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets, SupportedCipherSuite};
+use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets};
 use crate::tls13::Tls13CipherSuite;
 use crate::version::TLS13_VERSION;
 
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256
-pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls13(TLS13_CHACHA20_POLY1305_SHA256_INTERNAL);
-
-pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13CipherSuite {
+pub static TLS13_CHACHA20_POLY1305_SHA256: &Tls13CipherSuite = &Tls13CipherSuite {
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
         hash_provider: &super::hash::SHA256,
@@ -42,31 +39,27 @@ pub(crate) static TLS13_CHACHA20_POLY1305_SHA256_INTERNAL: &Tls13CipherSuite = &
 };
 
 /// The TLS1.3 ciphersuite TLS_AES_256_GCM_SHA384
-pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
-    SupportedCipherSuite::Tls13(&Tls13CipherSuite {
-        common: CipherSuiteCommon {
-            suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
-            hash_provider: &super::hash::SHA384,
-            confidentiality_limit: 1 << 24,
-        },
-        protocol_version: TLS13_VERSION,
-        hkdf_provider: &RingHkdf(hkdf::HKDF_SHA384, hmac::HMAC_SHA384),
-        aead_alg: &Aes256GcmAead(AeadAlgorithm(&aead::AES_256_GCM)),
-        quic: Some(&super::quic::KeyBuilder {
-            packet_alg: &aead::AES_256_GCM,
-            header_alg: &aead::quic::AES_256,
-            // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.1>
-            confidentiality_limit: 1 << 23,
-            // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.2>
-            integrity_limit: 1 << 52,
-        }),
-    });
+pub static TLS13_AES_256_GCM_SHA384: &Tls13CipherSuite = &Tls13CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
+        hash_provider: &super::hash::SHA384,
+        confidentiality_limit: 1 << 24,
+    },
+    protocol_version: TLS13_VERSION,
+    hkdf_provider: &RingHkdf(hkdf::HKDF_SHA384, hmac::HMAC_SHA384),
+    aead_alg: &Aes256GcmAead(AeadAlgorithm(&aead::AES_256_GCM)),
+    quic: Some(&super::quic::KeyBuilder {
+        packet_alg: &aead::AES_256_GCM,
+        header_alg: &aead::quic::AES_256,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.1>
+        confidentiality_limit: 1 << 23,
+        // ref: <https://datatracker.ietf.org/doc/html/rfc9001#section-b.1.2>
+        integrity_limit: 1 << 52,
+    }),
+};
 
 /// The TLS1.3 ciphersuite TLS_AES_128_GCM_SHA256
-pub static TLS13_AES_128_GCM_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite::Tls13(TLS13_AES_128_GCM_SHA256_INTERNAL);
-
-pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13CipherSuite {
+pub static TLS13_AES_128_GCM_SHA256: &Tls13CipherSuite = &Tls13CipherSuite {
     common: CipherSuiteCommon {
         suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
         hash_provider: &super::hash::SHA256,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -379,9 +379,7 @@ impl ExpectClientHello {
         let client_suites = self
             .config
             .provider
-            .cipher_suites
-            .iter()
-            .copied()
+            .iter_cipher_suites()
             .filter(|scs| {
                 client_hello
                     .cipher_suites
@@ -581,8 +579,7 @@ impl ExpectClientHello {
         let mut suitable_suites_iter = self
             .config
             .provider
-            .cipher_suites
-            .iter()
+            .iter_cipher_suites()
             .filter(|suite| {
                 // Reduce our supported ciphersuites by the certified key's algorithm.
                 suite.usable_for_signature_algorithm(sig_key_algorithm)
@@ -629,18 +626,18 @@ impl ExpectClientHello {
 
         if selected_version == ProtocolVersion::TLSv1_3 {
             // This unwrap is structurally guaranteed by the early return for `!ffdhe_possible && !ecdhe_possible`
-            return Ok((*suite, *maybe_skxg.unwrap()));
+            return Ok((suite, *maybe_skxg.unwrap()));
         }
 
         // For TLS1.2, the server can unilaterally choose a DHE group if it has one and
         // there was no better option.
         match maybe_skxg {
-            Some(skxg) => Ok((*suite, *skxg)),
+            Some(skxg) => Ok((suite, *skxg)),
             None if suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::DHE) => {
                 // If kx for the selected cipher suite is DHE and no DHE groups are specified in the extension,
                 // the server is free to choose DHE params, we choose the first DHE kx group of the provider.
                 if let Some(server_selected_ffdhe_skxg) = first_supported_dhe_kxg {
-                    Ok((*suite, *server_selected_ffdhe_skxg))
+                    Ok((suite, *server_selected_ffdhe_skxg))
                 } else {
                     Err(PeerIncompatible::NoKxGroupsInCommon)
                 }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -520,16 +520,14 @@ impl ServerConfig {
     /// also configured.
     pub(crate) fn supports_version(&self, v: ProtocolVersion) -> bool {
         self.provider
-            .cipher_suites
-            .iter()
+            .iter_cipher_suites()
             .any(|cs| cs.version().version() == v)
     }
 
     #[cfg(feature = "std")]
     pub(crate) fn supports_protocol(&self, proto: Protocol) -> bool {
         self.provider
-            .cipher_suites
-            .iter()
+            .iter_cipher_suites()
             .any(|cs| cs.usable_for_protocol(proto))
     }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -515,13 +515,8 @@ impl ServerConfig {
         &self.provider
     }
 
-    /// We support a given TLS version if it's quoted in the configured
-    /// versions *and* at least one ciphersuite for this version is
-    /// also configured.
     pub(crate) fn supports_version(&self, v: ProtocolVersion) -> bool {
-        self.provider
-            .iter_cipher_suites()
-            .any(|cs| cs.version().version() == v)
+        self.provider.supports_version(v)
     }
 
     #[cfg(feature = "std")]

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -116,16 +116,10 @@ impl SupportedCipherSuite {
     }
 
     /// Return true if this suite is usable for the given [`Protocol`].
-    ///
-    /// All cipher suites are usable for TCP-TLS.  Only TLS1.3 suites
-    /// with `Tls13CipherSuite::quic` provided are usable for QUIC.
     pub(crate) fn usable_for_protocol(&self, proto: Protocol) -> bool {
-        match proto {
-            Protocol::Tcp => true,
-            Protocol::Quic => self
-                .tls13()
-                .and_then(|cs| cs.quic)
-                .is_some(),
+        match self {
+            Self::Tls12(tls12) => tls12.usable_for_protocol(proto),
+            Self::Tls13(tls13) => tls13.usable_for_protocol(proto),
         }
     }
 

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -105,13 +105,10 @@ impl SupportedCipherSuite {
 
     /// Return true if this suite is usable for a key only offering `sig_alg`
     /// signatures.  This resolves to true for all TLS1.3 suites.
-    pub fn usable_for_signature_algorithm(&self, _sig_alg: SignatureAlgorithm) -> bool {
+    pub fn usable_for_signature_algorithm(&self, sig_alg: SignatureAlgorithm) -> bool {
         match self {
-            Self::Tls13(_) => true, // no constraint expressed by ciphersuite (e.g., TLS1.3)
-            Self::Tls12(inner) => inner
-                .sign
-                .iter()
-                .any(|scheme| scheme.algorithm() == _sig_alg),
+            Self::Tls12(tls12) => tls12.usable_for_signature_algorithm(sig_alg),
+            Self::Tls13(_) => true,
         }
     }
 

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -239,26 +239,26 @@ mod tests {
     use std::println;
 
     use super::provider::tls13::*;
+    use crate::SupportedCipherSuite;
 
     #[test]
     fn test_scs_is_debug() {
-        println!("{:?}", super::provider::ALL_CIPHER_SUITES);
+        println!(
+            "{:?}",
+            SupportedCipherSuite::Tls13(TLS13_AES_128_GCM_SHA256)
+        );
     }
 
     #[test]
     fn test_can_resume_to() {
         assert!(
             TLS13_AES_128_GCM_SHA256
-                .tls13()
-                .unwrap()
-                .can_resume_from(TLS13_CHACHA20_POLY1305_SHA256_INTERNAL)
+                .can_resume_from(TLS13_CHACHA20_POLY1305_SHA256)
                 .is_some()
         );
         assert!(
             TLS13_AES_256_GCM_SHA384
-                .tls13()
-                .unwrap()
-                .can_resume_from(TLS13_CHACHA20_POLY1305_SHA256_INTERNAL)
+                .can_resume_from(TLS13_CHACHA20_POLY1305_SHA256)
                 .is_none()
         );
     }

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -4,7 +4,6 @@ use crate::common_state::Protocol;
 use crate::crypto::cipher::{AeadKey, Iv};
 use crate::crypto::{self, KeyExchangeAlgorithm};
 use crate::enums::{CipherSuite, SignatureAlgorithm, SignatureScheme};
-use crate::msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS;
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
 use crate::versions::SupportedProtocolVersion;
@@ -135,17 +134,6 @@ impl SupportedCipherSuite {
         match self {
             Self::Tls12(cs) => cs.fips(),
             Self::Tls13(cs) => cs.fips(),
-        }
-    }
-
-    /// Return the list of `KeyExchangeAlgorithm`s supported by this cipher suite.
-    ///
-    /// TLS 1.3 cipher suites support both ECDHE and DHE key exchange, but TLS 1.2 suites
-    /// support one or the other.
-    pub(crate) fn key_exchange_algorithms(&self) -> &[KeyExchangeAlgorithm] {
-        match self {
-            Self::Tls12(tls12) => core::slice::from_ref(&tls12.kx),
-            Self::Tls13(_) => ALL_KEY_EXCHANGE_ALGORITHMS,
         }
     }
 

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -132,9 +132,9 @@ impl SupportedCipherSuite {
     ///
     /// TLS 1.3 cipher suites support all key exchange types, but TLS 1.2 suites
     /// support only one.
-    pub(crate) fn usable_for_kx_algorithm(&self, _kxa: KeyExchangeAlgorithm) -> bool {
+    pub(crate) fn usable_for_kx_algorithm(&self, kxa: KeyExchangeAlgorithm) -> bool {
         match self {
-            Self::Tls12(tls12) => tls12.kx == _kxa,
+            Self::Tls12(tls12) => tls12.usable_for_kx_algorithm(kxa),
             Self::Tls13(_) => true,
         }
     }

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -5,7 +5,7 @@ use core::fmt;
 
 use zeroize::{Zeroize, Zeroizing};
 
-use crate::common_state::{CommonState, Side};
+use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::ConnectionRandoms;
 use crate::crypto;
 use crate::crypto::cipher::{AeadKey, MessageDecrypter, MessageEncrypter, Tls12AeadAlgorithm};
@@ -82,6 +82,13 @@ impl Tls12CipherSuite {
     /// This means all the constituent parts that do cryptography return `true` for `fips()`.
     pub fn fips(&self) -> bool {
         self.common.fips() && self.prf_provider.fips() && self.aead_alg.fips()
+    }
+
+    /// Does this suite support the `proto` protocol?
+    ///
+    /// All TLS1.2 suites support TCP-TLS. No TLS1.2 suites support QUIC.
+    pub(crate) fn usable_for_protocol(&self, proto: Protocol) -> bool {
+        matches!(proto, Protocol::Tcp)
     }
 }
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -7,7 +7,6 @@ use zeroize::{Zeroize, Zeroizing};
 
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::ConnectionRandoms;
-use crate::crypto;
 use crate::crypto::cipher::{AeadKey, MessageDecrypter, MessageEncrypter, Tls12AeadAlgorithm};
 use crate::crypto::hash;
 use crate::enums::{AlertDescription, SignatureScheme};
@@ -16,6 +15,7 @@ use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::handshake::{KeyExchangeAlgorithm, KxDecode};
 use crate::suites::{CipherSuiteCommon, PartiallyExtractedSecrets, SupportedCipherSuite};
 use crate::version::Tls12Version;
+use crate::{SignatureAlgorithm, crypto};
 
 /// A TLS 1.2 cipher suite supported by rustls.
 #[allow(clippy::exhaustive_structs)]
@@ -89,6 +89,14 @@ impl Tls12CipherSuite {
     /// All TLS1.2 suites support TCP-TLS. No TLS1.2 suites support QUIC.
     pub(crate) fn usable_for_protocol(&self, proto: Protocol) -> bool {
         matches!(proto, Protocol::Tcp)
+    }
+
+    /// Return true if this suite is usable for a key only offering `sig_alg`
+    /// signatures.
+    pub(crate) fn usable_for_signature_algorithm(&self, sig_alg: SignatureAlgorithm) -> bool {
+        self.sign
+            .iter()
+            .any(|scheme| scheme.algorithm() == sig_alg)
     }
 }
 

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -98,6 +98,11 @@ impl Tls12CipherSuite {
             .iter()
             .any(|scheme| scheme.algorithm() == sig_alg)
     }
+
+    /// Say if the given `KeyExchangeAlgorithm` is supported by this cipher suite.
+    pub(crate) fn usable_for_kx_algorithm(&self, kxa: KeyExchangeAlgorithm) -> bool {
+        self.kx == kxa
+    }
 }
 
 impl From<&'static Tls12CipherSuite> for SupportedCipherSuite {

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use crate::common_state::Protocol;
 use crate::crypto;
 use crate::crypto::hash;
 use crate::suites::{CipherSuiteCommon, SupportedCipherSuite};
@@ -77,6 +78,16 @@ impl Tls13CipherSuite {
     pub fn quic_suite(&'static self) -> Option<crate::quic::Suite> {
         self.quic
             .map(|quic| crate::quic::Suite { quic, suite: self })
+    }
+
+    /// Does this suite support the `proto` protocol?
+    ///
+    /// All TLS1.3 suites support TCP-TLS. QUIC support is conditional on `quic` slot.
+    pub(crate) fn usable_for_protocol(&self, proto: Protocol) -> bool {
+        match proto {
+            Protocol::Tcp => true,
+            Protocol::Quic => self.quic.is_some(),
+        }
     }
 }
 

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -3,10 +3,10 @@
 
 pub use std::sync::Arc;
 
-use rustls::RootCertStore;
 use rustls::client::{ClientConfig, ServerCertVerifierBuilder, WebPkiServerVerifier};
 use rustls::crypto::CryptoProvider;
 use rustls::server::{ClientCertVerifierBuilder, ServerConfig, WebPkiClientVerifier};
+use rustls::{RootCertStore, SupportedCipherSuite};
 pub use rustls_test::*;
 
 pub fn server_config_builder(
@@ -56,4 +56,34 @@ pub fn all_versions(provider: &CryptoProvider) -> impl Iterator<Item = CryptoPro
         provider.clone().with_only_tls13(),
     ]
     .into_iter()
+}
+
+pub fn provider_with_one_suite(
+    provider: &CryptoProvider,
+    suite: SupportedCipherSuite,
+) -> CryptoProvider {
+    provider_with_suites(provider, &[suite])
+}
+
+pub fn provider_with_suites(
+    provider: &CryptoProvider,
+    suites: &[SupportedCipherSuite],
+) -> CryptoProvider {
+    let mut provider = CryptoProvider {
+        tls12_cipher_suites: vec![],
+        tls13_cipher_suites: vec![],
+        ..provider.clone()
+    };
+    for suite in suites {
+        match suite {
+            SupportedCipherSuite::Tls12(suite) => {
+                provider.tls12_cipher_suites.push(suite);
+            }
+            SupportedCipherSuite::Tls13(suite) => {
+                provider.tls13_cipher_suites.push(suite);
+            }
+            _ => unreachable!(),
+        }
+    }
+    provider
 }


### PR DESCRIPTION
I experimented with a bunch of ways of doing this which didn't lead to One Big Commit (like, introducing new fields, and moving things over to using the new fields in successive commits, and then removing the old field) but it ended up with too much back-and-forth especially in tests.

fixes #1659 