### PR TITLE
small tweaks from 2602

### DIFF
--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -333,7 +333,10 @@ fn filter_suites(mut provider: CryptoProvider, suites: &[String]) -> CryptoProvi
 
     for s in suites {
         if !known_suites.contains(&s.to_lowercase()) {
-            panic!("cannot look up ciphersuite '{s}'. should be one of {known_suites:?}");
+            panic!(
+                "cannot look up ciphersuite '{s}'. should be one of {known_suites}",
+                known_suites = known_suites.join(", ")
+            );
         }
     }
 

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -334,7 +334,7 @@ fn filter_suites(mut provider: CryptoProvider, suites: &[String]) -> CryptoProvi
     for s in suites {
         if !known_suites.contains(&s.to_lowercase()) {
             panic!(
-                "cannot look up ciphersuite '{s}'. should be one of {known_suites}",
+                "unsupported ciphersuite '{s}'; should be one of {known_suites}",
                 known_suites = known_suites.join(", ")
             );
         }

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -392,12 +392,12 @@ See the documentation of the CryptoProvider type for more information.
     pub(crate) fn iter_cipher_suites(&self) -> impl Iterator<Item = SupportedCipherSuite> + '_ {
         self.tls13_cipher_suites
             .iter()
-            .cloned()
+            .copied()
             .map(SupportedCipherSuite::Tls13)
             .chain(
                 self.tls12_cipher_suites
                     .iter()
-                    .cloned()
+                    .copied()
                     .map(SupportedCipherSuite::Tls12),
             )
     }


### PR DESCRIPTION
Two very tiny nits noticed reviewing https://github.com/rustls/rustls/pull/2602 post-merge.

The first is just a minor tweak to avoid a clunkier debug repr in an example panic message. The second fixes up a change made in https://github.com/rustls/rustls/pull/2602/commits/720113c20a9bc189549855b416fb00cde352bb73 that switched some callers from copying the `SupportedCipherSuite` iter items to cloning them. `SupportedCipherSuite` is `Copy` so I think its clearer to use `copied()` on the `Iterator`.