### PR TITLE
Spell check code using `typos`

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -1,0 +1,15 @@
+[default.extend-words]
+# encrypter as an active verb
+encrypter = "encrypter"
+
+# "type", but side-stepping the keyword and avoiding the very ugly r#type
+typ = "typ"
+
+# pn -> packet number in quic parlance
+pn = "pn"
+
+# as in Josh
+Aas = "Aas"
+
+[files]
+extend-exclude = ["*.json", "*.json.in", "*.svg", "macros.html", "test-ca/"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,6 +309,12 @@ jobs:
           ./admin/pull-readme
           git diff --exit-code
 
+      - name: Spell check code
+        uses: crate-ci/typos@v1
+        with:
+          config: .github/typos.toml
+
+
   coverage:
     name: Measure coverage
     runs-on: ubuntu-latest

--- a/admin/bench-measure.mk
+++ b/admin/bench-measure.mk
@@ -48,14 +48,14 @@ memory: $(BENCH)
 	$(MEMUSAGE) $^ memory TLS13_AES_256_GCM_SHA384 5000
 
 threads: $(BENCH)
-	for thr in $(shell admin/threads-seq.rs) ; do \
-	  $^ --threads $$thr handshake TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
-	  $^ --threads $$thr handshake-resume TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
-	  $^ --threads $$thr handshake-ticket TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
-	  $^ --key-type rsa2048 --threads $$thr handshake TLS13_AES_256_GCM_SHA384 ; \
-	  $^ --threads $$thr handshake-ticket TLS13_AES_256_GCM_SHA384 ; \
-	  $^ --threads $$thr bulk TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
-	  $^ --key-type rsa2048 --threads $$thr bulk TLS13_AES_256_GCM_SHA384 ; \
+	for t in $(shell admin/threads-seq.rs) ; do \
+	  $^ --threads $$t handshake TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$t handshake-resume TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$t handshake-ticket TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
+	  $^ --key-type rsa2048 --threads $$t handshake TLS13_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$t handshake-ticket TLS13_AES_256_GCM_SHA384 ; \
+	  $^ --threads $$t bulk TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ; \
+	  $^ --key-type rsa2048 --threads $$t bulk TLS13_AES_256_GCM_SHA384 ; \
 	done
 
 thread-latency: $(BENCH)

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -302,7 +302,7 @@ impl SelectedProvider {
             #[cfg(feature = "fips")]
             Some("aws-lc-rs-fips") => Self::AwsLcRsFips,
             Some("ring") => Self::Ring,
-            Some(other) => panic!("unrecognised value for BOGO_SHIM_PROVIDER: {other:?}"),
+            Some(other) => panic!("unrecognized value for BOGO_SHIM_PROVIDER: {other:?}"),
         }
     }
 

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -466,7 +466,7 @@ fn multithreaded(
 
         threads
             .into_iter()
-            .map(|thr| thr.join().unwrap())
+            .map(|thread| thread.join().unwrap())
             .collect::<Vec<Timings>>()
     })
 }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -139,9 +139,9 @@ impl CommonState {
         self.get_alpn_protocol()
     }
 
-    /// Retrieves the ciphersuite agreed with the peer.
+    /// Retrieves the cipher suite agreed with the peer.
     ///
-    /// This returns None until the ciphersuite is agreed.
+    /// This returns None until the cipher suite is agreed.
     pub fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
         self.suite
     }

--- a/rustls/src/conn/kernel.rs
+++ b/rustls/src/conn/kernel.rs
@@ -103,7 +103,7 @@ impl<Data> KernelConnection<Data> {
         })
     }
 
-    /// Retrieves the ciphersuite agreed with the peer.
+    /// Retrieves the cipher suite agreed with the peer.
     pub fn negotiated_cipher_suite(&self) -> SupportedCipherSuite {
         self.suite
     }

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -121,7 +121,7 @@ pub use crate::suites::CipherSuiteCommon;
 /// ```
 /// # #[cfg(feature = "aws-lc-rs")] {
 /// # use std::sync::Arc;
