### PR TITLE
Replace exporter API

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -1344,20 +1344,22 @@ fn exec(opts: &Options, mut sess: Connection, key_log: &KeyLogMemo, count: usize
 
         if !sess.is_handshaking() && opts.export_keying_material > 0 && !sent_exporter {
             let mut export = vec![0; opts.export_keying_material];
-            sess.export_keying_material(
-                &mut export,
-                opts.export_keying_material_label
-                    .as_bytes(),
-                if opts.export_keying_material_context_used {
-                    Some(
-                        opts.export_keying_material_context
-                            .as_bytes(),
-                    )
-                } else {
-                    None
-                },
-            )
-            .unwrap();
+            sess.exporter()
+                .unwrap()
+                .export_keying_material(
+                    &mut export,
+                    opts.export_keying_material_label
+                        .as_bytes(),
+                    if opts.export_keying_material_context_used {
+                        Some(
+                            opts.export_keying_material_context
+                                .as_bytes(),
+                        )
+                    } else {
+                        None
+                    },
+                )
+                .unwrap();
             sess.writer()
                 .write_all(&export)
                 .unwrap();

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1360,13 +1360,14 @@ impl State<ClientConnectionData> for ExpectTraffic {
         Ok(())
     }
 
-    fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
-        self.secrets
-            .extract_secrets(Side::Client)
-    }
-
-    fn into_external_state(self: Box<Self>) -> Result<Box<dyn KernelState + 'static>, Error> {
-        Ok(self)
+    fn into_external_state(
+        self: Box<Self>,
+    ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {
+        Ok((
+            self.secrets
+                .extract_secrets(Side::Client)?,
+            self,
+        ))
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1293,7 +1293,14 @@ impl State<ClientConnectionData> for ExpectFinished {
 
         cx.common
             .start_traffic(&mut cx.sendable_plaintext);
+
+        let extracted_secrets = match st.config.enable_secret_extraction {
+            true => Some(st.secrets.extract_secrets(Side::Client)),
+            false => None,
+        };
+
         Ok(Box::new(ExpectTraffic {
+            extracted_secrets,
             secrets: st.secrets,
             _cert_verified: st.cert_verified,
             _sig_verified: st.sig_verified,
@@ -1320,6 +1327,8 @@ impl State<ClientConnectionData> for ExpectFinished {
 
 // -- Traffic transit state --
 struct ExpectTraffic {
+    // only available if `config.enable_secret_extraction` is true
+    extracted_secrets: Option<Result<PartiallyExtractedSecrets, Error>>,
     secrets: ConnectionSecrets,
     _cert_verified: verify::ServerCertVerified,
     _sig_verified: verify::HandshakeSignatureValid,
@@ -1361,13 +1370,13 @@ impl State<ClientConnectionData> for ExpectTraffic {
     }
 
     fn into_external_state(
-        self: Box<Self>,
+        mut self: Box<Self>,
     ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {
-        Ok((
-            self.secrets
-                .extract_secrets(Side::Client)?,
-            self,
-        ))
+        let extracted_secrets = self
+            .extracted_secrets
+            .take()
+            .expect("into_external_state() => enable_secret_extraction")?;
+        Ok((extracted_secrets, self))
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -15,8 +15,8 @@ use crate::client::{ClientConfig, ClientSessionStore, hs};
 use crate::common_state::{
     CommonState, HandshakeFlightTls13, HandshakeKind, KxState, Protocol, Side, State,
 };
-use crate::conn::ConnectionRandoms;
 use crate::conn::kernel::{Direction, KernelContext, KernelState};
+use crate::conn::{BytesExporter, ConnectionRandoms};
 use crate::crypto::hash::Hash;
 use crate::crypto::{ActiveKeyExchange, SharedSecret};
 use crate::enums::{
@@ -42,8 +42,8 @@ use crate::sign::{CertifiedKey, Signer};
 use crate::suites::PartiallyExtractedSecrets;
 use crate::sync::Arc;
 use crate::tls13::key_schedule::{
-    KeyScheduleEarly, KeyScheduleHandshake, KeySchedulePreHandshake, KeyScheduleResumption,
-    KeyScheduleTraffic,
+    KeyScheduleEarly, KeyScheduleExporter, KeyScheduleHandshake, KeySchedulePreHandshake,
+    KeyScheduleResumption, KeyScheduleTraffic,
 };
 use crate::tls13::{
     Tls13CipherSuite, construct_client_verify_message, construct_server_verify_message,
@@ -1450,7 +1450,7 @@ impl State<ClientConnectionData> for ExpectFinished {
 
         /* Now move to our application traffic keys. */
         cx.common.check_aligned_handshake()?;
-        let (key_schedule, resumption) =
+        let (key_schedule, exporter, resumption) =
             key_schedule_pre_finished.into_traffic(cx.common, st.transcript.current_hash());
         cx.common
             .start_traffic(&mut cx.sendable_plaintext);
@@ -1469,6 +1469,7 @@ impl State<ClientConnectionData> for ExpectFinished {
             suite: st.suite,
             key_schedule,
             resumption,
+            exporter,
             _cert_verified: st.cert_verified,
             _sig_verified: st.sig_verified,
             _fin_verified: fin,
@@ -1495,6 +1496,7 @@ struct ExpectTraffic {
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTraffic,
     resumption: KeyScheduleResumption,
+    exporter: KeyScheduleExporter,
     _cert_verified: verify::ServerCertVerified,
     _sig_verified: verify::HandshakeSignatureValid,
     _fin_verified: verify::FinishedMessageVerified,
@@ -1635,7 +1637,7 @@ impl State<ClientConnectionData> for ExpectTraffic {
         label: &[u8],
         context: Option<&[u8]>,
     ) -> Result<(), Error> {
-        self.key_schedule
+        self.exporter
             .export_keying_material(output, label, context)
     }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -15,8 +15,8 @@ use crate::client::{ClientConfig, ClientSessionStore, hs};
 use crate::common_state::{
     CommonState, HandshakeFlightTls13, HandshakeKind, KxState, Protocol, Side, State,
 };
+use crate::conn::ConnectionRandoms;
 use crate::conn::kernel::{Direction, KernelContext, KernelState};
-use crate::conn::{BytesExporter, ConnectionRandoms};
 use crate::crypto::hash::Hash;
 use crate::crypto::{ActiveKeyExchange, SharedSecret};
 use crate::enums::{
@@ -42,8 +42,8 @@ use crate::sign::{CertifiedKey, Signer};
 use crate::suites::PartiallyExtractedSecrets;
 use crate::sync::Arc;
 use crate::tls13::key_schedule::{
-    KeyScheduleEarly, KeyScheduleExporter, KeyScheduleHandshake, KeySchedulePreHandshake,
-    KeyScheduleResumption, KeyScheduleTraffic,
+    KeyScheduleEarly, KeyScheduleHandshake, KeySchedulePreHandshake, KeyScheduleResumption,
+    KeyScheduleTraffic,
 };
 use crate::tls13::{
     Tls13CipherSuite, construct_client_verify_message, construct_server_verify_message,
@@ -1454,6 +1454,7 @@ impl State<ClientConnectionData> for ExpectFinished {
             key_schedule_pre_finished.into_traffic(cx.common, st.transcript.current_hash());
         cx.common
             .start_traffic(&mut cx.sendable_plaintext);
+        cx.common.exporter = Some(Box::new(exporter));
 
         // Now that we've reached the end of the normal handshake we must enforce ECH acceptance by
         // sending an alert and returning an error (potentially with retry configs) if the server
@@ -1469,7 +1470,6 @@ impl State<ClientConnectionData> for ExpectFinished {
             suite: st.suite,
             key_schedule,
             resumption,
-            exporter,
             _cert_verified: st.cert_verified,
             _sig_verified: st.sig_verified,
             _fin_verified: fin,
@@ -1496,7 +1496,6 @@ struct ExpectTraffic {
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTraffic,
     resumption: KeyScheduleResumption,
-    exporter: KeyScheduleExporter,
     _cert_verified: verify::ServerCertVerified,
     _sig_verified: verify::HandshakeSignatureValid,
     _fin_verified: verify::FinishedMessageVerified,
@@ -1631,16 +1630,6 @@ impl State<ClientConnectionData> for ExpectTraffic {
             .request_key_update_and_update_encrypter(common)
     }
 
-    fn export_keying_material(
-        &self,
-        output: &mut [u8],
-        label: &[u8],
-        context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        self.exporter
-            .export_keying_material(output, label, context)
-    }
-
     fn into_external_state(
         self: Box<Self>,
     ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {
@@ -1693,16 +1682,6 @@ impl State<ClientConnectionData> for ExpectQuicTraffic {
         self.0
             .handle_new_ticket_tls13(cx, nst)?;
         Ok(self)
-    }
-
-    fn export_keying_material(
-        &self,
-        output: &mut [u8],
-        label: &[u8],
-        context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        self.0
-            .export_keying_material(output, label, context)
     }
 
     fn into_external_state(

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1639,13 +1639,14 @@ impl State<ClientConnectionData> for ExpectTraffic {
             .export_keying_material(output, label, context)
     }
 
-    fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
-        self.key_schedule
-            .extract_secrets(Side::Client)
-    }
-
-    fn into_external_state(self: Box<Self>) -> Result<Box<dyn KernelState + 'static>, Error> {
-        Ok(self)
+    fn into_external_state(
+        self: Box<Self>,
+    ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {
+        Ok((
+            self.key_schedule
+                .extract_secrets(Side::Client)?,
+            self,
+        ))
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
@@ -1702,8 +1703,15 @@ impl State<ClientConnectionData> for ExpectQuicTraffic {
             .export_keying_material(output, label, context)
     }
 
-    fn into_external_state(self: Box<Self>) -> Result<Box<dyn KernelState + 'static>, Error> {
-        Ok(self)
+    fn into_external_state(
+        self: Box<Self>,
+    ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {
+        Ok((
+            self.0
+                .key_schedule
+                .extract_secrets(Side::Client)?,
+            self,
+        ))
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use pki_types::CertificateDer;
 
+use crate::conn::BytesExporter;
 use crate::conn::kernel::KernelState;
 use crate::crypto::SupportedKxGroup;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
@@ -35,6 +36,7 @@ pub struct CommonState {
     pub(crate) suite: Option<SupportedCipherSuite>,
     pub(crate) kx_state: KxState,
     pub(crate) alpn_protocol: Option<ProtocolName>,
+    pub(crate) exporter: Option<Box<dyn BytesExporter>>,
     pub(crate) aligned_handshake: bool,
     pub(crate) may_send_application_data: bool,
     pub(crate) may_receive_application_data: bool,
@@ -72,6 +74,7 @@ impl CommonState {
             suite: None,
             kx_state: KxState::default(),
             alpn_protocol: None,
+            exporter: None,
             aligned_handshake: true,
             may_send_application_data: false,
             may_receive_application_data: false,
@@ -849,15 +852,6 @@ pub(crate) trait State<Data>: Send + Sync {
     ) -> Result<Box<dyn State<Data> + 'm>, Error>
     where
         Self: 'm;
-
-    fn export_keying_material(
-        &self,
-        _output: &mut [u8],
-        _label: &[u8],
-        _context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        Err(Error::HandshakeNotComplete)
-    }
 
     fn send_key_update_request(&mut self, _common: &mut CommonState) -> Result<(), Error> {
         Err(Error::HandshakeNotComplete)

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -859,17 +859,15 @@ pub(crate) trait State<Data>: Send + Sync {
         Err(Error::HandshakeNotComplete)
     }
 
-    fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
-        Err(Error::HandshakeNotComplete)
-    }
-
     fn send_key_update_request(&mut self, _common: &mut CommonState) -> Result<(), Error> {
         Err(Error::HandshakeNotComplete)
     }
 
     fn handle_decrypt_error(&self) {}
 
-    fn into_external_state(self: Box<Self>) -> Result<Box<dyn KernelState + 'static>, Error> {
+    fn into_external_state(
+        self: Box<Self>,
+    ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {
         Err(Error::HandshakeNotComplete)
     }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1182,13 +1182,12 @@ impl<Data> ConnectionCore<Data> {
         let state = self.state?;
 
         let record_layer = &self.common_state.record_layer;
-        let secrets = state.extract_secrets()?;
+
+        let (secrets, state) = state.into_external_state()?;
         let secrets = ExtractedSecrets {
             tx: (record_layer.write_seq(), secrets.tx),
             rx: (record_layer.read_seq(), secrets.rx),
         };
-
-        let state = state.into_external_state()?;
         let external = KernelConnection::new(state, self.common_state)?;
 
         Ok((secrets, external))

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -358,6 +358,22 @@ https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof"
 #[cfg(feature = "std")]
 pub use connection::{Connection, Reader, Writer};
 
+/// This trait is for any object that can export keying material.
+///
+/// There are several such internal implementations, depending on the context
+/// and protocol version.
+pub(crate) trait BytesExporter: Send + Sync {
+    /// Fills in `output` with keying material.
+    ///
+    /// Must fill in `output` entirely, or return an error.
+    fn export_keying_material(
+        &self,
+        output: &mut [u8],
+        label: &[u8],
+        context: Option<&[u8]>,
+    ) -> Result<(), Error>;
+}
+
 #[derive(Debug)]
 pub(crate) struct ConnectionRandoms {
     pub(crate) client: [u8; 32],

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -13,8 +13,8 @@ use super::hs::{self, ServerContext};
 use super::server_conn::{ProducesTickets, ServerConfig, ServerConnectionData};
 use crate::check::inappropriate_message;
 use crate::common_state::{CommonState, HandshakeFlightTls12, HandshakeKind, Side, State};
-use crate::conn::ConnectionRandoms;
 use crate::conn::kernel::{Direction, KernelContext, KernelState};
+use crate::conn::{BytesExporter, ConnectionRandoms};
 use crate::crypto::ActiveKeyExchange;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
@@ -959,7 +959,7 @@ impl State<ServerConnectionData> for ExpectFinished {
 
         Ok(Box::new(ExpectTraffic {
             extracted_secrets,
-            secrets: self.secrets,
+            exporter: self.secrets.into_exporter(),
             _fin_verified,
         }))
     }
@@ -973,7 +973,7 @@ impl State<ServerConnectionData> for ExpectFinished {
 struct ExpectTraffic {
     // only available if `config.enable_secret_extraction` is true
     extracted_secrets: Option<Result<PartiallyExtractedSecrets, Error>>,
-    secrets: ConnectionSecrets,
+    exporter: Box<dyn BytesExporter>,
     _fin_verified: verify::FinishedMessageVerified,
 }
 
@@ -1008,9 +1008,8 @@ impl State<ServerConnectionData> for ExpectTraffic {
         label: &[u8],
         context: Option<&[u8]>,
     ) -> Result<(), Error> {
-        self.secrets
-            .export_keying_material(output, label, context);
-        Ok(())
+        self.exporter
+            .export_keying_material(output, label, context)
     }
 
     fn into_external_state(

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1001,13 +1001,14 @@ impl State<ServerConnectionData> for ExpectTraffic {
         Ok(())
     }
 
-    fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
-        self.secrets
-            .extract_secrets(Side::Server)
-    }
-
-    fn into_external_state(self: Box<Self>) -> Result<Box<dyn KernelState + 'static>, Error> {
-        Ok(self)
+    fn into_external_state(
+        self: Box<Self>,
+    ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {
+        Ok((
+            self.secrets
+                .extract_secrets(Side::Server)?,
+            self,
+        ))
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -13,8 +13,8 @@ use super::hs::{self, ServerContext};
 use super::server_conn::{ProducesTickets, ServerConfig, ServerConnectionData};
 use crate::check::inappropriate_message;
 use crate::common_state::{CommonState, HandshakeFlightTls12, HandshakeKind, Side, State};
+use crate::conn::ConnectionRandoms;
 use crate::conn::kernel::{Direction, KernelContext, KernelState};
-use crate::conn::{BytesExporter, ConnectionRandoms};
 use crate::crypto::ActiveKeyExchange;
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
@@ -957,9 +957,10 @@ impl State<ServerConnectionData> for ExpectFinished {
             false => None,
         };
 
+        cx.common.exporter = Some(self.secrets.into_exporter());
+
         Ok(Box::new(ExpectTraffic {
             extracted_secrets,
-            exporter: self.secrets.into_exporter(),
             _fin_verified,
         }))
     }
@@ -973,7 +974,6 @@ impl State<ServerConnectionData> for ExpectFinished {
 struct ExpectTraffic {
     // only available if `config.enable_secret_extraction` is true
     extracted_secrets: Option<Result<PartiallyExtractedSecrets, Error>>,
-    exporter: Box<dyn BytesExporter>,
     _fin_verified: verify::FinishedMessageVerified,
 }
 
@@ -1000,16 +1000,6 @@ impl State<ServerConnectionData> for ExpectTraffic {
             }
         }
         Ok(self)
-    }
-
-    fn export_keying_material(
-        &self,
-        output: &mut [u8],
-        label: &[u8],
-        context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        self.exporter
-            .export_keying_material(output, label, context)
     }
 
     fn into_external_state(

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -13,8 +13,8 @@ use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::common_state::{
     CommonState, HandshakeFlightTls13, HandshakeKind, Protocol, Side, State,
 };
+use crate::conn::ConnectionRandoms;
 use crate::conn::kernel::{Direction, KernelContext, KernelState};
-use crate::conn::{BytesExporter, ConnectionRandoms};
 use crate::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use crate::hash_hs::HandshakeHash;
@@ -31,8 +31,7 @@ use crate::server::ServerConfig;
 use crate::suites::PartiallyExtractedSecrets;
 use crate::sync::Arc;
 use crate::tls13::key_schedule::{
-    KeyScheduleExporter, KeyScheduleResumption, KeyScheduleTraffic,
-    KeyScheduleTrafficWithClientFinishedPending,
+    KeyScheduleResumption, KeyScheduleTraffic, KeyScheduleTrafficWithClientFinishedPending,
 };
 use crate::tls13::{
     Tls13CipherSuite, construct_client_verify_message, construct_server_verify_message,
@@ -1393,15 +1392,12 @@ impl State<ServerConnectionData> for ExpectFinished {
         // Application data may now flow, even if we have client auth enabled.
         cx.common
             .start_traffic(&mut cx.sendable_plaintext);
+        cx.common.exporter = Some(Box::new(exporter));
 
         Ok(match cx.common.is_quic() {
-            true => Box::new(ExpectQuicTraffic {
-                exporter,
-                _fin_verified: fin,
-            }),
+            true => Box::new(ExpectQuicTraffic { _fin_verified: fin }),
             false => Box::new(ExpectTraffic {
                 key_schedule: key_schedule_traffic,
-                exporter,
                 _fin_verified: fin,
             }),
         })
@@ -1415,7 +1411,6 @@ impl State<ServerConnectionData> for ExpectFinished {
 // --- Process traffic ---
 struct ExpectTraffic {
     key_schedule: KeyScheduleTraffic,
-    exporter: KeyScheduleExporter,
     _fin_verified: verify::FinishedMessageVerified,
 }
 
@@ -1475,16 +1470,6 @@ impl State<ServerConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
-    fn export_keying_material(
-        &self,
-        output: &mut [u8],
-        label: &[u8],
-        context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        self.exporter
-            .export_keying_material(output, label, context)
-    }
-
     fn send_key_update_request(&mut self, common: &mut CommonState) -> Result<(), Error> {
         self.key_schedule
             .request_key_update_and_update_encrypter(common)
@@ -1526,7 +1511,6 @@ impl KernelState for ExpectTraffic {
 }
 
 struct ExpectQuicTraffic {
-    exporter: KeyScheduleExporter,
     _fin_verified: verify::FinishedMessageVerified,
 }
 
@@ -1541,16 +1525,6 @@ impl State<ServerConnectionData> for ExpectQuicTraffic {
     {
         // reject all messages
         Err(inappropriate_message(&m.payload, &[]))
-    }
-
-    fn export_keying_material(
-        &self,
-        output: &mut [u8],
-        label: &[u8],
-        context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        self.exporter
-            .export_keying_material(output, label, context)
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1482,18 +1482,19 @@ impl State<ServerConnectionData> for ExpectTraffic {
             .export_keying_material(output, label, context)
     }
 
-    fn extract_secrets(&self) -> Result<PartiallyExtractedSecrets, Error> {
-        self.key_schedule
-            .extract_secrets(Side::Server)
-    }
-
     fn send_key_update_request(&mut self, common: &mut CommonState) -> Result<(), Error> {
         self.key_schedule
             .request_key_update_and_update_encrypter(common)
     }
 
-    fn into_external_state(self: Box<Self>) -> Result<Box<dyn KernelState + 'static>, Error> {
-        Ok(self)
+    fn into_external_state(
+        self: Box<Self>,
+    ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {
+        Ok((
+            self.key_schedule
+                .extract_secrets(Side::Server)?,
+            self,
+        ))
     }
 
     fn into_owned(self: Box<Self>) -> hs::NextState<'static> {

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -3,7 +3,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt;
 
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroizing;
 
 use crate::common_state::{CommonState, Side};
 use crate::conn::ConnectionRandoms;
@@ -109,7 +109,7 @@ impl fmt::Debug for Tls12CipherSuite {
 pub(crate) struct ConnectionSecrets {
     pub(crate) randoms: ConnectionRandoms,
     suite: &'static Tls12CipherSuite,
-    master_secret: [u8; 48],
+    master_secret: Zeroizing<[u8; 48]>,
     master_secret_prf: Box<dyn crypto::tls12::PrfSecret>,
 }
 
@@ -141,6 +141,7 @@ impl ConnectionSecrets {
             label.as_bytes(),
             seed.as_ref(),
         )?;
+        let master_secret = Zeroizing::new(master_secret);
 
         let master_secret_prf = suite
             .prf_provider
@@ -162,7 +163,7 @@ impl ConnectionSecrets {
         Self {
             randoms,
             suite,
-            master_secret: *master_secret,
+            master_secret: Zeroizing::new(*master_secret),
             master_secret_prf: suite
                 .prf_provider
                 .new_secret(master_secret),
@@ -291,12 +292,6 @@ impl ConnectionSecrets {
             Side::Server => (server_secrets, client_secrets),
         };
         Ok(PartiallyExtractedSecrets { tx, rx })
-    }
-}
-
-impl Drop for ConnectionSecrets {
-    fn drop(&mut self) {
-        self.master_secret.zeroize();
     }
 }
 

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -5,6 +5,7 @@ use alloc::string::ToString;
 use core::ops::Deref;
 
 use crate::common_state::{CommonState, Side};
+use crate::conn::BytesExporter;
 use crate::crypto::cipher::{AeadKey, Iv, MessageDecrypter, Tls13AeadAlgorithm};
 use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError, expand};
 use crate::crypto::{SharedSecret, hash, hmac};
@@ -403,7 +404,11 @@ impl KeyScheduleBeforeFinished {
     pub(crate) fn into_traffic(
         self,
         hs_hash: hash::Output,
-    ) -> (KeyScheduleTraffic, KeyScheduleResumption) {
+    ) -> (
+        KeyScheduleTraffic,
+        KeyScheduleExporter,
+        KeyScheduleResumption,
+    ) {
         let Self {
             ks,
             current_client_traffic_secret,
@@ -419,6 +424,9 @@ impl KeyScheduleBeforeFinished {
                 ks: ks.inner,
                 current_client_traffic_secret,
                 current_server_traffic_secret,
+            },
+            KeyScheduleExporter {
+                ks: ks.inner,
                 current_exporter_secret,
             },
             KeyScheduleResumption {
@@ -441,7 +449,11 @@ impl KeyScheduleClientBeforeFinished {
         self,
         common: &mut CommonState,
         hs_hash: hash::Output,
-    ) -> (KeyScheduleTraffic, KeyScheduleResumption) {
+    ) -> (
+        KeyScheduleTraffic,
+        KeyScheduleExporter,
+        KeyScheduleResumption,
+    ) {
         let next = self.0;
 
         debug_assert_eq!(common.side, Side::Client);
@@ -515,7 +527,6 @@ pub(crate) struct KeyScheduleTraffic {
     ks: KeyScheduleSuite,
     current_client_traffic_secret: OkmBlock,
     current_server_traffic_secret: OkmBlock,
-    current_exporter_secret: OkmBlock,
 }
 
 impl KeyScheduleTraffic {
@@ -550,16 +561,6 @@ impl KeyScheduleTraffic {
         let secret = self.ks.derive_next(current);
         *current = secret.clone();
         secret
-    }
-
-    pub(crate) fn export_keying_material(
-        &self,
-        out: &mut [u8],
-        label: &[u8],
-        context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        self.ks
-            .export_keying_material(&self.current_exporter_secret, out, label, context)
     }
 
     pub(crate) fn refresh_traffic_secret(
@@ -606,6 +607,23 @@ impl KeyScheduleTraffic {
             Side::Server => (server_secrets, client_secrets),
         };
         Ok(PartiallyExtractedSecrets { tx, rx })
+    }
+}
+
+pub(crate) struct KeyScheduleExporter {
+    ks: KeyScheduleSuite,
+    current_exporter_secret: OkmBlock,
+}
+
+impl BytesExporter for KeyScheduleExporter {
+    fn export_keying_material(
+        &self,
+        out: &mut [u8],
+        label: &[u8],
+        context: Option<&[u8]>,
+    ) -> Result<(), Error> {
+        self.ks
+            .export_keying_material(&self.current_exporter_secret, out, label, context)
     }
 }
 


### PR DESCRIPTION
This represents the exporter key material inside its own object, where the application controls the lifetime.  The application chooses when to take the object, and can do that at most once for a given connection.

The application can choose to keep the object alive indefinitely alongside the connection to obtain an equivalent to the previous behaviour.

An application that does nothing with exporters means the lifetime is as long as the connection (as before) which is OK because a secret which is used for nothing has no value.

This also makes it easier to do #2406, I think.

fixes #945 and follows the suggestion made in https://github.com/rustls/rustls/issues/945#issuecomment-1385503870