### PR TITLE
error: display other error for Display

### DIFF
--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -765,6 +765,8 @@ impl fmt::Display for CertificateError {
                 Ok(())
             }
 
+            Self::Other(other) => write!(f, "{other}"),
+
             other => write!(f, "{other:?}"),
         }
     }


### PR DESCRIPTION
`OtherError` implements `Display`, why not using for `Display` of `CertificateError`?