### PR TITLE
fix dead code warns w/o std feature

### DIFF
--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1268,6 +1268,7 @@ impl<Data> ConnectionCore<Data> {
         }
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn early_exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
         match self.common_state.early_exporter.take() {
             Some(inner) => Ok(KeyingMaterialExporter { inner }),

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -614,12 +614,12 @@ pub mod server {
     #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ServerSessionMemoryCache;
     pub use handy::{AlwaysResolvesServerRawPublicKeys, NoServerSessionStorage};
+    #[cfg(feature = "std")]
+    pub use server_conn::{Accepted, AcceptedAlert, Acceptor, ReadEarlyData, ServerConnection};
     pub use server_conn::{
-        Accepted, ClientHello, InvalidSniPolicy, ProducesTickets, ResolvesServerCert, ServerConfig,
+        ClientHello, InvalidSniPolicy, ProducesTickets, ResolvesServerCert, ServerConfig,
         ServerConnectionData, StoresServerSessions, UnbufferedServerConnection,
     };
-    #[cfg(feature = "std")]
-    pub use server_conn::{AcceptedAlert, Acceptor, ReadEarlyData, ServerConnection};
 
     pub use crate::verify::NoClientAuth;
     pub use crate::webpki::{

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -15,18 +15,22 @@ use crate::builder::ConfigBuilder;
 use crate::common_state::{CommonState, Side};
 #[cfg(feature = "std")]
 use crate::common_state::{Protocol, State};
-use crate::conn::{ConnectionCommon, ConnectionCore, UnbufferedConnectionCommon};
+#[cfg(feature = "std")]
+use crate::conn::ConnectionCommon;
+use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 #[cfg(doc)]
 use crate::crypto;
 use crate::crypto::CryptoProvider;
 use crate::enums::{CertificateType, CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
 use crate::kernel::KernelConnection;
+#[cfg(feature = "std")]
 use crate::log::trace;
 use crate::msgs::base::Payload;
-use crate::msgs::handshake::{
-    ClientHelloPayload, ProtocolName, ServerExtensionsInput, ServerNamePayload,
-};
+#[cfg(feature = "std")]
+use crate::msgs::handshake::ClientHelloPayload;
+use crate::msgs::handshake::{ProtocolName, ServerExtensionsInput, ServerNamePayload};
+#[cfg(feature = "std")]
 use crate::msgs::message::Message;
 use crate::suites::ExtractedSecrets;
 use crate::sync::Arc;
@@ -1050,12 +1054,14 @@ impl UnbufferedConnectionCommon<ServerConnectionData> {
 /// Represents a `ClientHello` message received through the [`Acceptor`].
 ///
 /// Contains the state required to resume the connection through [`Accepted::into_connection()`].
+#[cfg(feature = "std")]
 pub struct Accepted {
     connection: ConnectionCommon<ServerConnectionData>,
     message: Message<'static>,
     sig_schemes: Vec<SignatureScheme>,
 }
 
+#[cfg(feature = "std")]
 impl Accepted {
     /// Get the [`ClientHello`] for this connection.
     pub fn client_hello(&self) -> ClientHello<'_> {
@@ -1091,7 +1097,6 @@ impl Accepted {
     /// Takes the state returned from [`Acceptor::accept()`] as well as the [`ServerConfig`] and
     /// [`sign::CertifiedKey`] that should be used for the session. Returns an error if
     /// configuration-dependent validation of the received `ClientHello` message fails.
-    #[cfg(feature = "std")]
     pub fn into_connection(
         mut self,
         config: Arc<ServerConfig>,
@@ -1133,6 +1138,7 @@ impl Accepted {
     }
 }
 
+#[cfg(feature = "std")]
 impl Debug for Accepted {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Accepted").finish()


### PR DESCRIPTION
The [daily-tests.yml](https://github.com/rustls/rustls/actions/workflows/daily-tests.yml) `cargo hack` job has been sad since https://github.com/rustls/rustls/pull/2608  landed.

The only call-site for the `pub(crate)` `ConnectionCore::early_exporter()` fn is gated by the `std` feature, so it should be too.

Similarly, the mod private `Accepted` struct is only useful with `std` enabled and should be gated.

Here's a [manual dispatch](https://github.com/cpu/rustls/actions/runs/17746300794) of `daily-tests.yml` for this branch showing the fixes pass.