### PR TITLE
Use nightly compiler less

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,8 +233,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo fuzz
         uses: taiki-e/cache-cargo-install-action@v2
@@ -242,6 +242,9 @@ jobs:
           tool: cargo-fuzz
 
       - name: Smoke-test fuzz targets
+        env:
+          # cargo fuzz uses a bunch of -Z options
+          RUSTC_BOOTSTRAP: 1
         run: |
           cargo fuzz build
           for target in $(cargo fuzz list) ; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,7 +339,7 @@ jobs:
           persist-credentials: false
 
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-minimal-versions
         uses: taiki-e/install-action@cargo-minimal-versions
@@ -351,6 +351,9 @@ jobs:
       - name: Check direct-minimal-versions
         run: cargo minimal-versions --direct --ignore-private check
         working-directory: rustls/
+        env:
+          # `cargo minimal-versions` uses unstable cargo features
+          RUSTC_BOOTSTRAP: 1
 
   cross:
     name: cross-target testing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,8 +257,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Smoke-test benchmark program (ring)
         run: cargo run -p rustls-bench --profile=bench --locked --features ring -- --multiplier 0.1
@@ -273,6 +273,8 @@ jobs:
         run: cargo bench --locked --all-features
         env:
           RUSTFLAGS: --cfg=bench
+          # unit-benchmarks are permanantly unstable
+          RUSTC_BOOTSTRAP: 1
 
   docs:
     name: Check for documentation errors

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,6 +289,7 @@ jobs:
           persist-credentials: false
 
       - name: Install rust toolchain
+        # use nightly to mirror docs.rs
         uses: dtolnay/rust-toolchain@nightly
 
       - name: cargo doc (rustls; all features)


### PR DESCRIPTION
Nightly is pretty regularly broken (not surprising), so prefer to use stable+RUSTC_BOOTSTRAP=1 in cases where we want to use an unstable feature, but not a bleeding-edge compiler.
