### PR TITLE
Enable branch coverage measurement

### DIFF
--- a/admin/coverage
+++ b/admin/coverage
@@ -2,7 +2,11 @@
 
 set -e
 
-source <(cargo llvm-cov show-env --export-prefix "$@")
+# for branch coverage support, which is unstable
+export RUSTC_BOOTSTRAP=1
+OPTIONS=--branch
+
+source <(cargo llvm-cov show-env --export-prefix $OPTIONS "$@")
 cargo llvm-cov clean --workspace
 
 cargo build --locked --all-targets --all-features
@@ -17,4 +21,4 @@ cargo test --locked $(admin/all-features-except brotli rustls)
 ## bogo
 cargo test --locked --test bogo -- --ignored --test-threads 1
 
-cargo llvm-cov report --ignore-filename-regex "(bogo|rustls-test)/" "$@"
+cargo llvm-cov report --ignore-filename-regex "(bogo|rustls-test)/" $OPTIONS "$@"


### PR DESCRIPTION
This enables branch coverage collection. The llvm html output is very detailed but inscrutable. The codecov output is very simple but clear at least.

This decreases our coverage numbers because "partial" lines are no longer counted toward the headline line coverage (which is right, since only part of the line was executed). But I think this is accurate and good, actually.

re #916 