### PR TITLE
QUIC: add resumption data set and read via quic connection

### DIFF
--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -117,6 +117,42 @@ mod connection {
                 Self::Server(conn) => conn.core.exporter(),
             }
         }
+
+        /// Set the resumption data to embed in future resumption tickets supplied to the client.
+        ///
+        /// This method is only available for server connections. For client connections,
+        /// resumption data is received from the server and cannot be set.
+        ///
+        /// Defaults to the empty byte string. Must be less than 2^15 bytes to allow room for other
+        /// data. Should be called while `is_handshaking` returns true to ensure all transmitted
+        /// resumption tickets are affected.
+        ///
+        /// Integrity will be assured by rustls, but the data will be visible to the client. If secrecy
+        /// from the client is desired, encrypt the data separately.
+        pub fn set_resumption_data(&mut self, data: &[u8]) -> Result<(), Error> {
+            match self {
+                Self::Server(conn) => {
+                    conn.set_resumption_data(data);
+                    Ok(())
+                }
+                Self::Client(_) => Err(Error::General(
+                    "set_resumption_data is only available for server connections".into(),
+                )),
+            }
+        }
+
+        /// Retrieves the resumption data supplied by the peer, if any.
+        ///
+        /// For server connections, returns `Some` if and only if a valid resumption ticket
+        /// has been received from the cli
+        /// For client connections, this method is not typically used as clients receive
+        /// resumption tickets from servers.
+        pub fn received_resumption_data(&self) -> Option<&[u8]> {
+            match self {
+                Self::Server(conn) => conn.received_resumption_data(),
+                Self::Client(_) => None,
+            }
+        }
     }
 
     impl Deref for Connection {
@@ -312,6 +348,31 @@ mod connection {
         /// The server name is also used to match sessions during session resumption.
         pub fn server_name(&self) -> Option<&DnsName<'_>> {
             self.inner.core.data.sni.as_ref()
+        }
+
+        /// Set the resumption data to embed in future resumption tickets supplied to the client.
+        ///
+        /// Defaults to the empty byte string. Must be less than 2^15 bytes to allow room for other
+        /// data. Should be called while `is_handshaking` returns true to ensure all transmitted
+        /// resumption tickets are affected.
+        ///
+        /// Integrity will be assured by rustls, but the data will be visible to the client. If secrecy
+        /// from the client is desired, encrypt the data separately.
+        pub fn set_resumption_data(&mut self, data: &[u8]) {
+            assert!(data.len() < 2usize.pow(15));
+            self.inner.core.data.resumption_data = data.into();
+        }
+
+        /// Retrieves the resumption data supplied by the client, if any.
+        ///
+        /// Returns `Some` if and only if a valid resumption ticket has been received from the client.
+        pub fn received_resumption_data(&self) -> Option<&[u8]> {
+            self.inner
+                .core
+                .data
+                .received_resumption_data
+                .as_ref()
+                .map(|x| &x[..])
         }
     }
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1208,8 +1208,8 @@ impl ConnectionCore<ServerConnectionData> {
 #[derive(Default, Debug)]
 pub struct ServerConnectionData {
     pub(crate) sni: Option<DnsName<'static>>,
-    pub(super) received_resumption_data: Option<Vec<u8>>,
-    pub(super) resumption_data: Vec<u8>,
+    pub(crate) received_resumption_data: Option<Vec<u8>>,
+    pub(crate) resumption_data: Vec<u8>,
     pub(super) early_data: EarlyDataState,
 }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -5267,6 +5267,62 @@ mod test_quic {
     }
 
     #[test]
+    fn test_quic_resumption_data() {
+        let kt = KeyType::Rsa2048;
+        let provider = provider::default_provider().with_only_tls13();
+        let mut client_config = make_client_config(kt, &provider);
+        client_config.alpn_protocols = vec!["foo".into()];
+        client_config.enable_early_data = true;
+        let client_config = Arc::new(client_config);
+
+        let mut server_config = make_server_config(kt, &provider);
+        server_config.alpn_protocols = vec!["foo".into()];
+        server_config.max_early_data_size = 0xffff_ffff;
+        let server_config = Arc::new(server_config);
+
+        let client_params = b"client params";
+        let server_params = b"server params";
+
+        // Create server connection and set resumption data
+        let mut server = quic::ServerConnection::new(
+            server_config.clone(),
+            quic::Version::V1,
+            server_params.to_vec(),
+        )
+        .unwrap();
+
+        // Test setting resumption data
+        let test_data = b"test resumption data";
+        server.set_resumption_data(test_data);
+
+        // Test that we can retrieve it (though it won't be populated until a client sends it)
+        assert_eq!(server.received_resumption_data(), None);
+
+        // Test the Connection enum interface as well
+        let mut server_conn = quic::Connection::Server(server);
+
+        // Test setting resumption data through the enum
+        let test_data2 = b"test data 2";
+        server_conn.set_resumption_data(test_data2).unwrap();
+
+        // Test that received_resumption_data works through the enum
+        assert_eq!(server_conn.received_resumption_data(), None);
+
+        // Test that client connections return an error when trying to set resumption data
+        let client = quic::ClientConnection::new(
+            client_config,
+            quic::Version::V1,
+            server_name("localhost"),
+            client_params.to_vec(),
+        )
+        .unwrap();
+
+        let mut client_conn = quic::Connection::Client(client);
+        assert!(client_conn.set_resumption_data(test_data).is_err());
+        assert_eq!(client_conn.received_resumption_data(), None);
+    }
+
+    #[test]
     fn packet_key_api() {
         use cipher_suite::TLS13_AES_128_GCM_SHA256;
         use rustls::Side;


### PR DESCRIPTION
The application layer can provision TLS session resumption data via QUIC connections. A common use case is QUIC 0-RTT, where resumption data serves to store and retrieve 0-RTT parameters  which is bound to session ticket.