### PR TITLE
Use generics instead of enum wrappers for connection types

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -33,7 +33,7 @@ use rustls::client::danger::{
     HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdentity,
 };
 use rustls::client::{
-    ClientConfig, ClientConnectionData, EchConfig, EchGreaseConfig, EchMode, EchStatus, Resumption,
+    Client, ClientConfig, EchConfig, EchGreaseConfig, EchMode, EchStatus, Resumption,
     Tls12Resumption, WebPkiServerVerifier, WriteEarlyData,
 };
 use rustls::crypto::aws_lc_rs::hpke;
@@ -49,8 +49,7 @@ use rustls::server::danger::{
     ClientCertVerified, ClientCertVerifier, ClientIdentity, SignatureVerificationInput,
 };
 use rustls::server::{
-    ClientHello, ProducesTickets, ReadEarlyData, ServerConfig, ServerConnectionData,
-    WebPkiClientVerifier,
+    ClientHello, ProducesTickets, ReadEarlyData, Server, ServerConfig, WebPkiClientVerifier,
 };
 use rustls::{
     AlertDescription, CertificateCompressionAlgorithm, CertificateError, Connection,
@@ -1519,7 +1518,7 @@ where
     }
 }
 
-impl ConnectionExt for Connection<ClientConnectionData> {
+impl ConnectionExt for Connection<Client> {
     fn write_early_data(&mut self) -> Option<WriteEarlyData<'_>> {
         self.early_data()
     }
@@ -1537,7 +1536,7 @@ impl ConnectionExt for Connection<ClientConnectionData> {
     }
 }
 
-impl ConnectionExt for Connection<ServerConnectionData> {
+impl ConnectionExt for Connection<Server> {
     fn write_early_data(&mut self) -> Option<WriteEarlyData<'_>> {
         None
     }
@@ -2037,12 +2036,11 @@ pub fn main() {
                 let server_name = ServerName::try_from(opts.host_name.as_str())
                     .unwrap()
                     .to_owned();
-                let sess =
-                    Connection::<ClientConnectionData>::new(config.clone(), server_name).unwrap();
+                let sess = Connection::<Client>::new(config.clone(), server_name).unwrap();
                 exec(&opts, sess, &key_log, i);
             }
             SideConfig::Server(config) => {
-                let sess = Connection::<ServerConnectionData>::new(config.clone()).unwrap();
+                let sess = Connection::<Server>::new(config.clone()).unwrap();
                 exec(&opts, sess, &key_log, i);
             }
         }

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -30,10 +30,10 @@ use itertools::Itertools;
 use rayon::iter::Either;
 use rayon::prelude::*;
 use rustc_hash::FxHashMap;
