### PR TITLE
Take MSRV of 1.83

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.79"
+          toolchain: "1.83"
 
       - run: cargo check --locked --lib --all-features -p rustls
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ can replace all cryptography dependencies of rustls.  This is a route to being p
 to a wider set of architectures and environments, or compliance requirements.  See the
 [`crypto::CryptoProvider`] documentation for more details.
 
-Rustls requires Rust 1.79 or later.
+Rustls requires Rust 1.83 or later.
 
 [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 [`crypto::CryptoProvider`]: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,8 +29,8 @@ in the course of normal development, subject to these constraints:
 - Our MSRV will be no more recent than 9 versions old, or approximately 12 months.
 
 > [!TIP]
-> At the time of writing, the most recent Rust release is 1.88.  That means
-> our MSRV could be as recent as 1.79. As it happens, it is 1.79.
+> At the time of writing, the most recent Rust release is 1.90.  That means
+> our MSRV could be as recent as 1.81. As it happens, it is 1.83.
 
 - Our MSRV policy only covers the core library crate: it does not cover tests
   or example code, and is not binding on our dependencies.

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls"
 version = "0.24.0-dev.0"
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.83"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "../README.md"
 description = "Rustls is a modern TLS library written in Rust."

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -1012,7 +1012,7 @@ impl fmt::Display for EarlyDataError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for EarlyDataError {}
+impl core::error::Error for EarlyDataError {}
 
 /// State associated with a client connection.
 #[derive(Debug)]

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -1,10 +1,10 @@
 //! Unbuffered connection API
 
 use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use core::error::Error as StdError;
 use core::num::NonZeroUsize;
 use core::{fmt, mem};
-#[cfg(feature = "std")]
-use std::error::Error as StdError;
 
 use super::UnbufferedConnectionCommon;
 use crate::Error;

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -104,7 +104,7 @@ impl fmt::Display for UnsupportedOperationError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for UnsupportedOperationError {}
+impl core::error::Error for UnsupportedOperationError {}
 
 /// How a TLS1.2 `key_block` is partitioned.
 ///

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -11,7 +11,6 @@ use super::ring_like::rand::{SecureRandom, SystemRandom};
 use crate::error::Error;
 #[cfg(debug_assertions)]
 use crate::log::debug;
-use crate::polyfill::try_split_at;
 use crate::server::ProducesTickets;
 use crate::sync::Arc;
 
@@ -148,9 +147,9 @@ impl ProducesTickets for AeadTicketer {
             return None;
         }
 
-        let (alleged_key_name, ciphertext) = try_split_at(ciphertext, self.key_name.len())?;
+        let (alleged_key_name, ciphertext) = ciphertext.split_at_checked(self.key_name.len())?;
 
-        let (nonce, ciphertext) = try_split_at(ciphertext, self.alg.nonce_len())?;
+        let (nonce, ciphertext) = ciphertext.split_at_checked(self.alg.nonce_len())?;
 
         // checking the key_name is the expected one, *and* then putting it into the
         // additionally authenticated data is duplicative.  this check quickly rejects

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -1103,7 +1103,7 @@ impl From<SystemTimeError> for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl From<rand::GetRandomFailed> for Error {
     fn from(_: rand::GetRandomFailed) -> Self {
@@ -1234,9 +1234,9 @@ impl From<ApiMisuse> for Error {
 }
 
 mod other_error {
-    use core::fmt;
     #[cfg(feature = "std")]
-    use std::error::Error as StdError;
+    use core::error::Error as StdError;
+    use core::fmt;
 
     use super::Error;
     #[cfg(feature = "std")]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -25,7 +25,7 @@
 //! to a wider set of architectures and environments, or compliance requirements.  See the
 //! [`crypto::CryptoProvider`] documentation for more details.
 //!
-//! Rustls requires Rust 1.79 or later.
+//! Rustls requires Rust 1.83 or later.
 //!
 //! [ring-target-platforms]: https://github.com/briansmith/ring/blob/2e8363b433fa3b3962c877d9ed2e9145612f3160/include/ring-core/target.h#L18-L64
 //! [`crypto::CryptoProvider`]: crate::crypto::CryptoProvider

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -685,9 +685,6 @@ pub mod time_provider;
 /// APIs abstracting over locking primitives.
 pub mod lock;
 
-/// Polyfills for features that are not yet stabilized or available with current MSRV.
-pub(crate) mod polyfill;
-
 #[cfg(any(feature = "std", feature = "hashbrown"))]
 mod hash_map {
     #[cfg(feature = "std")]

--- a/rustls/src/polyfill.rs
+++ b/rustls/src/polyfill.rs
@@ -1,9 +1,0 @@
-/// Non-panicking `let (nonce, ciphertext) = ciphertext.split_at(...)`.
-// TODO(XXX): remove once MSRV reaches 1.80
-#[allow(dead_code)] // Complicated conditional compilation guards elided
-pub(crate) fn try_split_at(slice: &[u8], mid: usize) -> Option<(&[u8], &[u8])> {
-    match mid > slice.len() {
-        true => None,
-        false => Some(slice.split_at(mid)),
-    }
-}

--- a/rustls/src/webpki/anchors.rs
+++ b/rustls/src/webpki/anchors.rs
@@ -135,7 +135,7 @@ fn root_cert_store_debug() {
         subject_public_key_info: Der::from_slice(&[]),
         name_constraints: None,
     };
-    let store = RootCertStore::from_iter(iter::repeat(ta).take(138));
+    let store = RootCertStore::from_iter(iter::repeat_n(ta, 138));
 
     assert_eq!(
         format!("{store:?}"),

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -51,7 +51,7 @@ impl fmt::Display for VerifierBuilderError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for VerifierBuilderError {}
+impl core::error::Error for VerifierBuilderError {}
 
 fn pki_error(error: webpki::Error) -> Error {
     use webpki::Error::*;

--- a/rustls/tests/io.rs
+++ b/rustls/tests/io.rs
@@ -874,9 +874,7 @@ fn test_client_write_and_vectored_write_equivalence() {
 
     const N: usize = 1000;
 
-    let data_chunked: Vec<IoSlice> = std::iter::repeat(IoSlice::new(b"A"))
-        .take(N)
-        .collect();
+    let data_chunked: Vec<IoSlice> = std::iter::repeat_n(IoSlice::new(b"A"), N).collect();
     let bytes_written_chunked = client
         .writer()
         .write_vectored(&data_chunked)

--- a/rustls/tests/quic.rs
+++ b/rustls/tests/quic.rs
@@ -619,7 +619,7 @@ fn packet_key_api() {
     let header_len = PLAIN_HEADER.len();
     let tag_len = client_keys.local.packet.tag_len();
     let padding_len = 1200 - header_len - PAYLOAD.len() - tag_len;
-    buf.extend(std::iter::repeat(0).take(padding_len));
+    buf.extend(std::iter::repeat_n(0, padding_len));
     let (header, payload) = buf.split_at_mut(header_len);
     let tag = client_keys
         .local


### PR DESCRIPTION
According to our MSRV policy, that means the earliest release of 0.24 could be November. That is OK I think.

Aside from the improvements in this PR, the impetus is static-in-consts support which is needed for a much better formulation of #2652.