### PR TITLE
Enable & address `clippy::cloned_instead_of_copied`

### DIFF
--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -611,7 +611,7 @@ impl EchState {
                 .cipher_suites
                 .iter()
                 .filter(|cs| **cs != TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
-                .cloned()
+                .copied()
                 .collect(),
         };
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -918,7 +918,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             .as_deref()
             .unwrap_or_default()
             .iter()
-            .cloned()
+            .copied()
             .filter(SignatureScheme::supported_in_tls13)
             .collect::<Vec<SignatureScheme>>();
 
@@ -939,7 +939,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
                     .iter()
                     .find(|compressor| offered.contains(&compressor.algorithm()))
             })
-            .cloned();
+            .copied();
 
         let client_auth = ClientAuthDetails::resolve(
             self.config

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -321,6 +321,7 @@
 #![cfg_attr(not(any(bench, coverage_nightly)), forbid(unstable_features))]
 #![warn(
     clippy::alloc_instead_of_core,
+    clippy::cloned_instead_of_copied,
     clippy::exhaustive_enums,
     clippy::exhaustive_structs,
     clippy::manual_let_else,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1315,7 +1315,7 @@ impl ClientHelloPayload {
 
     pub(crate) fn has_certificate_compression_extension_with_duplicates(&self) -> bool {
         if let Some(algs) = &self.certificate_compression_algorithms {
-            has_duplicates::<_, _, u16>(algs.iter().cloned())
+            has_duplicates::<_, _, u16>(algs.iter().copied())
         } else {
             false
         }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -121,7 +121,7 @@ mod client_hello {
                         .cert_compressors
                         .iter()
                         .find(|compressor| offered.contains(&compressor.algorithm()))
-                        .cloned());
+                        .copied());
 
             let early_data_requested = client_hello
                 .early_data_request

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -73,7 +73,7 @@ impl Tls12CipherSuite {
         self.sign
             .iter()
             .filter(|pref| offered.contains(pref))
-            .cloned()
+            .copied()
             .collect()
     }
 


### PR DESCRIPTION
Seems like a pretty ironclad lint? Not clear to me why it's `allow` by default.

re #2615 