-use rustls::client::{ClientConnectionData, Resumption};
+use rustls::client::{Client, Resumption};
 use rustls::crypto::{CryptoProvider, GetRandomFailed, SecureRandom, aws_lc_rs, ring};
 use rustls::server::{
-    NoServerSessionStorage, ServerConnectionData, ServerSessionMemoryCache, WebPkiClientVerifier,
+    NoServerSessionStorage, Server, ServerSessionMemoryCache, WebPkiClientVerifier,
 };
 use rustls::{
     CipherSuite, ClientConfig, Connection, HandshakeKind, ProtocolVersion, RootCertStore,
@@ -574,12 +574,11 @@ impl ClientSideStepper<'_> {
 
 #[async_trait(?Send)]
 impl BenchStepper for ClientSideStepper<'_> {
-    type Endpoint = Connection<ClientConnectionData>;
+    type Endpoint = Connection<Client>;
 
     async fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
         let server_name = "localhost".try_into().unwrap();
-        let mut client =
-            Connection::<ClientConnectionData>::new(self.config.clone(), server_name).unwrap();
+        let mut client = Connection::<Client>::new(self.config.clone(), server_name).unwrap();
         client.set_buffer_limit(None);
 
         loop {
@@ -657,10 +656,10 @@ impl ServerSideStepper<'_> {
 
 #[async_trait(?Send)]
 impl BenchStepper for ServerSideStepper<'_> {
-    type Endpoint = Connection<ServerConnectionData>;
+    type Endpoint = Connection<Server>;
 
     async fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
-        let mut server = Connection::<ServerConnectionData>::new(self.config.clone()).unwrap();
+        let mut server = Connection::<Server>::new(self.config.clone()).unwrap();
         server.set_buffer_limit(None);
 
         while server.is_handshaking() {

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -36,7 +36,7 @@ use rustls::server::{
     NoServerSessionStorage, ServerConnectionData, ServerSessionMemoryCache, WebPkiClientVerifier,
 };
 use rustls::{
-    CipherSuite, ClientConfig, ConnectionCommon, HandshakeKind, ProtocolVersion, RootCertStore,
+    CipherSuite, ClientConfig, Connection, HandshakeKind, ProtocolVersion, RootCertStore,
     ServerConfig,
 };
 use rustls_test::KeyType;
@@ -574,13 +574,12 @@ impl ClientSideStepper<'_> {
 
 #[async_trait(?Send)]
 impl BenchStepper for ClientSideStepper<'_> {
-    type Endpoint = ConnectionCommon<ClientConnectionData>;
+    type Endpoint = Connection<ClientConnectionData>;
 
     async fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
         let server_name = "localhost".try_into().unwrap();
         let mut client =
-            ConnectionCommon::<ClientConnectionData>::new(self.config.clone(), server_name)
-                .unwrap();
+            Connection::<ClientConnectionData>::new(self.config.clone(), server_name).unwrap();
         client.set_buffer_limit(None);
 
         loop {
@@ -658,11 +657,10 @@ impl ServerSideStepper<'_> {
 
 #[async_trait(?Send)]
 impl BenchStepper for ServerSideStepper<'_> {
-    type Endpoint = ConnectionCommon<ServerConnectionData>;
+    type Endpoint = Connection<ServerConnectionData>;
 
     async fn handshake(&mut self) -> anyhow::Result<Self::Endpoint> {
-        let mut server =
-            ConnectionCommon::<ServerConnectionData>::new(self.config.clone()).unwrap();
+        let mut server = Connection::<ServerConnectionData>::new(self.config.clone()).unwrap();
         server.set_buffer_limit(None);
 
         while server.is_handshaking() {

--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -365,7 +365,9 @@ pub(crate) mod transport {
     use std::io::{Cursor, Read, Write};
 
     use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-    use rustls::{ClientConnection, ConnectionCommon, ServerConnection, SideData};
+    use rustls::client::ClientConnectionData;
+    use rustls::server::ServerConnectionData;
+    use rustls::{ConnectionCommon, SideData};
 
     use super::async_io::{AsyncRead, AsyncWrite};
 
@@ -451,7 +453,7 @@ pub(crate) mod transport {
     ///
     /// Returns the amount of plaintext bytes received.
     pub(crate) async fn read_plaintext_to_end_bounded(
-        client: &mut ClientConnection,
+        client: &mut ConnectionCommon<ClientConnectionData>,
         reader: &mut dyn AsyncRead,
     ) -> anyhow::Result<usize> {
         let mut chunk_buf = [0u8; 262_144];
@@ -503,7 +505,7 @@ pub(crate) mod transport {
 
     /// Writes a plaintext of size `plaintext_size`, using a bounded amount of memory
     pub(crate) async fn write_all_plaintext_bounded(
-        server: &mut ServerConnection,
+        server: &mut ConnectionCommon<ServerConnectionData>,
         writer: &mut dyn AsyncWrite,
         plaintext_size: usize,
     ) -> anyhow::Result<()> {

--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -365,8 +365,8 @@ pub(crate) mod transport {
     use std::io::{Cursor, Read, Write};
 
     use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-    use rustls::client::ClientConnectionData;
-    use rustls::server::ServerConnectionData;
+    use rustls::client::Client;
+    use rustls::server::Server;
     use rustls::{Connection, SideData};
 
     use super::async_io::{AsyncRead, AsyncWrite};
@@ -453,7 +453,7 @@ pub(crate) mod transport {
     ///
     /// Returns the amount of plaintext bytes received.
     pub(crate) async fn read_plaintext_to_end_bounded(
-        client: &mut Connection<ClientConnectionData>,
+        client: &mut Connection<Client>,
         reader: &mut dyn AsyncRead,
     ) -> anyhow::Result<usize> {
         let mut chunk_buf = [0u8; 262_144];
@@ -505,7 +505,7 @@ pub(crate) mod transport {
 
     /// Writes a plaintext of size `plaintext_size`, using a bounded amount of memory
     pub(crate) async fn write_all_plaintext_bounded(
-        server: &mut Connection<ServerConnectionData>,
+        server: &mut Connection<Server>,
         writer: &mut dyn AsyncWrite,
         plaintext_size: usize,
     ) -> anyhow::Result<()> {

--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -367,7 +367,7 @@ pub(crate) mod transport {
     use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
     use rustls::client::ClientConnectionData;
     use rustls::server::ServerConnectionData;
-    use rustls::{ConnectionCommon, SideData};
+    use rustls::{Connection, SideData};
 
     use super::async_io::{AsyncRead, AsyncWrite};
 
@@ -379,7 +379,7 @@ pub(crate) mod transport {
     ///
     /// The receiving end should use [`read_handshake_message`] to process the transmission.
     pub(crate) async fn send_handshake_message<T: SideData>(
-        conn: &mut ConnectionCommon<T>,
+        conn: &mut Connection<T>,
         writer: &mut dyn AsyncWrite,
         buf: &mut [u8],
     ) -> anyhow::Result<()> {
@@ -417,7 +417,7 @@ pub(crate) mod transport {
     /// Used in combination with [`send_handshake_message`] (see that function's documentation for
     /// more details).
     pub(crate) async fn read_handshake_message<T: SideData>(
-        conn: &mut ConnectionCommon<T>,
+        conn: &mut Connection<T>,
         reader: &mut dyn AsyncRead,
         buf: &mut [u8],
     ) -> anyhow::Result<usize> {
@@ -453,7 +453,7 @@ pub(crate) mod transport {
     ///
     /// Returns the amount of plaintext bytes received.
     pub(crate) async fn read_plaintext_to_end_bounded(
-        client: &mut ConnectionCommon<ClientConnectionData>,
+        client: &mut Connection<ClientConnectionData>,
         reader: &mut dyn AsyncRead,
     ) -> anyhow::Result<usize> {
         let mut chunk_buf = [0u8; 262_144];
@@ -505,7 +505,7 @@ pub(crate) mod transport {
 
     /// Writes a plaintext of size `plaintext_size`, using a bounded amount of memory
     pub(crate) async fn write_all_plaintext_bounded(
-        server: &mut ConnectionCommon<ServerConnectionData>,
+        server: &mut Connection<ServerConnectionData>,
         writer: &mut dyn AsyncWrite,
         plaintext_size: usize,
     ) -> anyhow::Result<()> {

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -41,7 +41,7 @@ use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::{ResolveError, Resolver, TokioResolver};
 use log::trace;
-use rustls::client::{ClientConnectionData, EchConfig, EchGreaseConfig, EchMode, EchStatus};
+use rustls::client::{Client, EchConfig, EchGreaseConfig, EchMode, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
 use rustls::crypto::hpke::Hpke;
@@ -132,8 +132,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     for i in 0..args.num_reqs {
         trace!("\nRequest {} of {}", i + 1, args.num_reqs);
-        let mut conn =
-            Connection::<ClientConnectionData>::new(config.clone(), server_name.clone())?;
+        let mut conn = Connection::<Client>::new(config.clone(), server_name.clone())?;
         // The "outer" server that we're connecting to.
         let sock_addr = (args.outer_hostname.as_str(), args.port)
             .to_socket_addrs()?

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -41,13 +41,13 @@ use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::{ResolveError, Resolver, TokioResolver};
 use log::trace;
-use rustls::RootCertStore;
-use rustls::client::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
+use rustls::client::{ClientConnectionData, EchConfig, EchGreaseConfig, EchMode, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
 use rustls::crypto::hpke::Hpke;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, EchConfigListBytes, ServerName};
+use rustls::{ConnectionCommon, RootCertStore};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -132,7 +132,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     for i in 0..args.num_reqs {
         trace!("\nRequest {} of {}", i + 1, args.num_reqs);
-        let mut conn = rustls::ClientConnection::new(config.clone(), server_name.clone())?;
+        let mut conn =
+            ConnectionCommon::<ClientConnectionData>::new(config.clone(), server_name.clone())?;
         // The "outer" server that we're connecting to.
         let sock_addr = (args.outer_hostname.as_str(), args.port)
             .to_socket_addrs()?

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -47,7 +47,7 @@ use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
 use rustls::crypto::hpke::Hpke;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, EchConfigListBytes, ServerName};
-use rustls::{ConnectionCommon, RootCertStore};
+use rustls::{Connection, RootCertStore};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -133,7 +133,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     for i in 0..args.num_reqs {
         trace!("\nRequest {} of {}", i + 1, args.num_reqs);
         let mut conn =
-            ConnectionCommon::<ClientConnectionData>::new(config.clone(), server_name.clone())?;
+            Connection::<ClientConnectionData>::new(config.clone(), server_name.clone())?;
         // The "outer" server that we're connecting to.
         let sock_addr = (args.outer_hostname.as_str(), args.port)
             .to_socket_addrs()?

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -31,7 +31,7 @@ fn main() {
     .unwrap();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
-    let mut conn = rustls::ConnectionCommon::<rustls::client::ClientConnectionData>::new(
+    let mut conn = rustls::Connection::<rustls::client::ClientConnectionData>::new(
         Arc::new(config),
         server_name,
     )

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -31,7 +31,11 @@ fn main() {
     .unwrap();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
-    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    let mut conn = rustls::ConnectionCommon::<rustls::client::ClientConnectionData>::new(
+        Arc::new(config),
+        server_name,
+    )
+    .unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write_all(

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -31,11 +31,8 @@ fn main() {
     .unwrap();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
-    let mut conn = rustls::Connection::<rustls::client::ClientConnectionData>::new(
-        Arc::new(config),
-        server_name,
-    )
-    .unwrap();
+    let mut conn =
+        rustls::Connection::<rustls::client::Client>::new(Arc::new(config), server_name).unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write_all(

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -27,7 +27,7 @@ fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str, port:
     let server_name = ServerName::try_from(domain_name)
         .expect("invalid DNS name")
         .to_owned();
-    let mut conn = rustls::ConnectionCommon::<rustls::client::ClientConnectionData>::new(
+    let mut conn = rustls::Connection::<rustls::client::ClientConnectionData>::new(
         config.clone(),
         server_name,
     )

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -27,7 +27,11 @@ fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str, port:
     let server_name = ServerName::try_from(domain_name)
         .expect("invalid DNS name")
         .to_owned();
-    let mut conn = rustls::ClientConnection::new(config.clone(), server_name).unwrap();
+    let mut conn = rustls::ConnectionCommon::<rustls::client::ClientConnectionData>::new(
+        config.clone(),
+        server_name,
+    )
+    .unwrap();
     let mut sock = TcpStream::connect(format!("{domain_name}:{port}")).unwrap();
     sock.set_nodelay(true).unwrap();
     let request = format!(

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -27,11 +27,8 @@ fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str, port:
     let server_name = ServerName::try_from(domain_name)
         .expect("invalid DNS name")
         .to_owned();
-    let mut conn = rustls::Connection::<rustls::client::ClientConnectionData>::new(
-        config.clone(),
-        server_name,
-    )
-    .unwrap();
+    let mut conn =
+        rustls::Connection::<rustls::client::Client>::new(config.clone(), server_name).unwrap();
     let mut sock = TcpStream::connect(format!("{domain_name}:{port}")).unwrap();
     sock.set_nodelay(true).unwrap();
     let request = format!(

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -20,7 +20,7 @@ use std::{env, io};
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::server::ServerConnectionData;
+use rustls::server::Server;
 
 fn main() -> Result<(), Box<dyn StdError>> {
     let mut args = env::args();
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
         println!("Accepting connection");
 
-        let mut conn = rustls::Connection::<ServerConnectionData>::new(Arc::new(config.clone()))?;
+        let mut conn = rustls::Connection::<Server>::new(Arc::new(config.clone()))?;
 
         let mut buf = Vec::new();
         let mut did_early_data = false;

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -51,8 +51,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
         println!("Accepting connection");
 
-        let mut conn =
-            rustls::ConnectionCommon::<ServerConnectionData>::new(Arc::new(config.clone()))?;
+        let mut conn = rustls::Connection::<ServerConnectionData>::new(Arc::new(config.clone()))?;
 
         let mut buf = Vec::new();
         let mut did_early_data = false;

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -20,6 +20,7 @@ use std::{env, io};
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::ServerConnectionData;
 
 fn main() -> Result<(), Box<dyn StdError>> {
     let mut args = env::args();
@@ -50,7 +51,8 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
         println!("Accepting connection");
 
-        let mut conn = rustls::ServerConnection::new(Arc::new(config.clone()))?;
+        let mut conn =
+            rustls::ConnectionCommon::<ServerConnectionData>::new(Arc::new(config.clone()))?;
 
         let mut buf = Vec::new();
         let mut did_early_data = false;

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -13,7 +13,7 @@ use std::net::TcpStream;
 use std::sync::Arc;
 
 use rustls::RootCertStore;
-use rustls::client::ClientConnectionData;
+use rustls::client::Client;
 
 fn main() {
     let root_store = RootCertStore {
@@ -31,8 +31,7 @@ fn main() {
     config.key_log = Arc::new(rustls::KeyLogFile::new());
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
-    let mut conn =
-        rustls::Connection::<ClientConnectionData>::new(Arc::new(config), server_name).unwrap();
+    let mut conn = rustls::Connection::<Client>::new(Arc::new(config), server_name).unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write_all(

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -13,6 +13,7 @@ use std::net::TcpStream;
 use std::sync::Arc;
 
 use rustls::RootCertStore;
+use rustls::client::ClientConnectionData;
 
 fn main() {
     let root_store = RootCertStore {
@@ -30,7 +31,9 @@ fn main() {
     config.key_log = Arc::new(rustls::KeyLogFile::new());
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
-    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    let mut conn =
+        rustls::ConnectionCommon::<ClientConnectionData>::new(Arc::new(config), server_name)
+            .unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write_all(

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -32,8 +32,7 @@ fn main() {
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
     let mut conn =
-        rustls::ConnectionCommon::<ClientConnectionData>::new(Arc::new(config), server_name)
-            .unwrap();
+        rustls::Connection::<ClientConnectionData>::new(Arc::new(config), server_name).unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write_all(

--- a/examples/src/bin/simpleserver.rs
+++ b/examples/src/bin/simpleserver.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::server::ServerConnectionData;
+use rustls::server::Server;
 
 fn main() -> Result<(), Box<dyn StdError>> {
     let mut args = env::args();
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
     let listener = TcpListener::bind(format!("[::]:{}", 4443)).unwrap();
     let (mut tcp_stream, _) = listener.accept()?;
-    let mut conn = rustls::Connection::<ServerConnectionData>::new(Arc::new(config))?;
+    let mut conn = rustls::Connection::<Server>::new(Arc::new(config))?;
     let mut tls_stream = rustls::Stream::new(&mut conn, &mut tcp_stream);
 
     tls_stream.write_all(b"Hello from the server")?;

--- a/examples/src/bin/simpleserver.rs
+++ b/examples/src/bin/simpleserver.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
     let listener = TcpListener::bind(format!("[::]:{}", 4443)).unwrap();
     let (mut tcp_stream, _) = listener.accept()?;
-    let mut conn = rustls::ConnectionCommon::<ServerConnectionData>::new(Arc::new(config))?;
+    let mut conn = rustls::Connection::<ServerConnectionData>::new(Arc::new(config))?;
     let mut tls_stream = rustls::Stream::new(&mut conn, &mut tcp_stream);
 
     tls_stream.write_all(b"Hello from the server")?;

--- a/examples/src/bin/simpleserver.rs
+++ b/examples/src/bin/simpleserver.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::ServerConnectionData;
 
 fn main() -> Result<(), Box<dyn StdError>> {
     let mut args = env::args();
@@ -37,7 +38,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
     let listener = TcpListener::bind(format!("[::]:{}", 4443)).unwrap();
     let (mut tcp_stream, _) = listener.accept()?;
-    let mut conn = rustls::ServerConnection::new(Arc::new(config))?;
+    let mut conn = rustls::ConnectionCommon::<ServerConnectionData>::new(Arc::new(config))?;
     let mut tls_stream = rustls::Stream::new(&mut conn, &mut tcp_stream);
 
     tls_stream.write_all(b"Hello from the server")?;

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -30,7 +30,7 @@ use rustls::client::ClientConnectionData;
 use rustls::crypto::{CryptoProvider, SupportedKxGroup, aws_lc_rs as provider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
-use rustls::{ConnectionCommon, ProtocolVersion, RootCertStore};
+use rustls::{Connection, ProtocolVersion, RootCertStore};
 
 const CLIENT: mio::Token = mio::Token(0);
 
@@ -40,7 +40,7 @@ struct TlsClient {
     socket: TcpStream,
     closing: bool,
     clean_closure: bool,
-    tls_conn: ConnectionCommon<ClientConnectionData>,
+    tls_conn: Connection<ClientConnectionData>,
 }
 
 impl TlsClient {
@@ -53,7 +53,7 @@ impl TlsClient {
             socket: sock,
             closing: false,
             clean_closure: false,
-            tls_conn: ConnectionCommon::<ClientConnectionData>::new(cfg, server_name).unwrap(),
+            tls_conn: Connection::<ClientConnectionData>::new(cfg, server_name).unwrap(),
         }
     }
 

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -26,10 +26,11 @@ use std::{process, str};
 
 use clap::Parser;
 use mio::net::TcpStream;
+use rustls::client::ClientConnectionData;
 use rustls::crypto::{CryptoProvider, SupportedKxGroup, aws_lc_rs as provider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
-use rustls::{ProtocolVersion, RootCertStore};
+use rustls::{ConnectionCommon, ProtocolVersion, RootCertStore};
 
 const CLIENT: mio::Token = mio::Token(0);
 
@@ -39,7 +40,7 @@ struct TlsClient {
     socket: TcpStream,
     closing: bool,
     clean_closure: bool,
-    tls_conn: rustls::ClientConnection,
+    tls_conn: ConnectionCommon<ClientConnectionData>,
 }
 
 impl TlsClient {
@@ -52,7 +53,7 @@ impl TlsClient {
             socket: sock,
             closing: false,
             clean_closure: false,
-            tls_conn: rustls::ClientConnection::new(cfg, server_name).unwrap(),
+            tls_conn: ConnectionCommon::<ClientConnectionData>::new(cfg, server_name).unwrap(),
         }
     }
 

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -26,7 +26,7 @@ use std::{process, str};
 
 use clap::Parser;
 use mio::net::TcpStream;
-use rustls::client::ClientConnectionData;
+use rustls::client::Client;
 use rustls::crypto::{CryptoProvider, SupportedKxGroup, aws_lc_rs as provider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
@@ -40,7 +40,7 @@ struct TlsClient {
     socket: TcpStream,
     closing: bool,
     clean_closure: bool,
-    tls_conn: Connection<ClientConnectionData>,
+    tls_conn: Connection<Client>,
 }
 
 impl TlsClient {
@@ -53,7 +53,7 @@ impl TlsClient {
             socket: sock,
             closing: false,
             clean_closure: false,
-            tls_conn: Connection::<ClientConnectionData>::new(cfg, server_name).unwrap(),
+            tls_conn: Connection::<Client>::new(cfg, server_name).unwrap(),
         }
     }
 

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -32,7 +32,7 @@ use rustls::crypto::{CryptoProvider, aws_lc_rs as provider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use rustls::server::{ServerConnectionData, WebPkiClientVerifier};
-use rustls::{ConnectionCommon, ProtocolVersion, RootCertStore};
+use rustls::{Connection, ProtocolVersion, RootCertStore};
 
 // Token for our listening socket.
 const LISTENER: mio::Token = mio::Token(0);
@@ -79,8 +79,7 @@ impl TlsServer {
                     debug!("Accepting new connection from {addr:?}");
 
                     let tls_conn =
-                        ConnectionCommon::<ServerConnectionData>::new(self.tls_config.clone())
-                            .unwrap();
+                        Connection::<ServerConnectionData>::new(self.tls_config.clone()).unwrap();
                     let mode = self.mode.clone();
 
                     let token = mio::Token(self.next_id);
@@ -127,7 +126,7 @@ struct OpenConnection {
     closing: bool,
     closed: bool,
     mode: ServerMode,
-    tls_conn: ConnectionCommon<ServerConnectionData>,
+    tls_conn: Connection<ServerConnectionData>,
     back: Option<TcpStream>,
     sent_http_response: bool,
 }
@@ -164,7 +163,7 @@ impl OpenConnection {
         socket: TcpStream,
         token: mio::Token,
         mode: ServerMode,
-        tls_conn: ConnectionCommon<ServerConnectionData>,
+        tls_conn: Connection<ServerConnectionData>,
     ) -> Self {
         let back = open_back(&mode);
         Self {

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -31,7 +31,7 @@ use mio::net::{TcpListener, TcpStream};
 use rustls::crypto::{CryptoProvider, aws_lc_rs as provider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
-use rustls::server::{ServerConnectionData, WebPkiClientVerifier};
+use rustls::server::{Server, WebPkiClientVerifier};
 use rustls::{Connection, ProtocolVersion, RootCertStore};
 
 // Token for our listening socket.
@@ -78,8 +78,7 @@ impl TlsServer {
                 Ok((socket, addr)) => {
                     debug!("Accepting new connection from {addr:?}");
 
-                    let tls_conn =
-                        Connection::<ServerConnectionData>::new(self.tls_config.clone()).unwrap();
+                    let tls_conn = Connection::<Server>::new(self.tls_config.clone()).unwrap();
                     let mode = self.mode.clone();
 
                     let token = mio::Token(self.next_id);
@@ -126,7 +125,7 @@ struct OpenConnection {
     closing: bool,
     closed: bool,
     mode: ServerMode,
-    tls_conn: Connection<ServerConnectionData>,
+    tls_conn: Connection<Server>,
     back: Option<TcpStream>,
     sent_http_response: bool,
 }
@@ -163,7 +162,7 @@ impl OpenConnection {
         socket: TcpStream,
         token: mio::Token,
         mode: ServerMode,
-        tls_conn: Connection<ServerConnectionData>,
+        tls_conn: Connection<Server>,
     ) -> Self {
         let back = open_back(&mode);
         Self {

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -31,8 +31,8 @@ use mio::net::{TcpListener, TcpStream};
 use rustls::crypto::{CryptoProvider, aws_lc_rs as provider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
-use rustls::server::WebPkiClientVerifier;
-use rustls::{ProtocolVersion, RootCertStore};
+use rustls::server::{ServerConnectionData, WebPkiClientVerifier};
+use rustls::{ConnectionCommon, ProtocolVersion, RootCertStore};
 
 // Token for our listening socket.
 const LISTENER: mio::Token = mio::Token(0);
@@ -78,7 +78,9 @@ impl TlsServer {
                 Ok((socket, addr)) => {
                     debug!("Accepting new connection from {addr:?}");
 
-                    let tls_conn = rustls::ServerConnection::new(self.tls_config.clone()).unwrap();
+                    let tls_conn =
+                        ConnectionCommon::<ServerConnectionData>::new(self.tls_config.clone())
+                            .unwrap();
                     let mode = self.mode.clone();
 
                     let token = mio::Token(self.next_id);
@@ -125,7 +127,7 @@ struct OpenConnection {
     closing: bool,
     closed: bool,
     mode: ServerMode,
-    tls_conn: rustls::ServerConnection,
+    tls_conn: ConnectionCommon<ServerConnectionData>,
     back: Option<TcpStream>,
     sent_http_response: bool,
 }
@@ -162,7 +164,7 @@ impl OpenConnection {
         socket: TcpStream,
         token: mio::Token,
         mode: ServerMode,
-        tls_conn: rustls::ServerConnection,
+        tls_conn: ConnectionCommon<ServerConnectionData>,
     ) -> Self {
         let back = open_back(&mode);
         Self {

--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -5,7 +5,7 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
+use rustls::client::{Client, UnbufferedClientConnection};
 use rustls::unbuffered::{
     AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,
     UnbufferedStatus, WriteTraffic,
@@ -237,7 +237,7 @@ async fn send_tls(
 
 fn encrypt_http_request(
     sent_request: &mut bool,
-    may_encrypt: &mut WriteTraffic<'_, ClientConnectionData>,
+    may_encrypt: &mut WriteTraffic<'_, Client>,
     outgoing_tls: &mut [u8],
     outgoing_used: &mut usize,
 ) -> bool {

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls::client::{ClientConnectionData, EarlyDataError, UnbufferedClientConnection};
+use rustls::client::{Client, EarlyDataError, UnbufferedClientConnection};
 use rustls::unbuffered::{
     AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,
     UnbufferedStatus, WriteTraffic,
@@ -255,7 +255,7 @@ fn send_tls(
 
 fn encrypt_http_request(
     sent_request: &mut bool,
-    may_encrypt: &mut WriteTraffic<'_, ClientConnectionData>,
+    may_encrypt: &mut WriteTraffic<'_, Client>,
     outgoing_tls: &mut [u8],
     outgoing_used: &mut usize,
 ) -> bool {

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::sync::Arc;
 
 use rustls::client::ClientConnectionData;
-use rustls::{ClientConfig, ConnectionCommon};
+use rustls::{ClientConfig, Connection};
 
 fuzz_target!(|data: &[u8]| {
     let _ = env_logger::try_init();
@@ -19,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
             .unwrap(),
     );
     let hostname = "localhost".try_into().unwrap();
-    let mut client = ConnectionCommon::<ClientConnectionData>::new(config, hostname).unwrap();
+    let mut client = Connection::<ClientConnectionData>::new(config, hostname).unwrap();
 
     let mut stream = io::Cursor::new(data);
     loop {

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -6,7 +6,7 @@ extern crate rustls;
 use std::io;
 use std::sync::Arc;
 
-use rustls::client::ClientConnectionData;
+use rustls::client::Client;
 use rustls::{ClientConfig, Connection};
 
 fuzz_target!(|data: &[u8]| {
@@ -19,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
             .unwrap(),
     );
     let hostname = "localhost".try_into().unwrap();
-    let mut client = Connection::<ClientConnectionData>::new(config, hostname).unwrap();
+    let mut client = Connection::<Client>::new(config, hostname).unwrap();
 
     let mut stream = io::Cursor::new(data);
     loop {

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -6,7 +6,8 @@ extern crate rustls;
 use std::io;
 use std::sync::Arc;
 
-use rustls::{ClientConfig, ClientConnection};
+use rustls::client::ClientConnectionData;
+use rustls::{ClientConfig, ConnectionCommon};
 
 fuzz_target!(|data: &[u8]| {
     let _ = env_logger::try_init();
@@ -18,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
             .unwrap(),
     );
     let hostname = "localhost".try_into().unwrap();
-    let mut client = ClientConnection::new(config, hostname).unwrap();
+    let mut client = ConnectionCommon::<ClientConnectionData>::new(config, hostname).unwrap();
 
     let mut stream = io::Cursor::new(data);
     loop {

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::sync::Arc;
 
 use rustls::server::{Accepted, Acceptor, ServerConnectionData};
-use rustls::{ConnectionCommon, ServerConfig};
+use rustls::{Connection, ServerConfig};
 
 fuzz_target!(|data: &[u8]| {
     let _ = env_logger::try_init();
@@ -26,7 +26,7 @@ fn fuzz_buffered_api(data: &[u8]) {
             .unwrap(),
     );
     let mut stream = io::Cursor::new(data);
-    let mut server = ConnectionCommon::<ServerConnectionData>::new(config).unwrap();
+    let mut server = Connection::<ServerConnectionData>::new(config).unwrap();
 
     service_connection(&mut stream, &mut server);
 }
@@ -69,10 +69,7 @@ fn fuzz_accepted(stream: &mut dyn io::Read, accepted: Accepted) {
     }
 }
 
-fn service_connection(
-    stream: &mut dyn io::Read,
-    server: &mut ConnectionCommon<ServerConnectionData>,
-) {
+fn service_connection(stream: &mut dyn io::Read, server: &mut Connection<ServerConnectionData>) {
     loop {
         let rd = server.read_tls(stream);
         if server.process_new_packets().is_err() {

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -6,7 +6,7 @@ extern crate rustls;
 use std::io;
 use std::sync::Arc;
 
-use rustls::server::{Accepted, Acceptor, ServerConnectionData};
+use rustls::server::{Accepted, Acceptor, Server};
 use rustls::{Connection, ServerConfig};
 
 fuzz_target!(|data: &[u8]| {
@@ -26,7 +26,7 @@ fn fuzz_buffered_api(data: &[u8]) {
             .unwrap(),
     );
     let mut stream = io::Cursor::new(data);
-    let mut server = Connection::<ServerConnectionData>::new(config).unwrap();
+    let mut server = Connection::<Server>::new(config).unwrap();
 
     service_connection(&mut stream, &mut server);
 }
@@ -69,7 +69,7 @@ fn fuzz_accepted(stream: &mut dyn io::Read, accepted: Accepted) {
     }
 }
 
-fn service_connection(stream: &mut dyn io::Read, server: &mut Connection<ServerConnectionData>) {
+fn service_connection(stream: &mut dyn io::Read, server: &mut Connection<Server>) {
     loop {
         let rd = server.read_tls(stream);
         if server.process_new_packets().is_err() {

--- a/openssl-tests/src/early_exporter.rs
+++ b/openssl-tests/src/early_exporter.rs
@@ -8,7 +8,7 @@ use rustls::crypto::aws_lc_rs as provider;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::ServerConnectionData;
-use rustls::{ConnectionCommon, ServerConfig};
+use rustls::{Connection, ServerConfig};
 
 use crate::utils::verify_openssl3_available;
 
@@ -31,7 +31,7 @@ fn test_early_exporter() {
         let config = Arc::new(config);
 
         for _ in 0..ITERS {
-            let mut server = ConnectionCommon::<ServerConnectionData>::new(config.clone()).unwrap();
+            let mut server = Connection::<ServerConnectionData>::new(config.clone()).unwrap();
             let (mut tcp_stream, _addr) = listener.accept().unwrap();
 
             // read clienthello and then inspect early_data status

--- a/openssl-tests/src/early_exporter.rs
+++ b/openssl-tests/src/early_exporter.rs
@@ -7,7 +7,7 @@ use openssl::ssl::{SslConnector, SslMethod, SslSession, SslStream};
 use rustls::crypto::aws_lc_rs as provider;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::server::ServerConnectionData;
+use rustls::server::Server;
 use rustls::{Connection, ServerConfig};
 
 use crate::utils::verify_openssl3_available;
@@ -31,7 +31,7 @@ fn test_early_exporter() {
         let config = Arc::new(config);
 
         for _ in 0..ITERS {
-            let mut server = Connection::<ServerConnectionData>::new(config.clone()).unwrap();
+            let mut server = Connection::<Server>::new(config.clone()).unwrap();
             let (mut tcp_stream, _addr) = listener.accept().unwrap();
 
             // read clienthello and then inspect early_data status

--- a/openssl-tests/src/early_exporter.rs
+++ b/openssl-tests/src/early_exporter.rs
@@ -4,10 +4,11 @@ use std::sync::Arc;
 use std::{str, thread};
 
 use openssl::ssl::{SslConnector, SslMethod, SslSession, SslStream};
-use rustls::ServerConfig;
 use rustls::crypto::aws_lc_rs as provider;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::ServerConnectionData;
+use rustls::{ConnectionCommon, ServerConfig};
 
 use crate::utils::verify_openssl3_available;
 
@@ -30,7 +31,7 @@ fn test_early_exporter() {
         let config = Arc::new(config);
 
         for _ in 0..ITERS {
-            let mut server = rustls::ServerConnection::new(config.clone()).unwrap();
+            let mut server = ConnectionCommon::<ServerConnectionData>::new(config.clone()).unwrap();
             let (mut tcp_stream, _addr) = listener.accept().unwrap();
 
             // read clienthello and then inspect early_data status

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -9,7 +9,7 @@ use rustls::crypto::{CryptoProvider, aws_lc_rs as provider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::ServerConnectionData;
-use rustls::{ClientConfig, ConnectionCommon, RootCertStore, ServerConfig};
+use rustls::{ClientConfig, Connection, RootCertStore, ServerConfig};
 
 use crate::ffdhe::{self, FfdheKxGroup};
 use crate::utils::verify_openssl3_available;
@@ -35,7 +35,7 @@ fn test_rustls_server_with_ffdhe_kx(provider: CryptoProvider, iters: usize) {
     let server_thread = thread::spawn(move || {
         let config = Arc::new(server_config_with_ffdhe_kx(provider));
         for _ in 0..iters {
-            let mut server = ConnectionCommon::<ServerConnectionData>::new(config.clone()).unwrap();
+            let mut server = Connection::<ServerConnectionData>::new(config.clone()).unwrap();
             let (mut tcp_stream, _addr) = listener.accept().unwrap();
             server
                 .writer()
@@ -122,7 +122,7 @@ fn test_rustls_client_with_ffdhe_kx(iters: usize) {
     // client:
     for _ in 0..iters {
         let mut tcp_stream = TcpStream::connect(("localhost", port)).unwrap();
-        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+        let mut client = Connection::<ClientConnectionData>::new(
             client_config_with_ffdhe_kx().into(),
             "localhost".try_into().unwrap(),
         )

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 use std::{fs, str, thread};
 
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
-use rustls::client::ClientConnectionData;
+use rustls::client::Client;
 use rustls::crypto::{CryptoProvider, aws_lc_rs as provider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::server::ServerConnectionData;
+use rustls::server::Server;
 use rustls::{ClientConfig, Connection, RootCertStore, ServerConfig};
 
 use crate::ffdhe::{self, FfdheKxGroup};
@@ -35,7 +35,7 @@ fn test_rustls_server_with_ffdhe_kx(provider: CryptoProvider, iters: usize) {
     let server_thread = thread::spawn(move || {
         let config = Arc::new(server_config_with_ffdhe_kx(provider));
         for _ in 0..iters {
-            let mut server = Connection::<ServerConnectionData>::new(config.clone()).unwrap();
+            let mut server = Connection::<Server>::new(config.clone()).unwrap();
             let (mut tcp_stream, _addr) = listener.accept().unwrap();
             server
                 .writer()
@@ -122,7 +122,7 @@ fn test_rustls_client_with_ffdhe_kx(iters: usize) {
     // client:
     for _ in 0..iters {
         let mut tcp_stream = TcpStream::connect(("localhost", port)).unwrap();
-        let mut client = Connection::<ClientConnectionData>::new(
+        let mut client = Connection::<Client>::new(
             client_config_with_ffdhe_kx().into(),
             "localhost".try_into().unwrap(),
         )

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -4,10 +4,12 @@ use std::sync::Arc;
 use std::{fs, str, thread};
 
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
+use rustls::client::ClientConnectionData;
 use rustls::crypto::{CryptoProvider, aws_lc_rs as provider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::{ClientConfig, RootCertStore, ServerConfig};
+use rustls::server::ServerConnectionData;
+use rustls::{ClientConfig, ConnectionCommon, RootCertStore, ServerConfig};
 
 use crate::ffdhe::{self, FfdheKxGroup};
 use crate::utils::verify_openssl3_available;
@@ -33,7 +35,7 @@ fn test_rustls_server_with_ffdhe_kx(provider: CryptoProvider, iters: usize) {
     let server_thread = thread::spawn(move || {
         let config = Arc::new(server_config_with_ffdhe_kx(provider));
         for _ in 0..iters {
-            let mut server = rustls::ServerConnection::new(config.clone()).unwrap();
+            let mut server = ConnectionCommon::<ServerConnectionData>::new(config.clone()).unwrap();
             let (mut tcp_stream, _addr) = listener.accept().unwrap();
             server
                 .writer()
@@ -120,7 +122,7 @@ fn test_rustls_client_with_ffdhe_kx(iters: usize) {
     // client:
     for _ in 0..iters {
         let mut tcp_stream = TcpStream::connect(("localhost", port)).unwrap();
-        let mut client = rustls::client::ClientConnection::new(
+        let mut client = ConnectionCommon::<ClientConnectionData>::new(
             client_config_with_ffdhe_kx().into(),
             "localhost".try_into().unwrap(),
         )

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -21,7 +21,7 @@ mod client {
     use rustls::server::danger::SignatureVerificationInput;
     use rustls::sign::CertifiedKey;
     use rustls::{
-        ApiMisuse, CertificateError, CertificateType, ClientConfig, ConnectionCommon, Error,
+        ApiMisuse, CertificateError, CertificateType, ClientConfig, Connection, Error,
         InconsistentKeys, PeerIdentity, PeerIncompatible, SignatureScheme, Stream,
     };
 
@@ -65,7 +65,7 @@ mod client {
     pub(super) fn run_client(config: ClientConfig, port: u16) -> Result<String, io::Error> {
         let server_name = "0.0.0.0".try_into().unwrap();
         let mut conn =
-            ConnectionCommon::<ClientConnectionData>::new(Arc::new(config), server_name).unwrap();
+            Connection::<ClientConnectionData>::new(Arc::new(config), server_name).unwrap();
         let mut sock = TcpStream::connect(format!("[::]:{port}")).unwrap();
         let mut tls = Stream::new(&mut conn, &mut sock);
 
@@ -159,7 +159,7 @@ mod server {
     use rustls::server::{AlwaysResolvesServerRawPublicKeys, ServerConnectionData};
     use rustls::sign::CertifiedKey;
     use rustls::{
-        ApiMisuse, CertificateError, CertificateType, ConnectionCommon, DistinguishedName, Error,
+        ApiMisuse, CertificateError, CertificateType, Connection, DistinguishedName, Error,
         InconsistentKeys, PeerIdentity, PeerIncompatible, ServerConfig, SignatureScheme,
     };
 
@@ -205,7 +205,7 @@ mod server {
     ) -> Result<String, io::Error> {
         let (mut stream, _) = listener.accept()?;
 
-        let mut conn = ConnectionCommon::<ServerConnectionData>::new(Arc::new(config)).unwrap();
+        let mut conn = Connection::<ServerConnectionData>::new(Arc::new(config)).unwrap();
         conn.complete_io(&mut stream)?;
 
         conn.writer()

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -12,7 +12,7 @@ mod client {
     use rustls::client::danger::{
         HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdentity,
     };
-    use rustls::client::{AlwaysResolvesClientRawPublicKeys, ClientConnectionData};
+    use rustls::client::{AlwaysResolvesClientRawPublicKeys, Client};
     use rustls::crypto::{
         WebPkiSupportedAlgorithms, aws_lc_rs as provider, verify_tls13_signature,
     };
@@ -64,8 +64,7 @@ mod client {
     /// This client reads a message and then writes 'Hello from the client' to the server.
     pub(super) fn run_client(config: ClientConfig, port: u16) -> Result<String, io::Error> {
         let server_name = "0.0.0.0".try_into().unwrap();
-        let mut conn =
-            Connection::<ClientConnectionData>::new(Arc::new(config), server_name).unwrap();
+        let mut conn = Connection::<Client>::new(Arc::new(config), server_name).unwrap();
         let mut sock = TcpStream::connect(format!("[::]:{port}")).unwrap();
         let mut tls = Stream::new(&mut conn, &mut sock);
 
@@ -156,7 +155,7 @@ mod server {
     use rustls::server::danger::{
         ClientCertVerified, ClientCertVerifier, ClientIdentity, SignatureVerificationInput,
     };
-    use rustls::server::{AlwaysResolvesServerRawPublicKeys, ServerConnectionData};
+    use rustls::server::{AlwaysResolvesServerRawPublicKeys, Server};
     use rustls::sign::CertifiedKey;
     use rustls::{
         ApiMisuse, CertificateError, CertificateType, Connection, DistinguishedName, Error,
@@ -205,7 +204,7 @@ mod server {
     ) -> Result<String, io::Error> {
         let (mut stream, _) = listener.accept()?;
 
-        let mut conn = Connection::<ServerConnectionData>::new(Arc::new(config)).unwrap();
+        let mut conn = Connection::<Server>::new(Arc::new(config)).unwrap();
         conn.complete_io(&mut stream)?;
 
         conn.writer()

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -9,10 +9,10 @@ mod client {
     use std::net::TcpStream;
     use std::sync::Arc;
 
-    use rustls::client::AlwaysResolvesClientRawPublicKeys;
     use rustls::client::danger::{
         HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdentity,
     };
+    use rustls::client::{AlwaysResolvesClientRawPublicKeys, ClientConnectionData};
     use rustls::crypto::{
         WebPkiSupportedAlgorithms, aws_lc_rs as provider, verify_tls13_signature,
     };
@@ -21,7 +21,7 @@ mod client {
     use rustls::server::danger::SignatureVerificationInput;
     use rustls::sign::CertifiedKey;
     use rustls::{
-        ApiMisuse, CertificateError, CertificateType, ClientConfig, ClientConnection, Error,
+        ApiMisuse, CertificateError, CertificateType, ClientConfig, ConnectionCommon, Error,
         InconsistentKeys, PeerIdentity, PeerIncompatible, SignatureScheme, Stream,
     };
 
@@ -64,7 +64,8 @@ mod client {
     /// This client reads a message and then writes 'Hello from the client' to the server.
     pub(super) fn run_client(config: ClientConfig, port: u16) -> Result<String, io::Error> {
         let server_name = "0.0.0.0".try_into().unwrap();
-        let mut conn = ClientConnection::new(Arc::new(config), server_name).unwrap();
+        let mut conn =
+            ConnectionCommon::<ClientConnectionData>::new(Arc::new(config), server_name).unwrap();
         let mut sock = TcpStream::connect(format!("[::]:{port}")).unwrap();
         let mut tls = Stream::new(&mut conn, &mut sock);
 
@@ -152,14 +153,14 @@ mod server {
     };
     use rustls::pki_types::pem::PemObject;
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, SubjectPublicKeyInfoDer};
-    use rustls::server::AlwaysResolvesServerRawPublicKeys;
     use rustls::server::danger::{
         ClientCertVerified, ClientCertVerifier, ClientIdentity, SignatureVerificationInput,
     };
+    use rustls::server::{AlwaysResolvesServerRawPublicKeys, ServerConnectionData};
     use rustls::sign::CertifiedKey;
     use rustls::{
-        ApiMisuse, CertificateError, CertificateType, DistinguishedName, Error, InconsistentKeys,
-        PeerIdentity, PeerIncompatible, ServerConfig, ServerConnection, SignatureScheme,
+        ApiMisuse, CertificateError, CertificateType, ConnectionCommon, DistinguishedName, Error,
+        InconsistentKeys, PeerIdentity, PeerIncompatible, ServerConfig, SignatureScheme,
     };
 
     /// Build a `ServerConfig` with the given server private key and a client public key to trust.
@@ -204,7 +205,7 @@ mod server {
     ) -> Result<String, io::Error> {
         let (mut stream, _) = listener.accept()?;
 
-        let mut conn = ServerConnection::new(Arc::new(config)).unwrap();
+        let mut conn = ConnectionCommon::<ServerConnectionData>::new(Arc::new(config)).unwrap();
         conn.complete_io(&mut stream)?;
 
         conn.writer()

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -18,7 +18,7 @@ fn main() {
             .unwrap();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
-    let mut conn = rustls::ConnectionCommon::<rustls::client::ClientConnectionData>::new(
+    let mut conn = rustls::Connection::<rustls::client::ClientConnectionData>::new(
         Arc::new(config),
         server_name,
     )

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -18,11 +18,8 @@ fn main() {
             .unwrap();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
-    let mut conn = rustls::Connection::<rustls::client::ClientConnectionData>::new(
-        Arc::new(config),
-        server_name,
-    )
-    .unwrap();
+    let mut conn =
+        rustls::Connection::<rustls::client::Client>::new(Arc::new(config), server_name).unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write_all(

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -18,7 +18,11 @@ fn main() {
             .unwrap();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
-    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    let mut conn = rustls::ConnectionCommon::<rustls::client::ClientConnectionData>::new(
+        Arc::new(config),
+        server_name,
+    )
+    .unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write_all(

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -19,7 +19,6 @@
 
 use core::mem;
 use core::num::NonZeroUsize;
-use core::ops::{Deref, DerefMut};
 use core::time::Duration;
 use std::fs::File;
 use std::io::{self, Read, Write};
@@ -28,16 +27,16 @@ use std::thread;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use clap::{Parser, ValueEnum};
-use rustls::client::{Resumption, UnbufferedClientConnection};
+use rustls::client::{ClientConnectionData, Resumption, UnbufferedClientConnection};
 use rustls::crypto::CryptoProvider;
 use rustls::server::{
-    NoServerSessionStorage, ProducesTickets, ServerSessionMemoryCache, UnbufferedServerConnection,
-    WebPkiClientVerifier,
+    NoServerSessionStorage, ProducesTickets, ServerConnectionData, ServerSessionMemoryCache,
+    UnbufferedServerConnection, WebPkiClientVerifier,
 };
 use rustls::unbuffered::{ConnectionState, EncryptError, InsufficientSizeError, UnbufferedStatus};
 use rustls::{
-    CipherSuite, ClientConfig, ClientConnection, ConnectionCommon, Error, HandshakeKind,
-    ProtocolVersion, RootCertStore, ServerConfig, ServerConnection, SideData,
+    CipherSuite, ClientConfig, ConnectionCommon, Error, HandshakeKind, ProtocolVersion,
+    RootCertStore, ServerConfig, SideData,
 };
 use rustls_test::KeyType;
 
@@ -329,10 +328,11 @@ fn bench_handshake_buffered(
 
         let mut client = time(&mut client_time, || {
             let server_name = "localhost".try_into().unwrap();
-            ClientConnection::new(client_config.clone(), server_name).unwrap()
+            ConnectionCommon::<ClientConnectionData>::new(client_config.clone(), server_name)
+                .unwrap()
         });
         let mut server = time(&mut server_time, || {
-            ServerConnection::new(server_config.clone()).unwrap()
+            ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap()
         });
 
         time(&mut server_time, || {
@@ -579,9 +579,10 @@ fn bench_bulk_buffered(
     rounds: u64,
 ) -> Timings {
     let server_name = "localhost".try_into().unwrap();
-    let mut client = ClientConnection::new(client_config, server_name).unwrap();
+    let mut client =
+        ConnectionCommon::<ClientConnectionData>::new(client_config, server_name).unwrap();
     client.set_buffer_limit(None);
-    let mut server = ServerConnection::new(server_config).unwrap();
+    let mut server = ConnectionCommon::<ServerConnectionData>::new(server_config).unwrap();
     server.set_buffer_limit(None);
 
     let mut timings = Timings::default();
@@ -668,9 +669,12 @@ fn bench_memory(
     let mut buffers = TempBuffers::new();
 
     for _i in 0..conn_count {
-        servers.push(ServerConnection::new(server_config.clone()).unwrap());
+        servers.push(ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap());
         let server_name = "localhost".try_into().unwrap();
-        clients.push(ClientConnection::new(client_config.clone(), server_name).unwrap());
+        clients.push(
+            ConnectionCommon::<ClientConnectionData>::new(client_config.clone(), server_name)
+                .unwrap(),
+        );
     }
 
     for _step in 0..5 {
@@ -1316,8 +1320,8 @@ impl UnbufferedConnection {
 
 fn do_handshake_step(
     buffers: &mut TempBuffers,
-    client: &mut ClientConnection,
-    server: &mut ServerConnection,
+    client: &mut ConnectionCommon<ClientConnectionData>,
+    server: &mut ConnectionCommon<ServerConnectionData>,
 ) -> bool {
     if server.is_handshaking() || client.is_handshaking() {
         transfer(buffers, client, server, None);
@@ -1330,8 +1334,8 @@ fn do_handshake_step(
 
 fn do_handshake(
     buffers: &mut TempBuffers,
-    client: &mut ClientConnection,
-    server: &mut ServerConnection,
+    client: &mut ConnectionCommon<ClientConnectionData>,
+    server: &mut ConnectionCommon<ServerConnectionData>,
 ) {
     while do_handshake_step(buffers, client, server) {}
 }
@@ -1347,18 +1351,12 @@ where
     r
 }
 
-fn transfer<L, R, LS, RS>(
+fn transfer(
     buffers: &mut TempBuffers,
-    left: &mut L,
-    right: &mut R,
+    left: &mut ConnectionCommon<impl SideData>,
+    right: &mut ConnectionCommon<impl SideData>,
     expect_data: Option<usize>,
-) -> f64
-where
-    L: DerefMut + Deref<Target = ConnectionCommon<LS>>,
-    R: DerefMut + Deref<Target = ConnectionCommon<RS>>,
-    LS: SideData,
-    RS: SideData,
-{
+) -> f64 {
     let mut read_time = 0f64;
     let mut data_left = expect_data;
 

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -27,10 +27,10 @@ use std::thread;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use clap::{Parser, ValueEnum};
-use rustls::client::{ClientConnectionData, Resumption, UnbufferedClientConnection};
+use rustls::client::{Client, Resumption, UnbufferedClientConnection};
 use rustls::crypto::CryptoProvider;
 use rustls::server::{
-    NoServerSessionStorage, ProducesTickets, ServerConnectionData, ServerSessionMemoryCache,
+    NoServerSessionStorage, ProducesTickets, Server, ServerSessionMemoryCache,
     UnbufferedServerConnection, WebPkiClientVerifier,
 };
 use rustls::unbuffered::{ConnectionState, EncryptError, InsufficientSizeError, UnbufferedStatus};
@@ -328,10 +328,10 @@ fn bench_handshake_buffered(
 
         let mut client = time(&mut client_time, || {
             let server_name = "localhost".try_into().unwrap();
-            Connection::<ClientConnectionData>::new(client_config.clone(), server_name).unwrap()
+            Connection::<Client>::new(client_config.clone(), server_name).unwrap()
         });
         let mut server = time(&mut server_time, || {
-            Connection::<ServerConnectionData>::new(server_config.clone()).unwrap()
+            Connection::<Server>::new(server_config.clone()).unwrap()
         });
 
         time(&mut server_time, || {
@@ -578,9 +578,9 @@ fn bench_bulk_buffered(
     rounds: u64,
 ) -> Timings {
     let server_name = "localhost".try_into().unwrap();
-    let mut client = Connection::<ClientConnectionData>::new(client_config, server_name).unwrap();
+    let mut client = Connection::<Client>::new(client_config, server_name).unwrap();
     client.set_buffer_limit(None);
-    let mut server = Connection::<ServerConnectionData>::new(server_config).unwrap();
+    let mut server = Connection::<Server>::new(server_config).unwrap();
     server.set_buffer_limit(None);
 
     let mut timings = Timings::default();
@@ -667,11 +667,9 @@ fn bench_memory(
     let mut buffers = TempBuffers::new();
 
     for _i in 0..conn_count {
-        servers.push(Connection::<ServerConnectionData>::new(server_config.clone()).unwrap());
+        servers.push(Connection::<Server>::new(server_config.clone()).unwrap());
         let server_name = "localhost".try_into().unwrap();
-        clients.push(
-            Connection::<ClientConnectionData>::new(client_config.clone(), server_name).unwrap(),
-        );
+        clients.push(Connection::<Client>::new(client_config.clone(), server_name).unwrap());
     }
 
     for _step in 0..5 {
@@ -1317,8 +1315,8 @@ impl UnbufferedConnection {
 
 fn do_handshake_step(
     buffers: &mut TempBuffers,
-    client: &mut Connection<ClientConnectionData>,
-    server: &mut Connection<ServerConnectionData>,
+    client: &mut Connection<Client>,
+    server: &mut Connection<Server>,
 ) -> bool {
     if server.is_handshaking() || client.is_handshaking() {
         transfer(buffers, client, server, None);
@@ -1331,8 +1329,8 @@ fn do_handshake_step(
 
 fn do_handshake(
     buffers: &mut TempBuffers,
-    client: &mut Connection<ClientConnectionData>,
-    server: &mut Connection<ServerConnectionData>,
+    client: &mut Connection<Client>,
+    server: &mut Connection<Server>,
 ) {
     while do_handshake_step(buffers, client, server) {}
 }

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -35,8 +35,8 @@ use rustls::server::{
 };
 use rustls::unbuffered::{ConnectionState, EncryptError, InsufficientSizeError, UnbufferedStatus};
 use rustls::{
-    CipherSuite, ClientConfig, ConnectionCommon, Error, HandshakeKind, ProtocolVersion,
-    RootCertStore, ServerConfig, SideData,
+    CipherSuite, ClientConfig, Connection, Error, HandshakeKind, ProtocolVersion, RootCertStore,
+    ServerConfig, SideData,
 };
 use rustls_test::KeyType;
 
@@ -328,11 +328,10 @@ fn bench_handshake_buffered(
 
         let mut client = time(&mut client_time, || {
             let server_name = "localhost".try_into().unwrap();
-            ConnectionCommon::<ClientConnectionData>::new(client_config.clone(), server_name)
-                .unwrap()
+            Connection::<ClientConnectionData>::new(client_config.clone(), server_name).unwrap()
         });
         let mut server = time(&mut server_time, || {
-            ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap()
+            Connection::<ServerConnectionData>::new(server_config.clone()).unwrap()
         });
 
         time(&mut server_time, || {
@@ -579,10 +578,9 @@ fn bench_bulk_buffered(
     rounds: u64,
 ) -> Timings {
     let server_name = "localhost".try_into().unwrap();
-    let mut client =
-        ConnectionCommon::<ClientConnectionData>::new(client_config, server_name).unwrap();
+    let mut client = Connection::<ClientConnectionData>::new(client_config, server_name).unwrap();
     client.set_buffer_limit(None);
-    let mut server = ConnectionCommon::<ServerConnectionData>::new(server_config).unwrap();
+    let mut server = Connection::<ServerConnectionData>::new(server_config).unwrap();
     server.set_buffer_limit(None);
 
     let mut timings = Timings::default();
@@ -669,11 +667,10 @@ fn bench_memory(
     let mut buffers = TempBuffers::new();
 
     for _i in 0..conn_count {
-        servers.push(ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap());
+        servers.push(Connection::<ServerConnectionData>::new(server_config.clone()).unwrap());
         let server_name = "localhost".try_into().unwrap();
         clients.push(
-            ConnectionCommon::<ClientConnectionData>::new(client_config.clone(), server_name)
-                .unwrap(),
+            Connection::<ClientConnectionData>::new(client_config.clone(), server_name).unwrap(),
         );
     }
 
@@ -1320,8 +1317,8 @@ impl UnbufferedConnection {
 
 fn do_handshake_step(
     buffers: &mut TempBuffers,
-    client: &mut ConnectionCommon<ClientConnectionData>,
-    server: &mut ConnectionCommon<ServerConnectionData>,
+    client: &mut Connection<ClientConnectionData>,
+    server: &mut Connection<ServerConnectionData>,
 ) -> bool {
     if server.is_handshaking() || client.is_handshaking() {
         transfer(buffers, client, server, None);
@@ -1334,8 +1331,8 @@ fn do_handshake_step(
 
 fn do_handshake(
     buffers: &mut TempBuffers,
-    client: &mut ConnectionCommon<ClientConnectionData>,
-    server: &mut ConnectionCommon<ServerConnectionData>,
+    client: &mut Connection<ClientConnectionData>,
+    server: &mut Connection<ServerConnectionData>,
 ) {
     while do_handshake_step(buffers, client, server) {}
 }
@@ -1353,8 +1350,8 @@ where
 
 fn transfer(
     buffers: &mut TempBuffers,
-    left: &mut ConnectionCommon<impl SideData>,
-    right: &mut ConnectionCommon<impl SideData>,
+    left: &mut Connection<impl SideData>,
+    right: &mut Connection<impl SideData>,
     expect_data: Option<usize>,
 ) -> f64 {
     let mut read_time = 0f64;

--- a/rustls-fuzzing-provider/tests/smoke.rs
+++ b/rustls-fuzzing-provider/tests/smoke.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use rustls::client::ClientConnectionData;
 use rustls::crypto::CryptoProvider;
 use rustls::server::ServerConnectionData;
-use rustls::{ClientConfig, ConnectionCommon, ServerConfig};
+use rustls::{ClientConfig, Connection, ServerConfig};
 
 // These tests exercise rustls_fuzzing_provider and makes sure it can
 // handshake with itself without errors.
@@ -80,7 +80,7 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         .with_no_client_auth()
         .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
         .unwrap();
-    let mut server = ConnectionCommon::<ServerConnectionData>::new(server_config.into()).unwrap();
+    let mut server = Connection::<ServerConnectionData>::new(server_config.into()).unwrap();
 
     let client_config = ClientConfig::builder_with_provider(provider.into())
         .dangerous()
@@ -89,7 +89,7 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         .unwrap();
     let hostname = "localhost".try_into().unwrap();
     let mut client =
-        ConnectionCommon::<ClientConnectionData>::new(client_config.into(), hostname).unwrap();
+        Connection::<ClientConnectionData>::new(client_config.into(), hostname).unwrap();
     server
         .writer()
         .write_all(b"hello from server")

--- a/rustls-fuzzing-provider/tests/smoke.rs
+++ b/rustls-fuzzing-provider/tests/smoke.rs
@@ -1,8 +1,10 @@
 use std::fs;
 use std::io::Write;
 
+use rustls::client::ClientConnectionData;
 use rustls::crypto::CryptoProvider;
-use rustls::{ClientConfig, ClientConnection, ServerConfig, ServerConnection};
+use rustls::server::ServerConnectionData;
+use rustls::{ClientConfig, ConnectionCommon, ServerConfig};
 
 // These tests exercise rustls_fuzzing_provider and makes sure it can
 // handshake with itself without errors.
@@ -78,7 +80,7 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         .with_no_client_auth()
         .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
         .unwrap();
-    let mut server = ServerConnection::new(server_config.into()).unwrap();
+    let mut server = ConnectionCommon::<ServerConnectionData>::new(server_config.into()).unwrap();
 
     let client_config = ClientConfig::builder_with_provider(provider.into())
         .dangerous()
@@ -86,7 +88,8 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         .with_no_client_auth()
         .unwrap();
     let hostname = "localhost".try_into().unwrap();
-    let mut client = ClientConnection::new(client_config.into(), hostname).unwrap();
+    let mut client =
+        ConnectionCommon::<ClientConnectionData>::new(client_config.into(), hostname).unwrap();
     server
         .writer()
         .write_all(b"hello from server")

--- a/rustls-fuzzing-provider/tests/smoke.rs
+++ b/rustls-fuzzing-provider/tests/smoke.rs
@@ -1,9 +1,9 @@
 use std::fs;
 use std::io::Write;
 
-use rustls::client::ClientConnectionData;
+use rustls::client::Client;
 use rustls::crypto::CryptoProvider;
-use rustls::server::ServerConnectionData;
+use rustls::server::Server;
 use rustls::{ClientConfig, Connection, ServerConfig};
 
 // These tests exercise rustls_fuzzing_provider and makes sure it can
@@ -80,7 +80,7 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         .with_no_client_auth()
         .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
         .unwrap();
-    let mut server = Connection::<ServerConnectionData>::new(server_config.into()).unwrap();
+    let mut server = Connection::<Server>::new(server_config.into()).unwrap();
 
     let client_config = ClientConfig::builder_with_provider(provider.into())
         .dangerous()
@@ -88,8 +88,7 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         .with_no_client_auth()
         .unwrap();
     let hostname = "localhost".try_into().unwrap();
-    let mut client =
-        Connection::<ClientConnectionData>::new(client_config.into(), hostname).unwrap();
+    let mut client = Connection::<Client>::new(client_config.into(), hostname).unwrap();
     server
         .writer()
         .write_all(b"hello from server")

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -766,7 +766,7 @@ pub fn do_unbuffered_handshake(
     client: &mut UnbufferedClientConnection,
     server: &mut UnbufferedServerConnection,
 ) {
-    fn is_idle<Data>(conn: &UnbufferedConnectionCommon<Data>, data: &[u8]) -> bool {
+    fn is_idle<Side: SideData>(conn: &UnbufferedConnectionCommon<Side>, data: &[u8]) -> bool {
         !conn.is_handshaking() && !conn.wants_write() && data.is_empty()
     }
 
@@ -1620,8 +1620,8 @@ impl ResolvesServerCert for ServerCheckCertResolve {
     }
 }
 
-pub struct OtherSession<'a, S> {
-    sess: &'a mut Connection<S>,
+pub struct OtherSession<'a, Side: SideData> {
+    sess: &'a mut Connection<Side>,
     pub reads: usize,
     pub writevs: Vec<Vec<usize>>,
     fail_ok: bool,

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -6,12 +6,12 @@ use std::sync::Arc;
 use bencher::{Bencher, benchmark_group, benchmark_main};
 use rustls::Connection;
 use rustls::crypto::ring as provider;
-use rustls::server::ServerConnectionData;
+use rustls::server::Server;
 use rustls_test::{KeyType, TestNonBlockIo, make_server_config};
 
 fn bench_ewouldblock(c: &mut Bencher) {
     let server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
-    let mut server = Connection::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
+    let mut server = Connection::<Server>::new(Arc::new(server_config)).unwrap();
     c.iter(|| server.read_tls(&mut TestNonBlockIo::default()));
 }
 

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -4,15 +4,14 @@
 use std::sync::Arc;
 
 use bencher::{Bencher, benchmark_group, benchmark_main};
-use rustls::ConnectionCommon;
+use rustls::Connection;
 use rustls::crypto::ring as provider;
 use rustls::server::ServerConnectionData;
 use rustls_test::{KeyType, TestNonBlockIo, make_server_config};
 
 fn bench_ewouldblock(c: &mut Bencher) {
     let server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
-    let mut server =
-        ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
+    let mut server = Connection::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
     c.iter(|| server.read_tls(&mut TestNonBlockIo::default()));
 }
 

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -4,13 +4,15 @@
 use std::sync::Arc;
 
 use bencher::{Bencher, benchmark_group, benchmark_main};
-use rustls::ServerConnection;
+use rustls::ConnectionCommon;
 use rustls::crypto::ring as provider;
+use rustls::server::ServerConnectionData;
 use rustls_test::{KeyType, TestNonBlockIo, make_server_config};
 
 fn bench_ewouldblock(c: &mut Bencher) {
     let server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
-    let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+    let mut server =
+        ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
     c.iter(|| server.read_tls(&mut TestNonBlockIo::default()));
 }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -787,25 +787,6 @@ mod connection {
             &mut self.inner
         }
     }
-
-    #[doc(hidden)]
-    impl<'a> TryFrom<&'a mut crate::Connection> for &'a mut ClientConnection {
-        type Error = ();
-
-        fn try_from(value: &'a mut crate::Connection) -> Result<Self, Self::Error> {
-            use crate::Connection::*;
-            match value {
-                Client(conn) => Ok(conn),
-                Server(_) => Err(()),
-            }
-        }
-    }
-
-    impl From<ClientConnection> for crate::Connection {
-        fn from(conn: ClientConnection) -> Self {
-            Self::Client(conn)
-        }
-    }
 }
 #[cfg(feature = "std")]
 pub use connection::{ClientConnection, WriteEarlyData};

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -581,7 +581,7 @@ mod connection {
     use super::{ClientConnectionData, ClientExtensionsInput};
     use crate::client::EchStatus;
     use crate::common_state::Protocol;
-    use crate::conn::{ConnectionCommon, ConnectionCore};
+    use crate::conn::{Connection, ConnectionCore};
     use crate::error::Error;
     use crate::sync::Arc;
     use crate::{ClientConfig, KeyingMaterialExporter};
@@ -592,11 +592,11 @@ mod connection {
     ///
     /// This type implements [`io::Write`].
     pub struct WriteEarlyData<'a> {
-        sess: &'a mut ConnectionCommon<ClientConnectionData>,
+        sess: &'a mut Connection<ClientConnectionData>,
     }
 
     impl<'a> WriteEarlyData<'a> {
-        fn new(sess: &'a mut ConnectionCommon<ClientConnectionData>) -> Self {
+        fn new(sess: &'a mut Connection<ClientConnectionData>) -> Self {
             WriteEarlyData { sess }
         }
 
@@ -623,12 +623,12 @@ mod connection {
         /// if called more than once per connection.
         ///
         /// If you are looking for the normal exporter, this is available from
-        /// [`ConnectionCommon::exporter()`].
+        /// [`Connection::exporter()`].
         ///
         /// [RFC5705]: https://datatracker.ietf.org/doc/html/rfc5705
         /// [RFC8446 S7.5]: https://datatracker.ietf.org/doc/html/rfc8446#section-7.5
         /// [RFC8446 appendix E.5.1]: https://datatracker.ietf.org/doc/html/rfc8446#appendix-E.5.1
-        /// [`ConnectionCommon::exporter()`]: crate::conn::ConnectionCommon::exporter()
+        /// [`Connection::exporter()`]: crate::conn::Connection::exporter()
         pub fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
             self.sess.core.early_exporter()
         }
@@ -655,7 +655,7 @@ mod connection {
         }
     }
 
-    impl ConnectionCommon<ClientConnectionData> {
+    impl Connection<ClientConnectionData> {
         /// Make a new ClientConnection.  `config` controls how
         /// we behave in the TLS protocol, `name` is the
         /// name of the server we want to talk to.
@@ -740,9 +740,9 @@ mod connection {
         }
     }
 
-    impl fmt::Debug for ConnectionCommon<ClientConnectionData> {
+    impl fmt::Debug for Connection<ClientConnectionData> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.debug_struct("ConnectionCommon<ClientConnectionData>")
+            f.debug_struct("Connection<ClientConnectionData>")
                 .finish()
         }
     }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -12,7 +12,7 @@ use super::{ResolvesClientCert, Tls12Resumption};
 #[cfg(feature = "log")]
 use crate::bs_debug;
 use crate::check::inappropriate_handshake_message;
-use crate::client::client_conn::ClientConnectionData;
+use crate::client::client_conn::Client;
 use crate::client::common::ClientHelloDetails;
 use crate::client::ech::EchState;
 use crate::client::{ClientConfig, EchMode, EchStatus, tls13};
@@ -43,9 +43,9 @@ use crate::tls13::Tls13CipherSuite;
 use crate::tls13::key_schedule::KeyScheduleEarly;
 use crate::verify::ServerCertVerifier;
 
-pub(super) type NextState<'a> = Box<dyn State<ClientConnectionData> + 'a>;
+pub(super) type NextState<'a> = Box<dyn State<Client> + 'a>;
 pub(super) type NextStateOrError<'a> = Result<NextState<'a>, Error>;
-pub(super) type ClientContext<'a> = crate::common_state::Context<'a, ClientConnectionData>;
+pub(super) type ClientContext<'a> = crate::common_state::Context<'a, Client>;
 
 pub(crate) struct ExpectServerHello {
     pub(super) input: ClientHelloInput,
@@ -154,7 +154,7 @@ impl ExpectServerHello {
     }
 }
 
-impl State<ClientConnectionData> for ExpectServerHello {
+impl State<Client> for ExpectServerHello {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -413,7 +413,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
     }
 }
 
-impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
+impl State<Client> for ExpectServerHelloOrHelloRetryRequest {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -5,7 +5,7 @@ use std::vec;
 
 use pki_types::{CertificateDer, ServerName};
 
-use crate::client::{ClientConfig, ClientConnection, Resumption, Tls12Resumption};
+use crate::client::{ClientConfig, ClientConnectionData, Resumption, Tls12Resumption};
 use crate::crypto::CryptoProvider;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::msgs::base::PayloadU16;
@@ -17,14 +17,14 @@ use crate::msgs::handshake::{
 };
 use crate::msgs::message::{Message, MessagePayload, OutboundOpaqueMessage};
 use crate::sync::Arc;
-use crate::{Error, PeerIncompatible, PeerMisbehaved, RootCertStore};
+use crate::{ConnectionCommon, Error, PeerIncompatible, PeerMisbehaved, RootCertStore};
 
 #[macro_rules_attribute::apply(test_for_each_provider)]
 mod tests {
     use std::sync::OnceLock;
 
     use super::super::*;
-    use crate::client::AlwaysResolvesClientRawPublicKeys;
+    use crate::client::{AlwaysResolvesClientRawPublicKeys, ClientConnectionData};
     use crate::crypto::cipher::MessageEncrypter;
     use crate::crypto::tls13::OkmBlock;
     use crate::enums::CertificateType;
@@ -44,7 +44,7 @@ mod tests {
         HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdentity,
         SignatureVerificationInput,
     };
-    use crate::{DigitallySignedStruct, DistinguishedName, KeyLog};
+    use crate::{ConnectionCommon, DigitallySignedStruct, DistinguishedName, KeyLog};
 
     /// Tests that session_ticket(35) extension
     /// is not sent if the client does not support TLS 1.2.
@@ -112,9 +112,11 @@ mod tests {
                 .with_root_certificates(roots())
                 .with_no_client_auth()
                 .unwrap();
-        let mut conn =
-            ClientConnection::new(config.into(), ServerName::try_from("localhost").unwrap())
-                .unwrap();
+        let mut conn = ConnectionCommon::<ClientConnectionData>::new(
+            config.into(),
+            ServerName::try_from("localhost").unwrap(),
+        )
+        .unwrap();
         let mut sent = Vec::new();
         conn.write_tls(&mut sent).unwrap();
 
@@ -156,9 +158,11 @@ mod tests {
         }
 
         let config = Arc::new(config);
-        let mut conn =
-            ClientConnection::new(config.clone(), ServerName::try_from("localhost").unwrap())
-                .unwrap();
+        let mut conn = ConnectionCommon::<ClientConnectionData>::new(
+            config.clone(),
+            ServerName::try_from("localhost").unwrap(),
+        )
+        .unwrap();
         let mut sent = Vec::new();
         conn.write_tls(&mut sent).unwrap();
 
@@ -223,9 +227,11 @@ mod tests {
             .with_no_client_auth()
             .unwrap();
 
-        let mut conn =
-            ClientConnection::new(config.into(), ServerName::try_from("localhost").unwrap())
-                .unwrap();
+        let mut conn = ConnectionCommon::<ClientConnectionData>::new(
+            config.into(),
+            ServerName::try_from("localhost").unwrap(),
+        )
+        .unwrap();
         let mut sent = Vec::new();
         conn.write_tls(&mut sent).unwrap();
 
@@ -400,7 +406,7 @@ mod tests {
         encrypted_extensions: ServerExtensions<'_>,
     ) -> Result<(), Error> {
         let fake_server_crypto = Arc::new(FakeServerCrypto::new());
-        let mut conn = ClientConnection::new(
+        let mut conn = ConnectionCommon::<ClientConnectionData>::new(
             client_config_for_rpk(fake_server_crypto.clone()).into(),
             ServerName::try_from("localhost").unwrap(),
         )
@@ -669,8 +675,10 @@ fn hybrid_kx_component_share_not_offered_unless_supported_separately() {
 }
 
 fn client_hello_sent_for_config(config: ClientConfig) -> Result<ClientHelloPayload, Error> {
-    let mut conn =
-        ClientConnection::new(config.into(), ServerName::try_from("localhost").unwrap())?;
+    let mut conn = ConnectionCommon::<ClientConnectionData>::new(
+        config.into(),
+        ServerName::try_from("localhost").unwrap(),
+    )?;
     let mut bytes = Vec::new();
     conn.write_tls(&mut bytes).unwrap();
 

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -17,7 +17,7 @@ use crate::msgs::handshake::{
 };
 use crate::msgs::message::{Message, MessagePayload, OutboundOpaqueMessage};
 use crate::sync::Arc;
-use crate::{ConnectionCommon, Error, PeerIncompatible, PeerMisbehaved, RootCertStore};
+use crate::{Connection, Error, PeerIncompatible, PeerMisbehaved, RootCertStore};
 
 #[macro_rules_attribute::apply(test_for_each_provider)]
 mod tests {
@@ -44,7 +44,7 @@ mod tests {
         HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdentity,
         SignatureVerificationInput,
     };
-    use crate::{ConnectionCommon, DigitallySignedStruct, DistinguishedName, KeyLog};
+    use crate::{Connection, DigitallySignedStruct, DistinguishedName, KeyLog};
 
     /// Tests that session_ticket(35) extension
     /// is not sent if the client does not support TLS 1.2.
@@ -112,7 +112,7 @@ mod tests {
                 .with_root_certificates(roots())
                 .with_no_client_auth()
                 .unwrap();
-        let mut conn = ConnectionCommon::<ClientConnectionData>::new(
+        let mut conn = Connection::<ClientConnectionData>::new(
             config.into(),
             ServerName::try_from("localhost").unwrap(),
         )
@@ -158,7 +158,7 @@ mod tests {
         }
 
         let config = Arc::new(config);
-        let mut conn = ConnectionCommon::<ClientConnectionData>::new(
+        let mut conn = Connection::<ClientConnectionData>::new(
             config.clone(),
             ServerName::try_from("localhost").unwrap(),
         )
@@ -227,7 +227,7 @@ mod tests {
             .with_no_client_auth()
             .unwrap();
 
-        let mut conn = ConnectionCommon::<ClientConnectionData>::new(
+        let mut conn = Connection::<ClientConnectionData>::new(
             config.into(),
             ServerName::try_from("localhost").unwrap(),
         )
@@ -406,7 +406,7 @@ mod tests {
         encrypted_extensions: ServerExtensions<'_>,
     ) -> Result<(), Error> {
         let fake_server_crypto = Arc::new(FakeServerCrypto::new());
-        let mut conn = ConnectionCommon::<ClientConnectionData>::new(
+        let mut conn = Connection::<ClientConnectionData>::new(
             client_config_for_rpk(fake_server_crypto.clone()).into(),
             ServerName::try_from("localhost").unwrap(),
         )
@@ -675,7 +675,7 @@ fn hybrid_kx_component_share_not_offered_unless_supported_separately() {
 }
 
 fn client_hello_sent_for_config(config: ClientConfig) -> Result<ClientHelloPayload, Error> {
-    let mut conn = ConnectionCommon::<ClientConnectionData>::new(
+    let mut conn = Connection::<ClientConnectionData>::new(
         config.into(),
         ServerName::try_from("localhost").unwrap(),
     )?;

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -5,7 +5,7 @@ use std::vec;
 
 use pki_types::{CertificateDer, ServerName};
 
-use crate::client::{ClientConfig, ClientConnectionData, Resumption, Tls12Resumption};
+use crate::client::{Client, ClientConfig, Resumption, Tls12Resumption};
 use crate::crypto::CryptoProvider;
 use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::msgs::base::PayloadU16;
@@ -24,7 +24,7 @@ mod tests {
     use std::sync::OnceLock;
 
     use super::super::*;
-    use crate::client::{AlwaysResolvesClientRawPublicKeys, ClientConnectionData};
+    use crate::client::{AlwaysResolvesClientRawPublicKeys, Client};
     use crate::crypto::cipher::MessageEncrypter;
     use crate::crypto::tls13::OkmBlock;
     use crate::enums::CertificateType;
@@ -112,11 +112,9 @@ mod tests {
                 .with_root_certificates(roots())
                 .with_no_client_auth()
                 .unwrap();
-        let mut conn = Connection::<ClientConnectionData>::new(
-            config.into(),
-            ServerName::try_from("localhost").unwrap(),
-        )
-        .unwrap();
+        let mut conn =
+            Connection::<Client>::new(config.into(), ServerName::try_from("localhost").unwrap())
+                .unwrap();
         let mut sent = Vec::new();
         conn.write_tls(&mut sent).unwrap();
 
@@ -158,11 +156,9 @@ mod tests {
         }
 
         let config = Arc::new(config);
-        let mut conn = Connection::<ClientConnectionData>::new(
-            config.clone(),
-            ServerName::try_from("localhost").unwrap(),
-        )
-        .unwrap();
+        let mut conn =
+            Connection::<Client>::new(config.clone(), ServerName::try_from("localhost").unwrap())
+                .unwrap();
         let mut sent = Vec::new();
         conn.write_tls(&mut sent).unwrap();
 
@@ -227,11 +223,9 @@ mod tests {
             .with_no_client_auth()
             .unwrap();
 
-        let mut conn = Connection::<ClientConnectionData>::new(
-            config.into(),
-            ServerName::try_from("localhost").unwrap(),
-        )
-        .unwrap();
+        let mut conn =
+            Connection::<Client>::new(config.into(), ServerName::try_from("localhost").unwrap())
+                .unwrap();
         let mut sent = Vec::new();
         conn.write_tls(&mut sent).unwrap();
 
@@ -406,7 +400,7 @@ mod tests {
         encrypted_extensions: ServerExtensions<'_>,
     ) -> Result<(), Error> {
         let fake_server_crypto = Arc::new(FakeServerCrypto::new());
-        let mut conn = Connection::<ClientConnectionData>::new(
+        let mut conn = Connection::<Client>::new(
             client_config_for_rpk(fake_server_crypto.clone()).into(),
             ServerName::try_from("localhost").unwrap(),
         )
@@ -675,10 +669,8 @@ fn hybrid_kx_component_share_not_offered_unless_supported_separately() {
 }
 
 fn client_hello_sent_for_config(config: ClientConfig) -> Result<ClientHelloPayload, Error> {
-    let mut conn = Connection::<ClientConnectionData>::new(
-        config.into(),
-        ServerName::try_from("localhost").unwrap(),
-    )?;
+    let mut conn =
+        Connection::<Client>::new(config.into(), ServerName::try_from("localhost").unwrap())?;
     let mut bytes = Vec::new();
     conn.write_tls(&mut bytes).unwrap();
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -7,7 +7,7 @@ use pki_types::ServerName;
 pub(crate) use server_hello::TLS12_HANDLER;
 use subtle::ConstantTimeEq;
 
-use super::client_conn::ClientConnectionData;
+use super::client_conn::Client;
 use super::hs::ClientContext;
 use crate::ConnectionTrafficSecrets;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
@@ -250,7 +250,7 @@ struct ExpectCertificate {
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectCertificate {
+impl State<Client> for ExpectCertificate {
     fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -315,7 +315,7 @@ struct ExpectCertificateStatusOrServerKx<'m> {
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx<'_> {
+impl State<Client> for ExpectCertificateStatusOrServerKx<'_> {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -397,7 +397,7 @@ struct ExpectCertificateStatus<'a> {
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateStatus<'_> {
+impl State<Client> for ExpectCertificateStatus<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -464,7 +464,7 @@ struct ExpectServerKx<'a> {
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectServerKx<'_> {
+impl State<Client> for ExpectServerKx<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -667,7 +667,7 @@ struct ExpectServerDoneOrCertReq<'a> {
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectServerDoneOrCertReq<'_> {
+impl State<Client> for ExpectServerDoneOrCertReq<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -749,7 +749,7 @@ struct ExpectCertificateRequest<'a> {
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateRequest<'_> {
+impl State<Client> for ExpectCertificateRequest<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -832,7 +832,7 @@ struct ExpectServerDone<'a> {
     must_issue_new_ticket: bool,
 }
 
-impl State<ClientConnectionData> for ExpectServerDone<'_> {
+impl State<Client> for ExpectServerDone<'_> {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1087,7 +1087,7 @@ struct ExpectNewTicket {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl State<ClientConnectionData> for ExpectNewTicket {
+impl State<Client> for ExpectNewTicket {
     fn handle<'m>(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -1139,7 +1139,7 @@ struct ExpectCcs {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl State<ClientConnectionData> for ExpectCcs {
+impl State<Client> for ExpectCcs {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1250,7 +1250,7 @@ impl ExpectFinished {
     }
 }
 
-impl State<ClientConnectionData> for ExpectFinished {
+impl State<Client> for ExpectFinished {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1338,7 +1338,7 @@ struct ExpectTraffic {
     _fin_verified: verify::FinishedMessageVerified,
 }
 
-impl State<ClientConnectionData> for ExpectTraffic {
+impl State<Client> for ExpectTraffic {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use pki_types::ServerName;
 use subtle::ConstantTimeEq;
 
-use super::client_conn::ClientConnectionData;
+use super::client_conn::Client;
 use super::hs::{ClientContext, ClientHelloInput, ClientSessionValue};
 use crate::check::inappropriate_handshake_message;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails, ServerCertDetails};
@@ -503,7 +503,7 @@ struct ExpectEncryptedExtensions {
     hello: ClientHelloDetails,
 }
 
-impl State<ClientConnectionData> for ExpectEncryptedExtensions {
+impl State<Client> for ExpectEncryptedExtensions {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -687,7 +687,7 @@ struct ExpectCertificateOrCompressedCertificateOrCertReq {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrCertReq {
+impl State<Client> for ExpectCertificateOrCompressedCertificateOrCertReq {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -772,7 +772,7 @@ struct ExpectCertificateOrCompressedCertificate {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificate {
+impl State<Client> for ExpectCertificateOrCompressedCertificate {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -840,7 +840,7 @@ struct ExpectCertificateOrCertReq {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
+impl State<Client> for ExpectCertificateOrCertReq {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -912,7 +912,7 @@ struct ExpectCertificateRequest {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateRequest {
+impl State<Client> for ExpectCertificateRequest {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1028,7 +1028,7 @@ struct ExpectCompressedCertificate {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ClientConnectionData> for ExpectCompressedCertificate {
+impl State<Client> for ExpectCompressedCertificate {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1134,7 +1134,7 @@ struct ExpectCertificate {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ClientConnectionData> for ExpectCertificate {
+impl State<Client> for ExpectCertificate {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1201,7 +1201,7 @@ struct ExpectCertificateVerify<'a> {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
+impl State<Client> for ExpectCertificateVerify<'_> {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1387,7 +1387,7 @@ struct ExpectFinished {
     ech_retry_configs: Option<Vec<EchConfigPayload>>,
 }
 
-impl State<ClientConnectionData> for ExpectFinished {
+impl State<Client> for ExpectFinished {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1632,7 +1632,7 @@ impl ExpectTraffic {
     }
 }
 
-impl State<ClientConnectionData> for ExpectTraffic {
+impl State<Client> for ExpectTraffic {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1705,7 +1705,7 @@ impl KernelState for ExpectTraffic {
 
 struct ExpectQuicTraffic(ExpectTraffic);
 
-impl State<ClientConnectionData> for ExpectQuicTraffic {
+impl State<Client> for ExpectQuicTraffic {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -832,12 +832,12 @@ impl IoState {
     }
 }
 
-pub(crate) trait State<Data>: Send + Sync {
+pub(crate) trait State<Side>: Send + Sync {
     fn handle<'m>(
         self: Box<Self>,
-        cx: &mut Context<'_, Data>,
+        cx: &mut Context<'_, Side>,
         message: Message<'m>,
-    ) -> Result<Box<dyn State<Data> + 'm>, Error>
+    ) -> Result<Box<dyn State<Side> + 'm>, Error>
     where
         Self: 'm;
 
@@ -853,7 +853,7 @@ pub(crate) trait State<Data>: Send + Sync {
         Err(Error::HandshakeNotComplete)
     }
 
-    fn into_owned(self: Box<Self>) -> Box<dyn State<Data> + 'static>;
+    fn into_owned(self: Box<Self>) -> Box<dyn State<Side> + 'static>;
 }
 
 pub(crate) struct Context<'a, Data> {

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -102,7 +102,7 @@ impl CommonState {
 
     /// Returns true if the caller should call [`Connection::write_tls`] as soon as possible.
     ///
-    /// [`Connection::write_tls`]: crate::Connection::write_tls
+    /// [`Connection::write_tls`]: crate::ConnectionCommon::write_tls
     pub fn wants_write(&self) -> bool {
         !self.sendable_tls.is_empty()
     }
@@ -113,7 +113,7 @@ impl CommonState {
     /// [`Connection::process_new_packets()`] has been called, this might start to return `false`
     /// while the final handshake packets still need to be extracted from the connection's buffers.
     ///
-    /// [`Connection::process_new_packets()`]: crate::Connection::process_new_packets
+    /// [`Connection::process_new_packets()`]: crate::ConnectionCommon::process_new_packets
     pub fn is_handshaking(&self) -> bool {
         !(self.may_send_application_data && self.may_receive_application_data)
     }
@@ -565,7 +565,7 @@ impl CommonState {
     ///
     /// Does nothing if any `close_notify` or fatal alert was already sent.
     ///
-    /// [`Connection::write_tls`]: crate::Connection::write_tls
+    /// [`Connection::write_tls`]: crate::ConnectionCommon::write_tls
     pub fn send_close_notify(&mut self) {
         if self.sent_fatal_alert {
             return;
@@ -657,8 +657,8 @@ impl CommonState {
     /// this returns false.  If your application respects this mechanism,
     /// only one full TLS message will be buffered by rustls.
     ///
-    /// [`Connection::reader`]: crate::Connection::reader
-    /// [`Connection::read_tls`]: crate::Connection::read_tls
+    /// [`Connection::reader`]: crate::ConnectionCommon::reader
+    /// [`Connection::read_tls`]: crate::ConnectionCommon::read_tls
     pub fn wants_read(&self) -> bool {
         // We want to read more data all the time, except when we have unprocessed plaintext.
         // This provides back-pressure to the TCP buffers. We also don't want to read more after
@@ -796,7 +796,7 @@ pub enum HandshakeKind {
 /// Values of this structure are returned from [`Connection::process_new_packets`]
 /// and tell the caller the current I/O state of the TLS connection.
 ///
-/// [`Connection::process_new_packets`]: crate::Connection::process_new_packets
+/// [`Connection::process_new_packets`]: crate::ConnectionCommon::process_new_packets
 #[derive(Debug, Eq, PartialEq)]
 pub struct IoState {
     tls_bytes_to_write: usize,
@@ -808,7 +808,7 @@ impl IoState {
     /// How many bytes could be written by [`Connection::write_tls`] if called
     /// right now.  A non-zero value implies [`CommonState::wants_write`].
     ///
-    /// [`Connection::write_tls`]: crate::Connection::write_tls
+    /// [`Connection::write_tls`]: crate::ConnectionCommon::write_tls
     pub fn tls_bytes_to_write(&self) -> usize {
         self.tls_bytes_to_write
     }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -102,7 +102,7 @@ impl CommonState {
 
     /// Returns true if the caller should call [`Connection::write_tls`] as soon as possible.
     ///
-    /// [`Connection::write_tls`]: crate::ConnectionCommon::write_tls
+    /// [`Connection::write_tls`]: crate::Connection::write_tls
     pub fn wants_write(&self) -> bool {
         !self.sendable_tls.is_empty()
     }
@@ -113,7 +113,7 @@ impl CommonState {
     /// [`Connection::process_new_packets()`] has been called, this might start to return `false`
     /// while the final handshake packets still need to be extracted from the connection's buffers.
     ///
-    /// [`Connection::process_new_packets()`]: crate::ConnectionCommon::process_new_packets
+    /// [`Connection::process_new_packets()`]: crate::Connection::process_new_packets
     pub fn is_handshaking(&self) -> bool {
         !(self.may_send_application_data && self.may_receive_application_data)
     }
@@ -565,7 +565,7 @@ impl CommonState {
     ///
     /// Does nothing if any `close_notify` or fatal alert was already sent.
     ///
-    /// [`Connection::write_tls`]: crate::ConnectionCommon::write_tls
+    /// [`Connection::write_tls`]: crate::Connection::write_tls
     pub fn send_close_notify(&mut self) {
         if self.sent_fatal_alert {
             return;
@@ -657,8 +657,8 @@ impl CommonState {
     /// this returns false.  If your application respects this mechanism,
     /// only one full TLS message will be buffered by rustls.
     ///
-    /// [`Connection::reader`]: crate::ConnectionCommon::reader
-    /// [`Connection::read_tls`]: crate::ConnectionCommon::read_tls
+    /// [`Connection::reader`]: crate::Connection::reader
+    /// [`Connection::read_tls`]: crate::Connection::read_tls
     pub fn wants_read(&self) -> bool {
         // We want to read more data all the time, except when we have unprocessed plaintext.
         // This provides back-pressure to the TCP buffers. We also don't want to read more after
@@ -796,7 +796,7 @@ pub enum HandshakeKind {
 /// Values of this structure are returned from [`Connection::process_new_packets`]
 /// and tell the caller the current I/O state of the TLS connection.
 ///
-/// [`Connection::process_new_packets`]: crate::ConnectionCommon::process_new_packets
+/// [`Connection::process_new_packets`]: crate::Connection::process_new_packets
 #[derive(Debug, Eq, PartialEq)]
 pub struct IoState {
     tls_bytes_to_write: usize,
@@ -808,7 +808,7 @@ impl IoState {
     /// How many bytes could be written by [`Connection::write_tls`] if called
     /// right now.  A non-zero value implies [`CommonState::wants_write`].
     ///
-    /// [`Connection::write_tls`]: crate::ConnectionCommon::write_tls
+    /// [`Connection::write_tls`]: crate::Connection::write_tls
     pub fn tls_bytes_to_write(&self) -> usize {
         self.tls_bytes_to_write
     }

--- a/rustls/src/conn/kernel.rs
+++ b/rustls/src/conn/kernel.rs
@@ -71,7 +71,7 @@ use crate::{CommonState, ConnectionTrafficSecrets, Error, ProtocolVersion, Suppo
 /// top of kTLS.
 ///
 /// See the [`crate::kernel`] module docs for more details.
-pub struct KernelConnection<Data> {
+pub struct KernelConnection<Side> {
     state: Box<dyn KernelState>,
 
     peer_identity: Option<PeerIdentity>,
@@ -81,10 +81,10 @@ pub struct KernelConnection<Data> {
     protocol: Protocol,
     suite: SupportedCipherSuite,
 
-    _data: PhantomData<Data>,
+    _data: PhantomData<Side>,
 }
 
-impl<Data> KernelConnection<Data> {
+impl<Side> KernelConnection<Side> {
     pub(crate) fn new(state: Box<dyn KernelState>, common: CommonState) -> Result<Self, Error> {
         Ok(Self {
             state,

--- a/rustls/src/conn/kernel.rs
+++ b/rustls/src/conn/kernel.rs
@@ -56,7 +56,7 @@
 use alloc::boxed::Box;
 use core::marker::PhantomData;
 
-use crate::client::ClientConnectionData;
+use crate::client::Client;
 use crate::common_state::Protocol;
 use crate::msgs::codec::Codec;
 use crate::msgs::handshake::NewSessionTicketPayloadTls13;
@@ -150,7 +150,7 @@ impl<Data> KernelConnection<Data> {
     }
 }
 
-impl KernelConnection<ClientConnectionData> {
+impl KernelConnection<Client> {
     /// Handle a `new_session_ticket` message from the peer.
     ///
     /// This will register the session ticket within with rustls so that it can
@@ -168,10 +168,10 @@ impl KernelConnection<ClientConnectionData> {
     /// ```no_run
     /// use rustls::{ContentType, HandshakeType};
     /// use rustls::kernel::KernelConnection;
-    /// use rustls::client::ClientConnectionData;
+    /// use rustls::client::Client;
     ///
-    /// # fn doctest(conn: &mut KernelConnection<ClientConnectionData>, typ: ContentType, message: &[u8]) -> Result<(), rustls::Error> {
-    /// let conn: &mut KernelConnection<ClientConnectionData> = // ...
+    /// # fn doctest(conn: &mut KernelConnection<Client>, typ: ContentType, message: &[u8]) -> Result<(), rustls::Error> {
+    /// let conn: &mut KernelConnection<Client> = // ...
     /// #   conn;
     /// let typ: ContentType = // ...
     /// #   typ;

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -677,8 +677,8 @@ impl<Side> Connection<Side> {
     }
 }
 
-impl<'a, Data> From<&'a mut Connection<Data>> for Context<'a, Data> {
-    fn from(conn: &'a mut Connection<Data>) -> Self {
+impl<'a, Side> From<&'a mut Connection<Side>> for Context<'a, Side> {
+    fn from(conn: &'a mut Connection<Side>) -> Self {
         Self {
             common: &mut conn.core.common_state,
             data: &mut conn.core.data,
@@ -712,14 +712,14 @@ impl<Side> From<ConnectionCore<Side>> for Connection<Side> {
 }
 
 /// Interface shared by unbuffered client and server connections.
-pub struct UnbufferedConnectionCommon<Data> {
-    pub(crate) core: ConnectionCore<Data>,
+pub struct UnbufferedConnectionCommon<Side> {
+    pub(crate) core: ConnectionCore<Side>,
     wants_write: bool,
     emitted_peer_closed_state: bool,
 }
 
-impl<Data> From<ConnectionCore<Data>> for UnbufferedConnectionCommon<Data> {
-    fn from(core: ConnectionCore<Data>) -> Self {
+impl<Side> From<ConnectionCore<Side>> for UnbufferedConnectionCommon<Side> {
+    fn from(core: ConnectionCore<Side>) -> Self {
         Self {
             core,
             wants_write: false,
@@ -728,7 +728,7 @@ impl<Data> From<ConnectionCore<Data>> for UnbufferedConnectionCommon<Data> {
     }
 }
 
-impl<Data> UnbufferedConnectionCommon<Data> {
+impl<Side> UnbufferedConnectionCommon<Side> {
     /// Extract secrets, so they can be used when configuring kTLS, for example.
     /// Should be used with care as it exposes secret key material.
     pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -30,9 +30,9 @@ mod connection {
     use core::ops::Deref;
     use std::io::{self, BufRead, Read};
 
-    use crate::{Connection, SideData};
     use crate::msgs::message::OutboundChunks;
     use crate::vecbuf::ChunkVecBuffer;
+    use crate::{Connection, SideData};
 
     /// A structure that implements [`std::io::Read`] for reading plaintext.
     pub struct Reader<'a> {
@@ -299,7 +299,23 @@ impl ConnectionRandoms {
     }
 }
 
-/// Interface shared by client and server connections.
+/// A TLS connection, parametrized by the side ([`Client`] or [`Server`]).
+///
+/// This is one of the core abstractions of the rutls API. It represents a single connection
+/// to a peer, and holds all the state associated with that connection. Note that it does
+/// not hold any IO objects: the application is responsible for reading and writing TLS records.
+/// If you want an object that does hold IO objects, see [`Stream`] and [`StreamOwned`].
+///
+/// This object is generic over the `Side` type parameter, which must be either [`Client`]
+/// or [`Server`]. While most of the API for a connection is shared between both types, some
+/// API is asymmetric, which is reflected by the type parameter. As such, some methods
+/// (including constructors) are specific on the `Side` type. See the implementations
+/// for [`Client`](#impl-Connection<Client>) and [`Server`](#impl-Connection<Server>) below.
+///
+/// [`Client`]: crate::client::Client
+/// [`Server`]: crate::server::Server
+/// [`Stream`]: crate::Stream
+/// [`StreamOwned`]: crate::StreamOwned
 pub struct Connection<Side: SideData> {
     pub(crate) core: ConnectionCore<Side>,
     deframer_buffer: DeframerVecBuffer,

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -8,28 +8,28 @@ use std::error::Error as StdError;
 
 use super::UnbufferedConnectionCommon;
 use crate::Error;
-use crate::client::ClientConnectionData;
+use crate::client::Client;
 use crate::msgs::deframer::buffers::DeframerSliceBuffer;
-use crate::server::ServerConnectionData;
+use crate::server::Server;
 
-impl UnbufferedConnectionCommon<ClientConnectionData> {
+impl UnbufferedConnectionCommon<Client> {
     /// Processes the TLS records in `incoming_tls` buffer until a new [`UnbufferedStatus`] is
     /// reached.
     pub fn process_tls_records<'c, 'i>(
         &'c mut self,
         incoming_tls: &'i mut [u8],
-    ) -> UnbufferedStatus<'c, 'i, ClientConnectionData> {
+    ) -> UnbufferedStatus<'c, 'i, Client> {
         self.process_tls_records_common(incoming_tls, |_| false, |_, _| unreachable!())
     }
 }
 
-impl UnbufferedConnectionCommon<ServerConnectionData> {
+impl UnbufferedConnectionCommon<Server> {
     /// Processes the TLS records in `incoming_tls` buffer until a new [`UnbufferedStatus`] is
     /// reached.
     pub fn process_tls_records<'c, 'i>(
         &'c mut self,
         incoming_tls: &'i mut [u8],
-    ) -> UnbufferedStatus<'c, 'i, ServerConnectionData> {
+    ) -> UnbufferedStatus<'c, 'i, Server> {
         self.process_tls_records_common(
             incoming_tls,
             |conn| conn.peek_early_data().is_some(),
@@ -387,11 +387,8 @@ pub struct ReadEarlyData<'c, 'i, Data> {
     chunk: Option<Vec<u8>>,
 }
 
-impl<'c, 'i> ReadEarlyData<'c, 'i, ServerConnectionData> {
-    fn new(
-        conn: &'c mut UnbufferedConnectionCommon<ServerConnectionData>,
-        _incoming_tls: &'i mut [u8],
-    ) -> Self {
+impl<'c, 'i> ReadEarlyData<'c, 'i, Server> {
+    fn new(conn: &'c mut UnbufferedConnectionCommon<Server>, _incoming_tls: &'i mut [u8]) -> Self {
         Self {
             conn,
             _incoming_tls,

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -476,10 +476,10 @@ impl<Data> WriteTraffic<'_, Data> {
     /// return a `ConnectionState::EncodeTlsData` that emits the `key_update`
     /// message.
     ///
-    /// See [`ConnectionCommon::refresh_traffic_keys()`] for full documentation,
+    /// See [`Connection::refresh_traffic_keys()`] for full documentation,
     /// including why you might call this and in what circumstances it will fail.
     ///
-    /// [`ConnectionCommon::refresh_traffic_keys()`]: crate::ConnectionCommon::refresh_traffic_keys
+    /// [`Connection::refresh_traffic_keys()`]: crate::Connection::refresh_traffic_keys
     pub fn refresh_traffic_keys(self) -> Result<(), Error> {
         self.conn.core.refresh_traffic_keys()
     }

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -38,13 +38,13 @@ impl UnbufferedConnectionCommon<Server> {
     }
 }
 
-impl<Data> UnbufferedConnectionCommon<Data> {
+impl<Side> UnbufferedConnectionCommon<Side> {
     fn process_tls_records_common<'c, 'i>(
         &'c mut self,
         incoming_tls: &'i mut [u8],
         mut early_data_available: impl FnMut(&mut Self) -> bool,
-        early_data_state: impl FnOnce(&'c mut Self, &'i mut [u8]) -> ConnectionState<'c, 'i, Data>,
-    ) -> UnbufferedStatus<'c, 'i, Data> {
+        early_data_state: impl FnOnce(&'c mut Self, &'i mut [u8]) -> ConnectionState<'c, 'i, Side>,
+    ) -> UnbufferedStatus<'c, 'i, Side> {
         let mut buffer = DeframerSliceBuffer::new(incoming_tls);
         let mut buffer_progress = self.core.hs_deframer.progress();
 
@@ -201,12 +201,12 @@ pub struct UnbufferedStatus<'c, 'i, Data> {
 
 /// The state of the [`UnbufferedConnectionCommon`] object
 #[non_exhaustive] // for forwards compatibility; to support caller-side certificate verification
-pub enum ConnectionState<'c, 'i, Data> {
+pub enum ConnectionState<'c, 'i, Side> {
     /// One, or more, application data records are available
     ///
     /// See [`ReadTraffic`] for more details on how to use the enclosed object to access
     /// the received data.
-    ReadTraffic(ReadTraffic<'c, 'i, Data>),
+    ReadTraffic(ReadTraffic<'c, 'i, Side>),
 
     /// Connection has been cleanly closed by the peer.
     ///
@@ -231,13 +231,13 @@ pub enum ConnectionState<'c, 'i, Data> {
     Closed,
 
     /// One, or more, early (RTT-0) data records are available
-    ReadEarlyData(ReadEarlyData<'c, 'i, Data>),
+    ReadEarlyData(ReadEarlyData<'c, 'i, Side>),
 
     /// A Handshake record is ready for encoding
     ///
     /// Call [`EncodeTlsData::encode`] on the enclosed object, providing an `outgoing_tls`
     /// buffer to store the encoding
-    EncodeTlsData(EncodeTlsData<'c, Data>),
+    EncodeTlsData(EncodeTlsData<'c, Side>),
 
     /// Previously encoded handshake records need to be transmitted
     ///
@@ -251,7 +251,7 @@ pub enum ConnectionState<'c, 'i, Data> {
     /// At some stages of the handshake process, it's possible to send application-data alongside
     /// handshake records. Call [`TransmitTlsData::may_encrypt_app_data`] on the enclosed
     /// object to probe if that's allowed.
-    TransmitTlsData(TransmitTlsData<'c, Data>),
+    TransmitTlsData(TransmitTlsData<'c, Side>),
 
     /// More TLS data is needed to continue with the handshake
     ///
@@ -272,7 +272,7 @@ pub enum ConnectionState<'c, 'i, Data> {
     /// [`UnbufferedConnectionCommon::process_tls_records`] invocation. When enough data has been
     /// appended to `incoming_tls`, [`UnbufferedConnectionCommon::process_tls_records`] will yield
     /// the [`ConnectionState::ReadTraffic`] state.
-    WriteTraffic(WriteTraffic<'c, Data>),
+    WriteTraffic(WriteTraffic<'c, Side>),
 }
 
 impl<'c, 'i, Data> From<ReadTraffic<'c, 'i, Data>> for ConnectionState<'c, 'i, Data> {
@@ -299,7 +299,7 @@ impl<'c, Data> From<TransmitTlsData<'c, Data>> for ConnectionState<'c, '_, Data>
     }
 }
 
-impl<Data> fmt::Debug for ConnectionState<'_, '_, Data> {
+impl<Side> fmt::Debug for ConnectionState<'_, '_, Side> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ReadTraffic(..) => f.debug_tuple("ReadTraffic").finish(),
@@ -326,8 +326,8 @@ impl<Data> fmt::Debug for ConnectionState<'_, '_, Data> {
 }
 
 /// Application data is available
-pub struct ReadTraffic<'c, 'i, Data> {
-    conn: &'c mut UnbufferedConnectionCommon<Data>,
+pub struct ReadTraffic<'c, 'i, Side> {
+    conn: &'c mut UnbufferedConnectionCommon<Side>,
     // for forwards compatibility; to support in-place decryption in the future
     _incoming_tls: &'i mut [u8],
 
@@ -336,8 +336,8 @@ pub struct ReadTraffic<'c, 'i, Data> {
     chunk: Option<Vec<u8>>,
 }
 
-impl<'c, 'i, Data> ReadTraffic<'c, 'i, Data> {
-    fn new(conn: &'c mut UnbufferedConnectionCommon<Data>, _incoming_tls: &'i mut [u8]) -> Self {
+impl<'c, 'i, Side> ReadTraffic<'c, 'i, Side> {
+    fn new(conn: &'c mut UnbufferedConnectionCommon<Side>, _incoming_tls: &'i mut [u8]) -> Self {
         Self {
             conn,
             _incoming_tls,
@@ -376,8 +376,8 @@ impl<'c, 'i, Data> ReadTraffic<'c, 'i, Data> {
 }
 
 /// Early application-data is available.
-pub struct ReadEarlyData<'c, 'i, Data> {
-    conn: &'c mut UnbufferedConnectionCommon<Data>,
+pub struct ReadEarlyData<'c, 'i, Side> {
+    conn: &'c mut UnbufferedConnectionCommon<Side>,
 
     // for forwards compatibility; to support in-place decryption in the future
     _incoming_tls: &'i mut [u8],
@@ -432,11 +432,11 @@ pub struct AppDataRecord<'i> {
 }
 
 /// Allows encrypting app-data
-pub struct WriteTraffic<'c, Data> {
-    conn: &'c mut UnbufferedConnectionCommon<Data>,
+pub struct WriteTraffic<'c, Side> {
+    conn: &'c mut UnbufferedConnectionCommon<Side>,
 }
 
-impl<Data> WriteTraffic<'_, Data> {
+impl<Side> WriteTraffic<'_, Side> {
     /// Encrypts `application_data` into the `outgoing_tls` buffer
     ///
     /// Returns the number of bytes that were written into `outgoing_tls`, or an error if
@@ -483,13 +483,13 @@ impl<Data> WriteTraffic<'_, Data> {
 }
 
 /// A handshake record must be encoded
-pub struct EncodeTlsData<'c, Data> {
-    conn: &'c mut UnbufferedConnectionCommon<Data>,
+pub struct EncodeTlsData<'c, Side> {
+    conn: &'c mut UnbufferedConnectionCommon<Side>,
     chunk: Option<Vec<u8>>,
 }
 
-impl<'c, Data> EncodeTlsData<'c, Data> {
-    fn new(conn: &'c mut UnbufferedConnectionCommon<Data>, chunk: Vec<u8>) -> Self {
+impl<'c, Side> EncodeTlsData<'c, Side> {
+    fn new(conn: &'c mut UnbufferedConnectionCommon<Side>, chunk: Vec<u8>) -> Self {
         Self {
             conn,
             chunk: Some(chunk),
@@ -522,11 +522,11 @@ impl<'c, Data> EncodeTlsData<'c, Data> {
 }
 
 /// Previously encoded TLS data must be transmitted
-pub struct TransmitTlsData<'c, Data> {
-    pub(crate) conn: &'c mut UnbufferedConnectionCommon<Data>,
+pub struct TransmitTlsData<'c, Side> {
+    pub(crate) conn: &'c mut UnbufferedConnectionCommon<Side>,
 }
 
-impl<Data> TransmitTlsData<'_, Data> {
+impl<Side> TransmitTlsData<'_, Side> {
     /// Signals that the previously encoded TLS data has been transmitted
     pub fn done(self) {
         self.conn.wants_write = false;
@@ -535,7 +535,7 @@ impl<Data> TransmitTlsData<'_, Data> {
     /// Returns an adapter that allows encrypting application data
     ///
     /// If allowed at this stage of the handshake process
-    pub fn may_encrypt_app_data(&mut self) -> Option<WriteTraffic<'_, Data>> {
+    pub fn may_encrypt_app_data(&mut self) -> Option<WriteTraffic<'_, Side>> {
         if self
             .conn
             .core

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -1199,8 +1199,7 @@ pub enum ApiMisuse {
     ///
     /// This is possible from:
     ///
-    /// - [`ClientConnection::dangerous_extract_secrets()`][crate::client::ClientConnection::dangerous_extract_secrets]
-    /// - [`ServerConnection::dangerous_extract_secrets()`][crate::server::ServerConnection::dangerous_extract_secrets]
+    /// - [`ConnectionCommon::dangerous_extract_secrets()`][crate::ConnectionCommon::dangerous_extract_secrets]
     /// - [`ClientConnection::dangerous_into_kernel_connection()`][crate::client::UnbufferedClientConnection::dangerous_into_kernel_connection]
     /// - [`ServerConnection::dangerous_into_kernel_connection()`][crate::server::UnbufferedServerConnection::dangerous_into_kernel_connection]
     ///

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -1119,11 +1119,11 @@ impl From<rand::GetRandomFailed> for Error {
 pub enum ApiMisuse {
     /// The [`KeyingMaterialExporter`][] was already consumed.
     ///
-    /// Methods that obtain an exporter (eg, [`ConnectionCommon::exporter()`][]) can only
+    /// Methods that obtain an exporter (eg, [`Connection::exporter()`][]) can only
     /// be used once.  This error is returned on subsequent calls.
     ///
     /// [`KeyingMaterialExporter`]: crate::KeyingMaterialExporter
-    /// [`ConnectionCommon::exporter()`]: crate::ConnectionCommon::exporter()
+    /// [`Connection::exporter()`]: crate::Connection::exporter()
     ExporterAlreadyUsed,
 
     /// The `context` parameter to [`KeyingMaterialExporter::derive()`][] was too long.
@@ -1199,7 +1199,7 @@ pub enum ApiMisuse {
     ///
     /// This is possible from:
     ///
-    /// - [`ConnectionCommon::dangerous_extract_secrets()`][crate::ConnectionCommon::dangerous_extract_secrets]
+    /// - [`Connection::dangerous_extract_secrets()`][crate::Connection::dangerous_extract_secrets]
     /// - [`ClientConnection::dangerous_into_kernel_connection()`][crate::client::UnbufferedClientConnection::dangerous_into_kernel_connection]
     /// - [`ServerConnection::dangerous_into_kernel_connection()`][crate::server::UnbufferedServerConnection::dangerous_into_kernel_connection]
     ///

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -114,9 +114,9 @@
 //! [`tokio-rustls`]: https://github.com/rustls/tokio-rustls
 //!
 //! ### Rustls provides encrypted pipes
-//! These are the [`ServerConnection`] and [`ClientConnection`] types.  You supply raw TLS traffic
-//! on the left (via the [`read_tls()`] and [`write_tls()`] methods) and then read/write the
-//! plaintext on the right:
+//! This is the [`ConnectionCommon`] type and its two specializations.
+//! You supply raw TLS traffic on the left (via the [`read_tls()`] and [`write_tls()`] methods)
+//! and then read/write the plaintext on the right:
 //!
 //! [`read_tls()`]: ConnectionCommon::read_tls
 //! [`write_tls()`]: ConnectionCommon::read_tls
@@ -189,7 +189,7 @@
 //! #     .unwrap();
 //! let rc_config = Arc::new(config);
 //! let example_com = "example.com".try_into().unwrap();
-//! let mut client = rustls::ClientConnection::new(rc_config, example_com);
+//! let mut client = rustls::ConnectionCommon::<ClientConnectionData>::new(rc_config, example_com);
 //! # }
 //! ```
 //!
@@ -218,7 +218,7 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(feature = "aws-lc-rs")] {
-//! # let mut client = rustls::ClientConnection::new(panic!(), panic!()).unwrap();
+//! # let mut client = rustls::ConnectionCommon::<ClientConnectionData>::new(panic!(), panic!()).unwrap();
 //! # struct Socket { }
 //! # impl Socket {
 //! #   fn ready_for_write(&self) -> bool { false }
@@ -566,13 +566,13 @@ pub mod client {
     mod tls13;
 
     pub use builder::WantsClientCert;
+    #[cfg(feature = "std")]
+    pub use client_conn::WriteEarlyData;
     pub use client_conn::{
         ClientConfig, ClientConnectionData, ClientSessionStore, EarlyDataError,
         MayEncryptEarlyData, ResolvesClientCert, Resumption, Tls12Resumption,
         UnbufferedClientConnection,
     };
-    #[cfg(feature = "std")]
-    pub use client_conn::{ClientConnection, WriteEarlyData};
     pub use ech::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
     pub use handy::AlwaysResolvesClientRawPublicKeys;
     #[cfg(any(feature = "std", feature = "hashbrown"))]
@@ -600,8 +600,6 @@ pub mod client {
 }
 
 pub use client::ClientConfig;
-#[cfg(feature = "std")]
-pub use client::ClientConnection;
 
 /// Items for use in a server.
 pub mod server {
@@ -621,7 +619,7 @@ pub mod server {
     pub use handy::ServerSessionMemoryCache;
     pub use handy::{AlwaysResolvesServerRawPublicKeys, NoServerSessionStorage};
     #[cfg(feature = "std")]
-    pub use server_conn::{Accepted, AcceptedAlert, Acceptor, ReadEarlyData, ServerConnection};
+    pub use server_conn::{Accepted, AcceptedAlert, Acceptor, ReadEarlyData};
     pub use server_conn::{
         ClientHello, InvalidSniPolicy, ProducesTickets, ResolvesServerCert, ServerConfig,
         ServerConnectionData, StoresServerSessions, UnbufferedServerConnection,
@@ -645,8 +643,6 @@ pub mod server {
 }
 
 pub use server::ServerConfig;
-#[cfg(feature = "std")]
-pub use server::ServerConnection;
 
 /// All defined protocol versions appear in this module.
 ///

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -114,12 +114,12 @@
 //! [`tokio-rustls`]: https://github.com/rustls/tokio-rustls
 //!
 //! ### Rustls provides encrypted pipes
-//! This is the [`ConnectionCommon`] type and its two specializations.
+//! This is the [`Connection`] type and its two specializations.
 //! You supply raw TLS traffic on the left (via the [`read_tls()`] and [`write_tls()`] methods)
 //! and then read/write the plaintext on the right:
 //!
-//! [`read_tls()`]: ConnectionCommon::read_tls
-//! [`write_tls()`]: ConnectionCommon::read_tls
+//! [`read_tls()`]: Connection::read_tls
+//! [`write_tls()`]: Connection::read_tls
 //!
 //! ```text
 //!          TLS                                   Plaintext
@@ -189,7 +189,7 @@
 //! #     .unwrap();
 //! let rc_config = Arc::new(config);
 //! let example_com = "example.com".try_into().unwrap();
-//! let mut client = rustls::ConnectionCommon::<ClientConnectionData>::new(rc_config, example_com);
+//! let mut client = rustls::Connection::<ClientConnectionData>::new(rc_config, example_com);
 //! # }
 //! ```
 //!
@@ -218,7 +218,7 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(feature = "aws-lc-rs")] {
-//! # let mut client = rustls::ConnectionCommon::<ClientConnectionData>::new(panic!(), panic!()).unwrap();
+//! # let mut client = rustls::Connection::<ClientConnectionData>::new(panic!(), panic!()).unwrap();
 //! # struct Socket { }
 //! # impl Socket {
 //! #   fn ready_for_write(&self) -> bool { false }
@@ -483,16 +483,16 @@ pub mod internal {
 
 /// Unbuffered connection API
 ///
-/// This is an alternative to the [`crate::ConnectionCommon`] API that does not internally buffer
+/// This is an alternative to the [`crate::Connection`] API that does not internally buffer
 /// TLS nor plaintext data. Instead those buffers are managed by the API user so they have
 /// control over when and how to allocate, resize and dispose of them.
 ///
-/// This API is lower level than the `ConnectionCommon` API and is built around a state machine
+/// This API is lower level than the `Connection` API and is built around a state machine
 /// interface where the API user must handle each state to advance and complete the
 /// handshake process.
 ///
-/// Like the `ConnectionCommon` API, no IO happens internally so all IO must be handled by the API
-/// user. Unlike the `ConnectionCommon` API, this API does not make use of the [`std::io::Read`] and
+/// Like the `Connection` API, no IO happens internally so all IO must be handled by the API
+/// user. Unlike the `Connection` API, this API does not make use of the [`std::io::Read`] and
 /// [`std::io::Write`] traits so it's usable in no-std context.
 ///
 /// The entry points into this API are [`crate::client::UnbufferedClientConnection::new`],
@@ -519,7 +519,7 @@ pub mod unbuffered {
 // The public interface is:
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier};
 pub use crate::common_state::{CommonState, HandshakeKind, IoState, Side};
-pub use crate::conn::{ConnectionCommon, KeyingMaterialExporter, SideData, kernel};
+pub use crate::conn::{Connection, KeyingMaterialExporter, SideData, kernel};
 #[cfg(feature = "std")]
 pub use crate::conn::{Reader, Writer};
 pub use crate::enums::{

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -189,7 +189,7 @@
 //! #     .unwrap();
 //! let rc_config = Arc::new(config);
 //! let example_com = "example.com".try_into().unwrap();
-//! let mut client = rustls::Connection::<ClientConnectionData>::new(rc_config, example_com);
+//! let mut client = rustls::Connection::<rustls::client::Client>::new(rc_config, example_com);
 //! # }
 //! ```
 //!
@@ -218,7 +218,7 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(feature = "aws-lc-rs")] {
-//! # let mut client = rustls::Connection::<ClientConnectionData>::new(panic!(), panic!()).unwrap();
+//! # let mut client = rustls::Connection::<rustls::client::Client>::new(panic!(), panic!()).unwrap();
 //! # struct Socket { }
 //! # impl Socket {
 //! #   fn ready_for_write(&self) -> bool { false }
@@ -569,9 +569,8 @@ pub mod client {
     #[cfg(feature = "std")]
     pub use client_conn::WriteEarlyData;
     pub use client_conn::{
-        ClientConfig, ClientConnectionData, ClientSessionStore, EarlyDataError,
-        MayEncryptEarlyData, ResolvesClientCert, Resumption, Tls12Resumption,
-        UnbufferedClientConnection,
+        Client, ClientConfig, ClientSessionStore, EarlyDataError, MayEncryptEarlyData,
+        ResolvesClientCert, Resumption, Tls12Resumption, UnbufferedClientConnection,
     };
     pub use ech::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
     pub use handy::AlwaysResolvesClientRawPublicKeys;
@@ -621,8 +620,8 @@ pub mod server {
     #[cfg(feature = "std")]
     pub use server_conn::{Accepted, AcceptedAlert, Acceptor, ReadEarlyData};
     pub use server_conn::{
-        ClientHello, InvalidSniPolicy, ProducesTickets, ResolvesServerCert, ServerConfig,
-        ServerConnectionData, StoresServerSessions, UnbufferedServerConnection,
+        ClientHello, InvalidSniPolicy, ProducesTickets, ResolvesServerCert, Server, ServerConfig,
+        StoresServerSessions, UnbufferedServerConnection,
     };
 
     pub use crate::verify::NoClientAuth;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -118,8 +118,8 @@
 //! on the left (via the [`read_tls()`] and [`write_tls()`] methods) and then read/write the
 //! plaintext on the right:
 //!
-//! [`read_tls()`]: Connection::read_tls
-//! [`write_tls()`]: Connection::read_tls
+//! [`read_tls()`]: ConnectionCommon::read_tls
+//! [`write_tls()`]: ConnectionCommon::read_tls
 //!
 //! ```text
 //!          TLS                                   Plaintext
@@ -519,9 +519,9 @@ pub mod unbuffered {
 // The public interface is:
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier};
 pub use crate::common_state::{CommonState, HandshakeKind, IoState, Side};
-#[cfg(feature = "std")]
-pub use crate::conn::{Connection, Reader, Writer};
 pub use crate::conn::{ConnectionCommon, KeyingMaterialExporter, SideData, kernel};
+#[cfg(feature = "std")]
+pub use crate::conn::{Reader, Writer};
 pub use crate::enums::{
     AlertDescription, CertificateCompressionAlgorithm, CertificateType, CipherSuite, ContentType,
     EchClientHelloType, HandshakeType, ProtocolVersion, SignatureAlgorithm, SignatureScheme,

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -128,7 +128,7 @@ mod connection {
     impl ClientConnection {
         /// Make a new QUIC ClientConnection.
         ///
-        /// This differs from `ClientConnection::new()` in that it takes an extra `params` argument,
+        /// This differs from `ConnectionCommon::<ClientConnectionData>::new()` in that it takes an extra `params` argument,
         /// which contains the TLS-encoded transport parameters to send.
         pub fn new(
             config: Arc<ClientConfig>,
@@ -247,7 +247,7 @@ mod connection {
     impl ServerConnection {
         /// Make a new QUIC ServerConnection.
         ///
-        /// This differs from `ServerConnection::new()` in that it takes an extra `params` argument,
+        /// This differs from `ConnectionCommon::<ServerConnectionData>::new()` in that it takes an extra `params` argument,
         /// which contains the TLS-encoded transport parameters to send.
         pub fn new(
             config: Arc<ServerConfig>,

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -53,7 +53,7 @@ mod connection {
     impl Connection {
         /// Return the TLS-encoded transport parameters for the session's peer.
         ///
-        /// See [`ConnectionCommon::quic_transport_parameters()`] for more details.
+        /// See [`Connection::quic_transport_parameters()`] for more details.
         pub fn quic_transport_parameters(&self) -> Option<&[u8]> {
             match self {
                 Self::Client(conn) => conn.quic_transport_parameters(),
@@ -128,7 +128,7 @@ mod connection {
     impl ClientConnection {
         /// Make a new QUIC ClientConnection.
         ///
-        /// This differs from `ConnectionCommon::<ClientConnectionData>::new()` in that it takes an extra `params` argument,
+        /// This differs from `ClientConnection::new()` in that it takes an extra `params` argument,
         /// which contains the TLS-encoded transport parameters to send.
         pub fn new(
             config: Arc<ClientConfig>,
@@ -247,7 +247,7 @@ mod connection {
     impl ServerConnection {
         /// Make a new QUIC ServerConnection.
         ///
-        /// This differs from `ConnectionCommon::<ServerConnectionData>::new()` in that it takes an extra `params` argument,
+        /// This differs from `ServerConnection::new()` in that it takes an extra `params` argument,
         /// which contains the TLS-encoded transport parameters to send.
         pub fn new(
             config: Arc<ServerConfig>,
@@ -949,10 +949,10 @@ impl Keys {
 /// QUIC uses 4 different sets of keys (and progressive key updates for long-running connections):
 ///
 /// * Initial: these can be created from [`Keys::initial()`]
-/// * 0-RTT keys: can be retrieved from [`ConnectionCommon::zero_rtt_keys()`]
-/// * Handshake: these are returned from [`ConnectionCommon::write_hs()`] after `ClientHello` and
+/// * 0-RTT keys: can be retrieved from [`Connection::zero_rtt_keys()`]
+/// * Handshake: these are returned from [`Connection::write_hs()`] after `ClientHello` and
 ///   `ServerHello` messages have been exchanged
-/// * 1-RTT keys: these are returned from [`ConnectionCommon::write_hs()`] after the handshake is done
+/// * 1-RTT keys: these are returned from [`Connection::write_hs()`] after the handshake is done
 ///
 /// Once the 1-RTT keys have been exchanged, either side may initiate a key update. Progressive
 /// update keys can be obtained from the [`Secrets`] returned in [`KeyChange::OneRtt`]. Note that

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -380,13 +380,13 @@ mod connection {
     }
 
     /// A shared interface for QUIC connections.
-    pub struct ConnectionCommon<Data> {
-        core: ConnectionCore<Data>,
+    pub struct ConnectionCommon<Side> {
+        core: ConnectionCore<Side>,
         deframer_buffer: DeframerVecBuffer,
         sendable_plaintext: ChunkVecBuffer,
     }
 
-    impl<Data: SideData> ConnectionCommon<Data> {
+    impl<Side: SideData> ConnectionCommon<Side> {
         /// Return the TLS-encoded transport parameters for the session's peer.
         ///
         /// While the transport parameters are technically available prior to the
@@ -469,7 +469,7 @@ mod connection {
         }
     }
 
-    impl<Data> Deref for ConnectionCommon<Data> {
+    impl<Side> Deref for ConnectionCommon<Side> {
         type Target = CommonState;
 
         fn deref(&self) -> &Self::Target {
@@ -477,14 +477,14 @@ mod connection {
         }
     }
 
-    impl<Data> DerefMut for ConnectionCommon<Data> {
+    impl<Side> DerefMut for ConnectionCommon<Side> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             &mut self.core.common_state
         }
     }
 
-    impl<Data> From<ConnectionCore<Data>> for ConnectionCommon<Data> {
-        fn from(core: ConnectionCore<Data>) -> Self {
+    impl<Side> From<ConnectionCore<Side>> for ConnectionCommon<Side> {
+        fn from(core: ConnectionCore<Side>) -> Self {
             Self {
                 core,
                 deframer_buffer: DeframerVecBuffer::default(),

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -380,7 +380,7 @@ mod connection {
     }
 
     /// A shared interface for QUIC connections.
-    pub struct ConnectionCommon<Side> {
+    pub struct ConnectionCommon<Side: SideData> {
         core: ConnectionCore<Side>,
         deframer_buffer: DeframerVecBuffer,
         sendable_plaintext: ChunkVecBuffer,
@@ -469,7 +469,7 @@ mod connection {
         }
     }
 
-    impl<Side> Deref for ConnectionCommon<Side> {
+    impl<Side: SideData> Deref for ConnectionCommon<Side> {
         type Target = CommonState;
 
         fn deref(&self) -> &Self::Target {
@@ -477,13 +477,13 @@ mod connection {
         }
     }
 
-    impl<Side> DerefMut for ConnectionCommon<Side> {
+    impl<Side: SideData> DerefMut for ConnectionCommon<Side> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             &mut self.core.common_state
         }
     }
 
-    impl<Side> From<ConnectionCore<Side>> for ConnectionCommon<Side> {
+    impl<Side: SideData> From<ConnectionCore<Side>> for ConnectionCommon<Side> {
         fn from(core: ConnectionCore<Side>) -> Self {
             Self {
                 core,

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -24,7 +24,7 @@ mod connection {
     use pki_types::{DnsName, ServerName};
 
     use super::{DirectionalKeys, KeyChange, Version};
-    use crate::client::{ClientConfig, ClientConnectionData};
+    use crate::client::{Client, ClientConfig};
     use crate::common_state::{CommonState, DEFAULT_BUFFER_LIMIT, Protocol};
     use crate::conn::{ConnectionCore, KeyingMaterialExporter, SideData};
     use crate::enums::{AlertDescription, ContentType, ProtocolVersion};
@@ -35,7 +35,7 @@ mod connection {
         ClientExtensionsInput, ServerExtensionsInput, TransportParameters,
     };
     use crate::msgs::message::InboundPlainMessage;
-    use crate::server::{ServerConfig, ServerConnectionData};
+    use crate::server::{Server, ServerConfig};
     use crate::suites::SupportedCipherSuite;
     use crate::sync::Arc;
     use crate::vecbuf::ChunkVecBuffer;
@@ -122,7 +122,7 @@ mod connection {
 
     /// A QUIC client connection.
     pub struct ClientConnection {
-        inner: ConnectionCommon<ClientConnectionData>,
+        inner: ConnectionCommon<Client>,
     }
 
     impl ClientConnection {
@@ -213,7 +213,7 @@ mod connection {
     }
 
     impl Deref for ClientConnection {
-        type Target = ConnectionCommon<ClientConnectionData>;
+        type Target = ConnectionCommon<Client>;
 
         fn deref(&self) -> &Self::Target {
             &self.inner
@@ -241,7 +241,7 @@ mod connection {
 
     /// A QUIC server connection.
     pub struct ServerConnection {
-        inner: ConnectionCommon<ServerConnectionData>,
+        inner: ConnectionCommon<Server>,
     }
 
     impl ServerConnection {
@@ -353,7 +353,7 @@ mod connection {
     }
 
     impl Deref for ServerConnection {
-        type Target = ConnectionCommon<ServerConnectionData>;
+        type Target = ConnectionCommon<Server>;
 
         fn deref(&self) -> &Self::Target {
             &self.inner

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::borrow::Borrow;
 use core::fmt;
 
-use super::server_conn::ServerConnectionData;
+use super::server_conn::Server;
 use super::{ClientHello, ServerConfig};
 use crate::SupportedCipherSuite;
 use crate::common_state::{KxState, Protocol, State};
@@ -33,9 +33,9 @@ use crate::sync::Arc;
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
 
-pub(super) type NextState<'a> = Box<dyn State<ServerConnectionData> + 'a>;
+pub(super) type NextState<'a> = Box<dyn State<Server> + 'a>;
 pub(super) type NextStateOrError<'a> = Result<NextState<'a>, Error>;
-pub(super) type ServerContext<'a> = crate::common_state::Context<'a, ServerConnectionData>;
+pub(super) type ServerContext<'a> = crate::common_state::Context<'a, Server>;
 
 #[derive(Default)]
 pub(super) struct ExtensionProcessing {
@@ -557,7 +557,7 @@ impl ExpectClientHello {
     }
 }
 
-impl State<ServerConnectionData> for ExpectClientHello {
+impl State<Server> for ExpectClientHello {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ServerContext<'_>,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -834,12 +834,6 @@ mod connection {
         }
     }
 
-    impl From<ServerConnection> for crate::Connection {
-        fn from(conn: ServerConnection) -> Self {
-            Self::Server(conn)
-        }
-    }
-
     /// Handle a server-side connection before configuration is available.
     ///
     /// `Acceptor` allows the caller to choose a [`ServerConfig`] after reading
@@ -912,7 +906,7 @@ mod connection {
         /// Returns an error if this `Acceptor` has already yielded an [`Accepted`]. For more details,
         /// refer to [`Connection::read_tls()`].
         ///
-        /// [`Connection::read_tls()`]: crate::Connection::read_tls
+        /// [`Connection::read_tls()`]: crate::ConnectionCommon::read_tls
         pub fn read_tls(&mut self, rd: &mut dyn io::Read) -> Result<usize, io::Error> {
             match &mut self.inner {
                 Some(conn) => conn.read_tls(rd),

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -1,7 +1,7 @@
 use std::prelude::v1::*;
 use std::vec;
 
-use super::ServerConnectionData;
+use super::Server;
 use super::hs::ClientHelloInput;
 use crate::common_state::Context;
 use crate::enums::{CipherSuite, SignatureScheme};
@@ -38,7 +38,7 @@ fn test_process_client_hello(hello: ClientHelloPayload) -> Result<(), Error> {
         false,
         &mut Context {
             common: &mut CommonState::new(Side::Server),
-            data: &mut ServerConnectionData::default(),
+            data: &mut Server::default(),
             sendable_plaintext: None,
         },
     )
@@ -74,7 +74,7 @@ mod tests {
         } else {
             config.require_ems = true;
         }
-        let mut conn = Connection::<ServerConnectionData>::new(config.into()).unwrap();
+        let mut conn = Connection::<Server>::new(config.into()).unwrap();
 
         let mut ch = minimal_client_hello();
         ch.extensions
@@ -116,7 +116,7 @@ mod tests {
         );
 
         server_chooses_ffdhe_group_for_client_hello(
-            Connection::<ServerConnectionData>::new(config.into()).unwrap(),
+            Connection::<Server>::new(config.into()).unwrap(),
             ch,
         );
     }
@@ -141,7 +141,7 @@ mod tests {
         ch.extensions.named_groups.take();
 
         server_chooses_ffdhe_group_for_client_hello(
-            Connection::<ServerConnectionData>::new(config.into()).unwrap(),
+            Connection::<Server>::new(config.into()).unwrap(),
             ch,
         );
     }
@@ -166,13 +166,13 @@ mod tests {
         ch.extensions.ec_point_formats.take();
 
         server_chooses_ffdhe_group_for_client_hello(
-            Connection::<ServerConnectionData>::new(config.into()).unwrap(),
+            Connection::<Server>::new(config.into()).unwrap(),
             ch,
         );
     }
 
     fn server_chooses_ffdhe_group_for_client_hello(
-        mut conn: Connection<ServerConnectionData>,
+        mut conn: Connection<Server>,
         client_hello: ClientHelloPayload,
     ) {
         let ch = Message {
@@ -202,8 +202,7 @@ mod tests {
             )),
         };
 
-        let mut conn =
-            Connection::<ServerConnectionData>::new(server_config_for_rpk().into()).unwrap();
+        let mut conn = Connection::<Server>::new(server_config_for_rpk().into()).unwrap();
         conn.read_tls(&mut ch.into_wire_bytes().as_slice())
             .unwrap();
         assert_eq!(
@@ -223,8 +222,7 @@ mod tests {
             )),
         };
 
-        let mut conn =
-            Connection::<ServerConnectionData>::new(server_config_for_rpk().into()).unwrap();
+        let mut conn = Connection::<Server>::new(server_config_for_rpk().into()).unwrap();
         conn.read_tls(&mut ch.into_wire_bytes().as_slice())
             .unwrap();
         assert_eq!(

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -59,7 +59,7 @@ mod tests {
     use crate::server::{AlwaysResolvesServerRawPublicKeys, ServerConfig};
     use crate::sign::CertifiedKey;
     use crate::sync::Arc;
-    use crate::{CipherSuiteCommon, ConnectionCommon, Tls12CipherSuite};
+    use crate::{CipherSuiteCommon, Connection, Tls12CipherSuite};
 
     #[test]
     fn test_server_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
@@ -74,7 +74,7 @@ mod tests {
         } else {
             config.require_ems = true;
         }
-        let mut conn = ConnectionCommon::<ServerConnectionData>::new(config.into()).unwrap();
+        let mut conn = Connection::<ServerConnectionData>::new(config.into()).unwrap();
 
         let mut ch = minimal_client_hello();
         ch.extensions
@@ -116,7 +116,7 @@ mod tests {
         );
 
         server_chooses_ffdhe_group_for_client_hello(
-            ConnectionCommon::<ServerConnectionData>::new(config.into()).unwrap(),
+            Connection::<ServerConnectionData>::new(config.into()).unwrap(),
             ch,
         );
     }
@@ -141,7 +141,7 @@ mod tests {
         ch.extensions.named_groups.take();
 
         server_chooses_ffdhe_group_for_client_hello(
-            ConnectionCommon::<ServerConnectionData>::new(config.into()).unwrap(),
+            Connection::<ServerConnectionData>::new(config.into()).unwrap(),
             ch,
         );
     }
@@ -166,13 +166,13 @@ mod tests {
         ch.extensions.ec_point_formats.take();
 
         server_chooses_ffdhe_group_for_client_hello(
-            ConnectionCommon::<ServerConnectionData>::new(config.into()).unwrap(),
+            Connection::<ServerConnectionData>::new(config.into()).unwrap(),
             ch,
         );
     }
 
     fn server_chooses_ffdhe_group_for_client_hello(
-        mut conn: ConnectionCommon<ServerConnectionData>,
+        mut conn: Connection<ServerConnectionData>,
         client_hello: ClientHelloPayload,
     ) {
         let ch = Message {
@@ -203,7 +203,7 @@ mod tests {
         };
 
         let mut conn =
-            ConnectionCommon::<ServerConnectionData>::new(server_config_for_rpk().into()).unwrap();
+            Connection::<ServerConnectionData>::new(server_config_for_rpk().into()).unwrap();
         conn.read_tls(&mut ch.into_wire_bytes().as_slice())
             .unwrap();
         assert_eq!(
@@ -224,7 +224,7 @@ mod tests {
         };
 
         let mut conn =
-            ConnectionCommon::<ServerConnectionData>::new(server_config_for_rpk().into()).unwrap();
+            Connection::<ServerConnectionData>::new(server_config_for_rpk().into()).unwrap();
         conn.read_tls(&mut ch.into_wire_bytes().as_slice())
             .unwrap();
         assert_eq!(

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -56,10 +56,10 @@ mod tests {
     use crate::ffdhe_groups::FfdheGroup;
     use crate::pki_types::pem::PemObject;
     use crate::pki_types::{CertificateDer, PrivateKeyDer};
-    use crate::server::{AlwaysResolvesServerRawPublicKeys, ServerConfig, ServerConnection};
+    use crate::server::{AlwaysResolvesServerRawPublicKeys, ServerConfig};
     use crate::sign::CertifiedKey;
     use crate::sync::Arc;
-    use crate::{CipherSuiteCommon, Tls12CipherSuite};
+    use crate::{CipherSuiteCommon, ConnectionCommon, Tls12CipherSuite};
 
     #[test]
     fn test_server_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
@@ -74,7 +74,7 @@ mod tests {
         } else {
             config.require_ems = true;
         }
-        let mut conn = ServerConnection::new(config.into()).unwrap();
+        let mut conn = ConnectionCommon::<ServerConnectionData>::new(config.into()).unwrap();
 
         let mut ch = minimal_client_hello();
         ch.extensions
@@ -116,7 +116,7 @@ mod tests {
         );
 
         server_chooses_ffdhe_group_for_client_hello(
-            ServerConnection::new(config.into()).unwrap(),
+            ConnectionCommon::<ServerConnectionData>::new(config.into()).unwrap(),
             ch,
         );
     }
@@ -141,7 +141,7 @@ mod tests {
         ch.extensions.named_groups.take();
 
         server_chooses_ffdhe_group_for_client_hello(
-            ServerConnection::new(config.into()).unwrap(),
+            ConnectionCommon::<ServerConnectionData>::new(config.into()).unwrap(),
             ch,
         );
     }
@@ -166,13 +166,13 @@ mod tests {
         ch.extensions.ec_point_formats.take();
 
         server_chooses_ffdhe_group_for_client_hello(
-            ServerConnection::new(config.into()).unwrap(),
+            ConnectionCommon::<ServerConnectionData>::new(config.into()).unwrap(),
             ch,
         );
     }
 
     fn server_chooses_ffdhe_group_for_client_hello(
-        mut conn: ServerConnection,
+        mut conn: ConnectionCommon<ServerConnectionData>,
         client_hello: ClientHelloPayload,
     ) {
         let ch = Message {
@@ -202,7 +202,8 @@ mod tests {
             )),
         };
 
-        let mut conn = ServerConnection::new(server_config_for_rpk().into()).unwrap();
+        let mut conn =
+            ConnectionCommon::<ServerConnectionData>::new(server_config_for_rpk().into()).unwrap();
         conn.read_tls(&mut ch.into_wire_bytes().as_slice())
             .unwrap();
         assert_eq!(
@@ -222,7 +223,8 @@ mod tests {
             )),
         };
 
-        let mut conn = ServerConnection::new(server_config_for_rpk().into()).unwrap();
+        let mut conn =
+            ConnectionCommon::<ServerConnectionData>::new(server_config_for_rpk().into()).unwrap();
         conn.read_tls(&mut ch.into_wire_bytes().as_slice())
             .unwrap();
         assert_eq!(

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -8,7 +8,7 @@ use pki_types::UnixTime;
 use subtle::ConstantTimeEq;
 
 use super::hs::{self, ServerContext};
-use super::server_conn::{ProducesTickets, ServerConfig, ServerConnectionData};
+use super::server_conn::{ProducesTickets, Server, ServerConfig};
 use crate::check::inappropriate_message;
 use crate::common_state::{CommonState, HandshakeFlightTls12, HandshakeKind, Side, State};
 use crate::conn::ConnectionRandoms;
@@ -476,7 +476,7 @@ struct ExpectCertificate {
     send_ticket: bool,
 }
 
-impl State<ServerConnectionData> for ExpectCertificate {
+impl State<Server> for ExpectCertificate {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -559,7 +559,7 @@ struct ExpectClientKx {
     send_ticket: bool,
 }
 
-impl State<ServerConnectionData> for ExpectClientKx {
+impl State<Server> for ExpectClientKx {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -654,7 +654,7 @@ struct ExpectCertificateVerify {
     send_ticket: bool,
 }
 
-impl State<ServerConnectionData> for ExpectCertificateVerify {
+impl State<Server> for ExpectCertificateVerify {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -738,7 +738,7 @@ struct ExpectCcs {
     send_ticket: bool,
 }
 
-impl State<ServerConnectionData> for ExpectCcs {
+impl State<Server> for ExpectCcs {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -873,7 +873,7 @@ struct ExpectFinished {
     send_ticket: bool,
 }
 
-impl State<ServerConnectionData> for ExpectFinished {
+impl State<Server> for ExpectFinished {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -972,7 +972,7 @@ struct ExpectTraffic {
 
 impl ExpectTraffic {}
 
-impl State<ServerConnectionData> for ExpectTraffic {
+impl State<Server> for ExpectTraffic {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ServerContext<'_>,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -6,7 +6,7 @@ use pki_types::{CertificateDer, UnixTime};
 use subtle::ConstantTimeEq;
 
 use super::hs::{self, HandshakeHashOrBuffer, ServerContext};
-use super::server_conn::ServerConnectionData;
+use super::server_conn::Server;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::common_state::{
     CommonState, HandshakeFlightTls13, HandshakeKind, Protocol, Side, State,
@@ -863,7 +863,7 @@ struct ExpectAndSkipRejectedEarlyData {
     next: Box<hs::ExpectClientHello>,
 }
 
-impl State<ServerConnectionData> for ExpectAndSkipRejectedEarlyData {
+impl State<Server> for ExpectAndSkipRejectedEarlyData {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -900,7 +900,7 @@ struct ExpectCertificateOrCompressedCertificate {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ServerConnectionData> for ExpectCertificateOrCompressedCertificate {
+impl State<Server> for ExpectCertificateOrCompressedCertificate {
     fn handle<'m>(
         self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -962,7 +962,7 @@ struct ExpectCompressedCertificate {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ServerConnectionData> for ExpectCompressedCertificate {
+impl State<Server> for ExpectCompressedCertificate {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -1062,7 +1062,7 @@ struct ExpectCertificate {
     expected_certificate_type: CertificateType,
 }
 
-impl State<ServerConnectionData> for ExpectCertificate {
+impl State<Server> for ExpectCertificate {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -1157,7 +1157,7 @@ struct ExpectCertificateVerify {
     send_tickets: usize,
 }
 
-impl State<ServerConnectionData> for ExpectCertificateVerify {
+impl State<Server> for ExpectCertificateVerify {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -1219,7 +1219,7 @@ struct ExpectEarlyData {
     send_tickets: usize,
 }
 
-impl State<ServerConnectionData> for ExpectEarlyData {
+impl State<Server> for ExpectEarlyData {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -1360,7 +1360,7 @@ impl ExpectFinished {
     }
 }
 
-impl State<ServerConnectionData> for ExpectFinished {
+impl State<Server> for ExpectFinished {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -1454,7 +1454,7 @@ impl ExpectTraffic {
     }
 }
 
-impl State<ServerConnectionData> for ExpectTraffic {
+impl State<Server> for ExpectTraffic {
     fn handle<'m>(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -1527,7 +1527,7 @@ struct ExpectQuicTraffic {
     _fin_verified: verify::FinishedMessageVerified,
 }
 
-impl State<ServerConnectionData> for ExpectQuicTraffic {
+impl State<Server> for ExpectQuicTraffic {
     fn handle<'m>(
         self: Box<Self>,
         _cx: &mut ServerContext<'_>,

--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -1,22 +1,22 @@
 use core::fmt;
 use std::io::{BufRead, IoSlice, Read, Result, Write};
 
-use crate::conn::{ConnectionCommon, SideData};
+use crate::conn::{Connection, SideData};
 
 /// This type implements `io::Read` and `io::Write`, encapsulating
 /// a Connection `C` and an underlying transport `T`, such as a socket.
 ///
-/// Relies on [`ConnectionCommon::complete_io()`] to perform the necessary I/O.
+/// Relies on [`Connection::complete_io()`] to perform the necessary I/O.
 ///
 /// This allows you to use a rustls Connection like a normal stream.
 #[allow(clippy::exhaustive_structs)]
 #[derive(Debug)]
 pub struct Stream<'a, S, T: 'a + Read + Write + ?Sized>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
 {
     /// Our TLS connection
-    pub conn: &'a mut ConnectionCommon<S>,
+    pub conn: &'a mut Connection<S>,
 
     /// The underlying transport, like a socket
     pub sock: &'a mut T,
@@ -24,13 +24,13 @@ where
 
 impl<'a, S, T> Stream<'a, S, T>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
     T: 'a + Read + Write,
     S: SideData,
 {
     /// Make a new Stream using the Connection `conn` and socket-like object
     /// `sock`.  This does not fail and does no IO.
-    pub fn new(conn: &'a mut ConnectionCommon<S>, sock: &'a mut T) -> Self {
+    pub fn new(conn: &'a mut Connection<S>, sock: &'a mut T) -> Self {
         Self { conn, sock }
     }
 
@@ -76,7 +76,7 @@ where
 
 impl<'a, S, T> Read for Stream<'a, S, T>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
     T: 'a + Read + Write,
     S: SideData,
 {
@@ -88,7 +88,7 @@ where
 
 impl<'a, S, T> BufRead for Stream<'a, S, T>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
     T: 'a + Read + Write,
     S: 'a + SideData,
 {
@@ -108,7 +108,7 @@ where
 
 impl<'a, S, T> Write for Stream<'a, S, T>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
     T: 'a + Read + Write,
     S: SideData,
 {
@@ -155,17 +155,17 @@ where
 /// This type implements `io::Read` and `io::Write`, encapsulating
 /// and owning a Connection `C` and an underlying transport `T`, such as a socket.
 ///
-/// Relies on [`ConnectionCommon::complete_io()`] to perform the necessary I/O.
+/// Relies on [`Connection::complete_io()`] to perform the necessary I/O.
 ///
 /// This allows you to use a rustls Connection like a normal stream.
 #[allow(clippy::exhaustive_structs)]
 #[derive(Debug)]
 pub struct StreamOwned<S, T: Read + Write + Sized>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
 {
     /// Our connection
-    pub conn: ConnectionCommon<S>,
+    pub conn: Connection<S>,
 
     /// The underlying transport, like a socket
     pub sock: T,
@@ -173,7 +173,7 @@ where
 
 impl<S, T> StreamOwned<S, T>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
     T: Read + Write,
     S: SideData,
 {
@@ -182,7 +182,7 @@ where
     ///
     /// This is the same as `Stream::new` except `conn` and `sock` are
     /// moved into the StreamOwned.
-    pub fn new(conn: ConnectionCommon<S>, sock: T) -> Self {
+    pub fn new(conn: Connection<S>, sock: T) -> Self {
         Self { conn, sock }
     }
 
@@ -197,14 +197,14 @@ where
     }
 
     /// Extract the `conn` and `sock` parts from the `StreamOwned`
-    pub fn into_parts(self) -> (ConnectionCommon<S>, T) {
+    pub fn into_parts(self) -> (Connection<S>, T) {
         (self.conn, self.sock)
     }
 }
 
 impl<'a, S, T> StreamOwned<S, T>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
     T: Read + Write,
     S: SideData,
 {
@@ -218,7 +218,7 @@ where
 
 impl<S, T> Read for StreamOwned<S, T>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
     T: Read + Write,
     S: SideData,
 {
@@ -229,7 +229,7 @@ where
 
 impl<S, T> BufRead for StreamOwned<S, T>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
     T: Read + Write,
     S: 'static + SideData,
 {
@@ -244,7 +244,7 @@ where
 
 impl<S, T> Write for StreamOwned<S, T>
 where
-    ConnectionCommon<S>: fmt::Debug,
+    Connection<S>: fmt::Debug,
     T: Read + Write,
     S: SideData,
 {
@@ -262,22 +262,22 @@ mod tests {
     use std::net::TcpStream;
 
     use super::{Stream, StreamOwned};
-    use crate::ConnectionCommon;
+    use crate::Connection;
     use crate::client::ClientConnectionData;
     use crate::server::ServerConnectionData;
 
     #[test]
     fn stream_can_be_created_for_connection_and_tcpstream() {
-        type _Test<'a> = Stream<'a, ConnectionCommon<ClientConnectionData>, TcpStream>;
+        type _Test<'a> = Stream<'a, Connection<ClientConnectionData>, TcpStream>;
     }
 
     #[test]
     fn streamowned_can_be_created_for_client_and_tcpstream() {
-        type _Test = StreamOwned<ConnectionCommon<ClientConnectionData>, TcpStream>;
+        type _Test = StreamOwned<Connection<ClientConnectionData>, TcpStream>;
     }
 
     #[test]
     fn streamowned_can_be_created_for_server_and_tcpstream() {
-        type _Test = StreamOwned<ConnectionCommon<ServerConnectionData>, TcpStream>;
+        type _Test = StreamOwned<Connection<ServerConnectionData>, TcpStream>;
     }
 }

--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -263,21 +263,21 @@ mod tests {
 
     use super::{Stream, StreamOwned};
     use crate::Connection;
-    use crate::client::ClientConnectionData;
-    use crate::server::ServerConnectionData;
+    use crate::client::Client;
+    use crate::server::Server;
 
     #[test]
     fn stream_can_be_created_for_connection_and_tcpstream() {
-        type _Test<'a> = Stream<'a, Connection<ClientConnectionData>, TcpStream>;
+        type _Test<'a> = Stream<'a, Connection<Client>, TcpStream>;
     }
 
     #[test]
     fn streamowned_can_be_created_for_client_and_tcpstream() {
-        type _Test = StreamOwned<Connection<ClientConnectionData>, TcpStream>;
+        type _Test = StreamOwned<Connection<Client>, TcpStream>;
     }
 
     #[test]
     fn streamowned_can_be_created_for_server_and_tcpstream() {
-        type _Test = StreamOwned<Connection<ServerConnectionData>, TcpStream>;
+        type _Test = StreamOwned<Connection<Server>, TcpStream>;
     }
 }

--- a/rustls/src/stream.rs
+++ b/rustls/src/stream.rs
@@ -11,7 +11,7 @@ use crate::conn::{Connection, SideData};
 /// This allows you to use a rustls Connection like a normal stream.
 #[allow(clippy::exhaustive_structs)]
 #[derive(Debug)]
-pub struct Stream<'a, S, T: 'a + Read + Write + ?Sized>
+pub struct Stream<'a, S: SideData, T: 'a + Read + Write + ?Sized>
 where
     Connection<S>: fmt::Debug,
 {
@@ -160,7 +160,7 @@ where
 /// This allows you to use a rustls Connection like a normal stream.
 #[allow(clippy::exhaustive_structs)]
 #[derive(Debug)]
-pub struct StreamOwned<S, T: Read + Write + Sized>
+pub struct StreamOwned<S: SideData, T: Read + Write + Sized>
 where
     Connection<S>: fmt::Debug,
 {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1067,8 +1067,6 @@ fn test_client_rejects_illegal_tls13_ccs() {
     transfer(&mut client, &mut server);
     server.process_new_packets().unwrap();
 
-    let (mut server, mut client) = (server.into(), client.into());
-
     transfer_altered(&mut server, corrupt_ccs, &mut client);
     assert_eq!(
         client.process_new_packets(),
@@ -1263,12 +1261,7 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
     transfer(&mut client, &mut server);
     server.process_new_packets().unwrap();
-    let mut client = client.into();
-    transfer_altered(
-        &mut server.into(),
-        inject_corrupt_finished_message,
-        &mut client,
-    );
+    transfer_altered(&mut server, inject_corrupt_finished_message, &mut client);
 
     // discard storage operations up to this point, to observe the one we want to test for.
     storage.ops_and_reset();
@@ -1651,10 +1644,9 @@ fn server_invalid_sni_policy() {
         });
         server_config.invalid_sni_policy = policy;
 
-        let client =
+        let mut client =
             ClientConnection::new(Arc::new(client_config), server_name(SERVER_NAME_GOOD)).unwrap();
-        let server = ServerConnection::new(Arc::new(server_config)).unwrap();
-        let (mut client, mut server) = (client.into(), server.into());
+        let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
 
         transfer_altered(&mut client, replace_sni(sni), &mut server);
         assert_eq!(

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -4,8 +4,8 @@
 
 use std::sync::Arc;
 
-use rustls::client::ClientConnectionData;
-use rustls::server::ServerConnectionData;
+use rustls::client::Client;
+use rustls::server::Server;
 use rustls::server::danger::ClientCertVerified;
 use rustls::{
     AlertDescription, CertificateError, Connection, Error, InvalidMessage, PeerIdentity,
@@ -103,13 +103,10 @@ fn client_verifier_no_auth_yes_root() {
 
         for version_provider in all_versions(&provider) {
             let client_config = make_client_config(*kt, &version_provider);
-            let mut server =
-                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
-            let mut client = Connection::<ClientConnectionData>::new(
-                Arc::new(client_config),
-                server_name("localhost"),
-            )
-            .unwrap();
+            let mut server = Connection::<Server>::new(server_config.clone()).unwrap();
+            let mut client =
+                Connection::<Client>::new(Arc::new(client_config), server_name("localhost"))
+                    .unwrap();
             let errs = do_handshake_until_both_error(&mut client, &mut server);
             assert_eq!(
                 errs,
@@ -137,13 +134,10 @@ fn client_verifier_fails_properly() {
 
         for version_provider in all_versions(&provider) {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
-            let mut server =
-                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
-            let mut client = Connection::<ClientConnectionData>::new(
-                Arc::new(client_config),
-                server_name("localhost"),
-            )
-            .unwrap();
+            let mut server = Connection::<Server>::new(server_config.clone()).unwrap();
+            let mut client =
+                Connection::<Client>::new(Arc::new(client_config), server_name("localhost"))
+                    .unwrap();
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_eq!(
                 err,

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -8,7 +8,7 @@ use rustls::client::ClientConnectionData;
 use rustls::server::ServerConnectionData;
 use rustls::server::danger::ClientCertVerified;
 use rustls::{
-    AlertDescription, CertificateError, ConnectionCommon, Error, InvalidMessage, PeerIdentity,
+    AlertDescription, CertificateError, Connection, Error, InvalidMessage, PeerIdentity,
     PeerMisbehaved, ServerConfig,
 };
 use rustls_test::{
@@ -104,8 +104,8 @@ fn client_verifier_no_auth_yes_root() {
         for version_provider in all_versions(&provider) {
             let client_config = make_client_config(*kt, &version_provider);
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("localhost"),
             )
@@ -138,8 +138,8 @@ fn client_verifier_fails_properly() {
         for version_provider in all_versions(&provider) {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("localhost"),
             )

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -4,10 +4,12 @@
 
 use std::sync::Arc;
 
+use rustls::client::ClientConnectionData;
+use rustls::server::ServerConnectionData;
 use rustls::server::danger::ClientCertVerified;
 use rustls::{
-    AlertDescription, CertificateError, ClientConnection, Error, InvalidMessage, PeerIdentity,
-    PeerMisbehaved, ServerConfig, ServerConnection,
+    AlertDescription, CertificateError, ConnectionCommon, Error, InvalidMessage, PeerIdentity,
+    PeerMisbehaved, ServerConfig,
 };
 use rustls_test::{
     ErrorFromPeer, KeyType, MockClientVerifier, do_handshake, do_handshake_until_both_error,
@@ -101,9 +103,13 @@ fn client_verifier_no_auth_yes_root() {
 
         for version_provider in all_versions(&provider) {
             let client_config = make_client_config(*kt, &version_provider);
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-            let mut client =
-                ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
+            let mut server =
+                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+                Arc::new(client_config),
+                server_name("localhost"),
+            )
+            .unwrap();
             let errs = do_handshake_until_both_error(&mut client, &mut server);
             assert_eq!(
                 errs,
@@ -131,9 +137,13 @@ fn client_verifier_fails_properly() {
 
         for version_provider in all_versions(&provider) {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-            let mut client =
-                ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
+            let mut server =
+                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+                Arc::new(client_config),
+                server_name("localhost"),
+            )
+            .unwrap();
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_eq!(
                 err,

--- a/rustls/tests/crypto.rs
+++ b/rustls/tests/crypto.rs
@@ -5,9 +5,9 @@
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 
-use rustls::client::ClientConnectionData;
+use rustls::client::Client;
 use rustls::crypto::CryptoProvider;
-use rustls::server::ServerConnectionData;
+use rustls::server::Server;
 use rustls::sign::CertifiedKey;
 use rustls::{
     ClientConfig, Connection, ConnectionTrafficSecrets, Error, KeyLog, ServerConfig,
@@ -393,10 +393,7 @@ fn test_refresh_traffic_keys() {
     let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::default_provider());
     do_handshake(&mut client, &mut server);
 
-    fn check_both_directions(
-        client: &mut Connection<ClientConnectionData>,
-        server: &mut Connection<ServerConnectionData>,
-    ) {
+    fn check_both_directions(client: &mut Connection<Client>, server: &mut Connection<Server>) {
         client
             .writer()
             .write_all(b"to-server-1")

--- a/rustls/tests/crypto.rs
+++ b/rustls/tests/crypto.rs
@@ -10,7 +10,7 @@ use rustls::crypto::CryptoProvider;
 use rustls::server::ServerConnectionData;
 use rustls::sign::CertifiedKey;
 use rustls::{
-    ClientConfig, ConnectionCommon, ConnectionTrafficSecrets, Error, KeyLog, ServerConfig,
+    ClientConfig, Connection, ConnectionTrafficSecrets, Error, KeyLog, ServerConfig,
     SupportedCipherSuite,
 };
 use rustls_test::{
@@ -394,8 +394,8 @@ fn test_refresh_traffic_keys() {
     do_handshake(&mut client, &mut server);
 
     fn check_both_directions(
-        client: &mut ConnectionCommon<ClientConnectionData>,
-        server: &mut ConnectionCommon<ServerConnectionData>,
+        client: &mut Connection<ClientConnectionData>,
+        server: &mut Connection<ServerConnectionData>,
     ) {
         client
             .writer()

--- a/rustls/tests/crypto.rs
+++ b/rustls/tests/crypto.rs
@@ -5,11 +5,13 @@
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 
+use rustls::client::ClientConnectionData;
 use rustls::crypto::CryptoProvider;
+use rustls::server::ServerConnectionData;
 use rustls::sign::CertifiedKey;
 use rustls::{
-    ClientConfig, ClientConnection, ConnectionTrafficSecrets, Error, KeyLog, ServerConfig,
-    ServerConnection, SupportedCipherSuite,
+    ClientConfig, ConnectionCommon, ConnectionTrafficSecrets, Error, KeyLog, ServerConfig,
+    SupportedCipherSuite,
 };
 use rustls_test::{
     ClientConfigExt, KeyType, ServerConfigExt, aes_128_gcm_with_1024_confidentiality_limit,
@@ -391,7 +393,10 @@ fn test_refresh_traffic_keys() {
     let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::default_provider());
     do_handshake(&mut client, &mut server);
 
-    fn check_both_directions(client: &mut ClientConnection, server: &mut ServerConnection) {
+    fn check_both_directions(
+        client: &mut ConnectionCommon<ClientConnectionData>,
+        server: &mut ConnectionCommon<ServerConnectionData>,
+    ) {
         client
             .writer()
             .write_all(b"to-server-1")

--- a/rustls/tests/io.rs
+++ b/rustls/tests/io.rs
@@ -7,11 +7,11 @@ use std::io::{self, BufRead, IoSlice, Read, Write};
 use std::sync::Arc;
 
 use pki_types::DnsName;
+use rustls::client::ClientConnectionData;
 use rustls::crypto::CryptoProvider;
+use rustls::server::ServerConnectionData;
 use rustls::{
-    AlertDescription, ApiMisuse, ClientConfig, ClientConnection, ContentType, Error, HandshakeType,
-    InvalidMessage, NamedGroup, PeerIncompatible, ProtocolVersion, ServerConfig, ServerConnection,
-    Stream, StreamOwned,
+    AlertDescription, ApiMisuse, ClientConfig, ConnectionCommon, ContentType, Error, HandshakeType, InvalidMessage, NamedGroup, PeerIncompatible, ProtocolVersion, ServerConfig, Stream, StreamOwned
 };
 use rustls_test::{
     ClientConfigExt, ErrorFromPeer, KeyType, OtherSession, ServerConfigExt, TestNonBlockIo,
@@ -1300,7 +1300,7 @@ fn test_client_mtu_reduction() {
         }
     }
 
-    fn collect_write_lengths(client: &mut ClientConnection) -> Vec<usize> {
+    fn collect_write_lengths(client: &mut ConnectionCommon<ClientConnectionData>) -> Vec<usize> {
         let mut collector = CollectWrites { writevs: vec![] };
 
         client
@@ -1314,8 +1314,11 @@ fn test_client_mtu_reduction() {
     for kt in KeyType::all_for_provider(&provider) {
         let mut client_config = make_client_config(*kt, &provider);
         client_config.max_fragment_size = Some(64);
-        let mut client =
-            ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
+        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            Arc::new(client_config),
+            server_name("localhost"),
+        )
+        .unwrap();
         let writes = collect_write_lengths(&mut client);
         println!("writes at mtu=64: {writes:?}");
         assert!(writes.iter().all(|x| *x <= 64));
@@ -1378,7 +1381,8 @@ fn check_client_max_fragment_size(size: usize) -> Option<Error> {
     let provider = provider::default_provider();
     let mut client_config = make_client_config(KeyType::Ed25519, &provider);
     client_config.max_fragment_size = Some(size);
-    ClientConnection::new(Arc::new(client_config), server_name("localhost")).err()
+    ConnectionCommon::<ClientConnectionData>::new(Arc::new(client_config), server_name("localhost"))
+        .err()
 }
 
 #[test]
@@ -1442,7 +1446,9 @@ fn test_acceptor() {
 
     let provider = provider::default_provider();
     let client_config = Arc::new(make_client_config(KeyType::Ed25519, &provider));
-    let mut client = ClientConnection::new(client_config, server_name("localhost")).unwrap();
+    let mut client =
+        ConnectionCommon::<ClientConnectionData>::new(client_config, server_name("localhost"))
+            .unwrap();
     let mut buf = Vec::new();
     client.write_tls(&mut buf).unwrap();
 
@@ -1553,7 +1559,11 @@ fn test_acceptor_rejected_handshake() {
             .into(),
     )
     .finish(KeyType::Ed25519);
-    let mut client = ClientConnection::new(client_config.into(), server_name("localhost")).unwrap();
+    let mut client = ConnectionCommon::<ClientConnectionData>::new(
+        client_config.into(),
+        server_name("localhost"),
+    )
+    .unwrap();
     let mut buf = Vec::new();
     client.write_tls(&mut buf).unwrap();
 
@@ -1876,7 +1886,7 @@ fn client_closes_uncleanly() {
 
 #[test]
 fn test_complete_io_errors_if_close_notify_received_too_early() {
-    let mut server = ServerConnection::new(Arc::new(make_server_config(
+    let mut server = ConnectionCommon::<ServerConnectionData>::new(Arc::new(make_server_config(
         KeyType::Rsa2048,
         &provider::default_provider(),
     )))

--- a/rustls/tests/resolve.rs
+++ b/rustls/tests/resolve.rs
@@ -6,13 +6,14 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use pki_types::{CertificateDer, DnsName};
-use rustls::client::ResolvesClientCert;
-use rustls::server::{ClientHello, ResolvesServerCert, ResolvesServerCertUsingSni};
+use rustls::client::{ClientConnectionData, ResolvesClientCert};
+use rustls::server::{
+    ClientHello, ResolvesServerCert, ResolvesServerCertUsingSni, ServerConnectionData,
+};
 use rustls::sign::{CertifiedKey, SigningKey};
 use rustls::{
-    ApiMisuse, CertificateError, CipherSuite, ClientConfig, ClientConnection, DistinguishedName,
-    Error, PeerMisbehaved, ProtocolVersion, ServerConfig, ServerConnection, SignatureScheme,
-    SupportedCipherSuite,
+    ApiMisuse, CertificateError, CipherSuite, ClientConfig, ConnectionCommon, DistinguishedName,
+    Error, PeerMisbehaved, ProtocolVersion, ServerConfig, SignatureScheme, SupportedCipherSuite,
 };
 use rustls_test::{
     ClientConfigExt, ErrorFromPeer, KeyType, ServerCheckCertResolve,
@@ -38,10 +39,13 @@ fn server_cert_resolve_with_sni() {
             ..Default::default()
         });
 
-        let mut client =
-            ClientConnection::new(Arc::new(client_config), server_name("the.value.from.sni"))
-                .unwrap();
-        let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            Arc::new(client_config),
+            server_name("the.value.from.sni"),
+        )
+        .unwrap();
+        let mut server =
+            ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert!(err.is_err());
@@ -61,9 +65,13 @@ fn server_cert_resolve_with_alpn() {
             ..Default::default()
         });
 
-        let mut client =
-            ClientConnection::new(Arc::new(client_config), server_name("sni-value")).unwrap();
-        let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            Arc::new(client_config),
+            server_name("sni-value"),
+        )
+        .unwrap();
+        let mut server =
+            ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert!(err.is_err());
@@ -106,9 +114,13 @@ fn client_trims_terminating_dot() {
             ..Default::default()
         });
 
-        let mut client =
-            ClientConnection::new(Arc::new(client_config), server_name("some-host.com.")).unwrap();
-        let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            Arc::new(client_config),
+            server_name("some-host.com."),
+        )
+        .unwrap();
+        let mut server =
+            ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert!(err.is_err());
@@ -133,9 +145,13 @@ fn check_sigalgs_reduced_by_ciphersuite(
         ..Default::default()
     });
 
-    let mut client =
-        ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
-    let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+    let mut client = ConnectionCommon::<ClientConnectionData>::new(
+        Arc::new(client_config),
+        server_name("localhost"),
+    )
+    .unwrap();
+    let mut server =
+        ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
 
     let err = do_handshake_until_error(&mut client, &mut server);
     assert!(err.is_err());
@@ -209,10 +225,13 @@ fn client_with_sni_disabled_does_not_send_sni() {
             let mut client_config = make_client_config(*kt, &version_provider);
             client_config.enable_sni = false;
 
-            let mut client =
-                ClientConnection::new(Arc::new(client_config), server_name("value-not-sent"))
-                    .unwrap();
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
+            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+                Arc::new(client_config),
+                server_name("value-not-sent"),
+            )
+            .unwrap();
+            let mut server =
+                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
 
             let err = do_handshake_until_error(&mut client, &mut server);
             dbg!(&err);
@@ -423,10 +442,13 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
 
     for version_provider in all_versions(&provider) {
         let client_config = make_client_config(kt, &version_provider);
-        let mut server = ServerConnection::new(server_config.clone()).unwrap();
-        let mut client =
-            ClientConnection::new(Arc::new(client_config), server_name("thisdoesNOTexist.com"))
-                .unwrap();
+        let mut server =
+            ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            Arc::new(client_config),
+            server_name("thisdoesNOTexist.com"),
+        )
+        .unwrap();
 
         assert_eq!(None, server.server_name());
         transfer(&mut client, &mut server);
@@ -461,8 +483,8 @@ fn sni_resolver_works() {
     server_config.cert_resolver = Arc::new(resolver);
     let server_config = Arc::new(server_config);
 
-    let mut server1 = ServerConnection::new(server_config.clone()).unwrap();
-    let mut client1 = ClientConnection::new(
+    let mut server1 = ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+    let mut client1 = ConnectionCommon::<ClientConnectionData>::new(
         Arc::new(make_client_config(kt, &provider)),
         server_name("localhost"),
     )
@@ -470,8 +492,8 @@ fn sni_resolver_works() {
     let err = do_handshake_until_error(&mut client1, &mut server1);
     assert_eq!(err, Ok(()));
 
-    let mut server2 = ServerConnection::new(server_config.clone()).unwrap();
-    let mut client2 = ClientConnection::new(
+    let mut server2 = ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+    let mut client2 = ConnectionCommon::<ClientConnectionData>::new(
         Arc::new(make_client_config(kt, &provider)),
         server_name("notlocalhost"),
     )
@@ -530,8 +552,8 @@ fn sni_resolver_lower_cases_configured_names() {
     server_config.cert_resolver = Arc::new(resolver);
     let server_config = Arc::new(server_config);
 
-    let mut server1 = ServerConnection::new(server_config.clone()).unwrap();
-    let mut client1 = ClientConnection::new(
+    let mut server1 = ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+    let mut client1 = ConnectionCommon::<ClientConnectionData>::new(
         Arc::new(make_client_config(kt, &provider)),
         server_name("localhost"),
     )
@@ -561,8 +583,8 @@ fn sni_resolver_lower_cases_queried_names() {
     server_config.cert_resolver = Arc::new(resolver);
     let server_config = Arc::new(server_config);
 
-    let mut server1 = ServerConnection::new(server_config.clone()).unwrap();
-    let mut client1 = ClientConnection::new(
+    let mut server1 = ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+    let mut client1 = ConnectionCommon::<ClientConnectionData>::new(
         Arc::new(make_client_config(kt, &provider)),
         server_name("LOCALHOST"),
     )

--- a/rustls/tests/resolve.rs
+++ b/rustls/tests/resolve.rs
@@ -12,8 +12,8 @@ use rustls::server::{
 };
 use rustls::sign::{CertifiedKey, SigningKey};
 use rustls::{
-    ApiMisuse, CertificateError, CipherSuite, ClientConfig, ConnectionCommon, DistinguishedName,
-    Error, PeerMisbehaved, ProtocolVersion, ServerConfig, SignatureScheme, SupportedCipherSuite,
+    ApiMisuse, CertificateError, CipherSuite, ClientConfig, Connection, DistinguishedName, Error,
+    PeerMisbehaved, ProtocolVersion, ServerConfig, SignatureScheme, SupportedCipherSuite,
 };
 use rustls_test::{
     ClientConfigExt, ErrorFromPeer, KeyType, ServerCheckCertResolve,
@@ -39,13 +39,12 @@ fn server_cert_resolve_with_sni() {
             ..Default::default()
         });
 
-        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+        let mut client = Connection::<ClientConnectionData>::new(
             Arc::new(client_config),
             server_name("the.value.from.sni"),
         )
         .unwrap();
-        let mut server =
-            ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
+        let mut server = Connection::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert!(err.is_err());
@@ -65,13 +64,12 @@ fn server_cert_resolve_with_alpn() {
             ..Default::default()
         });
 
-        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+        let mut client = Connection::<ClientConnectionData>::new(
             Arc::new(client_config),
             server_name("sni-value"),
         )
         .unwrap();
-        let mut server =
-            ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
+        let mut server = Connection::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert!(err.is_err());
@@ -114,13 +112,12 @@ fn client_trims_terminating_dot() {
             ..Default::default()
         });
 
-        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+        let mut client = Connection::<ClientConnectionData>::new(
             Arc::new(client_config),
             server_name("some-host.com."),
         )
         .unwrap();
-        let mut server =
-            ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
+        let mut server = Connection::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert!(err.is_err());
@@ -145,13 +142,10 @@ fn check_sigalgs_reduced_by_ciphersuite(
         ..Default::default()
     });
 
-    let mut client = ConnectionCommon::<ClientConnectionData>::new(
-        Arc::new(client_config),
-        server_name("localhost"),
-    )
-    .unwrap();
-    let mut server =
-        ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
+    let mut client =
+        Connection::<ClientConnectionData>::new(Arc::new(client_config), server_name("localhost"))
+            .unwrap();
+    let mut server = Connection::<ServerConnectionData>::new(Arc::new(server_config)).unwrap();
 
     let err = do_handshake_until_error(&mut client, &mut server);
     assert!(err.is_err());
@@ -225,13 +219,13 @@ fn client_with_sni_disabled_does_not_send_sni() {
             let mut client_config = make_client_config(*kt, &version_provider);
             client_config.enable_sni = false;
 
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("value-not-sent"),
             )
             .unwrap();
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
 
             let err = do_handshake_until_error(&mut client, &mut server);
             dbg!(&err);
@@ -442,9 +436,8 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
 
     for version_provider in all_versions(&provider) {
         let client_config = make_client_config(kt, &version_provider);
-        let mut server =
-            ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
-        let mut client = ConnectionCommon::<ClientConnectionData>::new(
+        let mut server = Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
+        let mut client = Connection::<ClientConnectionData>::new(
             Arc::new(client_config),
             server_name("thisdoesNOTexist.com"),
         )
@@ -483,8 +476,8 @@ fn sni_resolver_works() {
     server_config.cert_resolver = Arc::new(resolver);
     let server_config = Arc::new(server_config);
 
-    let mut server1 = ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
-    let mut client1 = ConnectionCommon::<ClientConnectionData>::new(
+    let mut server1 = Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
+    let mut client1 = Connection::<ClientConnectionData>::new(
         Arc::new(make_client_config(kt, &provider)),
         server_name("localhost"),
     )
@@ -492,8 +485,8 @@ fn sni_resolver_works() {
     let err = do_handshake_until_error(&mut client1, &mut server1);
     assert_eq!(err, Ok(()));
 
-    let mut server2 = ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
-    let mut client2 = ConnectionCommon::<ClientConnectionData>::new(
+    let mut server2 = Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
+    let mut client2 = Connection::<ClientConnectionData>::new(
         Arc::new(make_client_config(kt, &provider)),
         server_name("notlocalhost"),
     )
@@ -552,8 +545,8 @@ fn sni_resolver_lower_cases_configured_names() {
     server_config.cert_resolver = Arc::new(resolver);
     let server_config = Arc::new(server_config);
 
-    let mut server1 = ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
-    let mut client1 = ConnectionCommon::<ClientConnectionData>::new(
+    let mut server1 = Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
+    let mut client1 = Connection::<ClientConnectionData>::new(
         Arc::new(make_client_config(kt, &provider)),
         server_name("localhost"),
     )
@@ -583,8 +576,8 @@ fn sni_resolver_lower_cases_queried_names() {
     server_config.cert_resolver = Arc::new(resolver);
     let server_config = Arc::new(server_config);
 
-    let mut server1 = ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
-    let mut client1 = ConnectionCommon::<ClientConnectionData>::new(
+    let mut server1 = Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
+    let mut client1 = Connection::<ClientConnectionData>::new(
         Arc::new(make_client_config(kt, &provider)),
         server_name("LOCALHOST"),
     )

--- a/rustls/tests/resume.rs
+++ b/rustls/tests/resume.rs
@@ -7,10 +7,11 @@ use std::io::{Read, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use rustls::client::Resumption;
+use rustls::client::{ClientConnectionData, Resumption};
+use rustls::server::ServerConnectionData;
 use rustls::{
-    ApiMisuse, CertificateIdentity, ClientConfig, ClientConnection, Error, HandshakeKind,
-    NamedGroup, PeerIdentity, PeerMisbehaved, ProtocolVersion, ServerConfig, ServerConnection,
+    ApiMisuse, CertificateIdentity, ClientConfig, ConnectionCommon, Error, HandshakeKind,
+    NamedGroup, PeerIdentity, PeerMisbehaved, ProtocolVersion, ServerConfig,
 };
 use rustls_test::{
     ClientStorage, ClientStorageOp, ErrorFromPeer, KeyType, ServerConfigExt, do_handshake,
@@ -195,9 +196,12 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
     server_config_2.session_storage = Arc::new(rustls::server::NoServerSessionStorage {});
 
     dbg!("handshake 1");
-    let mut client_1 =
-        ClientConnection::new(client_config.clone(), "localhost".try_into().unwrap()).unwrap();
-    let mut server_1 = ServerConnection::new(server_config_1).unwrap();
+    let mut client_1 = ConnectionCommon::<ClientConnectionData>::new(
+        client_config.clone(),
+        "localhost".try_into().unwrap(),
+    )
+    .unwrap();
+    let mut server_1 = ConnectionCommon::<ServerConnectionData>::new(server_config_1).unwrap();
     do_handshake(&mut client_1, &mut server_1);
 
     assert_eq!(client_storage.ops().len(), 7);
@@ -216,9 +220,13 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
     ));
 
     dbg!("handshake 2");
-    let mut client_2 =
-        ClientConnection::new(client_config, "localhost".try_into().unwrap()).unwrap();
-    let mut server_2 = ServerConnection::new(Arc::new(server_config_2)).unwrap();
+    let mut client_2 = ConnectionCommon::<ClientConnectionData>::new(
+        client_config,
+        "localhost".try_into().unwrap(),
+    )
+    .unwrap();
+    let mut server_2 =
+        ConnectionCommon::<ServerConnectionData>::new(Arc::new(server_config_2)).unwrap();
     do_handshake(&mut client_2, &mut server_2);
     println!("hs2 storage ops: {:#?}", client_storage.ops());
     assert_eq!(client_storage.ops().len(), 9);
@@ -537,7 +545,7 @@ fn early_data_is_available_on_resumption() {
 
 #[test]
 fn early_data_not_available_on_server_before_client_hello() {
-    let mut server = ServerConnection::new(Arc::new(make_server_config(
+    let mut server = ConnectionCommon::<ServerConnectionData>::new(Arc::new(make_server_config(
         KeyType::Rsa2048,
         &provider::default_provider(),
     )))

--- a/rustls/tests/resume.rs
+++ b/rustls/tests/resume.rs
@@ -7,8 +7,8 @@ use std::io::{Read, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use rustls::client::{ClientConnectionData, Resumption};
-use rustls::server::ServerConnectionData;
+use rustls::client::{Client, Resumption};
+use rustls::server::Server;
 use rustls::{
     ApiMisuse, CertificateIdentity, ClientConfig, Connection, Error, HandshakeKind, NamedGroup,
     PeerIdentity, PeerMisbehaved, ProtocolVersion, ServerConfig,
@@ -196,12 +196,9 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
     server_config_2.session_storage = Arc::new(rustls::server::NoServerSessionStorage {});
 
     dbg!("handshake 1");
-    let mut client_1 = Connection::<ClientConnectionData>::new(
-        client_config.clone(),
-        "localhost".try_into().unwrap(),
-    )
-    .unwrap();
-    let mut server_1 = Connection::<ServerConnectionData>::new(server_config_1).unwrap();
+    let mut client_1 =
+        Connection::<Client>::new(client_config.clone(), "localhost".try_into().unwrap()).unwrap();
+    let mut server_1 = Connection::<Server>::new(server_config_1).unwrap();
     do_handshake(&mut client_1, &mut server_1);
 
     assert_eq!(client_storage.ops().len(), 7);
@@ -221,9 +218,8 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
 
     dbg!("handshake 2");
     let mut client_2 =
-        Connection::<ClientConnectionData>::new(client_config, "localhost".try_into().unwrap())
-            .unwrap();
-    let mut server_2 = Connection::<ServerConnectionData>::new(Arc::new(server_config_2)).unwrap();
+        Connection::<Client>::new(client_config, "localhost".try_into().unwrap()).unwrap();
+    let mut server_2 = Connection::<Server>::new(Arc::new(server_config_2)).unwrap();
     do_handshake(&mut client_2, &mut server_2);
     println!("hs2 storage ops: {:#?}", client_storage.ops());
     assert_eq!(client_storage.ops().len(), 9);
@@ -542,7 +538,7 @@ fn early_data_is_available_on_resumption() {
 
 #[test]
 fn early_data_not_available_on_server_before_client_hello() {
-    let mut server = Connection::<ServerConnectionData>::new(Arc::new(make_server_config(
+    let mut server = Connection::<Server>::new(Arc::new(make_server_config(
         KeyType::Rsa2048,
         &provider::default_provider(),
     )))

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -15,7 +15,7 @@ use rustls::client::{
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert, ServerConnectionData};
 use rustls::sign::CertifiedKey;
 use rustls::{
-    AlertDescription, CertificateError, CertificateType, ClientConfig, ConnectionCommon,
+    AlertDescription, CertificateError, CertificateType, ClientConfig, Connection,
     DistinguishedName, Error, ExtendedKeyPurpose, InvalidMessage, RootCertStore, ServerConfig,
 };
 use rustls_test::{
@@ -296,9 +296,8 @@ fn client_checks_server_certificate_with_given_ip_address() {
         name: &'static str,
     ) -> Result<(), ErrorFromPeer> {
         let mut client =
-            ConnectionCommon::<ClientConnectionData>::new(client_config, server_name(name))
-                .unwrap();
-        let mut server = ConnectionCommon::<ServerConnectionData>::new(server_config).unwrap();
+            Connection::<ClientConnectionData>::new(client_config, server_name(name)).unwrap();
+        let mut server = Connection::<ServerConnectionData>::new(server_config).unwrap();
         do_handshake_until_error(&mut client, &mut server)
     }
 
@@ -348,13 +347,13 @@ fn client_checks_server_certificate_with_given_name() {
 
         for version_provider in all_versions(&provider) {
             let client_config = make_client_config(*kt, &version_provider);
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("not-the-right-hostname.com"),
             )
             .unwrap();
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
 
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_eq!(
@@ -382,13 +381,13 @@ fn client_check_server_certificate_ee_revoked() {
         for version_provider in all_versions(&provider) {
             let client_config =
                 make_client_config_with_verifier(builder.clone(), &version_provider);
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("localhost"),
             )
             .unwrap();
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
 
             // We expect the handshake to fail since the server's EE certificate is revoked.
             let err = do_handshake_until_error(&mut client, &mut server);
@@ -429,13 +428,13 @@ fn client_check_server_certificate_ee_unknown_revocation() {
                 forbid_unknown_verifier.clone(),
                 &version_provider,
             );
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("localhost"),
             )
             .unwrap();
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
 
             // We expect if we use the forbid_unknown_verifier that the handshake will fail since the
             // server's EE certificate's revocation status is unknown given the CRLs we've provided.
@@ -450,13 +449,13 @@ fn client_check_server_certificate_ee_unknown_revocation() {
             // We expect if we use the allow_unknown_verifier that the handshake will not fail.
             let client_config =
                 make_client_config_with_verifier(allow_unknown_verifier.clone(), &version_provider);
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("localhost"),
             )
             .unwrap();
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
             let res = do_handshake_until_error(&mut client, &mut server);
             assert!(res.is_ok());
         }
@@ -490,13 +489,13 @@ fn client_check_server_certificate_intermediate_revoked() {
                 full_chain_verifier_builder.clone(),
                 &version_provider,
             );
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("localhost"),
             )
             .unwrap();
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
 
             // We expect the handshake to fail when using the full chain verifier since the intermediate's
             // EE certificate is revoked.
@@ -510,13 +509,13 @@ fn client_check_server_certificate_intermediate_revoked() {
 
             let client_config =
                 make_client_config_with_verifier(ee_verifier_builder.clone(), &version_provider);
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("localhost"),
             )
             .unwrap();
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
             // We expect the handshake to succeed when we use the verifier that only checks the EE certificate
             // revocation status. The revoked intermediate status should not be checked.
             let res = do_handshake_until_error(&mut client, &mut server);
@@ -551,13 +550,13 @@ fn client_check_server_certificate_ee_crl_expired() {
                 enforce_expiration_builder.clone(),
                 &version_provider,
             );
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("localhost"),
             )
             .unwrap();
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
 
             // We expect the handshake to fail since the CRL is expired.
             let err = do_handshake_until_error(&mut client, &mut server);
@@ -572,13 +571,13 @@ fn client_check_server_certificate_ee_crl_expired() {
                 ignore_expiration_builder.clone(),
                 &version_provider,
             );
-            let mut client = ConnectionCommon::<ClientConnectionData>::new(
+            let mut client = Connection::<ClientConnectionData>::new(
                 Arc::new(client_config),
                 server_name("localhost"),
             )
             .unwrap();
             let mut server =
-                ConnectionCommon::<ServerConnectionData>::new(server_config.clone()).unwrap();
+                Connection::<ServerConnectionData>::new(server_config.clone()).unwrap();
 
             // We expect the handshake to succeed when CRL expiration is ignored.
             let res = do_handshake_until_error(&mut client, &mut server);

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1223,7 +1223,7 @@ fn advance_server(
     state
 }
 
-fn handle_state<Side>(
+fn handle_state<Side: SideData>(
     state: ConnectionState<'_, '_, Side>,
     outgoing: &mut Buffer,
     actions: Actions,
@@ -1321,7 +1321,7 @@ fn handle_state<Side>(
     }
 }
 
-fn queue_close_notify<Side>(state: &mut WriteTraffic<'_, Side>, outgoing: &mut Buffer) {
+fn queue_close_notify<Side: SideData>(state: &mut WriteTraffic<'_, Side>, outgoing: &mut Buffer) {
     write_with_buffer_size_checks(
         |out_buf| state.queue_close_notify(out_buf),
         map_encrypt_error,
@@ -1329,7 +1329,11 @@ fn queue_close_notify<Side>(state: &mut WriteTraffic<'_, Side>, outgoing: &mut B
     );
 }
 
-fn encrypt<Side>(state: &mut WriteTraffic<'_, Side>, app_data: &[u8], outgoing: &mut Buffer) {
+fn encrypt<Side: SideData>(
+    state: &mut WriteTraffic<'_, Side>,
+    app_data: &[u8],
+    outgoing: &mut Buffer,
+) {
     write_with_buffer_size_checks(
         |out_buf| state.encrypt(app_data, out_buf),
         map_encrypt_error,

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -3,9 +3,9 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use rustls::client::{ClientConnectionData, EarlyDataError, UnbufferedClientConnection};
+use rustls::client::{Client, EarlyDataError, UnbufferedClientConnection};
 use rustls::crypto::CryptoProvider;
-use rustls::server::{ServerConnectionData, UnbufferedServerConnection};
+use rustls::server::{Server, UnbufferedServerConnection};
 use rustls::unbuffered::{
     ConnectionState, EncodeError, EncryptError, InsufficientSizeError, ReadTraffic,
     UnbufferedConnectionCommon, UnbufferedStatus, WriteTraffic,
@@ -1142,7 +1142,7 @@ struct Outcome {
 }
 
 fn advance_client(
-    conn: &mut UnbufferedConnectionCommon<ClientConnectionData>,
+    conn: &mut UnbufferedConnectionCommon<Client>,
     buffers: &mut Buffers,
     actions: Actions,
     transcript: &mut Vec<String>,
@@ -1188,7 +1188,7 @@ fn advance_client(
 }
 
 fn advance_server(
-    conn: &mut UnbufferedConnectionCommon<ServerConnectionData>,
+    conn: &mut UnbufferedConnectionCommon<Server>,
     buffers: &mut Buffers,
     actions: Actions,
     transcript: &mut Vec<String>,

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -1223,8 +1223,8 @@ fn advance_server(
     state
 }
 
-fn handle_state<Data>(
-    state: ConnectionState<'_, '_, Data>,
+fn handle_state<Side>(
+    state: ConnectionState<'_, '_, Side>,
     outgoing: &mut Buffer,
     actions: Actions,
 ) -> State {
@@ -1321,7 +1321,7 @@ fn handle_state<Data>(
     }
 }
 
-fn queue_close_notify<Data>(state: &mut WriteTraffic<'_, Data>, outgoing: &mut Buffer) {
+fn queue_close_notify<Side>(state: &mut WriteTraffic<'_, Side>, outgoing: &mut Buffer) {
     write_with_buffer_size_checks(
         |out_buf| state.queue_close_notify(out_buf),
         map_encrypt_error,
@@ -1329,7 +1329,7 @@ fn queue_close_notify<Data>(state: &mut WriteTraffic<'_, Data>, outgoing: &mut B
     );
 }
 
-fn encrypt<Data>(state: &mut WriteTraffic<'_, Data>, app_data: &[u8], outgoing: &mut Buffer) {
+fn encrypt<Side>(state: &mut WriteTraffic<'_, Side>, app_data: &[u8], outgoing: &mut Buffer) {
     write_with_buffer_size_checks(
         |out_buf| state.encrypt(app_data, out_buf),
         map_encrypt_error,


### PR DESCRIPTION
Replaces `ClientConnection` with `Connection<Client>`, which seems like a pretty nice way to move forward. Makes generics quite a bit simpler: instead of `impl DerefMut<Target = ConnectionCommon<impl SideData>>` we can now say `ConnectionCommon<impl SideData>`).

Remaining steps:

- QUIC
- Unbuffered

Maybe having `Client` and `Server` types is a little weird and they should be `ClientData` and `ServerData`?

Would like early feedback before resolving all CI issues.