-/// # mod fictious_hsm_api { pub fn load_private_key(key_der: pki_types::PrivateKeyDer<'static>) -> ! { unreachable!(); } }
+/// # mod fictitious_hsm_api { pub fn load_private_key(key_der: pki_types::PrivateKeyDer<'static>) -> ! { unreachable!(); } }
 /// use rustls::crypto::aws_lc_rs;
 ///
 /// pub fn provider() -> rustls::crypto::CryptoProvider {
@@ -136,7 +136,7 @@ pub use crate::suites::CipherSuiteCommon;
 ///
 /// impl rustls::crypto::KeyProvider for HsmKeyLoader {
 ///     fn load_private_key(&self, key_der: pki_types::PrivateKeyDer<'static>) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
-///          fictious_hsm_api::load_private_key(key_der)
+///          fictitious_hsm_api::load_private_key(key_der)
 ///     }
 /// }
 /// # }

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -529,7 +529,7 @@ pub trait ActiveKeyExchange: Send + Sync {
     /// Completes the key exchange, given the peer's public key.
     ///
     /// This method must return an error if `peer_pub_key` is invalid: either
-    /// mis-encoded, or an invalid public key (such as, but not limited to, being
+    /// misencoded, or an invalid public key (such as, but not limited to, being
     /// in a small order subgroup).
     ///
     /// If the key exchange algorithm is FFDHE, the result must be left-padded with zeros,
@@ -559,7 +559,7 @@ pub trait ActiveKeyExchange: Send + Sync {
     /// implementation of this method handle TLS 1.2-specific requirements.
     ///
     /// This method must return an error if `peer_pub_key` is invalid: either
-    /// mis-encoded, or an invalid public key (such as, but not limited to, being
+    /// misencoded, or an invalid public key (such as, but not limited to, being
     /// in a small order subgroup).
     ///
     /// The shared secret is returned as a [`SharedSecret`] which can be constructed
@@ -650,7 +650,7 @@ pub trait ActiveKeyExchange: Send + Sync {
     /// This is only called if `hybrid_component` returns `Some(_)`.
     ///
     /// This method must return an error if `peer_pub_key` is invalid: either
-    /// mis-encoded, or an invalid public key (such as, but not limited to, being
+    /// misencoded, or an invalid public key (such as, but not limited to, being
     /// in a small order subgroup).
     ///
     /// The shared secret is returned as a [`SharedSecret`] which can be constructed

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -150,7 +150,7 @@ impl quic::PacketKey for PacketKey {
     ///
     /// On success, returns the slice of `payload` containing the decrypted data.
     ///
-    /// When provided, the `path_id` is used for multipath ecryption as described in
+    /// When provided, the `path_id` is used for multipath encryption as described in
     /// <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-15.html#section-2.4>.
     fn decrypt_in_place<'a>(
         &self,

--- a/rustls/src/crypto/tls13.rs
+++ b/rustls/src/crypto/tls13.rs
@@ -370,7 +370,7 @@ mod tests {
 
         let hkdf = HkdfUsingHmac(&hmac::HMAC_SHA384);
         let ikm = &[0x0b; 40];
-        let info = &[&b"hel"[..], &b"lo"[..]];
+        let info = &[&b"hell"[..], &b"o"[..]];
 
         let output: ByteArray<96> = expand(
             hkdf.extract_from_secret(None, ikm)

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -6,7 +6,7 @@ use crate::msgs::enums::HashAlgorithm;
 enum_builder! {
     /// The `AlertDescription` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum AlertDescription {
         CloseNotify => 0x00,
@@ -164,7 +164,7 @@ impl core::fmt::Display for AlertDescription {
 enum_builder! {
     /// The `HandshakeType` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum HandshakeType {
         HelloRequest => 0x00,
@@ -193,7 +193,7 @@ enum_builder! {
 enum_builder! {
     /// The `ContentType` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum ContentType {
         ChangeCipherSpec => 0x14,
@@ -207,7 +207,7 @@ enum_builder! {
 enum_builder! {
     /// The `ProtocolVersion` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u16)]
     pub enum ProtocolVersion {
         SSLv2 => 0x0002,
@@ -225,7 +225,7 @@ enum_builder! {
 enum_builder! {
     /// The `CipherSuite` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u16)]
     pub enum CipherSuite {
         /// The `TLS_DHE_RSA_WITH_AES_128_GCM_SHA256` cipher suite.  Recommended=Y.  Defined in
@@ -578,7 +578,7 @@ enum_builder! {
 enum_builder! {
     /// The `SignatureScheme` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u16)]
     pub enum SignatureScheme {
         RSA_PKCS1_SHA1 => 0x0201,
@@ -663,7 +663,7 @@ impl SignatureScheme {
 enum_builder! {
     /// The `SignatureAlgorithm` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum SignatureAlgorithm {
         Anonymous => 0x00,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -1143,7 +1143,7 @@ pub enum ApiMisuse {
 
     /// The `output` object to [`KeyingMaterialExporter::derive()`][] was zero length.
     ///
-    /// This doesn't make sense, so we explicitely return an error (rather than simply
+    /// This doesn't make sense, so we explicitly return an error (rather than simply
     /// producing no output as requested.)
     ///
     /// [`KeyingMaterialExporter::derive()`]: crate::KeyingMaterialExporter::derive()

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -7,7 +7,7 @@ use crate::msgs::codec::{Codec, Reader};
 enum_builder! {
     /// The `HashAlgorithm` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum HashAlgorithm {
         NONE => 0x00,
@@ -49,7 +49,7 @@ impl HashAlgorithm {
 enum_builder! {
     /// The `ClientCertificateType` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub(crate) enum ClientCertificateType {
         RSASign => 0x01,
@@ -68,7 +68,7 @@ enum_builder! {
 enum_builder! {
     /// The `Compression` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum Compression {
         Null => 0x00,
@@ -80,7 +80,7 @@ enum_builder! {
 enum_builder! {
     /// The `AlertLevel` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum AlertLevel {
         Warning => 0x01,
@@ -91,7 +91,7 @@ enum_builder! {
 enum_builder! {
     /// The `HeartbeatMessageType` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub(crate) enum HeartbeatMessageType {
         Request => 0x01,
@@ -102,7 +102,7 @@ enum_builder! {
 enum_builder! {
     /// The `ExtensionType` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u16)]
     pub enum ExtensionType {
         ServerName => 0x0000,
@@ -180,7 +180,7 @@ impl ExtensionType {
 enum_builder! {
     /// The `ServerNameType` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub(crate) enum ServerNameType {
         HostName => 0x00,
@@ -190,7 +190,7 @@ enum_builder! {
 enum_builder! {
     /// The `NamedGroup` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     ///
     /// This enum is used for recognizing key exchange groups advertised
     /// by a peer during a TLS handshake. It is **not** a list of groups that
@@ -263,7 +263,7 @@ impl NamedGroup {
 enum_builder! {
     /// The `ECPointFormat` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum ECPointFormat {
         Uncompressed => 0x00,
@@ -275,7 +275,7 @@ enum_builder! {
 enum_builder! {
     /// The `HeartbeatMode` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub(crate) enum HeartbeatMode {
         PeerAllowedToSend => 0x01,
@@ -286,7 +286,7 @@ enum_builder! {
 enum_builder! {
     /// The `ECCurveType` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub(crate) enum ECCurveType {
         ExplicitPrime => 0x01,
@@ -298,7 +298,7 @@ enum_builder! {
 enum_builder! {
     /// The `PskKeyExchangeMode` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum PskKeyExchangeMode {
         PSK_KE => 0x00,
@@ -309,7 +309,7 @@ enum_builder! {
 enum_builder! {
     /// The `KeyUpdateRequest` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum KeyUpdateRequest {
         UpdateNotRequested => 0x00,
@@ -320,7 +320,7 @@ enum_builder! {
 enum_builder! {
     /// The `CertificateStatusType` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.
-    /// The `Unknown` item is used when processing unrecognised ordinals.
+    /// The `Unknown` item is used when processing unrecognized ordinals.
     #[repr(u8)]
     pub enum CertificateStatusType {
         OCSP => 0x01,

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -13,8 +13,8 @@ macro_rules! enum_builder {
           $(
               !Debug:
               $(
-                  $(#[doc = $enum_comment_nd:literal])*
-                  $enum_var_nd:ident => $enum_val_nd:literal
+                  $(#[doc = $enum_comment_no_debug:literal])*
+                  $enum_var_no_debug:ident => $enum_val_no_debug:literal
               ),*
               $(,)?
           )?
@@ -31,8 +31,8 @@ macro_rules! enum_builder {
             $(
                 ,
                 $(
-                    $(#[doc = $enum_comment_nd])*
-                    $enum_var_nd
+                    $(#[doc = $enum_comment_no_debug])*
+                    $enum_var_no_debug
                 ),*
             )?
             ,Unknown($uint)
@@ -50,7 +50,7 @@ macro_rules! enum_builder {
             $enum_vis fn as_str(&self) -> Option<&'static str> {
                 match self {
                     $( $enum_name::$enum_var => Some(stringify!($enum_var))),*
-                    $(, $( $enum_name::$enum_var_nd => Some(stringify!($enum_var_nd))),* )?
+                    $(, $( $enum_name::$enum_var_no_debug => Some(stringify!($enum_var_no_debug))),* )?
                     ,$enum_name::Unknown(_) => None,
                 }
             }
@@ -75,7 +75,7 @@ macro_rules! enum_builder {
             fn from(x: $uint) -> Self {
                 match x {
                     $($enum_val => $enum_name::$enum_var),*
-                    $(, $($enum_val_nd => $enum_name::$enum_var_nd),* )?
+                    $(, $($enum_val_no_debug => $enum_name::$enum_var_no_debug),* )?
                     , x => $enum_name::Unknown(x),
                 }
             }
@@ -85,7 +85,7 @@ macro_rules! enum_builder {
             fn from(value: $enum_name) -> Self {
                 match value {
                     $( $enum_name::$enum_var => $enum_val),*
-                    $(, $( $enum_name::$enum_var_nd => $enum_val_nd),* )?
+                    $(, $( $enum_name::$enum_var_no_debug => $enum_val_no_debug),* )?
                     ,$enum_name::Unknown(x) => x
                 }
             }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -731,7 +731,7 @@ pub trait PacketKey: Send + Sync {
     ///
     /// Fails if and only if the payload is longer than allowed by the cipher suite's AEAD algorithm.
     ///
-    /// When provided, the `path_id` is used for multipath ecryption as described in
+    /// When provided, the `path_id` is used for multipath encryption as described in
     /// <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-15.html#section-2.4>.
     fn encrypt_in_place(
         &self,
@@ -749,7 +749,7 @@ pub trait PacketKey: Send + Sync {
     ///
     /// On success, returns the slice of `payload` containing the decrypted data.
     ///
-    /// When provided, the `path_id` is used for multipath ecryption as described in
+    /// When provided, the `path_id` is used for multipath encryption as described in
     /// <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-15.html#section-2.4>.
     fn decrypt_in_place<'a>(
         &self,

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -520,7 +520,7 @@ mod tests {
     }
 
     #[test]
-    fn test_client_verifier_without_crls_opptional_auth() {
+    fn test_client_verifier_without_crls_optional_auth() {
         // We should be able to build a verifier that allows client authentication,
         // and anonymous access, that does no revocation checking.
         let builder = WebPkiClientVerifier::builder_with_provider(

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6210,7 +6210,7 @@ fn bad_client_max_fragment_sizes() {
 }
 
 #[test]
-fn handshakes_complete_and_data_flows_with_gratuitious_max_fragment_sizes() {
+fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
     // general exercising of msgs::fragmenter and msgs::deframer
     let provider = provider::default_provider();
     for kt in KeyType::all_for_provider(&provider) {


### PR DESCRIPTION
fixes #2099