### PR TITLE
verify: introduce PeerIdentity type

### DIFF
--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -25,9 +25,7 @@ use rustls::client::{
     WebPkiServerVerifier,
 };
 use rustls::crypto::cipher::{InboundOpaqueMessage, MessageDecrypter, MessageEncrypter};
-use rustls::crypto::{
-    CryptoProvider, WebPkiSupportedAlgorithms, verify_tls13_signature_with_raw_key,
-};
+use rustls::crypto::{CryptoProvider, WebPkiSupportedAlgorithms, verify_tls13_signature};
 use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::message::{Message, OutboundOpaqueMessage, PlainMessage};
 use rustls::pki_types::pem::PemObject;
@@ -1114,10 +1112,8 @@ impl ServerCertVerifier for MockServerVerifier {
         println!("verify_tls13_signature({input:?})");
         match &self.tls13_signature_error {
             Some(error) => Err(error.clone()),
-            _ if self.requires_raw_public_keys => verify_tls13_signature_with_raw_key(
-                input.message,
-                &SubjectPublicKeyInfoDer::from(input.signer.as_ref()),
-                input.signature,
+            _ if self.requires_raw_public_keys => verify_tls13_signature(
+                input,
                 self.raw_public_key_algorithms
                     .as_ref()
                     .unwrap(),
@@ -1276,10 +1272,8 @@ impl ClientCertVerifier for MockClientVerifier {
         input: &SignatureVerificationInput<'_>,
     ) -> Result<HandshakeSignatureValid, Error> {
         if self.expect_raw_public_keys {
-            verify_tls13_signature_with_raw_key(
-                input.message,
-                &SubjectPublicKeyInfoDer::from(input.signer.as_ref()),
-                input.signature,
+            verify_tls13_signature(
+                input,
                 self.raw_public_key_algorithms
                     .as_ref()
                     .unwrap(),

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -241,7 +241,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientRawPublicKeys {
 mod tests {
     use std::prelude::v1::*;
 
-    use pki_types::{ServerName, UnixTime};
+    use pki_types::{CertificateDer, ServerName, UnixTime};
 
     use super::NoClientSessionStorage;
     use super::provider::cipher_suite;
@@ -249,10 +249,12 @@ mod tests {
     use crate::client::{ClientSessionStore, ResolvesClientCert};
     use crate::msgs::base::PayloadU16;
     use crate::msgs::enums::NamedGroup;
-    use crate::msgs::handshake::{CertificateChain, SessionId};
+    use crate::msgs::handshake::SessionId;
     use crate::msgs::persist::Tls13ClientSessionValue;
     use crate::sync::Arc;
-    use crate::verify::{ServerIdentity, SignatureVerificationInput};
+    use crate::verify::{
+        CertificateIdentity, PeerIdentity, ServerIdentity, SignatureVerificationInput,
+    };
     use crate::{Error, SignatureScheme, sign};
 
     #[test]
@@ -276,7 +278,10 @@ mod tests {
                     SessionId::empty(),
                     Arc::new(PayloadU16::empty()),
                     &[0u8; 48],
-                    CertificateChain::default(),
+                    PeerIdentity::X509(CertificateIdentity {
+                        end_entity: CertificateDer::from(&[][..]),
+                        intermediates: Vec::new(),
+                    }),
                     &server_cert_verifier,
                     &resolves_client_cert,
                     now,
@@ -294,7 +299,10 @@ mod tests {
                 cipher_suite::TLS13_AES_256_GCM_SHA384,
                 Arc::new(PayloadU16::empty()),
                 &[],
-                CertificateChain::default(),
+                PeerIdentity::X509(CertificateIdentity {
+                    end_entity: CertificateDer::from(&[][..]),
+                    intermediates: Vec::new(),
+                }),
                 &server_cert_verifier,
                 &resolves_client_cert,
                 now,

--- a/rustls/src/conn/kernel.rs
+++ b/rustls/src/conn/kernel.rs
@@ -59,8 +59,9 @@ use core::marker::PhantomData;
 use crate::client::ClientConnectionData;
 use crate::common_state::Protocol;
 use crate::msgs::codec::Codec;
-use crate::msgs::handshake::{CertificateChain, NewSessionTicketPayloadTls13};
+use crate::msgs::handshake::NewSessionTicketPayloadTls13;
 use crate::quic::Quic;
+use crate::verify::PeerIdentity;
 use crate::{CommonState, ConnectionTrafficSecrets, Error, ProtocolVersion, SupportedCipherSuite};
 
 /// A kernel connection.
@@ -73,7 +74,7 @@ use crate::{CommonState, ConnectionTrafficSecrets, Error, ProtocolVersion, Suppo
 pub struct KernelConnection<Data> {
     state: Box<dyn KernelState>,
 
-    peer_certificates: Option<CertificateChain<'static>>,
+    peer_identity: Option<PeerIdentity>,
     quic: Quic,
 
     negotiated_version: ProtocolVersion,
@@ -88,7 +89,7 @@ impl<Data> KernelConnection<Data> {
         Ok(Self {
             state,
 
-            peer_certificates: common.peer_certificates,
+            peer_identity: common.peer_identity,
             quic: common.quic,
             negotiated_version: common
                 .negotiated_version
@@ -225,7 +226,7 @@ impl KernelConnection<ClientConnectionData> {
 
         let nst = NewSessionTicketPayloadTls13::read_bytes(payload)?;
         let mut cx = KernelContext {
-            peer_certificates: self.peer_certificates.as_ref(),
+            peer_identity: self.peer_identity.as_ref(),
             protocol: self.protocol,
             quic: &self.quic,
         };
@@ -250,7 +251,7 @@ pub(crate) trait KernelState: Send + Sync {
 }
 
 pub(crate) struct KernelContext<'a> {
-    pub(crate) peer_certificates: Option<&'a CertificateChain<'static>>,
+    pub(crate) peer_identity: Option<&'a PeerIdentity>,
     pub(crate) protocol: Protocol,
     pub(crate) quic: &'a Quic,
 }

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -11,7 +11,6 @@ use crate::sign::SigningKey;
 use crate::sync::Arc;
 pub use crate::webpki::{
     WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature,
-    verify_tls13_signature_with_raw_key,
 };
 use crate::{
     ApiMisuse, Error, NamedGroup, ProtocolVersion, SupportedCipherSuite, SupportedProtocolVersion,

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -701,6 +701,12 @@ enum_builder! {
     }
 }
 
+impl Default for CertificateType {
+    fn default() -> Self {
+        Self::X509
+    }
+}
+
 enum_builder! {
     /// The type of Encrypted Client Hello (`EchClientHelloType`).
     ///

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -364,6 +364,7 @@ pub enum PeerIncompatible {
     ExtendedMasterSecretExtensionRequired,
     IncorrectCertificateTypeExtension,
     KeyShareExtensionRequired,
+    MultipleRawKeys,
     NamedGroupsExtensionRequired,
     NoCertificateRequestSignatureSchemesInCommon,
     NoCipherSuitesInCommon,
@@ -380,6 +381,7 @@ pub enum PeerIncompatible {
     Tls12NotOfferedOrEnabled,
     Tls13RequiredForQuic,
     UncompressedEcPointsRequired,
+    UnknownCertificateType(u8),
     UnsolicitedCertificateTypeExtension,
 }
 
@@ -1166,6 +1168,9 @@ pub enum ApiMisuse {
     /// [`quic::HeaderProtectionKey::encrypt_in_place()`]: crate::quic::HeaderProtectionKey::encrypt_in_place()
     InvalidQuicHeaderProtectionPacketNumberLength,
 
+    /// Raw keys cannot be used with TLS 1.2.
+    InvalidSignerForProtocolVersion,
+
     /// QUIC attempted with a configuration that does not support TLS1.3.
     QuicRequiresTls13Support,
 
@@ -1212,6 +1217,12 @@ pub enum ApiMisuse {
     /// functions.  You must ensure any prior generated TLS records are extracted
     /// from the library before using one of these functions.
     SecretExtractionWithPendingSendableData,
+
+    /// Attempt to verify a certificate with an unsupported type.
+    ///
+    /// A verifier indicated support for a certificate type but then failed to verify the peer's
+    /// identity of that type.
+    UnverifiableCertificateType,
 }
 
 impl From<ApiMisuse> for Error {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -543,7 +543,7 @@ pub use crate::suites::{
 pub use crate::ticketer::TicketRotator;
 pub use crate::tls12::Tls12CipherSuite;
 pub use crate::tls13::Tls13CipherSuite;
-pub use crate::verify::DigitallySignedStruct;
+pub use crate::verify::{CertificateIdentity, DigitallySignedStruct, PeerIdentity};
 pub use crate::versions::{ALL_VERSIONS, DEFAULT_VERSIONS, SupportedProtocolVersion};
 pub use crate::webpki::RootCertStore;
 
@@ -630,8 +630,7 @@ pub mod server {
     /// Dangerous configuration that should be audited and used with extreme care.
     pub mod danger {
         pub use crate::verify::{
-            CertificateIdentity, ClientCertVerified, ClientCertVerifier, ClientIdentity,
-            SignatureVerificationInput,
+            ClientCertVerified, ClientCertVerifier, ClientIdentity, SignatureVerificationInput,
         };
     }
 

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
-use pki_types::CertificateDer;
+use pki_types::{CertificateDer, SubjectPublicKeyInfoDer};
 
 use crate::error::InvalidMessage;
 
@@ -281,6 +281,10 @@ impl TlsListElement for CertificateDer<'_> {
         max: CERTIFICATE_MAX_SIZE_LIMIT,
         error: InvalidMessage::CertificatePayloadTooLarge,
     };
+}
+
+impl TlsListElement for SubjectPublicKeyInfoDer<'_> {
+    const SIZE_LEN: ListLength = CertificateDer::SIZE_LEN;
 }
 
 /// A trait for types that can be encoded and decoded in a list.

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -26,7 +26,7 @@ use pki_types::{CertificateDer, ServerName, UnixTime};
 use webpki_roots;
 
 use crate::crypto::CryptoProvider;
-use crate::verify::{CertificateIdentity, ServerCertVerifier, ServerIdentity};
+use crate::verify::{CertificateIdentity, PeerIdentity, ServerCertVerifier, ServerIdentity};
 use crate::webpki::{RootCertStore, WebPkiServerVerifier};
 
 #[macro_rules_attribute::apply(bench_for_each_provider)]
@@ -230,13 +230,12 @@ impl Context {
     fn verify_once(&self) {
         const OCSP_RESPONSE: &[u8] = &[];
 
-        let (end_entity, intermediates) = self.chain.split_first().unwrap();
         self.verifier
             .verify_server_cert(&ServerIdentity {
-                certificates: &CertificateIdentity {
-                    end_entity,
-                    intermediates,
-                },
+                identity: &PeerIdentity::X509(CertificateIdentity {
+                    end_entity: self.chain[0].clone(),
+                    intermediates: self.chain[1..].to_vec(),
+                }),
                 server_name: &self.server_name,
                 ocsp_response: OCSP_RESPONSE,
                 now: self.now,

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -23,10 +23,7 @@ pub use server_verifier::{ServerCertVerifierBuilder, WebPkiServerVerifier};
 pub use verify::{
     ParsedCertificate, verify_server_cert_signed_by_trust_anchor, verify_server_name,
 };
-pub use verify::{
-    WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature,
-    verify_tls13_signature_with_raw_key,
-};
+pub use verify::{WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature};
 
 /// An error that can occur when building a certificate verifier.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Next step towards the vision from

- #2560

Previously:

- #2634 (-25)
- #2633 (+26)
- #2632 (-48)
- #2614 (-78)

This does expose the existence of non-certificate identities in the `CommonState::peer_identity()` API that replaces `peer_certificates()`, but otherwise confines the complexity mostly to verifier implementations and resumption. I don't think this is the end state, there is probably more that can be done here.

It might also be possible to shave off smaller commit.