### PR TITLE
`--deny warnings` for feature combination builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,24 +77,24 @@ jobs:
       # this is required for fips on windows.
       # nb. "--all-targets" does not include doctests
       - name: cargo test (release; all features)
-        run: cargo test --release --locked --all-features --all-targets
+        run: cargo test --locked --release --all-features --all-targets
         env:
           RUST_BACKTRACE: 1
 
       # nb. this is separate since `--doc` option cannot be combined with other target option(s) ref:
       # - https://doc.rust-lang.org/cargo/commands/cargo-test.html
       - name: cargo test --doc (release; all-features)
-        run: cargo test --release --locked --all-features --doc
+        run: cargo test --locked --release --all-features --doc
         env:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; aws-lc-rs)
-        run: cargo test --no-default-features --features aws-lc-rs,log,std --all-targets
+        run: cargo test --locked --no-default-features --features aws-lc-rs,log,std --all-targets
         env:
           RUST_BACKTRACE: 1
 
       - name: cargo test (release; fips)
-        run: cargo test --release --no-default-features --features fips,log,std --all-targets
+        run: cargo test --locked --release --no-default-features --features fips,log,std --all-targets
         env:
           RUST_BACKTRACE: 1
 
@@ -108,13 +108,13 @@ jobs:
         run: cargo build --locked -p rustls-provider-example --no-default-features
 
       - name: cargo test (debug; rustls-provider-example; all features)
-        run: cargo test --all-features -p rustls-provider-example
+        run: cargo test --locked --all-features -p rustls-provider-example
 
       - name: cargo build (debug; rustls-provider-test)
         run: cargo build --locked -p rustls-provider-test
 
       - name: cargo test (debug; rustls-provider-test; all features)
-        run: cargo test --all-features -p rustls-provider-test
+        run: cargo test --locked --all-features -p rustls-provider-test
 
       - name: cargo package --all-features -p rustls
         run: cargo package --all-features -p rustls
@@ -183,11 +183,11 @@ jobs:
         working-directory: rustls
 
       - name: cargo test (debug; no default features; std+aws-lc-rs)
-        run: cargo test --no-default-features --features aws-lc-rs,std
+        run: cargo test --locked --no-default-features --features aws-lc-rs,std
         working-directory: rustls
 
       - name: cargo test (debug; no default features; std+fips)
-        run: cargo test --no-default-features --features fips,std
+        run: cargo test --locked --no-default-features --features fips,std
         working-directory: rustls
 
       - name: cargo test (release; no run)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,16 +151,22 @@ jobs:
       - name: cargo build (debug; default features)
         run: cargo build --locked
         working-directory: rustls
+        env:
+          RUSTFLAGS: --deny warnings
 
         # this target does _not_ include the libstd crate in its sysroot
         # it will catch unwanted usage of libstd in _dependencies_
       - name: cargo build (debug; no default features; no-std)
         run: cargo build --locked --no-default-features --target x86_64-unknown-none
         working-directory: rustls
+        env:
+          RUSTFLAGS: --deny warnings
 
       - name: cargo build (debug; no default features; no-std, hashbrown)
         run: cargo build --locked --no-default-features --features hashbrown --target x86_64-unknown-none
         working-directory: rustls
+        env:
+          RUSTFLAGS: --deny warnings
 
       - name: cargo test (debug; default features)
         run: cargo test --locked

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -157,7 +157,6 @@ jobs:
             --package rustls
             --feature-powerset
             --no-dev-deps
-            --group-features aws-lc-rs,aws-lc-rs
             --group-features fips,aws-lc-rs
             --mutually-exclusive-features fips,ring
             --mutually-exclusive-features custom_provider,aws-lc-rs

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -665,7 +665,7 @@ pub mod sign {
 pub mod quic;
 
 /// APIs for implementing TLS tickets
-#[cfg(any(feature = "std", feature = "hashbrown"))] // < XXX: incorrect feature gate
+#[cfg(feature = "std")]
 pub mod ticketer;
 
 /// This is the rustls manual.

--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -1,17 +1,13 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::mem;
-#[cfg(feature = "std")]
 use std::sync::{RwLock, RwLockReadGuard};
 
 use pki_types::UnixTime;
 
 use crate::Error;
 use crate::server::ProducesTickets;
-#[cfg(not(feature = "std"))]
-use crate::time_provider::TimeProvider;
 
-#[cfg(feature = "std")]
 #[derive(Debug)]
 pub(crate) struct TicketRotatorState {
     current: Box<dyn ProducesTickets>,
@@ -111,7 +107,6 @@ impl TicketRotator {
     pub(crate) const SIX_HOURS: u32 = 6 * 60 * 60;
 }
 
-#[cfg(feature = "std")]
 impl ProducesTickets for TicketRotator {
     fn lifetime(&self) -> u32 {
         self.lifetime
@@ -143,7 +138,6 @@ impl ProducesTickets for TicketRotator {
     }
 }
 
-#[cfg(feature = "std")]
 impl core::fmt::Debug for TicketRotator {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("TicketRotator")


### PR DESCRIPTION
This would have caught #2653 synchronously in the standard PR builds.

As it is these warnings were hit but don't cause an error: https://github.com/rustls/rustls/actions/runs/17742255530/job/50418930016#step:5:16