### PR TITLE
Allow const-constructable `CryptoProvider`

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -19,6 +19,7 @@
 )]
 
 use core::fmt::{Debug, Formatter};
+use std::borrow::Cow;
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex};
 use std::{env, net, process, thread, time};
@@ -223,6 +224,7 @@ impl Options {
         if let Some(groups) = &self.groups {
             provider
                 .kx_groups
+                .to_mut()
                 .retain(|kxg| groups.contains(&kxg.name()));
         }
 
@@ -312,9 +314,9 @@ impl SelectedProvider {
                 // this includes rustls-post-quantum, which just returns an altered
                 // version of `aws_lc_rs::default_provider()`
                 CryptoProvider {
-                    kx_groups: aws_lc_rs::ALL_KX_GROUPS.to_vec(),
-                    tls12_cipher_suites: aws_lc_rs::ALL_TLS12_CIPHER_SUITES.to_vec(),
-                    tls13_cipher_suites: aws_lc_rs::ALL_TLS13_CIPHER_SUITES.to_vec(),
+                    kx_groups: Cow::Borrowed(aws_lc_rs::ALL_KX_GROUPS),
+                    tls12_cipher_suites: Cow::Borrowed(aws_lc_rs::ALL_TLS12_CIPHER_SUITES),
+                    tls13_cipher_suites: Cow::Borrowed(aws_lc_rs::ALL_TLS13_CIPHER_SUITES),
                     ..aws_lc_rs::default_provider()
                 }
             }

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -317,11 +317,11 @@ impl SelectedProvider {
                     kx_groups: Cow::Borrowed(aws_lc_rs::ALL_KX_GROUPS),
                     tls12_cipher_suites: Cow::Borrowed(aws_lc_rs::ALL_TLS12_CIPHER_SUITES),
                     tls13_cipher_suites: Cow::Borrowed(aws_lc_rs::ALL_TLS13_CIPHER_SUITES),
-                    ..aws_lc_rs::default_provider()
+                    ..aws_lc_rs::DEFAULT_PROVIDER
                 }
             }
 
-            Self::Ring => ring::default_provider(),
+            Self::Ring => ring::DEFAULT_PROVIDER,
         }
     }
 
@@ -2266,7 +2266,7 @@ impl compress::CertCompressor for RandomAlgorithm {
         let random_byte = {
             let mut bytes = [0];
             // nb. provider is irrelevant for this use
-            ring::default_provider()
+            ring::DEFAULT_PROVIDER
                 .secure_random
                 .fill(&mut bytes)
                 .unwrap();

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -311,12 +311,12 @@ fn all_benchmarks_params() -> Vec<BenchmarkParams> {
 
     for (provider, ticketer, provider_name) in [
         (
-            derandomize(ring::default_provider()),
+            derandomize(ring::DEFAULT_PROVIDER),
             &(ring_ticketer as fn() -> Arc<dyn rustls::server::ProducesTickets>),
             "ring",
         ),
         (
-            derandomize(aws_lc_rs::default_provider()),
+            derandomize(aws_lc_rs::DEFAULT_PROVIDER),
             &(aws_lc_rs_ticketer as fn() -> Arc<dyn rustls::server::ProducesTickets>),
             "aws_lc_rs",
         ),

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -379,9 +379,7 @@ fn all_benchmarks_params() -> Vec<BenchmarkParams> {
         as fn() -> Arc<dyn rustls::server::ProducesTickets>);
 
     all.push(BenchmarkParams::new(
-        rustls_fuzzing_provider::provider()
-            .with_only_tls13()
-            .into(),
+        rustls_fuzzing_provider::PROVIDER_TLS13.into(),
         make_ticketer,
         AuthKeySource::FuzzingProvider,
         ProtocolVersion::TLSv1_3,
@@ -389,9 +387,7 @@ fn all_benchmarks_params() -> Vec<BenchmarkParams> {
     ));
 
     all.push(BenchmarkParams::new(
-        rustls_fuzzing_provider::provider()
-            .with_only_tls12()
-            .into(),
+        rustls_fuzzing_provider::PROVIDER_TLS12.into(),
         make_ticketer,
         AuthKeySource::FuzzingProvider,
         ProtocolVersion::TLSv1_2,

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -404,9 +404,11 @@ fn all_benchmarks_params() -> Vec<BenchmarkParams> {
 fn select_suite(mut provider: CryptoProvider, name: CipherSuite) -> Arc<CryptoProvider> {
     provider
         .tls12_cipher_suites
+        .to_mut()
         .retain(|suite| suite.common.suite == name);
     provider
         .tls13_cipher_suites
+        .to_mut()
         .retain(|suite| suite.common.suite == name);
     provider.into()
 }

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -114,14 +114,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     // Construct a rustls client config with a TLS1.3-only provider, and ECH enabled.
-    let mut config = rustls::ClientConfig::builder_with_provider(
-        aws_lc_rs::DEFAULT_PROVIDER
-            .with_only_tls13()
-            .into(),
-    )
-    .with_ech(ech_mode)
-    .with_root_certificates(root_store)
-    .with_no_client_auth()?;
+    let mut config =
+        rustls::ClientConfig::builder_with_provider(aws_lc_rs::DEFAULT_TLS13_PROVIDER.into())
+            .with_ech(ech_mode)
+            .with_root_certificates(root_store)
+            .with_no_client_auth()?;
 
     // Allow using SSLKEYLOGFILE.
     config.key_log = Arc::new(rustls::KeyLogFile::new());

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -113,9 +113,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         },
     };
 
-    // Construct a rustls client config with a custom provider, and ECH enabled.
+    // Construct a rustls client config with a TLS1.3-only provider, and ECH enabled.
     let mut config = rustls::ClientConfig::builder_with_provider(
-        aws_lc_rs::default_provider()
+        aws_lc_rs::DEFAULT_PROVIDER
             .with_only_tls13()
             .into(),
     )

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -2,6 +2,7 @@
 //! so that unused cryptography in rustls can be discarded by the linker.  You can
 //! observe using `nm` that the binary of this program does not contain any AES code.
 
+use std::borrow::Cow;
 use std::io::{Read, Write, stdout};
 use std::net::TcpStream;
 use std::sync::Arc;
@@ -17,9 +18,11 @@ fn main() {
 
     let config = rustls::ClientConfig::builder_with_provider(
         CryptoProvider {
-            tls12_cipher_suites: vec![],
-            tls13_cipher_suites: vec![provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256],
-            kx_groups: vec![provider::kx_group::X25519],
+            tls12_cipher_suites: Cow::Borrowed(&[]),
+            tls13_cipher_suites: Cow::Owned(vec![
+                provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+            ]),
+            kx_groups: Cow::Owned(vec![provider::kx_group::X25519]),
             signature_verification_algorithms: provider::SUPPORTED_SIG_ALGS,
             secure_random: provider::DEFAULT_SECURE_RANDOM,
             key_provider: provider::DEFAULT_KEY_PROVIDER,

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -16,22 +16,10 @@ fn main() {
             .cloned(),
     );
 
-    let config = rustls::ClientConfig::builder_with_provider(
-        CryptoProvider {
-            tls12_cipher_suites: Cow::Borrowed(&[]),
-            tls13_cipher_suites: Cow::Owned(vec![
-                provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
-            ]),
-            kx_groups: Cow::Owned(vec![provider::kx_group::X25519]),
-            signature_verification_algorithms: provider::SUPPORTED_SIG_ALGS,
-            secure_random: provider::DEFAULT_SECURE_RANDOM,
-            key_provider: provider::DEFAULT_KEY_PROVIDER,
-        }
-        .into(),
-    )
-    .with_root_certificates(root_store)
-    .with_no_client_auth()
-    .unwrap();
+    let config = rustls::ClientConfig::builder_with_provider(PROVIDER.into())
+        .with_root_certificates(root_store)
+        .with_no_client_auth()
+        .unwrap();
 
     let server_name = "www.rust-lang.org".try_into().unwrap();
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
@@ -62,3 +50,10 @@ fn main() {
     tls.read_to_end(&mut plaintext).unwrap();
     stdout().write_all(&plaintext).unwrap();
 }
+
+const PROVIDER: CryptoProvider = CryptoProvider {
+    tls12_cipher_suites: Cow::Borrowed(&[]),
+    tls13_cipher_suites: Cow::Borrowed(&[provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]),
+    kx_groups: Cow::Borrowed(&[provider::kx_group::X25519]),
+    ..provider::DEFAULT_PROVIDER
+};

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -20,7 +20,7 @@ fn main() {
     };
 
     let mut config = rustls::ClientConfig::builder_with_provider(
-        rustls::crypto::aws_lc_rs::default_provider().into(),
+        rustls::crypto::aws_lc_rs::DEFAULT_PROVIDER.into(),
     )
     .with_root_certificates(root_store)
     .with_no_client_auth()

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -287,20 +287,20 @@ impl Args {
             ),
         };
 
+        let provider = match lookup_versions(&self.protover).as_slice() {
+            [ProtocolVersion::TLSv1_2] => provider::DEFAULT_TLS12_PROVIDER,
+            [ProtocolVersion::TLSv1_3] => provider::DEFAULT_TLS13_PROVIDER,
+            _ => provider::DEFAULT_PROVIDER,
+        };
+
         let provider = CryptoProvider {
             kx_groups,
-            ..provider::DEFAULT_PROVIDER
+            ..provider
         };
 
-        let provider = match self.suite.as_slice() {
+        match self.suite.as_slice() {
             [] => provider,
             _ => filter_suites(provider, &self.suite),
-        };
-
-        match lookup_versions(&self.protover).as_slice() {
-            [ProtocolVersion::TLSv1_2] => provider.with_only_tls12(),
-            [ProtocolVersion::TLSv1_3] => provider.with_only_tls13(),
-            _ => provider,
         }
     }
 }

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -289,7 +289,7 @@ impl Args {
 
         let provider = CryptoProvider {
             kx_groups,
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         };
 
         let provider = match self.suite.as_slice() {
@@ -502,7 +502,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
         config
             .dangerous()
             .set_certificate_verifier(Arc::new(danger::NoCertificateVerification::new(
-                provider::default_provider(),
+                provider::DEFAULT_PROVIDER,
             )));
     }
 

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -510,13 +510,17 @@ fn filter_suites(mut provider: CryptoProvider, suites: &[String]) -> CryptoProvi
 
     for s in suites {
         if !known_suites.contains(&s.to_lowercase()) {
-            panic!("cannot look up ciphersuite '{s}'. should be one of {known_suites:?}");
+            panic!(
+                "unsupported ciphersuite '{s}'; should be one of {known_suites}",
+                known_suites = known_suites.join(", ")
+            );
         }
     }
 
     // now discard non-named suites
     provider
         .tls12_cipher_suites
+        .to_mut()
         .retain(|cs| {
             let name = format!("{:?}", cs.common.suite).to_lowercase();
             suites
@@ -525,6 +529,7 @@ fn filter_suites(mut provider: CryptoProvider, suites: &[String]) -> CryptoProvi
         });
     provider
         .tls13_cipher_suites
+        .to_mut()
         .retain(|cs| {
             let name = format!("{:?}", cs.common.suite).to_lowercase();
             suites

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -473,7 +473,7 @@ struct Args {
 
 impl Args {
     fn provider(&self) -> (Vec<ProtocolVersion>, CryptoProvider) {
-        let provider = provider::default_provider();
+        let provider = provider::DEFAULT_PROVIDER;
 
         let provider = match self.suite.as_slice() {
             [] => provider,

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -11,7 +11,7 @@ use rustls::{ClientConfig, ClientConnection};
 fuzz_target!(|data: &[u8]| {
     let _ = env_logger::try_init();
     let config = Arc::new(
-        ClientConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
+        ClientConfig::builder_with_provider(rustls_fuzzing_provider::PROVIDER.into())
             .dangerous()
             .with_custom_certificate_verifier(rustls_fuzzing_provider::server_verifier())
             .with_no_client_auth()

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -20,7 +20,7 @@ fuzz_target!(|data: &[u8]| {
 
 fn fuzz_buffered_api(data: &[u8]) {
     let config = Arc::new(
-        ServerConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
+        ServerConfig::builder_with_provider(rustls_fuzzing_provider::PROVIDER.into())
             .with_no_client_auth()
             .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
             .unwrap(),
@@ -58,7 +58,7 @@ fn fuzz_acceptor_api(data: &[u8]) {
 
 fn fuzz_accepted(stream: &mut dyn io::Read, accepted: Accepted) {
     let mut maybe_server = accepted.into_connection(Arc::new(
-        ServerConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
+        ServerConfig::builder_with_provider(rustls_fuzzing_provider::PROVIDER.into())
             .with_no_client_auth()
             .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
             .unwrap(),

--- a/fuzz/fuzzers/unbuffered.rs
+++ b/fuzz/fuzzers/unbuffered.rs
@@ -19,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
 });
 
 fn client(data: &mut [u8]) {
-    let config = ClientConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
+    let config = ClientConfig::builder_with_provider(rustls_fuzzing_provider::PROVIDER.into())
         .dangerous()
         .with_custom_certificate_verifier(rustls_fuzzing_provider::server_verifier())
         .with_no_client_auth()
@@ -30,7 +30,7 @@ fn client(data: &mut [u8]) {
 }
 
 fn server(data: &mut [u8]) {
-    let config = ServerConfig::builder_with_provider(rustls_fuzzing_provider::provider().into())
+    let config = ServerConfig::builder_with_provider(rustls_fuzzing_provider::PROVIDER.into())
         .with_no_client_auth()
         .with_cert_resolver(rustls_fuzzing_provider::server_cert_resolver())
         .unwrap();

--- a/openssl-tests/src/early_exporter.rs
+++ b/openssl-tests/src/early_exporter.rs
@@ -22,7 +22,7 @@ fn test_early_exporter() {
     let port = listener.local_addr().unwrap().port();
 
     let server_thread = thread::spawn(move || {
-        let mut config = ServerConfig::builder_with_provider(provider::default_provider().into())
+        let mut config = ServerConfig::builder_with_provider(provider::DEFAULT_PROVIDER.into())
             .with_no_client_auth()
             .with_single_cert(load_certs(), load_private_key())
             .unwrap();

--- a/openssl-tests/src/ffdhe.rs
+++ b/openssl-tests/src/ffdhe.rs
@@ -15,7 +15,7 @@ pub(crate) struct FfdheKxGroup(pub NamedGroup, pub FfdheGroup<'static>);
 impl SupportedKxGroup for FfdheKxGroup {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, rustls::Error> {
         let mut x = vec![0; 64];
-        provider::default_provider()
+        provider::DEFAULT_PROVIDER
             .secure_random
             .fill(&mut x)?;
         let x = BigUint::from_bytes_be(&x);

--- a/openssl-tests/src/ffdhe.rs
+++ b/openssl-tests/src/ffdhe.rs
@@ -6,6 +6,9 @@ use rustls::crypto::{
 use rustls::ffdhe_groups::FfdheGroup;
 use rustls::{CipherSuite, NamedGroup, Tls12CipherSuite};
 
+pub(crate) const FFDHE2048_GROUP: &dyn SupportedKxGroup =
+    &FfdheKxGroup(NamedGroup::FFDHE2048, rustls::ffdhe_groups::FFDHE2048);
+
 #[derive(Debug)]
 pub(crate) struct FfdheKxGroup(pub NamedGroup, pub FfdheGroup<'static>);
 

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
@@ -9,7 +10,7 @@ use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::{ClientConfig, RootCertStore, ServerConfig};
 
-use crate::ffdhe::{self, FfdheKxGroup};
+use crate::ffdhe::{self, FFDHE2048_GROUP};
 use crate::utils::verify_openssl3_available;
 
 #[test]
@@ -195,12 +196,9 @@ fn load_private_key() -> PrivateKeyDer<'static> {
 
 fn ffdhe_provider() -> CryptoProvider {
     CryptoProvider {
-        tls12_cipher_suites: vec![&ffdhe::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256],
-        tls13_cipher_suites: vec![provider::cipher_suite::TLS13_AES_128_GCM_SHA256],
-        kx_groups: vec![&FfdheKxGroup(
-            rustls::NamedGroup::FFDHE2048,
-            rustls::ffdhe_groups::FFDHE2048,
-        )],
+        tls12_cipher_suites: Cow::Owned(vec![&ffdhe::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256]),
+        tls13_cipher_suites: Cow::Owned(vec![provider::cipher_suite::TLS13_AES_128_GCM_SHA256]),
+        kx_groups: Cow::Owned(vec![FFDHE2048_GROUP]),
         ..provider::default_provider()
     }
 }

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -199,7 +199,7 @@ fn ffdhe_provider() -> CryptoProvider {
         tls12_cipher_suites: Cow::Owned(vec![&ffdhe::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256]),
         tls13_cipher_suites: Cow::Owned(vec![provider::cipher_suite::TLS13_AES_128_GCM_SHA256]),
         kx_groups: Cow::Owned(vec![FFDHE2048_GROUP]),
-        ..provider::default_provider()
+        ..provider::DEFAULT_PROVIDER
     }
 }
 

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -27,7 +27,7 @@ mod client {
 
     /// Build a `ClientConfig` with the given client private key and a server public key to trust.
     pub(super) fn make_config(client_private_key: &str, server_pub_key: &str) -> ClientConfig {
-        let client_private_key = Arc::new(provider::default_provider())
+        let client_private_key = Arc::new(provider::DEFAULT_PROVIDER)
             .key_provider
             .load_private_key(
                 PrivateKeyDer::from_pem_file(client_private_key)
@@ -91,7 +91,7 @@ mod client {
         fn new(trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>) -> Self {
             Self {
                 trusted_spki,
-                supported_algs: provider::default_provider().signature_verification_algorithms,
+                supported_algs: provider::DEFAULT_PROVIDER.signature_verification_algorithms,
             }
         }
     }
@@ -162,7 +162,7 @@ mod server {
         let client_raw_key = SubjectPublicKeyInfoDer::from_pem_file(client_pub_key)
             .expect("cannot open pub key file");
 
-        let server_private_key = provider::default_provider()
+        let server_private_key = provider::DEFAULT_PROVIDER
             .key_provider
             .load_private_key(
                 PrivateKeyDer::from_pem_file(server_private_key)
@@ -238,7 +238,7 @@ mod server {
         pub(crate) fn new(trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>) -> Self {
             Self {
                 trusted_spki,
-                supported_algs: provider::default_provider().signature_verification_algorithms,
+                supported_algs: provider::DEFAULT_PROVIDER.signature_verification_algorithms,
             }
         }
     }

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -17,8 +17,8 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
-#[cfg(feature = "std")]
 use alloc::sync::Arc;
 
 use rustls::crypto::CryptoProvider;
@@ -34,9 +34,9 @@ mod verify;
 
 pub fn provider() -> CryptoProvider {
     CryptoProvider {
-        tls12_cipher_suites: ALL_TLS12_CIPHER_SUITES.to_vec(),
-        tls13_cipher_suites: ALL_TLS13_CIPHER_SUITES.to_vec(),
-        kx_groups: kx::ALL_KX_GROUPS.to_vec(),
+        tls12_cipher_suites: Cow::Borrowed(ALL_TLS12_CIPHER_SUITES),
+        tls13_cipher_suites: Cow::Borrowed(ALL_TLS13_CIPHER_SUITES),
+        kx_groups: Cow::Borrowed(kx::ALL_KX_GROUPS),
         signature_verification_algorithms: verify::ALGORITHMS,
         secure_random: &Provider,
         key_provider: &Provider,

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -988,9 +988,11 @@ impl Provider {
         let mut provider = self.build();
         provider
             .tls12_cipher_suites
+            .to_mut()
             .retain(|cs| cs.common.suite == name);
         provider
             .tls13_cipher_suites
+            .to_mut()
             .retain(|cs| cs.common.suite == name);
         provider
     }

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -959,13 +959,13 @@ impl Provider {
     fn build(self) -> CryptoProvider {
         match self {
             #[cfg(feature = "aws-lc-rs")]
-            Self::AwsLcRs => rustls::crypto::aws_lc_rs::default_provider(),
+            Self::AwsLcRs => rustls::crypto::aws_lc_rs::DEFAULT_PROVIDER,
             #[cfg(all(feature = "aws-lc-rs", feature = "fips"))]
             Self::AwsLcRsFips => rustls::crypto::default_fips_provider(),
             #[cfg(feature = "graviola")]
             Self::Graviola => rustls_graviola::default_provider(),
             #[cfg(feature = "ring")]
-            Self::Ring => rustls::crypto::ring::default_provider(),
+            Self::Ring => rustls::crypto::ring::DEFAULT_PROVIDER,
             Self::_None => unreachable!(),
         }
     }

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -12,6 +12,7 @@
     unused_qualifications
 )]
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use rustls::client::WebPkiServerVerifier;
@@ -40,9 +41,9 @@ use rustls::{
 /// This is a `CryptoProvider` that provides NO SECURITY and is for fuzzing only.
 pub fn provider() -> crypto::CryptoProvider {
     crypto::CryptoProvider {
-        tls12_cipher_suites: vec![TLS_FUZZING_SUITE],
-        tls13_cipher_suites: vec![TLS13_FUZZING_SUITE],
-        kx_groups: vec![&KeyExchangeGroup],
+        tls12_cipher_suites: Cow::Owned(vec![TLS_FUZZING_SUITE]),
+        tls13_cipher_suites: Cow::Owned(vec![TLS13_FUZZING_SUITE]),
+        kx_groups: Cow::Owned(vec![KEY_EXCHANGE_GROUP]),
         signature_verification_algorithms: VERIFY_ALGORITHMS,
         secure_random: &Provider,
         key_provider: &Provider,
@@ -236,6 +237,8 @@ impl crypto::ActiveKeyExchange for ActiveKeyExchange {
         NamedGroup::from(0xfe00)
     }
 }
+
+const KEY_EXCHANGE_GROUP: &dyn crypto::SupportedKxGroup = &KeyExchangeGroup;
 
 #[derive(Debug)]
 struct KeyExchangeGroup;

--- a/rustls-fuzzing-provider/tests/smoke.rs
+++ b/rustls-fuzzing-provider/tests/smoke.rs
@@ -11,7 +11,7 @@ use rustls::{ClientConfig, ClientConnection, ServerConfig, ServerConnection};
 
 #[test]
 fn pairwise_tls12() {
-    let transcript = test_version(rustls_fuzzing_provider::provider().with_only_tls12());
+    let transcript = test_version(rustls_fuzzing_provider::PROVIDER_TLS12);
 
     fs::write(
         "../fuzz/corpus/unbuffered/tls12-server.bin",
@@ -42,7 +42,7 @@ fn pairwise_tls12() {
 
 #[test]
 fn pairwise_tls13() {
-    let transcript = test_version(rustls_fuzzing_provider::provider().with_only_tls13());
+    let transcript = test_version(rustls_fuzzing_provider::PROVIDER_TLS13);
 
     fs::write(
         "../fuzz/corpus/unbuffered/tls13-server.bin",

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -15,6 +15,7 @@
 
 use core::ops::{Deref, DerefMut};
 use core::{fmt, mem};
+use std::borrow::Cow;
 use std::io;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -518,7 +519,7 @@ pub fn make_server_config_with_kx_groups(
 ) -> ServerConfig {
     ServerConfig::builder_with_provider(
         CryptoProvider {
-            kx_groups,
+            kx_groups: Cow::Owned(kx_groups),
             ..provider.clone()
         }
         .into(),
@@ -650,7 +651,7 @@ pub fn make_client_config_with_kx_groups(
 ) -> ClientConfig {
     ClientConfig::builder_with_provider(
         CryptoProvider {
-            kx_groups,
+            kx_groups: Cow::Owned(kx_groups),
             ..provider.clone()
         }
         .into(),
@@ -1492,8 +1493,8 @@ pub fn aes_128_gcm_with_1024_confidentiality_limit(
     });
 
     CryptoProvider {
-        tls12_cipher_suites: vec![tls12_limited],
-        tls13_cipher_suites: vec![tls13_limited],
+        tls12_cipher_suites: Cow::Owned(vec![tls12_limited]),
+        tls13_cipher_suites: Cow::Owned(vec![tls13_limited]),
         ..provider
     }
     .into()
@@ -1517,7 +1518,7 @@ pub fn unsafe_plaintext_crypto_provider(provider: CryptoProvider) -> Arc<CryptoP
     });
 
     CryptoProvider {
-        tls13_cipher_suites: vec![tls13],
+        tls13_cipher_suites: Cow::Owned(vec![tls13]),
         ..provider
     }
     .into()

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -9,7 +9,7 @@ use rustls::crypto::ring as provider;
 use rustls_test::{KeyType, TestNonBlockIo, make_server_config};
 
 fn bench_ewouldblock(c: &mut Bencher) {
-    let server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
+    let server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
     c.iter(|| server.read_tls(&mut TestNonBlockIo::default()));
 }

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -27,7 +27,7 @@ use crate::{ClientConfig, ServerConfig};
 ///
 /// ```
 /// # #[cfg(feature = "aws-lc-rs")] {
-/// # rustls::crypto::aws_lc_rs::default_provider().install_default();
+/// # rustls::crypto::aws_lc_rs::DEFAULT_PROVIDER.install_default();
 /// use rustls::{ClientConfig, ServerConfig};
 /// ClientConfig::builder()
 /// //  ...
@@ -63,7 +63,7 @@ use crate::{ClientConfig, ServerConfig};
 ///
 /// ```
 /// # #[cfg(feature = "aws-lc-rs")] {
-/// # rustls::crypto::aws_lc_rs::default_provider().install_default();
+/// # rustls::crypto::aws_lc_rs::DEFAULT_PROVIDER.install_default();
 /// # use rustls::ClientConfig;
 /// # let root_certs = rustls::RootCertStore::empty();
 /// ClientConfig::builder()
@@ -88,8 +88,8 @@ use crate::{ClientConfig, ServerConfig};
 ///
 /// ```no_run
 /// # #[cfg(feature = "aws-lc-rs")] {
-/// # rustls::crypto::aws_lc_rs::default_provider().install_default();
 /// # use std::sync::Arc;
+/// # rustls::crypto::aws_lc_rs::DEFAULT_PROVIDER.install_default();
 /// # use rustls::ServerConfig;
 /// # let certs = vec![];
 /// # let private_key = pki_types::PrivateKeyDer::from(

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -52,7 +52,7 @@ mod tests {
     #[test]
     fn test_no_session_ticket_request_on_tls_1_3() {
         let mut config = ClientConfig::builder_with_provider(
-            super::provider::default_provider()
+            super::provider::DEFAULT_PROVIDER
                 .with_only_tls13()
                 .into(),
         )
@@ -69,7 +69,7 @@ mod tests {
     fn test_no_renegotiation_scsv_on_tls_1_3() {
         let ch = client_hello_sent_for_config(
             ClientConfig::builder_with_provider(
-                super::provider::default_provider()
+                super::provider::DEFAULT_PROVIDER
                     .with_only_tls13()
                     .into(),
             )
@@ -87,8 +87,8 @@ mod tests {
     #[test]
     fn test_client_does_not_offer_sha1() {
         for provider in [
-            super::provider::default_provider().with_only_tls12(),
-            super::provider::default_provider().with_only_tls13(),
+            super::provider::DEFAULT_PROVIDER.with_only_tls12(),
+            super::provider::DEFAULT_PROVIDER.with_only_tls13(),
         ] {
             let config = ClientConfig::builder_with_provider(provider.into())
                 .with_root_certificates(roots())
@@ -108,11 +108,10 @@ mod tests {
 
     #[test]
     fn test_client_rejects_hrr_with_varied_session_id() {
-        let config =
-            ClientConfig::builder_with_provider(super::provider::default_provider().into())
-                .with_root_certificates(roots())
-                .with_no_client_auth()
-                .unwrap();
+        let config = ClientConfig::builder_with_provider(super::provider::DEFAULT_PROVIDER.into())
+            .with_root_certificates(roots())
+            .with_no_client_auth()
+            .unwrap();
         let mut conn =
             ClientConnection::new(config.into(), ServerName::try_from("localhost").unwrap())
                 .unwrap();
@@ -146,7 +145,7 @@ mod tests {
     #[test]
     fn test_client_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
         let mut config =
-            ClientConfig::builder_with_provider(super::provider::default_provider().into())
+            ClientConfig::builder_with_provider(super::provider::DEFAULT_PROVIDER.into())
                 .with_root_certificates(roots())
                 .with_no_client_auth()
                 .unwrap();
@@ -193,8 +192,8 @@ mod tests {
             )]));
 
         for (provider, cas_extension_expected) in [
-            (super::provider::default_provider().with_only_tls12(), false),
-            (super::provider::default_provider().with_only_tls13(), true),
+            (super::provider::DEFAULT_PROVIDER.with_only_tls12(), false),
+            (super::provider::DEFAULT_PROVIDER.with_only_tls13(), true),
         ] {
             let client_hello = client_hello_sent_for_config(
                 ClientConfig::builder_with_provider(provider.into())
@@ -462,7 +461,7 @@ mod tests {
     }
 
     fn client_certified_key() -> CertifiedKey {
-        let key = super::provider::default_provider()
+        let key = super::provider::DEFAULT_PROVIDER
             .key_provider
             .load_private_key(client_key())
             .unwrap();
@@ -487,7 +486,7 @@ mod tests {
         // creation of fake server messages.
         CryptoProvider {
             kx_groups: Cow::Owned(vec![super::provider::kx_group::X25519]),
-            ..super::provider::default_provider()
+            ..super::provider::DEFAULT_PROVIDER
         }
     }
 
@@ -618,7 +617,7 @@ mod tests {
 #[test]
 fn hybrid_kx_component_share_offered_if_supported_separately() {
     let ch = client_hello_sent_for_config(
-        ClientConfig::builder_with_provider(crate::crypto::aws_lc_rs::default_provider().into())
+        ClientConfig::builder_with_provider(crate::crypto::aws_lc_rs::DEFAULT_PROVIDER.into())
             .with_root_certificates(roots())
             .with_no_client_auth()
             .unwrap(),
@@ -641,7 +640,7 @@ fn hybrid_kx_component_share_not_offered_unless_supported_separately() {
     use crate::crypto::aws_lc_rs;
     let provider = CryptoProvider {
         kx_groups: Cow::Owned(vec![aws_lc_rs::kx_group::X25519MLKEM768]),
-        ..aws_lc_rs::default_provider()
+        ..aws_lc_rs::DEFAULT_PROVIDER
     };
     let ch = client_hello_sent_for_config(
         ClientConfig::builder_with_provider(provider.into())

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -1,4 +1,5 @@
 #![cfg(any(feature = "ring", feature = "aws-lc-rs"))]
+use alloc::borrow::Cow;
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::prelude::v1::*;
 use std::vec;
@@ -485,7 +486,7 @@ mod tests {
         // ensures X25519 is offered irrespective of cfg(feature = "fips"), which eases
         // creation of fake server messages.
         CryptoProvider {
-            kx_groups: vec![super::provider::kx_group::X25519],
+            kx_groups: Cow::Owned(vec![super::provider::kx_group::X25519]),
             ..super::provider::default_provider()
         }
     }
@@ -639,7 +640,7 @@ fn hybrid_kx_component_share_offered_if_supported_separately() {
 fn hybrid_kx_component_share_not_offered_unless_supported_separately() {
     use crate::crypto::aws_lc_rs;
     let provider = CryptoProvider {
-        kx_groups: vec![aws_lc_rs::kx_group::X25519MLKEM768],
+        kx_groups: Cow::Owned(vec![aws_lc_rs::kx_group::X25519MLKEM768]),
         ..aws_lc_rs::default_provider()
     };
     let ch = client_hello_sent_for_config(

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 
 // aws-lc-rs has a -- roughly -- ring-compatible API, so we just reuse all that
@@ -40,9 +41,9 @@ pub(crate) mod tls13;
 /// A `CryptoProvider` backed by aws-lc-rs.
 pub fn default_provider() -> CryptoProvider {
     CryptoProvider {
-        tls12_cipher_suites: DEFAULT_TLS12_CIPHER_SUITES.to_vec(),
-        tls13_cipher_suites: DEFAULT_TLS13_CIPHER_SUITES.to_vec(),
-        kx_groups: DEFAULT_KX_GROUPS.to_vec(),
+        tls12_cipher_suites: Cow::Borrowed(DEFAULT_TLS12_CIPHER_SUITES),
+        tls13_cipher_suites: Cow::Borrowed(DEFAULT_TLS13_CIPHER_SUITES),
+        kx_groups: Cow::Borrowed(DEFAULT_KX_GROUPS),
         signature_verification_algorithms: SUPPORTED_SIG_ALGS,
         secure_random: &AwsLcRs,
         key_provider: &AwsLcRs,

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -48,6 +48,20 @@ pub const DEFAULT_PROVIDER: CryptoProvider = CryptoProvider {
     key_provider: &AwsLcRs,
 };
 
+/// The default `CryptoProvider` backed by aws-lc-rs that only supports TLS1.3.
+pub const DEFAULT_TLS13_PROVIDER: CryptoProvider = CryptoProvider {
+    tls12_cipher_suites: Cow::Borrowed(&[]),
+    ..DEFAULT_PROVIDER
+};
+
+/// The default `CryptoProvider` backed by aws-lc-rs that only supports TLS1.2.
+///
+/// Use of TLS1.3 is **strongly** recommended.
+pub const DEFAULT_TLS12_PROVIDER: CryptoProvider = CryptoProvider {
+    tls13_cipher_suites: Cow::Borrowed(&[]),
+    ..DEFAULT_PROVIDER
+};
+
 /// `KeyProvider` impl for aws-lc-rs
 pub static DEFAULT_KEY_PROVIDER: &dyn KeyProvider = &AwsLcRs;
 

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -38,17 +38,15 @@ pub(crate) mod ticketer;
 pub(crate) mod tls12;
 pub(crate) mod tls13;
 
-/// A `CryptoProvider` backed by aws-lc-rs.
-pub fn default_provider() -> CryptoProvider {
-    CryptoProvider {
-        tls12_cipher_suites: Cow::Borrowed(DEFAULT_TLS12_CIPHER_SUITES),
-        tls13_cipher_suites: Cow::Borrowed(DEFAULT_TLS13_CIPHER_SUITES),
-        kx_groups: Cow::Borrowed(DEFAULT_KX_GROUPS),
-        signature_verification_algorithms: SUPPORTED_SIG_ALGS,
-        secure_random: &AwsLcRs,
-        key_provider: &AwsLcRs,
-    }
-}
+/// The default `CryptoProvider` backed by aws-lc-rs.
+pub const DEFAULT_PROVIDER: CryptoProvider = CryptoProvider {
+    tls12_cipher_suites: Cow::Borrowed(DEFAULT_TLS12_CIPHER_SUITES),
+    tls13_cipher_suites: Cow::Borrowed(DEFAULT_TLS13_CIPHER_SUITES),
+    kx_groups: Cow::Borrowed(DEFAULT_KX_GROUPS),
+    signature_verification_algorithms: SUPPORTED_SIG_ALGS,
+    secure_random: &AwsLcRs,
+    key_provider: &AwsLcRs,
+};
 
 /// `KeyProvider` impl for aws-lc-rs
 pub static DEFAULT_KEY_PROVIDER: &dyn KeyProvider = &AwsLcRs;

--- a/rustls/src/crypto/aws_lc_rs/sign.rs
+++ b/rustls/src/crypto/aws_lc_rs/sign.rs
@@ -356,7 +356,7 @@ mod tests {
     use pki_types::{PrivatePkcs1KeyDer, PrivateSec1KeyDer};
 
     use super::*;
-    use crate::crypto::aws_lc_rs::default_provider;
+    use crate::crypto::aws_lc_rs::DEFAULT_PROVIDER;
 
     #[test]
     fn can_load_ecdsa_nistp256_pkcs8() {
@@ -364,7 +364,7 @@ mod tests {
             PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/nistp256key.pkcs8.der")[..]);
         assert!(Ed25519Signer::try_from(&key).is_err());
         let key = PrivateKeyDer::Pkcs8(key);
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -373,7 +373,7 @@ mod tests {
         let key = PrivateKeyDer::Sec1(PrivateSec1KeyDer::from(
             &include_bytes!("../../testdata/nistp256key.der")[..],
         ));
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -383,7 +383,7 @@ mod tests {
             &include_bytes!("../../testdata/nistp256key.der")[..],
         ));
 
-        let k = load_key(&default_provider(), key.clone_key()).unwrap();
+        let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256 }"
@@ -420,7 +420,7 @@ mod tests {
             PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/nistp384key.pkcs8.der")[..]);
         assert!(Ed25519Signer::try_from(&key).is_err());
         let key = PrivateKeyDer::Pkcs8(key);
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -429,7 +429,7 @@ mod tests {
         let key = PrivateKeyDer::Sec1(PrivateSec1KeyDer::from(
             &include_bytes!("../../testdata/nistp384key.der")[..],
         ));
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -439,7 +439,7 @@ mod tests {
             &include_bytes!("../../testdata/nistp384key.der")[..],
         ));
 
-        let k = load_key(&default_provider(), key.clone_key()).unwrap();
+        let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384 }"
@@ -476,7 +476,7 @@ mod tests {
             PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/nistp521key.pkcs8.der")[..]);
         assert!(Ed25519Signer::try_from(&key).is_err());
         let key = PrivateKeyDer::Pkcs8(key);
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -485,7 +485,7 @@ mod tests {
         let key = PrivateKeyDer::Sec1(PrivateSec1KeyDer::from(
             &include_bytes!("../../testdata/nistp521key.der")[..],
         ));
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -495,7 +495,7 @@ mod tests {
             &include_bytes!("../../testdata/nistp521key.der")[..],
         ));
 
-        let k = load_key(&default_provider(), key.clone_key()).unwrap();
+        let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP521_SHA512 }"
@@ -535,7 +535,7 @@ mod tests {
         let key = PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/eddsakey.der")[..]);
         assert!(Ed25519Signer::try_from(&key).is_ok());
         let key = PrivateKeyDer::Pkcs8(key);
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_err());
     }
 
@@ -569,7 +569,7 @@ mod tests {
             PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/rsa2048key.pkcs8.der")[..]);
         assert!(Ed25519Signer::try_from(&key).is_err());
         let key = PrivateKeyDer::Pkcs8(key);
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_err());
     }
 
@@ -578,7 +578,7 @@ mod tests {
         let key = PrivateKeyDer::Pkcs1(PrivatePkcs1KeyDer::from(
             &include_bytes!("../../testdata/rsa2048key.pkcs1.der")[..],
         ));
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_err());
     }
 
@@ -588,7 +588,7 @@ mod tests {
             &include_bytes!("../../testdata/rsa2048key.pkcs8.der")[..],
         ));
 
-        let k = load_key(&default_provider(), key.clone_key()).unwrap();
+        let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(format!("{k:?}"), "RsaSigningKey { algorithm: RSA }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::RSA);
 
@@ -624,7 +624,7 @@ mod tests {
     fn cannot_load_invalid_pkcs8_encoding() {
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(&b"invalid"[..]));
         assert_eq!(
-            load_key(&default_provider(), key.clone_key()).err(),
+            load_key(&DEFAULT_PROVIDER, key.clone_key()).err(),
             Some(Error::General(
                 "failed to parse private key as RSA, ECDSA, or EdDSA".into()
             ))
@@ -647,7 +647,7 @@ mod tests {
 #[cfg(bench)]
 mod benchmarks {
     use super::*;
-    use crate::crypto::aws_lc_rs::default_provider;
+    use crate::crypto::aws_lc_rs::DEFAULT_PROVIDER;
 
     #[bench]
     fn bench_rsa2048_pkcs1_sha256(b: &mut test::Bencher) {
@@ -755,9 +755,8 @@ mod benchmarks {
             &include_bytes!("../../testdata/rsa2048key.pkcs8.der")[..],
         ));
 
-        let provider = default_provider();
         b.iter(|| {
-            test::black_box(load_key(&provider, key.clone_key()).unwrap());
+            test::black_box(load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap());
         });
     }
 
@@ -767,9 +766,8 @@ mod benchmarks {
             &include_bytes!("../../testdata/rsa4096key.pkcs8.der")[..],
         ));
 
-        let provider = default_provider();
         b.iter(|| {
-            test::black_box(load_key(&provider, key.clone_key()).unwrap());
+            test::black_box(load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap());
         });
     }
 

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -338,22 +338,6 @@ See the documentation of the CryptoProvider type for more information.
             && key_provider.fips()
     }
 
-    /// Return a new `CryptoProvider` that only supports TLS1.3.
-    pub fn with_only_tls13(self) -> Self {
-        Self {
-            tls12_cipher_suites: Cow::Borrowed(&[]),
-            ..self
-        }
-    }
-
-    /// Return a new `CryptoProvider` that only supports TLS1.2.
-    pub fn with_only_tls12(self) -> Self {
-        Self {
-            tls13_cipher_suites: Cow::Borrowed(&[]),
-            ..self
-        }
-    }
-
     pub(crate) fn consistency_check(&self) -> Result<(), Error> {
         if self.tls12_cipher_suites.is_empty() && self.tls13_cipher_suites.is_empty() {
             return Err(ApiMisuse::NoCipherSuitesConfigured.into());

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -60,10 +60,10 @@ pub use crate::suites::CipherSuiteCommon;
 /// This crate comes with two built-in options, provided as
 /// `CryptoProvider` structures:
 ///
-/// - [`crypto::aws_lc_rs::default_provider`]: (behind the `aws_lc_rs` crate feature).
+/// - [`crypto::aws_lc_rs::DEFAULT_PROVIDER`]: (behind the `aws_lc_rs` crate feature).
 ///   This provider uses the [aws-lc-rs](https://github.com/aws/aws-lc-rs)
 ///   crate.  The `fips` crate feature makes this option use FIPS140-3-approved cryptography.
-/// - [`crypto::ring::default_provider`]: (behind the `ring` crate feature).
+/// - [`crypto::ring::DEFAULT_PROVIDER`]: (behind the `ring` crate feature).
 ///   This provider uses the [*ring*](https://github.com/briansmith/ring) crate.
 ///
 /// This structure provides defaults. Everything in it can be overridden at
@@ -129,7 +129,7 @@ pub use crate::suites::CipherSuiteCommon;
 /// pub fn provider() -> rustls::crypto::CryptoProvider {
 ///   rustls::crypto::CryptoProvider{
 ///     key_provider: &HsmKeyLoader,
-///     ..aws_lc_rs::default_provider()
+///     ..aws_lc_rs::DEFAULT_PROVIDER
 ///   }
 /// }
 ///
@@ -295,7 +295,7 @@ See the documentation of the CryptoProvider type for more information.
             not(feature = "custom-provider")
         ))]
         {
-            return Some(ring::default_provider());
+            return Some(ring::DEFAULT_PROVIDER);
         }
 
         #[cfg(all(
@@ -304,7 +304,7 @@ See the documentation of the CryptoProvider type for more information.
             not(feature = "custom-provider")
         ))]
         {
-            return Some(aws_lc_rs::default_provider());
+            return Some(aws_lc_rs::DEFAULT_PROVIDER);
         }
 
         #[allow(unreachable_code)]
@@ -801,7 +801,7 @@ impl From<Vec<u8>> for SharedSecret {
 #[cfg(all(feature = "aws-lc-rs", any(feature = "fips", rustls_docsrs)))]
 #[cfg_attr(rustls_docsrs, doc(cfg(feature = "fips")))]
 pub fn default_fips_provider() -> CryptoProvider {
-    aws_lc_rs::default_provider()
+    aws_lc_rs::DEFAULT_PROVIDER
 }
 
 mod static_default {

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -60,7 +60,7 @@ pub use crate::suites::CipherSuiteCommon;
 /// This crate comes with two built-in options, provided as
 /// `CryptoProvider` structures:
 ///
-/// - [`crypto::aws_lc_rs::DEFAULT_PROVIDER`]: (behind the `aws_lc_rs` crate feature).
+/// - [`crypto::aws_lc_rs::DEFAULT_PROVIDER`]: (behind the `aws-lc-rs` crate feature).
 ///   This provider uses the [aws-lc-rs](https://github.com/aws/aws-lc-rs)
 ///   crate.  The `fips` crate feature makes this option use FIPS140-3-approved cryptography.
 /// - [`crypto::ring::DEFAULT_PROVIDER`]: (behind the `ring` crate feature).

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::boxed::Box;
 
 use pki_types::PrivateKeyDer;
@@ -29,9 +30,9 @@ pub(crate) mod tls13;
 /// [*ring*]: https://github.com/briansmith/ring
 pub fn default_provider() -> CryptoProvider {
     CryptoProvider {
-        tls12_cipher_suites: DEFAULT_TLS12_CIPHER_SUITES.to_vec(),
-        tls13_cipher_suites: DEFAULT_TLS13_CIPHER_SUITES.to_vec(),
-        kx_groups: DEFAULT_KX_GROUPS.to_vec(),
+        tls12_cipher_suites: Cow::Borrowed(DEFAULT_TLS12_CIPHER_SUITES),
+        tls13_cipher_suites: Cow::Borrowed(DEFAULT_TLS13_CIPHER_SUITES),
+        kx_groups: Cow::Borrowed(DEFAULT_KX_GROUPS),
         signature_verification_algorithms: SUPPORTED_SIG_ALGS,
         secure_random: &Ring,
         key_provider: &Ring,

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -25,19 +25,17 @@ pub(crate) mod ticketer;
 pub(crate) mod tls12;
 pub(crate) mod tls13;
 
-/// A `CryptoProvider` backed by the [*ring*] crate.
+/// The default `CryptoProvider` backed by [*ring*].
 ///
 /// [*ring*]: https://github.com/briansmith/ring
-pub fn default_provider() -> CryptoProvider {
-    CryptoProvider {
-        tls12_cipher_suites: Cow::Borrowed(DEFAULT_TLS12_CIPHER_SUITES),
-        tls13_cipher_suites: Cow::Borrowed(DEFAULT_TLS13_CIPHER_SUITES),
-        kx_groups: Cow::Borrowed(DEFAULT_KX_GROUPS),
-        signature_verification_algorithms: SUPPORTED_SIG_ALGS,
-        secure_random: &Ring,
-        key_provider: &Ring,
-    }
-}
+pub const DEFAULT_PROVIDER: CryptoProvider = CryptoProvider {
+    tls12_cipher_suites: Cow::Borrowed(DEFAULT_TLS12_CIPHER_SUITES),
+    tls13_cipher_suites: Cow::Borrowed(DEFAULT_TLS13_CIPHER_SUITES),
+    kx_groups: Cow::Borrowed(DEFAULT_KX_GROUPS),
+    signature_verification_algorithms: SUPPORTED_SIG_ALGS,
+    secure_random: &Ring,
+    key_provider: &Ring,
+};
 
 /// Default crypto provider.
 #[derive(Debug)]

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -37,6 +37,20 @@ pub const DEFAULT_PROVIDER: CryptoProvider = CryptoProvider {
     key_provider: &Ring,
 };
 
+/// The default `CryptoProvider` backed by *ring* that only supports TLS1.3.
+pub const DEFAULT_TLS13_PROVIDER: CryptoProvider = CryptoProvider {
+    tls12_cipher_suites: Cow::Borrowed(&[]),
+    ..DEFAULT_PROVIDER
+};
+
+/// The default `CryptoProvider` backed by *ring* that only supports TLS1.2.
+///
+/// Use of TLS1.3 is **strongly** recommended.
+pub const DEFAULT_TLS12_PROVIDER: CryptoProvider = CryptoProvider {
+    tls13_cipher_suites: Cow::Borrowed(&[]),
+    ..DEFAULT_PROVIDER
+};
+
 /// Default crypto provider.
 #[derive(Debug)]
 struct Ring;

--- a/rustls/src/crypto/ring/sign.rs
+++ b/rustls/src/crypto/ring/sign.rs
@@ -390,7 +390,7 @@ mod tests {
     use pki_types::{PrivatePkcs1KeyDer, PrivateSec1KeyDer};
 
     use super::*;
-    use crate::crypto::ring::default_provider;
+    use crate::crypto::ring::DEFAULT_PROVIDER;
 
     #[test]
     fn can_load_ecdsa_nistp256_pkcs8() {
@@ -398,7 +398,7 @@ mod tests {
             PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/nistp256key.pkcs8.der")[..]);
         assert!(Ed25519Signer::try_from(&key).is_err());
         let key = PrivateKeyDer::Pkcs8(key);
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -407,7 +407,7 @@ mod tests {
         let key = PrivateKeyDer::Sec1(PrivateSec1KeyDer::from(
             &include_bytes!("../../testdata/nistp256key.der")[..],
         ));
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -417,7 +417,7 @@ mod tests {
             &include_bytes!("../../testdata/nistp256key.der")[..],
         ));
 
-        let k = load_key(&default_provider(), key.clone_key()).unwrap();
+        let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256 }"
@@ -454,7 +454,7 @@ mod tests {
             PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/nistp384key.pkcs8.der")[..]);
         assert!(Ed25519Signer::try_from(&key).is_err());
         let key = PrivateKeyDer::Pkcs8(key);
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -463,7 +463,7 @@ mod tests {
         let key = PrivateKeyDer::Sec1(PrivateSec1KeyDer::from(
             &include_bytes!("../../testdata/nistp384key.der")[..],
         ));
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_ok());
     }
 
@@ -473,7 +473,7 @@ mod tests {
             &include_bytes!("../../testdata/nistp384key.der")[..],
         ));
 
-        let k = load_key(&default_provider(), key.clone_key()).unwrap();
+        let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384 }"
@@ -509,7 +509,7 @@ mod tests {
         let key = PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/eddsakey.der")[..]);
         assert!(Ed25519Signer::try_from(&key).is_ok());
         let key = PrivateKeyDer::Pkcs8(key);
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_err());
     }
 
@@ -543,7 +543,7 @@ mod tests {
             PrivatePkcs8KeyDer::from(&include_bytes!("../../testdata/rsa2048key.pkcs8.der")[..]);
         assert!(Ed25519Signer::try_from(&key).is_err());
         let key = PrivateKeyDer::Pkcs8(key);
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_err());
     }
 
@@ -552,7 +552,7 @@ mod tests {
         let key = PrivateKeyDer::Pkcs1(PrivatePkcs1KeyDer::from(
             &include_bytes!("../../testdata/rsa2048key.pkcs1.der")[..],
         ));
-        assert!(load_key(&default_provider(), key.clone_key()).is_ok());
+        assert!(load_key(&DEFAULT_PROVIDER, key.clone_key()).is_ok());
         assert!(EcdsaSigner::try_from(&key).is_err());
     }
 
@@ -562,7 +562,7 @@ mod tests {
             &include_bytes!("../../testdata/rsa2048key.pkcs8.der")[..],
         ));
 
-        let k = load_key(&default_provider(), key.clone_key()).unwrap();
+        let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(format!("{k:?}"), "RsaSigningKey { algorithm: RSA }");
         assert_eq!(k.algorithm(), SignatureAlgorithm::RSA);
 
@@ -598,7 +598,7 @@ mod tests {
     fn cannot_load_invalid_pkcs8_encoding() {
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(&b"invalid"[..]));
         assert_eq!(
-            load_key(&default_provider(), key.clone_key()).err(),
+            load_key(&DEFAULT_PROVIDER, key.clone_key()).err(),
             Some(Error::General(
                 "failed to parse private key as RSA, ECDSA, or EdDSA".into()
             ))
@@ -621,7 +621,7 @@ mod tests {
 #[cfg(bench)]
 mod benchmarks {
     use super::*;
-    use crate::crypto::ring::default_provider;
+    use crate::crypto::ring::DEFAULT_PROVIDER;
 
     #[bench]
     fn bench_rsa2048_pkcs1_sha256(b: &mut test::Bencher) {
@@ -713,9 +713,8 @@ mod benchmarks {
             &include_bytes!("../../testdata/rsa2048key.pkcs8.der")[..],
         ));
 
-        let provider = default_provider();
         b.iter(|| {
-            test::black_box(load_key(&provider, key.clone_key()).unwrap());
+            test::black_box(load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap());
         });
     }
 
@@ -725,9 +724,8 @@ mod benchmarks {
             &include_bytes!("../../testdata/rsa4096key.pkcs8.der")[..],
         ));
 
-        let provider = default_provider();
         b.iter(|| {
-            test::black_box(load_key(&provider, key.clone_key()).unwrap());
+            test::black_box(load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap());
         });
     }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -177,7 +177,7 @@
 //! # use rustls;
 //! # use webpki;
 //! # use std::sync::Arc;
-//! # rustls::crypto::aws_lc_rs::default_provider().install_default();
+//! # rustls::crypto::aws_lc_rs::DEFAULT_PROVIDER.install_default();
 //! # let root_store = rustls::RootCertStore::from_iter(
 //! #  webpki_roots::TLS_SERVER_ROOTS
 //! #      .iter()

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -442,7 +442,8 @@ impl ExpectClientHello {
         let mut ecdhe_possible = false;
         let mut ffdhe_possible = false;
         let mut ffdhe_offered = false;
-        let mut supported_groups = Vec::with_capacity(client_groups.len());
+        let mut supported_groups: Vec<&'static dyn SupportedKxGroup> =
+            Vec::with_capacity(client_groups.len());
 
         for offered_group in client_groups {
             let supported = self

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_server_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
-        let provider = super::provider::default_provider().with_only_tls12();
+        let provider = super::provider::DEFAULT_PROVIDER.with_only_tls12();
         let mut config = ServerConfig::builder_with_provider(provider.into())
             .with_no_client_auth()
             .with_single_cert(server_cert(), server_key())
@@ -234,20 +234,22 @@ mod tests {
     }
 
     fn server_config_for_rpk() -> ServerConfig {
-        let x25519_provider = CryptoProvider {
-            kx_groups: Cow::Owned(vec![super::provider::kx_group::X25519]),
-            ..super::provider::default_provider()
-        };
-        ServerConfig::builder_with_provider(x25519_provider.with_only_tls12().into())
-            .with_no_client_auth()
-            .with_cert_resolver(Arc::new(AlwaysResolvesServerRawPublicKeys::new(
-                server_certified_key(),
-            )))
-            .unwrap()
+        ServerConfig::builder_with_provider(
+            CryptoProvider {
+                kx_groups: Cow::Owned(vec![super::provider::kx_group::X25519]),
+                ..super::provider::DEFAULT_PROVIDER.with_only_tls12()
+            }
+            .into(),
+        )
+        .with_no_client_auth()
+        .with_cert_resolver(Arc::new(AlwaysResolvesServerRawPublicKeys::new(
+            server_certified_key(),
+        )))
+        .unwrap()
     }
 
     fn server_certified_key() -> CertifiedKey {
-        let key = super::provider::default_provider()
+        let key = super::provider::DEFAULT_PROVIDER
             .key_provider
             .load_private_key(server_key())
             .unwrap();
@@ -278,7 +280,7 @@ mod tests {
         CryptoProvider {
             kx_groups: Cow::Owned(vec![FAKE_FFDHE_GROUP]),
             tls12_cipher_suites: Cow::Owned(vec![&TLS_DHE_RSA_WITH_AES_128_GCM_SHA256]),
-            ..super::provider::default_provider()
+            ..super::provider::DEFAULT_PROVIDER
         }
     }
 

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_server_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
-        let provider = super::provider::DEFAULT_PROVIDER.with_only_tls12();
+        let provider = super::provider::DEFAULT_TLS12_PROVIDER;
         let mut config = ServerConfig::builder_with_provider(provider.into())
             .with_no_client_auth()
             .with_single_cert(server_cert(), server_key())
@@ -102,9 +102,11 @@ mod tests {
     #[test]
     fn server_picks_ffdhe_group_when_clienthello_has_no_ffdhe_group_in_groups_ext() {
         let config = ServerConfig::builder_with_provider(
-            ffdhe_provider()
-                .with_only_tls12()
-                .into(),
+            CryptoProvider {
+                tls13_cipher_suites: Default::default(),
+                ..ffdhe_provider()
+            }
+            .into(),
         )
         .with_no_client_auth()
         .with_single_cert(server_cert(), server_key())
@@ -126,9 +128,11 @@ mod tests {
     #[test]
     fn server_picks_ffdhe_group_when_clienthello_has_no_groups_ext() {
         let config = ServerConfig::builder_with_provider(
-            ffdhe_provider()
-                .with_only_tls12()
-                .into(),
+            CryptoProvider {
+                tls13_cipher_suites: Default::default(),
+                ..ffdhe_provider()
+            }
+            .into(),
         )
         .with_no_client_auth()
         .with_single_cert(server_cert(), server_key())
@@ -151,9 +155,11 @@ mod tests {
     #[test]
     fn server_accepts_client_with_no_ecpoints_extension_and_only_ffdhe_cipher_suites() {
         let config = ServerConfig::builder_with_provider(
-            ffdhe_provider()
-                .with_only_tls12()
-                .into(),
+            CryptoProvider {
+                tls13_cipher_suites: Default::default(),
+                ..ffdhe_provider()
+            }
+            .into(),
         )
         .with_no_client_auth()
         .with_single_cert(server_cert(), server_key())
@@ -237,7 +243,7 @@ mod tests {
         ServerConfig::builder_with_provider(
             CryptoProvider {
                 kx_groups: Cow::Owned(vec![super::provider::kx_group::X25519]),
-                ..super::provider::DEFAULT_PROVIDER.with_only_tls12()
+                ..super::provider::DEFAULT_TLS12_PROVIDER
             }
             .into(),
         )

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -47,6 +47,8 @@ fn test_process_client_hello(hello: ClientHelloPayload) -> Result<(), Error> {
 
 #[macro_rules_attribute::apply(test_for_each_provider)]
 mod tests {
+    use alloc::borrow::Cow;
+
     use super::super::*;
     use crate::common_state::KxState;
     use crate::crypto::{
@@ -233,7 +235,7 @@ mod tests {
 
     fn server_config_for_rpk() -> ServerConfig {
         let x25519_provider = CryptoProvider {
-            kx_groups: vec![super::provider::kx_group::X25519],
+            kx_groups: Cow::Owned(vec![super::provider::kx_group::X25519]),
             ..super::provider::default_provider()
         };
         ServerConfig::builder_with_provider(x25519_provider.with_only_tls12().into())
@@ -274,8 +276,8 @@ mod tests {
 
     fn ffdhe_provider() -> CryptoProvider {
         CryptoProvider {
-            kx_groups: vec![FAKE_FFDHE_GROUP],
-            tls12_cipher_suites: vec![&TLS_DHE_RSA_WITH_AES_128_GCM_SHA256],
+            kx_groups: Cow::Owned(vec![FAKE_FFDHE_GROUP]),
+            tls12_cipher_suites: Cow::Owned(vec![&TLS_DHE_RSA_WITH_AES_128_GCM_SHA256]),
             ..super::provider::default_provider()
         }
     }

--- a/rustls/src/test_macros.rs
+++ b/rustls/src/test_macros.rs
@@ -57,7 +57,7 @@ macro_rules! bench_for_each_provider {
 mod tests {
     #[test]
     fn test_each_provider() {
-        std::println!("provider is {:?}", super::provider::default_provider());
+        std::println!("provider is {:?}", super::provider::DEFAULT_PROVIDER);
     }
 }
 
@@ -66,6 +66,6 @@ mod tests {
 mod benchmarks {
     #[bench]
     fn bench_each_provider(b: &mut test::Bencher) {
-        b.iter(|| super::provider::default_provider());
+        b.iter(|| super::provider::DEFAULT_PROVIDER);
     }
 }

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -36,7 +36,7 @@ mod benchmarks {
     #[bench]
     fn reddit_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "reddit.com",
             &[
                 include_bytes!("testdata/cert-reddit.0.der"),
@@ -49,7 +49,7 @@ mod benchmarks {
     #[bench]
     fn github_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "github.com",
             &[
                 include_bytes!("testdata/cert-github.0.der"),
@@ -63,7 +63,7 @@ mod benchmarks {
     #[bench]
     fn arstechnica_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "arstechnica.com",
             &[
                 include_bytes!("testdata/cert-arstechnica.0.der"),
@@ -77,7 +77,7 @@ mod benchmarks {
     #[bench]
     fn servo_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "servo.org",
             &[
                 include_bytes!("testdata/cert-servo.0.der"),
@@ -91,7 +91,7 @@ mod benchmarks {
     #[bench]
     fn twitter_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "twitter.com",
             &[
                 include_bytes!("testdata/cert-twitter.0.der"),
@@ -104,7 +104,7 @@ mod benchmarks {
     #[bench]
     fn wikipedia_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "wikipedia.org",
             &[
                 include_bytes!("testdata/cert-wikipedia.0.der"),
@@ -117,7 +117,7 @@ mod benchmarks {
     #[bench]
     fn google_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "www.google.com",
             &[
                 include_bytes!("testdata/cert-google.0.der"),
@@ -131,7 +131,7 @@ mod benchmarks {
     #[bench]
     fn hn_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "news.ycombinator.com",
             &[
                 include_bytes!("testdata/cert-hn.0.der"),
@@ -144,7 +144,7 @@ mod benchmarks {
     #[bench]
     fn stackoverflow_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "stackoverflow.com",
             &[
                 include_bytes!("testdata/cert-stackoverflow.0.der"),
@@ -157,7 +157,7 @@ mod benchmarks {
     #[bench]
     fn duckduckgo_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "duckduckgo.com",
             &[
                 include_bytes!("testdata/cert-duckduckgo.0.der"),
@@ -171,7 +171,7 @@ mod benchmarks {
     #[bench]
     fn rustlang_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "www.rust-lang.org",
             &[
                 include_bytes!("testdata/cert-rustlang.0.der"),
@@ -186,7 +186,7 @@ mod benchmarks {
     #[bench]
     fn wapo_cert(b: &mut test::Bencher) {
         let ctx = Context::new(
-            provider::default_provider(),
+            provider::DEFAULT_PROVIDER,
             "www.washingtonpost.com",
             &[
                 include_bytes!("testdata/cert-wapo.0.der"),

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -484,10 +484,8 @@ mod tests {
     fn test_client_verifier_required_auth() {
         // We should be able to build a verifier that requires client authentication, and does
         // no revocation checking.
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        );
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER);
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -497,11 +495,9 @@ mod tests {
     fn test_client_verifier_optional_auth() {
         // We should be able to build a verifier that allows client authentication, and anonymous
         // access, and does no revocation checking.
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .allow_unauthenticated();
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .allow_unauthenticated();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -512,10 +508,8 @@ mod tests {
         // We should be able to build a verifier that requires client authentication, and does
         // no revocation checking, that hasn't been configured to determine how to handle
         // unauthenticated clients yet.
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        );
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER);
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -525,11 +519,9 @@ mod tests {
     fn test_client_verifier_without_crls_optional_auth() {
         // We should be able to build a verifier that allows client authentication,
         // and anonymous access, that does no revocation checking.
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .allow_unauthenticated();
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .allow_unauthenticated();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -538,12 +530,10 @@ mod tests {
     #[test]
     fn test_with_invalid_crls() {
         // Trying to build a client verifier with invalid CRLs should error at build time.
-        let result = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .with_crls(vec![CertificateRevocationListDer::from(vec![0xFF])])
-        .build();
+        let result =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .with_crls(vec![CertificateRevocationListDer::from(vec![0xFF])])
+                .build();
         assert!(matches!(result, Err(VerifierBuilderError::InvalidCrl(_))));
     }
 
@@ -555,12 +545,10 @@ mod tests {
             load_crls(&[
                 include_bytes!("../../../test-ca/eddsa/client.revoked.crl.pem").as_slice(),
             ]);
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .with_crls(initial_crls.clone())
-        .with_crls(extra_crls.clone());
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .with_crls(initial_crls.clone())
+                .with_crls(extra_crls.clone());
 
         // There should be the expected number of crls.
         assert_eq!(builder.crls.len(), initial_crls.len() + extra_crls.len());
@@ -573,11 +561,9 @@ mod tests {
     fn test_client_verifier_with_crls_required_auth_implicit() {
         // We should be able to build a verifier that requires client authentication, and that does
         // revocation checking with CRLs, and that does not allow any anonymous access.
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .with_crls(test_crls());
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .with_crls(test_crls());
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -587,12 +573,10 @@ mod tests {
     fn test_client_verifier_with_crls_optional_auth() {
         // We should be able to build a verifier that supports client authentication, that does
         // revocation checking with CRLs, and that allows anonymous access.
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .with_crls(test_crls())
-        .allow_unauthenticated();
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .with_crls(test_crls())
+                .allow_unauthenticated();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -601,12 +585,10 @@ mod tests {
     #[test]
     fn test_client_verifier_ee_only() {
         // We should be able to build a client verifier that only checks EE revocation status.
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .with_crls(test_crls())
-        .only_check_end_entity_revocation();
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .with_crls(test_crls())
+                .only_check_end_entity_revocation();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -615,12 +597,10 @@ mod tests {
     #[test]
     fn test_client_verifier_allow_unknown() {
         // We should be able to build a client verifier that allows unknown revocation status
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .with_crls(test_crls())
-        .allow_unknown_revocation_status();
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .with_crls(test_crls())
+                .allow_unknown_revocation_status();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -629,12 +609,10 @@ mod tests {
     #[test]
     fn test_client_verifier_enforce_expiration() {
         // We should be able to build a client verifier that allows unknown revocation status
-        let builder = WebPkiClientVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .with_crls(test_crls())
-        .enforce_revocation_expiration();
+        let builder =
+            WebPkiClientVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .with_crls(test_crls())
+                .enforce_revocation_expiration();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -645,7 +623,7 @@ mod tests {
         // Trying to create a client verifier builder with no trust anchors should fail at build time
         let result = WebPkiClientVerifier::builder_with_provider(
             RootCertStore::empty().into(),
-            &provider::default_provider(),
+            &provider::DEFAULT_PROVIDER,
         )
         .build();
         assert!(matches!(result, Err(VerifierBuilderError::NoRootAnchors)));

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -341,12 +341,10 @@ mod tests {
     #[test]
     fn test_with_invalid_crls() {
         // Trying to build a server verifier with invalid CRLs should error at build time.
-        let result = WebPkiServerVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .with_crls(vec![CertificateRevocationListDer::from(vec![0xFF])])
-        .build();
+        let result =
+            WebPkiServerVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .with_crls(vec![CertificateRevocationListDer::from(vec![0xFF])])
+                .build();
         assert!(matches!(result, Err(VerifierBuilderError::InvalidCrl(_))));
     }
 
@@ -359,12 +357,10 @@ mod tests {
                 include_bytes!("../../../test-ca/eddsa/client.revoked.crl.pem").as_slice(),
             ]);
 
-        let builder = WebPkiServerVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .with_crls(initial_crls.clone())
-        .with_crls(extra_crls.clone());
+        let builder =
+            WebPkiServerVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .with_crls(initial_crls.clone())
+                .with_crls(extra_crls.clone());
 
         // There should be the expected number of crls.
         assert_eq!(builder.crls.len(), initial_crls.len() + extra_crls.len());
@@ -378,7 +374,7 @@ mod tests {
         // Trying to create a server verifier builder with no trust anchors should fail at build time
         let result = WebPkiServerVerifier::builder_with_provider(
             RootCertStore::empty().into(),
-            &provider::default_provider(),
+            &provider::DEFAULT_PROVIDER,
         )
         .build();
         assert!(matches!(result, Err(VerifierBuilderError::NoRootAnchors)));
@@ -387,11 +383,9 @@ mod tests {
     #[test]
     fn test_server_verifier_ee_only() {
         // We should be able to build a server cert. verifier that only checks the EE cert.
-        let builder = WebPkiServerVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .only_check_end_entity_revocation();
+        let builder =
+            WebPkiServerVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .only_check_end_entity_revocation();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -401,11 +395,9 @@ mod tests {
     fn test_server_verifier_allow_unknown() {
         // We should be able to build a server cert. verifier that allows unknown revocation
         // status.
-        let builder = WebPkiServerVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .allow_unknown_revocation_status();
+        let builder =
+            WebPkiServerVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .allow_unknown_revocation_status();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -415,12 +407,10 @@ mod tests {
     fn test_server_verifier_allow_unknown_ee_only() {
         // We should be able to build a server cert. verifier that allows unknown revocation
         // status and only checks the EE cert.
-        let builder = WebPkiServerVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .allow_unknown_revocation_status()
-        .only_check_end_entity_revocation();
+        let builder =
+            WebPkiServerVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .allow_unknown_revocation_status()
+                .only_check_end_entity_revocation();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();
@@ -430,11 +420,9 @@ mod tests {
     fn test_server_verifier_enforce_expiration() {
         // We should be able to build a server cert. verifier that allows unknown revocation
         // status.
-        let builder = WebPkiServerVerifier::builder_with_provider(
-            test_roots(),
-            &provider::default_provider(),
-        )
-        .enforce_revocation_expiration();
+        let builder =
+            WebPkiServerVerifier::builder_with_provider(test_roots(), &provider::DEFAULT_PROVIDER)
+                .enforce_revocation_expiration();
         // The builder should be Debug.
         println!("{builder:?}");
         builder.build().unwrap();

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -275,7 +275,7 @@ mod tests {
             "WebPkiSupportedAlgorithms { all: [ .. ], mapping: [ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256] }",
             format!(
                 "{:?}",
-                crate::crypto::ring::default_provider().signature_verification_algorithms
+                crate::crypto::ring::DEFAULT_PROVIDER.signature_verification_algorithms
             )
         );
     }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -36,9 +36,10 @@ use rustls_test::{
     unsafe_plaintext_crypto_provider,
 };
 
-use super::common::{all_versions, provider_with_one_suite, provider_with_suites};
+use super::common::{provider_with_one_suite, provider_with_suites};
 use super::{
-    COUNTS, CountingLogger, provider, provider_is_aws_lc_rs, provider_is_fips, provider_is_ring,
+    ALL_VERSIONS, COUNTS, CountingLogger, provider, provider_is_aws_lc_rs, provider_is_fips,
+    provider_is_ring,
 };
 
 fn alpn_test_error(
@@ -52,7 +53,7 @@ fn alpn_test_error(
 
     let server_config = Arc::new(server_config);
 
-    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
+    for version_provider in ALL_VERSIONS {
         let mut client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         client_config
             .alpn_protocols
@@ -323,7 +324,7 @@ fn config_builder_for_server_with_time() {
 fn client_can_get_server_cert() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_configs(client_config, make_server_config(*kt, &provider));
@@ -345,7 +346,7 @@ fn client_can_get_server_cert_after_resumption() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = make_server_config(*kt, &provider);
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_configs(client_config.clone(), server_config.clone());
@@ -374,7 +375,7 @@ fn server_can_get_client_cert() {
             *kt, &provider,
         ));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -400,7 +401,7 @@ fn server_can_get_client_cert_after_resumption() {
             *kt, &provider,
         ));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let client_config = Arc::new(client_config);
             let (mut client, mut server) =
@@ -586,7 +587,7 @@ fn server_connection_is_debug() {
 fn server_exposes_offered_sni() {
     let kt = KeyType::Rsa2048;
     let provider = provider::DEFAULT_PROVIDER;
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config(kt, &version_provider);
         let mut client = ClientConnection::new(
             Arc::new(client_config),
@@ -610,7 +611,7 @@ fn server_exposes_offered_sni_smashed_to_lowercase() {
     // webpki actually does this for us in its DnsName type
     let kt = KeyType::Rsa2048;
     let provider = provider::DEFAULT_PROVIDER;
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config(kt, &version_provider);
         let mut client = ClientConnection::new(
             Arc::new(client_config),
@@ -1084,7 +1085,7 @@ fn test_no_warning_logging_during_successful_sessions() {
 
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_configs(client_config, make_server_config(*kt, &provider));

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -47,13 +47,12 @@ fn alpn_test_error(
     agreed: Option<&[u8]>,
     expected_error: Option<ErrorFromPeer>,
 ) {
-    let provider = provider::default_provider();
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     server_config.alpn_protocols = server_protos;
 
     let server_config = Arc::new(server_config);
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
         let mut client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         client_config
             .alpn_protocols
@@ -112,7 +111,7 @@ fn alpn() {
 
 #[test]
 fn connection_level_alpn_protocols() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
     let server_config = Arc::new(server_config);
@@ -146,7 +145,7 @@ fn version_test(
     server_versions: &[ProtocolVersion],
     result: Option<ProtocolVersion>,
 ) {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let client_provider = apply_versions(provider.clone(), client_versions);
     let server_provider = apply_versions(provider, server_versions);
 
@@ -234,7 +233,7 @@ fn config_builder_for_client_rejects_empty_kx_groups() {
         ClientConfig::builder_with_provider(
             CryptoProvider {
                 kx_groups: Cow::Borrowed(&[]),
-                ..provider::default_provider()
+                ..provider::DEFAULT_PROVIDER
             }
             .into()
         )
@@ -252,7 +251,7 @@ fn config_builder_for_client_rejects_empty_cipher_suites() {
             CryptoProvider {
                 tls12_cipher_suites: Cow::Borrowed(&[]),
                 tls13_cipher_suites: Cow::Borrowed(&[]),
-                ..provider::default_provider()
+                ..provider::DEFAULT_PROVIDER
             }
             .into()
         )
@@ -269,7 +268,7 @@ fn config_builder_for_server_rejects_empty_kx_groups() {
         ServerConfig::builder_with_provider(
             CryptoProvider {
                 kx_groups: Cow::Borrowed(&[]),
-                ..provider::default_provider()
+                ..provider::DEFAULT_PROVIDER
             }
             .into()
         )
@@ -287,7 +286,7 @@ fn config_builder_for_server_rejects_empty_cipher_suites() {
             CryptoProvider {
                 tls12_cipher_suites: Cow::Borrowed(&[]),
                 tls13_cipher_suites: Cow::Borrowed(&[]),
-                ..provider::default_provider()
+                ..provider::DEFAULT_PROVIDER
             }
             .into()
         )
@@ -301,7 +300,7 @@ fn config_builder_for_server_rejects_empty_cipher_suites() {
 #[test]
 fn config_builder_for_client_with_time() {
     ClientConfig::builder_with_details(
-        provider::default_provider().into(),
+        provider::DEFAULT_PROVIDER.into(),
         Arc::new(rustls::time_provider::DefaultTimeProvider),
     );
 }
@@ -309,14 +308,14 @@ fn config_builder_for_client_with_time() {
 #[test]
 fn config_builder_for_server_with_time() {
     ServerConfig::builder_with_details(
-        provider::default_provider().into(),
+        provider::DEFAULT_PROVIDER.into(),
         Arc::new(rustls::time_provider::DefaultTimeProvider),
     );
 }
 
 #[test]
 fn client_can_get_server_cert() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         for version_provider in all_versions(&provider) {
             let client_config = make_client_config(*kt, &version_provider);
@@ -337,7 +336,7 @@ fn client_can_get_server_cert() {
 
 #[test]
 fn client_can_get_server_cert_after_resumption() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = make_server_config(*kt, &provider);
         for version_provider in all_versions(&provider) {
@@ -363,7 +362,7 @@ fn client_can_get_server_cert_after_resumption() {
 
 #[test]
 fn server_can_get_client_cert() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config_with_mandatory_client_auth(
             *kt, &provider,
@@ -389,7 +388,7 @@ fn server_can_get_client_cert() {
 
 #[test]
 fn server_can_get_client_cert_after_resumption() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config_with_mandatory_client_auth(
             *kt, &provider,
@@ -422,13 +421,13 @@ fn test_config_builders_debug() {
         CryptoProvider {
             tls13_cipher_suites: Cow::Owned(vec![cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]),
             kx_groups: Cow::Owned(vec![provider::kx_group::X25519]),
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         }
         .into(),
     );
     let _ = format!("{b:?}");
     let b = ServerConfig::builder_with_provider(
-        provider::default_provider()
+        provider::DEFAULT_PROVIDER
             .with_only_tls13()
             .into(),
     );
@@ -440,13 +439,13 @@ fn test_config_builders_debug() {
         CryptoProvider {
             tls13_cipher_suites: Cow::Owned(vec![cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]),
             kx_groups: Cow::Owned(vec![provider::kx_group::X25519]),
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         }
         .into(),
     );
     let _ = format!("{b:?}");
     let b = ClientConfig::builder_with_provider(
-        provider::default_provider()
+        provider::DEFAULT_PROVIDER
             .with_only_tls13()
             .into(),
     );
@@ -455,7 +454,7 @@ fn test_config_builders_debug() {
 
 #[test]
 fn test_tls13_valid_early_plaintext_alert() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     // Perform the start of a TLS 1.3 handshake, sending a client hello to the server.
     // The client will not have written a CCS or any encrypted messages to the server yet.
@@ -483,7 +482,7 @@ fn test_tls13_valid_early_plaintext_alert() {
 
 #[test]
 fn test_tls13_too_short_early_plaintext_alert() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     // Perform the start of a TLS 1.3 handshake, sending a client hello to the server.
     // The client will not have written a CCS or any encrypted messages to the server yet.
@@ -505,7 +504,7 @@ fn test_tls13_too_short_early_plaintext_alert() {
 
 #[test]
 fn test_tls13_late_plaintext_alert() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     // Complete a bi-directional TLS1.3 handshake. After this point no plaintext messages
     // should occur.
@@ -525,7 +524,7 @@ fn test_tls13_late_plaintext_alert() {
 
 #[test]
 fn client_error_is_sticky() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     client
         .read_tls(&mut b"\x16\x03\x03\x00\x08\x0f\x00\x00\x04junk".as_ref())
         .unwrap();
@@ -537,7 +536,7 @@ fn client_error_is_sticky() {
 
 #[test]
 fn server_error_is_sticky() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     server
         .read_tls(&mut b"\x16\x03\x03\x00\x08\x0f\x00\x00\x04junk".as_ref())
         .unwrap();
@@ -550,7 +549,7 @@ fn server_error_is_sticky() {
 #[allow(clippy::unnecessary_operation)]
 #[test]
 fn server_is_send_and_sync() {
-    let (_, server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     &server as &dyn Send;
     &server as &dyn Sync;
 }
@@ -558,37 +557,37 @@ fn server_is_send_and_sync() {
 #[allow(clippy::unnecessary_operation)]
 #[test]
 fn client_is_send_and_sync() {
-    let (client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     &client as &dyn Send;
     &client as &dyn Sync;
 }
 
 #[test]
 fn server_config_is_clone() {
-    let _ = make_server_config(KeyType::Rsa2048, &provider::default_provider());
+    let _ = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 }
 
 #[test]
 fn client_config_is_clone() {
-    let _ = make_client_config(KeyType::Rsa2048, &provider::default_provider());
+    let _ = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 }
 
 #[test]
 fn client_connection_is_debug() {
-    let (client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     println!("{client:?}");
 }
 
 #[test]
 fn server_connection_is_debug() {
-    let (_, server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     println!("{server:?}");
 }
 
 #[test]
 fn server_exposes_offered_sni() {
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for version_provider in all_versions(&provider) {
         let client_config = make_client_config(kt, &version_provider);
         let mut client = ClientConnection::new(
@@ -612,7 +611,7 @@ fn server_exposes_offered_sni() {
 fn server_exposes_offered_sni_smashed_to_lowercase() {
     // webpki actually does this for us in its DnsName type
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for version_provider in all_versions(&provider) {
         let client_config = make_client_config(kt, &version_provider);
         let mut client = ClientConnection::new(
@@ -764,7 +763,7 @@ fn do_exporter_test(
 
 #[test]
 fn test_tls12_exporter() {
-    let provider = provider::default_provider().with_only_tls12();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls12();
     for kt in KeyType::all_for_provider(&provider) {
         let client_config = make_client_config(*kt, &provider);
         let server_config = make_server_config(*kt, &provider);
@@ -787,7 +786,7 @@ fn test_tls12_exporter() {
 
 #[test]
 fn test_tls13_exporter() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     for kt in KeyType::all_for_provider(&provider) {
         let client_config = make_client_config(*kt, &provider);
         let server_config = make_server_config(*kt, &provider);
@@ -798,7 +797,7 @@ fn test_tls13_exporter() {
 
 #[test]
 fn test_tls13_exporter_maximum_output_length() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let client_config = make_client_config(KeyType::EcdsaP256, &provider);
     let server_config = make_server_config(KeyType::EcdsaP256, &provider);
 
@@ -925,7 +924,7 @@ fn test_ciphersuites() -> Vec<(ProtocolVersion, KeyType, CipherSuite)> {
 
 #[test]
 fn negotiated_ciphersuite_default() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         do_suite_and_kx_test(
             make_client_config(*kt, &provider),
@@ -950,13 +949,13 @@ fn negotiated_ciphersuite_client() {
     for (version, kt, suite) in test_ciphersuites() {
         let scs = find_suite(suite);
         let client_config = ClientConfig::builder_with_provider(
-            provider_with_one_suite(&provider::default_provider(), scs).into(),
+            provider_with_one_suite(&provider::DEFAULT_PROVIDER, scs).into(),
         )
         .finish(kt);
 
         do_suite_and_kx_test(
             client_config,
-            make_server_config(kt, &provider::default_provider()),
+            make_server_config(kt, &provider::DEFAULT_PROVIDER),
             scs,
             expected_kx_for_version(version),
             version,
@@ -969,12 +968,12 @@ fn negotiated_ciphersuite_server() {
     for (version, kt, suite) in test_ciphersuites() {
         let scs = find_suite(suite);
         let server_config = ServerConfig::builder_with_provider(
-            provider_with_one_suite(&provider::default_provider(), scs).into(),
+            provider_with_one_suite(&provider::DEFAULT_PROVIDER, scs).into(),
         )
         .finish(kt);
 
         do_suite_and_kx_test(
-            make_client_config(kt, &provider::default_provider()),
+            make_client_config(kt, &provider::DEFAULT_PROVIDER),
             server_config,
             scs,
             expected_kx_for_version(version),
@@ -1002,13 +1001,13 @@ fn negotiated_ciphersuite_server_ignoring_client_preference() {
         assert_ne!(scs, scs_other);
 
         let mut server_config = ServerConfig::builder_with_provider(
-            provider_with_suites(&provider::default_provider(), &[scs, scs_other]).into(),
+            provider_with_suites(&provider::DEFAULT_PROVIDER, &[scs, scs_other]).into(),
         )
         .finish(kt);
         server_config.ignore_client_order = true;
 
         let client_config = ClientConfig::builder_with_provider(
-            provider_with_suites(&provider::default_provider(), &[scs_other, scs]).into(),
+            provider_with_suites(&provider::DEFAULT_PROVIDER, &[scs_other, scs]).into(),
         )
         .finish(kt);
 
@@ -1065,7 +1064,7 @@ fn test_client_rejects_illegal_tls13_ccs() {
         Altered::InPlace
     }
 
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     transfer(&mut client, &mut server);
     server.process_new_packets().unwrap();
 
@@ -1085,7 +1084,7 @@ fn test_no_warning_logging_during_successful_sessions() {
     CountingLogger::install();
     CountingLogger::reset();
 
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         for version_provider in all_versions(&provider) {
             let client_config = make_client_config(*kt, &version_provider);
@@ -1119,13 +1118,12 @@ fn test_no_warning_logging_during_successful_sessions() {
 #[cfg(all(feature = "ring", feature = "aws-lc-rs"))]
 #[test]
 fn test_explicit_provider_selection() {
-    let client_config = rustls::ClientConfig::builder_with_provider(
-        rustls::crypto::ring::default_provider().into(),
-    )
-    .finish(KeyType::Rsa2048);
+    let client_config =
+        rustls::ClientConfig::builder_with_provider(rustls::crypto::ring::DEFAULT_PROVIDER.into())
+            .finish(KeyType::Rsa2048);
 
     let server_config = rustls::ServerConfig::builder_with_provider(
-        rustls::crypto::aws_lc_rs::default_provider().into(),
+        rustls::crypto::aws_lc_rs::DEFAULT_PROVIDER.into(),
     )
     .finish(KeyType::Rsa2048);
 
@@ -1169,7 +1167,7 @@ fn test_client_construction_fails_if_random_source_fails_in_first_request() {
     let client_config = rustls::ClientConfig::builder_with_provider(
         CryptoProvider {
             secure_random: &FAULTY_RANDOM,
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         }
         .into(),
     )
@@ -1190,7 +1188,7 @@ fn test_client_construction_fails_if_random_source_fails_in_second_request() {
     let client_config = rustls::ClientConfig::builder_with_provider(
         CryptoProvider {
             secure_random: &FAULTY_RANDOM,
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         }
         .into(),
     )
@@ -1214,7 +1212,7 @@ fn test_client_construction_requires_66_bytes_of_random_material() {
     let client_config = rustls::ClientConfig::builder_with_provider(
         CryptoProvider {
             secure_random: &FAULTY_RANDOM,
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         }
         .into(),
     )
@@ -1250,7 +1248,7 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
         }
     }
 
-    let provider = provider::default_provider().with_only_tls12();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls12();
     let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
     let storage = Arc::new(ClientStorage::new());
     client_config.resumption = Resumption::store(storage.clone());
@@ -1291,7 +1289,7 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
 #[test]
 fn test_client_fips_service_indicator() {
     assert_eq!(
-        make_client_config(KeyType::Rsa2048, &provider::default_provider()).fips(),
+        make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).fips(),
         provider_is_fips()
     );
 }
@@ -1299,14 +1297,14 @@ fn test_client_fips_service_indicator() {
 #[test]
 fn test_server_fips_service_indicator() {
     assert_eq!(
-        make_server_config(KeyType::Rsa2048, &provider::default_provider()).fips(),
+        make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).fips(),
         provider_is_fips()
     );
 }
 
 #[test]
 fn test_connection_fips_service_indicator() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let client_config = Arc::new(make_client_config(KeyType::Rsa2048, &provider));
     let server_config = Arc::new(make_server_config(KeyType::Rsa2048, &provider));
     let conn_pair = make_pair_for_arc_configs(&client_config, &server_config);
@@ -1322,7 +1320,7 @@ fn test_client_fips_service_indicator_includes_require_ems() {
         return;
     }
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider::default_provider());
+    let mut client_config = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(client_config.fips());
     client_config.require_ems = false;
     assert!(!client_config.fips());
@@ -1334,7 +1332,7 @@ fn test_server_fips_service_indicator_includes_require_ems() {
         return;
     }
 
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
+    let mut server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(server_config.fips());
     server_config.require_ems = false;
     assert!(!server_config.fips());
@@ -1363,7 +1361,7 @@ fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
         // A ECH client configuration should only be considered FIPS approved if the
         // ECH HPKE suite is itself FIPS approved.
         let config = ClientConfig::builder_with_provider(
-            provider::default_provider()
+            provider::DEFAULT_PROVIDER
                 .with_only_tls13()
                 .into(),
         )
@@ -1374,7 +1372,7 @@ fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
         // The same applies if an ECH GREASE client configuration is used.
         let (public_key, _) = suite.generate_key_pair().unwrap();
         let config = ClientConfig::builder_with_provider(
-            provider::default_provider()
+            provider::DEFAULT_PROVIDER
                 .with_only_tls13()
                 .into(),
         )
@@ -1391,7 +1389,7 @@ fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
 
 #[test]
 fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let client_config = make_client_config(KeyType::Rsa2048, &provider);
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.enable_secret_extraction = true;
@@ -1424,7 +1422,7 @@ fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
 
 #[test]
 fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
-    let provider = provider::default_provider().with_only_tls12();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls12();
     let client_config = make_client_config(KeyType::Rsa2048, &provider);
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.enable_secret_extraction = true;
@@ -1463,7 +1461,7 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
 
 #[test]
 fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
     client_config.enable_secret_extraction = true;
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
@@ -1490,7 +1488,7 @@ fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
 
 #[test]
 fn test_illegal_client_renegotiation_attempt_during_tls12_handshake() {
-    let provider = provider::default_provider().with_only_tls12();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls12();
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
     let client_config = make_client_config(KeyType::Rsa2048, &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -1527,7 +1525,7 @@ fn tls13_packed_handshake() {
     // regression test for https://github.com/rustls/rustls/issues/2040
     // (did not affect the buffered api)
     let client_config = ClientConfig::builder_with_provider(unsafe_plaintext_crypto_provider(
-        provider::default_provider(),
+        provider::DEFAULT_PROVIDER,
     ))
     .dangerous()
     .with_custom_certificate_verifier(Arc::new(MockServerVerifier::rejects_certificate(
@@ -1564,7 +1562,7 @@ fn tls13_packed_handshake() {
 
 #[test]
 fn large_client_hello() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let hello = include_bytes!("data/bug2227-clienthello.bin");
     let mut cursor = io::Cursor::new(hello);
     loop {
@@ -1642,7 +1640,7 @@ fn server_invalid_sni_policy() {
     ));
 
     for (policy, sni, expected_result) in test_cases {
-        let provider = provider::default_provider();
+        let provider = provider::DEFAULT_PROVIDER;
         let client_config = make_client_config(KeyType::EcdsaP256, &provider);
         let mut server_config = make_server_config(KeyType::EcdsaP256, &provider);
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
 
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 use std::{io, mem};
@@ -232,7 +233,7 @@ fn config_builder_for_client_rejects_empty_kx_groups() {
     assert_eq!(
         ClientConfig::builder_with_provider(
             CryptoProvider {
-                kx_groups: Vec::default(),
+                kx_groups: Cow::Borrowed(&[]),
                 ..provider::default_provider()
             }
             .into()
@@ -249,8 +250,8 @@ fn config_builder_for_client_rejects_empty_cipher_suites() {
     assert_eq!(
         ClientConfig::builder_with_provider(
             CryptoProvider {
-                tls12_cipher_suites: Vec::default(),
-                tls13_cipher_suites: Vec::default(),
+                tls12_cipher_suites: Cow::Borrowed(&[]),
+                tls13_cipher_suites: Cow::Borrowed(&[]),
                 ..provider::default_provider()
             }
             .into()
@@ -267,7 +268,7 @@ fn config_builder_for_server_rejects_empty_kx_groups() {
     assert_eq!(
         ServerConfig::builder_with_provider(
             CryptoProvider {
-                kx_groups: Vec::default(),
+                kx_groups: Cow::Borrowed(&[]),
                 ..provider::default_provider()
             }
             .into()
@@ -284,8 +285,8 @@ fn config_builder_for_server_rejects_empty_cipher_suites() {
     assert_eq!(
         ServerConfig::builder_with_provider(
             CryptoProvider {
-                tls12_cipher_suites: Vec::default(),
-                tls13_cipher_suites: Vec::default(),
+                tls12_cipher_suites: Cow::Borrowed(&[]),
+                tls13_cipher_suites: Cow::Borrowed(&[]),
                 ..provider::default_provider()
             }
             .into()
@@ -419,8 +420,8 @@ fn test_config_builders_debug() {
 
     let b = ServerConfig::builder_with_provider(
         CryptoProvider {
-            tls13_cipher_suites: vec![cipher_suite::TLS13_CHACHA20_POLY1305_SHA256],
-            kx_groups: vec![provider::kx_group::X25519],
+            tls13_cipher_suites: Cow::Owned(vec![cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]),
+            kx_groups: Cow::Owned(vec![provider::kx_group::X25519]),
             ..provider::default_provider()
         }
         .into(),
@@ -437,8 +438,8 @@ fn test_config_builders_debug() {
 
     let b = ClientConfig::builder_with_provider(
         CryptoProvider {
-            tls13_cipher_suites: vec![cipher_suite::TLS13_CHACHA20_POLY1305_SHA256],
-            kx_groups: vec![provider::kx_group::X25519],
+            tls13_cipher_suites: Cow::Owned(vec![cipher_suite::TLS13_CHACHA20_POLY1305_SHA256]),
+            kx_groups: Cow::Owned(vec![provider::kx_group::X25519]),
             ..provider::default_provider()
         }
         .into(),

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -17,8 +17,7 @@ use rustls_test::{
     server_name, webpki_client_verifier_builder,
 };
 
-use super::common::all_versions;
-use super::provider;
+use super::{ALL_VERSIONS, provider};
 
 // Client is authorized!
 fn ver_ok() -> Result<PeerVerified, Error> {
@@ -54,7 +53,7 @@ fn client_verifier_works() {
         let server_config = server_config_with_verifier(*kt, client_verifier);
         let server_config = Arc::new(server_config);
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config.clone()), &server_config);
@@ -74,7 +73,7 @@ fn client_verifier_no_schemes() {
         let server_config = server_config_with_verifier(*kt, client_verifier);
         let server_config = Arc::new(server_config);
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config.clone()), &server_config);
@@ -99,7 +98,7 @@ fn client_verifier_no_auth_yes_root() {
         let server_config = server_config_with_verifier(*kt, client_verifier);
         let server_config = Arc::new(server_config);
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config(*kt, &version_provider);
             let mut server = ServerConnection::new(server_config.clone()).unwrap();
             let mut client =
@@ -129,7 +128,7 @@ fn client_verifier_fails_properly() {
         let server_config = server_config_with_verifier(*kt, client_verifier);
         let server_config = Arc::new(server_config);
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let mut server = ServerConnection::new(server_config.clone()).unwrap();
             let mut client =
@@ -163,7 +162,7 @@ fn server_allow_any_anonymous_or_authenticated_client() {
             .unwrap();
         let server_config = Arc::new(server_config);
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = if client_cert_chain.is_some() {
                 make_client_config_with_auth(kt, &version_provider)
             } else {
@@ -199,7 +198,7 @@ fn client_auth_works() {
             *kt, &provider,
         ));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -248,7 +247,7 @@ fn client_mandatory_auth_client_revocation_works() {
             make_server_config_with_client_verifier(*kt, ee_verifier_builder, &provider),
         );
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             // Connecting to the server with a CRL that indicates the client certificate is revoked
             // should fail with the expected error.
             let client_config = Arc::new(make_client_config_with_auth(*kt, &version_provider));
@@ -313,7 +312,7 @@ fn client_mandatory_auth_intermediate_revocation_works() {
             &provider,
         ));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             // When checking the full chain, we expect an error - the intermediate is revoked.
             let client_config = Arc::new(make_client_config_with_auth(*kt, &version_provider));
             let (mut client, mut server) =
@@ -345,7 +344,7 @@ fn client_optional_auth_client_revocation_works() {
             *kt, crls, &provider,
         ));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -39,7 +39,7 @@ fn server_config_with_verifier(
     kt: KeyType,
     client_cert_verifier: MockClientVerifier,
 ) -> ServerConfig {
-    ServerConfig::builder_with_provider(provider::default_provider().into())
+    ServerConfig::builder_with_provider(provider::DEFAULT_PROVIDER.into())
         .with_client_cert_verifier(Arc::new(client_cert_verifier))
         .with_single_cert(kt.chain(), kt.key())
         .unwrap()
@@ -48,7 +48,7 @@ fn server_config_with_verifier(
 #[test]
 // Happy path, we resolve to a root, it is verified OK, should be able to connect
 fn client_verifier_works() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
         let client_verifier = MockClientVerifier::new(ver_ok, *kt, &provider);
         let server_config = server_config_with_verifier(*kt, client_verifier);
@@ -67,7 +67,7 @@ fn client_verifier_works() {
 // Server offers no verification schemes
 #[test]
 fn client_verifier_no_schemes() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
         let mut client_verifier = MockClientVerifier::new(ver_ok, *kt, &provider);
         client_verifier.offered_schemes = Some(vec![]);
@@ -92,7 +92,7 @@ fn client_verifier_no_schemes() {
 // If we do have a root, we must do auth
 #[test]
 fn client_verifier_no_auth_yes_root() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
         let client_verifier = MockClientVerifier::new(ver_unreachable, *kt, &provider);
 
@@ -123,7 +123,7 @@ fn client_verifier_no_auth_yes_root() {
 #[test]
 // Triple checks we propagate the rustls::Error through
 fn client_verifier_fails_properly() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
         let client_verifier = MockClientVerifier::new(ver_err, *kt, &provider);
         let server_config = server_config_with_verifier(*kt, client_verifier);
@@ -149,7 +149,7 @@ fn client_verifier_fails_properly() {
 /// certificate and not being given one.
 #[test]
 fn server_allow_any_anonymous_or_authenticated_client() {
-    let provider = Arc::new(provider::default_provider());
+    let provider = Arc::new(provider::DEFAULT_PROVIDER);
     let kt = KeyType::Rsa2048;
     for client_cert_chain in [None, Some(kt.client_chain())] {
         let client_auth = webpki_client_verifier_builder(kt.client_root_store(), &provider)
@@ -193,7 +193,7 @@ fn server_allow_any_anonymous_or_authenticated_client() {
 
 #[test]
 fn client_auth_works() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config_with_mandatory_client_auth(
             *kt, &provider,
@@ -210,7 +210,7 @@ fn client_auth_works() {
 
 #[test]
 fn client_mandatory_auth_client_revocation_works() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         // Create a server configuration that includes a CRL that specifies the client certificate
         // is revoked.
@@ -284,7 +284,7 @@ fn client_mandatory_auth_client_revocation_works() {
 
 #[test]
 fn client_mandatory_auth_intermediate_revocation_works() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         // Create a server configuration that includes a CRL that specifies the intermediate certificate
         // is revoked. We check the full chain for revocation status (default), and allow unknown
@@ -336,7 +336,7 @@ fn client_mandatory_auth_intermediate_revocation_works() {
 
 #[test]
 fn client_optional_auth_client_revocation_works() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         // Create a server configuration that includes a CRL that specifies the client certificate
         // is revoked.

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -38,20 +38,6 @@ fn exactly_one_provider() -> bool {
     ))
 }
 
-pub fn all_versions(provider: &CryptoProvider) -> impl Iterator<Item = CryptoProvider> {
-    vec![
-        CryptoProvider {
-            tls13_cipher_suites: Default::default(),
-            ..provider.clone()
-        },
-        CryptoProvider {
-            tls12_cipher_suites: Default::default(),
-            ..provider.clone()
-        },
-    ]
-    .into_iter()
-}
-
 pub fn provider_with_one_suite(
     provider: &CryptoProvider,
     suite: SupportedCipherSuite,

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -40,8 +40,14 @@ fn exactly_one_provider() -> bool {
 
 pub fn all_versions(provider: &CryptoProvider) -> impl Iterator<Item = CryptoProvider> {
     vec![
-        provider.clone().with_only_tls12(),
-        provider.clone().with_only_tls13(),
+        CryptoProvider {
+            tls13_cipher_suites: Default::default(),
+            ..provider.clone()
+        },
+        CryptoProvider {
+            tls12_cipher_suites: Default::default(),
+            ..provider.clone()
+        },
     ]
     .into_iter()
 }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![allow(clippy::disallowed_types)]
 
+use std::borrow::Cow;
 pub use std::sync::Arc;
 
 use rustls::client::{ServerVerifierBuilder, WebPkiServerVerifier};
@@ -56,21 +57,23 @@ pub fn provider_with_suites(
     provider: &CryptoProvider,
     suites: &[SupportedCipherSuite],
 ) -> CryptoProvider {
-    let mut provider = CryptoProvider {
-        tls12_cipher_suites: vec![],
-        tls13_cipher_suites: vec![],
-        ..provider.clone()
-    };
+    let mut tls12_cipher_suites = vec![];
+    let mut tls13_cipher_suites = vec![];
+
     for suite in suites {
         match suite {
             SupportedCipherSuite::Tls12(suite) => {
-                provider.tls12_cipher_suites.push(suite);
+                tls12_cipher_suites.push(*suite);
             }
             SupportedCipherSuite::Tls13(suite) => {
-                provider.tls13_cipher_suites.push(suite);
+                tls13_cipher_suites.push(*suite);
             }
             _ => unreachable!(),
         }
     }
-    provider
+    CryptoProvider {
+        tls12_cipher_suites: Cow::Owned(tls12_cipher_suites),
+        tls13_cipher_suites: Cow::Owned(tls13_cipher_suites),
+        ..provider.clone()
+    }
 }

--- a/rustls/tests/compress.rs
+++ b/rustls/tests/compress.rs
@@ -27,7 +27,7 @@ use super::provider;
 fn test_server_uses_cached_compressed_certificates() {
     static COMPRESS_COUNT: AtomicUsize = AtomicUsize::new(0);
 
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.cert_compressors = vec![&CountingCompressor];
     let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
@@ -66,7 +66,7 @@ fn test_server_uses_cached_compressed_certificates() {
 
 #[test]
 fn test_server_uses_uncompressed_certificate_if_compression_fails() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.cert_compressors = vec![&FailingCompressor];
     let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
@@ -78,7 +78,7 @@ fn test_server_uses_uncompressed_certificate_if_compression_fails() {
 
 #[test]
 fn test_client_uses_uncompressed_certificate_if_compression_fails() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config =
         make_server_config_with_mandatory_client_auth(KeyType::Rsa2048, &provider);
     server_config.cert_decompressors = vec![&NeverDecompressor];
@@ -129,7 +129,7 @@ impl rustls::compress::CertDecompressor for NeverDecompressor {
 fn test_server_can_opt_out_of_compression_cache() {
     static COMPRESS_COUNT: AtomicUsize = AtomicUsize::new(0);
 
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.cert_compressors = vec![&AlwaysInteractiveCompressor];
     server_config.cert_compression_cache = Arc::new(rustls::compress::CompressionCache::Disabled);
@@ -170,7 +170,7 @@ fn test_server_can_opt_out_of_compression_cache() {
 
 #[test]
 fn test_cert_decompression_by_client_produces_invalid_cert_payload() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.cert_compressors = vec![&IdentityCompressor];
     let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
@@ -192,7 +192,7 @@ fn test_cert_decompression_by_client_produces_invalid_cert_payload() {
 
 #[test]
 fn test_cert_decompression_by_server_produces_invalid_cert_payload() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config =
         make_server_config_with_mandatory_client_auth(KeyType::Rsa2048, &provider);
     server_config.cert_decompressors = vec![&GarbageDecompressor];
@@ -215,7 +215,7 @@ fn test_cert_decompression_by_server_produces_invalid_cert_payload() {
 
 #[test]
 fn test_cert_decompression_by_server_fails() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config =
         make_server_config_with_mandatory_client_auth(KeyType::Rsa2048, &provider);
     server_config.cert_decompressors = vec![&FailingDecompressor];
@@ -239,12 +239,12 @@ fn test_cert_decompression_by_server_fails() {
 #[cfg(feature = "zlib")]
 #[test]
 fn test_cert_decompression_by_server_would_result_in_excessively_large_cert() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let server_config = make_server_config_with_mandatory_client_auth(KeyType::Rsa2048, &provider);
     let mut client_config = make_client_config_with_auth(KeyType::Rsa2048, &provider);
 
     let big_cert = CertificateDer::from(vec![0u8; 0xffff]);
-    let key = provider::default_provider()
+    let key = provider::DEFAULT_PROVIDER
         .key_provider
         .load_private_key(KeyType::Rsa2048.client_key())
         .unwrap();

--- a/rustls/tests/crypto.rs
+++ b/rustls/tests/crypto.rs
@@ -27,7 +27,7 @@ fn key_log_for_tls12() {
     let client_key_log = Arc::new(KeyLogToVec::new("client"));
     let server_key_log = Arc::new(KeyLogToVec::new("server"));
 
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls12();
+    let provider = provider::DEFAULT_TLS12_PROVIDER;
     let kt = KeyType::Rsa2048;
     let mut client_config = make_client_config(kt, &provider);
     client_config.key_log = client_key_log.clone();
@@ -64,7 +64,7 @@ fn key_log_for_tls13() {
     let client_key_log = Arc::new(KeyLogToVec::new("client"));
     let server_key_log = Arc::new(KeyLogToVec::new("server"));
 
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     let kt = KeyType::Rsa2048;
     let mut client_config = make_client_config(kt, &provider);
     client_config.key_log = client_key_log.clone();
@@ -487,12 +487,12 @@ fn test_automatic_refresh_traffic_keys() {
 
 #[test]
 fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
-    let provider = Arc::new(
-        Arc::unwrap_or_clone(aes_128_gcm_with_1024_confidentiality_limit(dbg!(
+    let provider = Arc::new(CryptoProvider {
+        tls13_cipher_suites: Default::default(),
+        ..Arc::unwrap_or_clone(aes_128_gcm_with_1024_confidentiality_limit(dbg!(
             provider::DEFAULT_PROVIDER
         )))
-        .with_only_tls12(),
-    );
+    });
 
     let client_config =
         ClientConfig::builder_with_provider(provider.clone()).finish(KeyType::Ed25519);

--- a/rustls/tests/crypto.rs
+++ b/rustls/tests/crypto.rs
@@ -27,7 +27,7 @@ fn key_log_for_tls12() {
     let client_key_log = Arc::new(KeyLogToVec::new("client"));
     let server_key_log = Arc::new(KeyLogToVec::new("server"));
 
-    let provider = provider::default_provider().with_only_tls12();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls12();
     let kt = KeyType::Rsa2048;
     let mut client_config = make_client_config(kt, &provider);
     client_config.key_log = client_key_log.clone();
@@ -64,7 +64,7 @@ fn key_log_for_tls13() {
     let client_key_log = Arc::new(KeyLogToVec::new("client"));
     let server_key_log = Arc::new(KeyLogToVec::new("server"));
 
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let kt = KeyType::Rsa2048;
     let mut client_config = make_client_config(kt, &provider);
     client_config.key_log = client_key_log.clone();
@@ -186,7 +186,7 @@ fn test_secret_extraction_enabled() {
     // We support 3 different AEAD algorithms (AES-128-GCM mode, AES-256-GCM, and
     // Chacha20Poly1305), so that's 2*3 = 6 combinations to test.
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for suite in [
         SupportedCipherSuite::Tls13(cipher_suite::TLS13_AES_128_GCM_SHA256),
         SupportedCipherSuite::Tls13(cipher_suite::TLS13_AES_256_GCM_SHA384),
@@ -258,7 +258,7 @@ fn test_secret_extract_produces_correct_variant() {
         let kt = KeyType::Rsa2048;
 
         let provider: Arc<CryptoProvider> =
-            provider_with_one_suite(&provider::default_provider(), suite).into();
+            provider_with_one_suite(&provider::DEFAULT_PROVIDER, suite).into();
 
         let mut server_config = ServerConfig::builder_with_provider(provider.clone()).finish(kt);
 
@@ -320,7 +320,7 @@ fn test_secret_extraction_disabled_or_too_early() {
     let kt = KeyType::Rsa2048;
     let provider = Arc::new(CryptoProvider {
         tls13_cipher_suites: Cow::Owned(vec![cipher_suite::TLS13_AES_128_GCM_SHA256]),
-        ..provider::default_provider()
+        ..provider::DEFAULT_PROVIDER
     });
 
     for (server_enable, client_enable) in [(true, false), (false, true)] {
@@ -372,7 +372,7 @@ fn test_secret_extraction_disabled_or_too_early() {
 
 #[test]
 fn test_refresh_traffic_keys_during_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::DEFAULT_PROVIDER);
     assert_eq!(
         client
             .refresh_traffic_keys()
@@ -389,7 +389,7 @@ fn test_refresh_traffic_keys_during_handshake() {
 
 #[test]
 fn test_refresh_traffic_keys() {
-    let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     fn check_both_directions(client: &mut ClientConnection, server: &mut ServerConnection) {
@@ -432,7 +432,7 @@ fn test_automatic_refresh_traffic_keys() {
     }
 
     const KEY_UPDATE_SIZE: usize = encrypted_size(5);
-    let provider = aes_128_gcm_with_1024_confidentiality_limit(provider::default_provider());
+    let provider = aes_128_gcm_with_1024_confidentiality_limit(provider::DEFAULT_PROVIDER);
 
     let client_config =
         ClientConfig::builder_with_provider(provider.clone()).finish(KeyType::Ed25519);
@@ -489,7 +489,7 @@ fn test_automatic_refresh_traffic_keys() {
 fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
     let provider = Arc::new(
         Arc::unwrap_or_clone(aes_128_gcm_with_1024_confidentiality_limit(dbg!(
-            provider::default_provider()
+            provider::DEFAULT_PROVIDER
         )))
         .with_only_tls12(),
     );
@@ -527,7 +527,7 @@ fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
 
 #[test]
 fn test_keys_match_for_all_signing_key_types() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let key = provider
             .key_provider

--- a/rustls/tests/crypto.rs
+++ b/rustls/tests/crypto.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
 
+use std::borrow::Cow;
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 
@@ -318,7 +319,7 @@ fn test_secret_extract_produces_correct_variant() {
 fn test_secret_extraction_disabled_or_too_early() {
     let kt = KeyType::Rsa2048;
     let provider = Arc::new(CryptoProvider {
-        tls13_cipher_suites: vec![cipher_suite::TLS13_AES_128_GCM_SHA256],
+        tls13_cipher_suites: Cow::Owned(vec![cipher_suite::TLS13_AES_128_GCM_SHA256]),
         ..provider::default_provider()
     });
 

--- a/rustls/tests/ffdhe.rs
+++ b/rustls/tests/ffdhe.rs
@@ -31,7 +31,7 @@ fn config_builder_for_client_rejects_cipher_suites_without_compatible_kx_groups(
             provider::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
             &TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
         ]),
-        ..provider::default_provider()
+        ..provider::DEFAULT_PROVIDER
     };
 
     let build_err = ClientConfig::builder_with_provider(bad_crypto_provider.into())
@@ -94,7 +94,7 @@ fn server_avoids_dhe_cipher_suites_when_client_has_no_known_dhe_in_groups_ext() 
             ]),
             tls13_cipher_suites: Cow::Owned(vec![]),
             kx_groups: Cow::Owned(vec![&FFDHE4096_KX_GROUP, provider::kx_group::SECP256R1]),
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         }
         .into(),
     )
@@ -107,7 +107,7 @@ fn server_avoids_dhe_cipher_suites_when_client_has_no_known_dhe_in_groups_ext() 
                 provider::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
             ]),
             kx_groups: Cow::Owned(vec![&FFDHE2048_KX_GROUP, provider::kx_group::SECP256R1]),
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         }
         .into(),
     )
@@ -141,7 +141,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ]),
             tls13_cipher_suites: Cow::Owned(vec![provider::cipher_suite::TLS13_AES_128_GCM_SHA256]),
             kx_groups: Cow::Owned(vec![provider::kx_group::SECP256R1, &FFDHE2048_KX_GROUP]),
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         }
         .into(),
     )
@@ -221,7 +221,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ]),
             tls13_cipher_suites: Cow::Owned(vec![provider::cipher_suite::TLS13_AES_128_GCM_SHA256]),
             kx_groups: Cow::Owned(client_kx_groups),
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         };
         let provider = match protocol_version {
             ProtocolVersion::TLSv1_2 => provider.with_only_tls12(),
@@ -267,7 +267,7 @@ pub fn ffdhe_provider() -> CryptoProvider {
             provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
         ]),
         kx_groups: Cow::Owned(FFDHE_KX_GROUPS.to_vec()),
-        ..provider::default_provider()
+        ..provider::DEFAULT_PROVIDER
     }
 }
 

--- a/rustls/tests/ffdhe.rs
+++ b/rustls/tests/ffdhe.rs
@@ -224,8 +224,14 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             ..provider::DEFAULT_PROVIDER
         };
         let provider = match protocol_version {
-            ProtocolVersion::TLSv1_2 => provider.with_only_tls12(),
-            ProtocolVersion::TLSv1_3 => provider.with_only_tls13(),
+            ProtocolVersion::TLSv1_2 => CryptoProvider {
+                tls13_cipher_suites: Default::default(),
+                ..provider
+            },
+            ProtocolVersion::TLSv1_3 => CryptoProvider {
+                tls12_cipher_suites: Default::default(),
+                ..provider
+            },
             _ => unreachable!(),
         };
         let client_config = rustls::ClientConfig::builder_with_provider(provider.into())

--- a/rustls/tests/io.rs
+++ b/rustls/tests/io.rs
@@ -28,10 +28,12 @@ use crate::common::all_versions;
 
 #[test]
 fn buffered_client_data_sent() {
-    let provider = provider::default_provider();
-    let server_config = Arc::new(make_server_config(KeyType::Rsa2048, &provider));
+    let server_config = Arc::new(make_server_config(
+        KeyType::Rsa2048,
+        &provider::DEFAULT_PROVIDER,
+    ));
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -48,10 +50,12 @@ fn buffered_client_data_sent() {
 
 #[test]
 fn buffered_server_data_sent() {
-    let provider = provider::default_provider();
-    let server_config = Arc::new(make_server_config(KeyType::Rsa2048, &provider));
+    let server_config = Arc::new(make_server_config(
+        KeyType::Rsa2048,
+        &provider::DEFAULT_PROVIDER,
+    ));
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -68,10 +72,12 @@ fn buffered_server_data_sent() {
 
 #[test]
 fn buffered_both_data_sent() {
-    let provider = provider::default_provider();
-    let server_config = Arc::new(make_server_config(KeyType::Rsa2048, &provider));
+    let server_config = Arc::new(make_server_config(
+        KeyType::Rsa2048,
+        &provider::DEFAULT_PROVIDER,
+    ));
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -105,7 +111,7 @@ fn buffered_both_data_sent() {
 
 #[test]
 fn server_respects_buffer_limit_pre_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     server.set_buffer_limit(Some(32));
 
@@ -133,7 +139,7 @@ fn server_respects_buffer_limit_pre_handshake() {
 
 #[test]
 fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     server.set_buffer_limit(Some(32));
 
@@ -157,7 +163,7 @@ fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
 
 #[test]
 fn server_respects_buffer_limit_post_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     // this test will vary in behaviour depending on the default suites
     do_handshake(&mut client, &mut server);
@@ -186,7 +192,7 @@ fn server_respects_buffer_limit_post_handshake() {
 
 #[test]
 fn client_respects_buffer_limit_pre_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     client.set_buffer_limit(Some(32));
 
@@ -214,7 +220,7 @@ fn client_respects_buffer_limit_pre_handshake() {
 
 #[test]
 fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     client.set_buffer_limit(Some(32));
 
@@ -238,7 +244,7 @@ fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
 
 #[test]
 fn client_respects_buffer_limit_post_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     do_handshake(&mut client, &mut server);
     client.set_buffer_limit(Some(48));
@@ -267,7 +273,7 @@ fn client_respects_buffer_limit_post_handshake() {
 #[test]
 fn client_detects_broken_write_vectored_impl() {
     // see https://github.com/rustls/rustls/issues/2316
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let err = client
         .write_tls(&mut BrokenWriteVectored)
         .unwrap_err();
@@ -295,7 +301,7 @@ fn client_detects_broken_write_vectored_impl() {
 
 #[test]
 fn buf_read() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     do_handshake(&mut client, &mut server);
 
@@ -326,35 +332,35 @@ fn buf_read() {
 
 #[test]
 fn server_read_returns_wouldblock_when_no_data() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(matches!(server.reader().read(&mut [0u8; 1]),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn client_read_returns_wouldblock_when_no_data() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(matches!(client.reader().read(&mut [0u8; 1]),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn server_fill_buf_returns_wouldblock_when_no_data() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(matches!(server.reader().fill_buf(),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn client_fill_buf_returns_wouldblock_when_no_data() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(matches!(client.reader().fill_buf(),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn new_server_returns_initial_io_state() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let io_state = server.process_new_packets().unwrap();
     println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
@@ -364,7 +370,7 @@ fn new_server_returns_initial_io_state() {
 
 #[test]
 fn new_client_returns_initial_io_state() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let io_state = client.process_new_packets().unwrap();
     println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
@@ -374,7 +380,7 @@ fn new_client_returns_initial_io_state() {
 
 #[test]
 fn client_complete_io_for_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     assert!(client.is_handshaking());
     let (rdlen, wrlen) = client
@@ -387,7 +393,7 @@ fn client_complete_io_for_handshake() {
 
 #[test]
 fn buffered_client_complete_io_for_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     assert!(client.is_handshaking());
     let (rdlen, wrlen) = client
@@ -400,7 +406,7 @@ fn buffered_client_complete_io_for_handshake() {
 
 #[test]
 fn client_complete_io_for_handshake_eof() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let mut input = io::Cursor::new(Vec::new());
 
     assert!(client.is_handshaking());
@@ -412,7 +418,7 @@ fn client_complete_io_for_handshake_eof() {
 
 #[test]
 fn client_complete_io_for_write() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
 
@@ -442,7 +448,7 @@ fn client_complete_io_for_write() {
 
 #[test]
 fn client_complete_io_with_nonblocking_io() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     // absolutely no progress writing ClientHello
     assert_eq!(
@@ -454,7 +460,7 @@ fn client_complete_io_with_nonblocking_io() {
     );
 
     // a little progress writing ClientHello
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert_eq!(
         client
             .complete_io(&mut TestNonBlockIo {
@@ -466,7 +472,7 @@ fn client_complete_io_with_nonblocking_io() {
     );
 
     // complete writing ClientHello
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert_eq!(
         client
             .complete_io(&mut TestNonBlockIo {
@@ -479,7 +485,7 @@ fn client_complete_io_with_nonblocking_io() {
     );
 
     // complete writing ClientHello, partial read of ServerHello
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let (rd, wr) = dbg!(client.complete_io(&mut TestNonBlockIo {
         writes: vec![4096],
         reads: vec![vec![ContentType::Handshake.into()]],
@@ -489,7 +495,7 @@ fn client_complete_io_with_nonblocking_io() {
     assert!(wr > 1);
 
     // data phase:
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     // read
@@ -535,7 +541,7 @@ fn client_complete_io_with_nonblocking_io() {
 
 #[test]
 fn buffered_client_complete_io_for_write() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
 
@@ -565,7 +571,7 @@ fn buffered_client_complete_io_for_write() {
 
 #[test]
 fn client_complete_io_for_read() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
 
@@ -587,7 +593,7 @@ fn client_complete_io_for_read() {
 
 #[test]
 fn server_complete_io_for_handshake() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
 
@@ -603,7 +609,7 @@ fn server_complete_io_for_handshake() {
 
 #[test]
 fn server_complete_io_for_handshake_eof() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let mut input = io::Cursor::new(Vec::new());
 
     assert!(server.is_handshaking());
@@ -615,7 +621,7 @@ fn server_complete_io_for_handshake_eof() {
 
 #[test]
 fn server_complete_io_for_write() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
 
@@ -644,7 +650,7 @@ fn server_complete_io_for_write() {
 
 #[test]
 fn server_complete_io_for_write_eof() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
 
@@ -701,7 +707,7 @@ impl<const N: usize> std::io::Read for EofWriter<N> {
 
 #[test]
 fn server_complete_io_for_read() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
 
@@ -723,7 +729,7 @@ fn server_complete_io_for_read() {
 
 #[test]
 fn server_complete_io_for_handshake_ending_with_alert() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::default_provider());
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
     assert!(server.is_handshaking());
@@ -758,7 +764,7 @@ enum StreamKind {
 }
 
 fn test_client_stream_write(stream_kind: StreamKind) {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
         let data = b"hello";
@@ -775,7 +781,7 @@ fn test_client_stream_write(stream_kind: StreamKind) {
 }
 
 fn test_server_stream_write(stream_kind: StreamKind) {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
         let data = b"hello";
@@ -827,7 +833,7 @@ fn test_stream_read(read_kind: ReadKind, mut stream: impl BufRead, data: &[u8]) 
 }
 
 fn test_client_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
         let data = b"world";
@@ -848,7 +854,7 @@ fn test_client_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
 }
 
 fn test_server_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
         let data = b"world";
@@ -870,7 +876,7 @@ fn test_server_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
 
 #[test]
 fn test_client_write_and_vectored_write_equivalence() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     const N: usize = 1000;
@@ -923,7 +929,7 @@ impl io::Write for FailsWrites {
 
 #[test]
 fn stream_write_reports_underlying_io_error_before_plaintext_processed() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     let mut pipe = FailsWrites {
@@ -943,7 +949,7 @@ fn stream_write_reports_underlying_io_error_before_plaintext_processed() {
 
 #[test]
 fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     let mut pipe = FailsWrites {
@@ -961,7 +967,7 @@ fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
 
 #[test]
 fn client_stream_handshake_error() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::default_provider());
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
     {
@@ -984,7 +990,7 @@ fn client_stream_handshake_error() {
 
 #[test]
 fn client_streamowned_handshake_error() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::default_provider());
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (client, mut server) = make_pair_for_configs(client_config, server_config);
 
     let pipe = OtherSession::new_fails(&mut server);
@@ -1007,7 +1013,7 @@ fn client_streamowned_handshake_error() {
 
 #[test]
 fn server_stream_handshake_error() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::default_provider());
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
     client
@@ -1030,7 +1036,7 @@ fn server_stream_handshake_error() {
 
 #[test]
 fn server_streamowned_handshake_error() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::default_provider());
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (mut client, server) = make_pair_for_configs(client_config, server_config);
 
     client
@@ -1051,7 +1057,7 @@ fn server_streamowned_handshake_error() {
 
 #[test]
 fn vectored_write_for_server_appdata() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     server
@@ -1076,7 +1082,7 @@ fn vectored_write_for_server_appdata() {
 
 #[test]
 fn vectored_write_for_client_appdata() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     client
@@ -1101,7 +1107,7 @@ fn vectored_write_for_client_appdata() {
 
 #[test]
 fn vectored_write_for_server_handshake_with_half_rtt_data() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.send_half_rtt_data = true;
     let (mut client, mut server) = make_pair_for_configs(
@@ -1147,7 +1153,7 @@ fn vectored_write_for_server_handshake_with_half_rtt_data() {
 
 fn check_half_rtt_does_not_work(server_config: ServerConfig) {
     let (mut client, mut server) = make_pair_for_configs(
-        make_client_config_with_auth(KeyType::Rsa2048, &provider::default_provider()),
+        make_client_config_with_auth(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER),
         server_config,
     );
 
@@ -1195,7 +1201,7 @@ fn check_half_rtt_does_not_work(server_config: ServerConfig) {
 fn vectored_write_for_server_handshake_no_half_rtt_with_client_auth() {
     let mut server_config = make_server_config_with_mandatory_client_auth(
         KeyType::Rsa2048,
-        &provider::default_provider(),
+        &provider::DEFAULT_PROVIDER,
     );
     server_config.send_half_rtt_data = true; // ask even though it will be ignored
     check_half_rtt_does_not_work(server_config);
@@ -1203,14 +1209,14 @@ fn vectored_write_for_server_handshake_no_half_rtt_with_client_auth() {
 
 #[test]
 fn vectored_write_for_server_handshake_no_half_rtt_by_default() {
-    let server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
+    let server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(!server_config.send_half_rtt_data);
     check_half_rtt_does_not_work(server_config);
 }
 
 #[test]
 fn vectored_write_for_client_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     client
         .writer()
@@ -1247,7 +1253,7 @@ fn vectored_write_for_client_handshake() {
 
 #[test]
 fn vectored_write_with_slow_client() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
     client.set_buffer_limit(Some(32));
 
@@ -1309,7 +1315,7 @@ fn test_client_mtu_reduction() {
         collector.writevs[0].clone()
     }
 
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let mut client_config = make_client_config(*kt, &provider);
         client_config.max_fragment_size = Some(64);
@@ -1324,7 +1330,7 @@ fn test_client_mtu_reduction() {
 
 #[test]
 fn test_server_mtu_reduction() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.max_fragment_size = Some(64);
     server_config.send_half_rtt_data = true;
@@ -1374,7 +1380,7 @@ fn test_server_mtu_reduction() {
 }
 
 fn check_client_max_fragment_size(size: usize) -> Option<Error> {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut client_config = make_client_config(KeyType::Ed25519, &provider);
     client_config.max_fragment_size = Some(size);
     ClientConnection::new(Arc::new(client_config), server_name("localhost")).err()
@@ -1404,7 +1410,7 @@ fn bad_client_max_fragment_sizes() {
 #[test]
 fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
     // general exercising of msgs::fragmenter and msgs::deframer
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         for version_provider in all_versions(&provider) {
             // no hidden significance to these numbers
@@ -1439,7 +1445,7 @@ fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
 fn test_acceptor() {
     use rustls::server::Acceptor;
 
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let client_config = Arc::new(make_client_config(KeyType::Ed25519, &provider));
     let mut client = ClientConnection::new(client_config, server_name("localhost")).unwrap();
     let mut buf = Vec::new();
@@ -1458,7 +1464,7 @@ fn test_acceptor() {
     );
     assert_eq!(
         ch.named_groups().unwrap(),
-        provider::default_provider()
+        provider::DEFAULT_PROVIDER
             .kx_groups
             .iter()
             .map(|kx| kx.name())
@@ -1547,7 +1553,7 @@ fn test_acceptor_rejected_handshake() {
     use rustls::server::Acceptor;
 
     let client_config = ClientConfig::builder_with_provider(
-        provider::default_provider()
+        provider::DEFAULT_PROVIDER
             .with_only_tls13()
             .into(),
     )
@@ -1557,7 +1563,7 @@ fn test_acceptor_rejected_handshake() {
     client.write_tls(&mut buf).unwrap();
 
     let server_config = ServerConfig::builder_with_provider(
-        provider::default_provider()
+        provider::DEFAULT_PROVIDER
             .with_only_tls12()
             .into(),
     )
@@ -1595,7 +1601,7 @@ fn test_received_plaintext_backpressure() {
 
 fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
 
     let server_config = Arc::new(
         ServerConfig::builder_with_provider(
@@ -1693,19 +1699,19 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
 
 #[test]
 fn server_flush_does_nothing() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(matches!(server.writer().flush(), Ok(())));
 }
 
 #[test]
 fn client_flush_does_nothing() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(matches!(client.writer().flush(), Ok(())));
 }
 
 #[test]
 fn server_close_notify() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let kt = KeyType::Rsa2048;
     let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
 
@@ -1745,7 +1751,7 @@ fn server_close_notify() {
 
 #[test]
 fn client_close_notify() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let kt = KeyType::Rsa2048;
     let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
 
@@ -1785,7 +1791,7 @@ fn client_close_notify() {
 
 #[test]
 fn server_closes_uncleanly() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let kt = KeyType::Rsa2048;
     let server_config = Arc::new(make_server_config(kt, &provider));
 
@@ -1831,7 +1837,7 @@ fn server_closes_uncleanly() {
 
 #[test]
 fn client_closes_uncleanly() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let kt = KeyType::Rsa2048;
     let server_config = Arc::new(make_server_config(kt, &provider));
 
@@ -1879,7 +1885,7 @@ fn client_closes_uncleanly() {
 fn test_complete_io_errors_if_close_notify_received_too_early() {
     let mut server = ServerConnection::new(Arc::new(make_server_config(
         KeyType::Rsa2048,
-        &provider::default_provider(),
+        &provider::DEFAULT_PROVIDER,
     )))
     .unwrap();
     let client_hello_followed_by_close_notify_alert = b"\
@@ -1910,7 +1916,7 @@ fn test_complete_io_errors_if_close_notify_received_too_early() {
 
 #[test]
 fn test_complete_io_with_no_io_needed() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
     client
         .writer()
@@ -1948,7 +1954,7 @@ fn test_complete_io_with_no_io_needed() {
 
 #[test]
 fn test_junk_after_close_notify_received() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
     client
         .writer()
@@ -1991,7 +1997,7 @@ fn test_junk_after_close_notify_received() {
 
 #[test]
 fn test_data_after_close_notify_is_ignored() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     client
@@ -2023,7 +2029,7 @@ fn test_data_after_close_notify_is_ignored() {
 
 #[test]
 fn test_close_notify_sent_prior_to_handshake_complete() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     client.send_close_notify();
     assert_eq!(
         do_handshake_until_error(&mut client, &mut server),
@@ -2035,7 +2041,7 @@ fn test_close_notify_sent_prior_to_handshake_complete() {
 
 #[test]
 fn test_subsequent_close_notify_ignored() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     client.send_close_notify();
     assert!(transfer(&mut client, &mut server) > 0);
 
@@ -2046,7 +2052,7 @@ fn test_subsequent_close_notify_ignored() {
 
 #[test]
 fn test_second_close_notify_after_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
     client.send_close_notify();
     assert!(transfer(&mut client, &mut server) > 0);
@@ -2059,7 +2065,7 @@ fn test_second_close_notify_after_handshake() {
 
 #[test]
 fn test_read_tls_artificial_eof_after_close_notify() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
     client.send_close_notify();
     assert!(transfer(&mut client, &mut server) > 0);

--- a/rustls/tests/io.rs
+++ b/rustls/tests/io.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
 
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::io::{self, BufRead, IoSlice, Read, Write};
 use std::sync::Arc;
@@ -1599,7 +1600,9 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
     let server_config = Arc::new(
         ServerConfig::builder_with_provider(
             CryptoProvider {
-                tls13_cipher_suites: vec![provider::cipher_suite::TLS13_AES_128_GCM_SHA256],
+                tls13_cipher_suites: Cow::Owned(vec![
+                    provider::cipher_suite::TLS13_AES_128_GCM_SHA256,
+                ]),
                 ..provider.clone()
             }
             .into(),

--- a/rustls/tests/io.rs
+++ b/rustls/tests/io.rs
@@ -1552,22 +1552,16 @@ fn test_acceptor() {
 fn test_acceptor_rejected_handshake() {
     use rustls::server::Acceptor;
 
-    let client_config = ClientConfig::builder_with_provider(
-        provider::DEFAULT_PROVIDER
-            .with_only_tls13()
-            .into(),
-    )
-    .finish(KeyType::Ed25519);
+    let client_config =
+        ClientConfig::builder_with_provider(provider::DEFAULT_TLS13_PROVIDER.into())
+            .finish(KeyType::Ed25519);
     let mut client = ClientConnection::new(client_config.into(), server_name("localhost")).unwrap();
     let mut buf = Vec::new();
     client.write_tls(&mut buf).unwrap();
 
-    let server_config = ServerConfig::builder_with_provider(
-        provider::DEFAULT_PROVIDER
-            .with_only_tls12()
-            .into(),
-    )
-    .finish(KeyType::Ed25519);
+    let server_config =
+        ServerConfig::builder_with_provider(provider::DEFAULT_TLS12_PROVIDER.into())
+            .finish(KeyType::Ed25519);
     let mut acceptor = Acceptor::default();
     acceptor
         .read_tls(&mut buf.as_slice())

--- a/rustls/tests/io.rs
+++ b/rustls/tests/io.rs
@@ -23,8 +23,7 @@ use rustls_test::{
     make_server_config_with_mandatory_client_auth, server_name, transfer, transfer_eof,
 };
 
-use super::provider;
-use crate::common::all_versions;
+use super::{ALL_VERSIONS, provider};
 
 #[test]
 fn buffered_client_data_sent() {
@@ -33,7 +32,7 @@ fn buffered_client_data_sent() {
         &provider::DEFAULT_PROVIDER,
     ));
 
-    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -55,7 +54,7 @@ fn buffered_server_data_sent() {
         &provider::DEFAULT_PROVIDER,
     ));
 
-    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -77,7 +76,7 @@ fn buffered_both_data_sent() {
         &provider::DEFAULT_PROVIDER,
     ));
 
-    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -1412,7 +1411,7 @@ fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
     // general exercising of msgs::fragmenter and msgs::deframer
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             // no hidden significance to these numbers
             for frag_size in [37, 61, 101, 257] {
                 println!("test kt={kt:?} version={version_provider:?} frag={frag_size:?}");
@@ -1709,7 +1708,7 @@ fn server_close_notify() {
     let kt = KeyType::Rsa2048;
     let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config_with_auth(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -1749,7 +1748,7 @@ fn client_close_notify() {
     let kt = KeyType::Rsa2048;
     let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config_with_auth(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -1789,7 +1788,7 @@ fn server_closes_uncleanly() {
     let kt = KeyType::Rsa2048;
     let server_config = Arc::new(make_server_config(kt, &provider));
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
@@ -1835,7 +1834,7 @@ fn client_closes_uncleanly() {
     let kt = KeyType::Rsa2048;
     let server_config = Arc::new(make_server_config(kt, &provider));
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);

--- a/rustls/tests/key_log_file_env.rs
+++ b/rustls/tests/key_log_file_env.rs
@@ -32,10 +32,9 @@ use rustls_test::{
     transfer,
 };
 
-use super::{provider, serialized};
+use super::{ALL_VERSIONS, provider, serialized};
 
 mod common;
-use common::all_versions;
 
 #[test]
 fn exercise_key_log_file_for_client() {
@@ -44,7 +43,7 @@ fn exercise_key_log_file_for_client() {
         let server_config = Arc::new(make_server_config(KeyType::Rsa2048, &provider));
         unsafe { env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt") };
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let mut client_config = make_client_config(KeyType::Rsa2048, &version_provider);
             client_config.key_log = Arc::new(rustls::KeyLogFile::new());
 
@@ -70,7 +69,7 @@ fn exercise_key_log_file_for_server() {
 
         let server_config = Arc::new(server_config);
 
-        for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);

--- a/rustls/tests/key_log_file_env.rs
+++ b/rustls/tests/key_log_file_env.rs
@@ -40,7 +40,7 @@ use common::all_versions;
 #[test]
 fn exercise_key_log_file_for_client() {
     serialized(|| {
-        let provider = provider::default_provider();
+        let provider = provider::DEFAULT_PROVIDER;
         let server_config = Arc::new(make_server_config(KeyType::Rsa2048, &provider));
         unsafe { env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt") };
 
@@ -63,15 +63,14 @@ fn exercise_key_log_file_for_client() {
 #[test]
 fn exercise_key_log_file_for_server() {
     serialized(|| {
-        let provider = provider::default_provider();
-        let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+        let mut server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
         unsafe { env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt") };
         server_config.key_log = Arc::new(rustls::KeyLogFile::new());
 
         let server_config = Arc::new(server_config);
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
             let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);

--- a/rustls/tests/kx.rs
+++ b/rustls/tests/kx.rs
@@ -52,14 +52,8 @@ fn test_client_config_keyshare_mismatch() {
 #[test]
 fn exercise_all_key_exchange_methods() {
     for (version, version_provider) in [
-        (
-            ProtocolVersion::TLSv1_3,
-            provider::DEFAULT_PROVIDER.with_only_tls13(),
-        ),
-        (
-            ProtocolVersion::TLSv1_2,
-            provider::DEFAULT_PROVIDER.with_only_tls12(),
-        ),
+        (ProtocolVersion::TLSv1_3, provider::DEFAULT_TLS13_PROVIDER),
+        (ProtocolVersion::TLSv1_2, provider::DEFAULT_TLS12_PROVIDER),
     ] {
         for kx_group in provider::ALL_KX_GROUPS {
             if !kx_group

--- a/rustls/tests/kx.rs
+++ b/rustls/tests/kx.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use rustls::client::Resumption;
@@ -371,7 +372,7 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
             ),
             ServerConfig::builder_with_provider(
                 CryptoProvider {
-                    kx_groups: vec![provider::kx_group::SECP384R1],
+                    kx_groups: Cow::Owned(vec![provider::kx_group::SECP384R1]),
                     ..version_provider
                 }
                 .into(),
@@ -398,7 +399,7 @@ fn hybrid_kx_component_share_offered_but_server_chooses_something_else() {
     let kt = KeyType::Rsa2048;
     let client_config = ClientConfig::builder_with_provider(
         CryptoProvider {
-            kx_groups: vec![&FakeHybrid, provider::kx_group::SECP384R1],
+            kx_groups: Cow::Owned(vec![&FakeHybrid, provider::kx_group::SECP384R1]),
             ..provider::default_provider()
         }
         .into(),

--- a/rustls/tests/kx.rs
+++ b/rustls/tests/kx.rs
@@ -23,7 +23,7 @@ use super::provider;
 
 #[test]
 fn test_client_config_keyshare() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let kx_groups = vec![provider::kx_group::SECP384R1];
     let client_config =
         make_client_config_with_kx_groups(KeyType::Rsa2048, kx_groups.clone(), &provider);
@@ -34,7 +34,7 @@ fn test_client_config_keyshare() {
 
 #[test]
 fn test_client_config_keyshare_mismatch() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let client_config = make_client_config_with_kx_groups(
         KeyType::Rsa2048,
         vec![provider::kx_group::SECP384R1],
@@ -54,11 +54,11 @@ fn exercise_all_key_exchange_methods() {
     for (version, version_provider) in [
         (
             ProtocolVersion::TLSv1_3,
-            provider::default_provider().with_only_tls13(),
+            provider::DEFAULT_PROVIDER.with_only_tls13(),
         ),
         (
             ProtocolVersion::TLSv1_2,
-            provider::default_provider().with_only_tls12(),
+            provider::DEFAULT_PROVIDER.with_only_tls12(),
         ),
     ] {
         for kx_group in provider::ALL_KX_GROUPS {
@@ -88,7 +88,7 @@ fn exercise_all_key_exchange_methods() {
 
 #[test]
 fn test_client_sends_helloretryrequest() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     // client sends a secp384r1 key share
     let mut client_config = make_client_config_with_kx_groups(
         KeyType::Rsa2048,
@@ -211,7 +211,7 @@ fn test_client_sends_helloretryrequest() {
 fn test_client_attempts_to_use_unsupported_kx_group() {
     // common to both client configs
     let shared_storage = Arc::new(ClientStorage::new());
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
 
     // first, client sends a secp-256 share and server agrees. secp-256 is inserted
     //   into kx group cache.
@@ -270,7 +270,7 @@ fn test_client_sends_share_for_less_preferred_group() {
 
     // common to both client configs
     let shared_storage = Arc::new(ClientStorage::new());
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
 
     // first, client sends a secp384r1 share and server agrees. secp384r1 is inserted
     //   into kx group cache.
@@ -332,7 +332,7 @@ fn test_client_sends_share_for_less_preferred_group() {
 
 #[test]
 fn test_server_rejects_clients_without_any_kx_groups() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     server
         .read_tls(
             &mut encoding::message_framing(
@@ -363,7 +363,7 @@ fn test_server_rejects_clients_without_any_kx_groups() {
 
 #[test]
 fn test_server_rejects_clients_without_any_kx_group_overlap() {
-    for version_provider in all_versions(&provider::default_provider()) {
+    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
         let (mut client, mut server) = make_pair_for_configs(
             make_client_config_with_kx_groups(
                 KeyType::Rsa2048,
@@ -400,12 +400,12 @@ fn hybrid_kx_component_share_offered_but_server_chooses_something_else() {
     let client_config = ClientConfig::builder_with_provider(
         CryptoProvider {
             kx_groups: Cow::Owned(vec![&FakeHybrid, provider::kx_group::SECP384R1]),
-            ..provider::default_provider()
+            ..provider::DEFAULT_PROVIDER
         }
         .into(),
     )
     .finish(kt);
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let server_config = make_server_config(kt, &provider);
 
     let (mut client_1, mut server) = make_pair_for_configs(client_config, server_config);

--- a/rustls/tests/kx.rs
+++ b/rustls/tests/kx.rs
@@ -18,8 +18,7 @@ use rustls_test::{
     make_pair_for_configs, make_server_config, make_server_config_with_kx_groups, transfer,
 };
 
-use super::common::all_versions;
-use super::provider;
+use super::{ALL_VERSIONS, provider};
 
 #[test]
 fn test_client_config_keyshare() {
@@ -357,7 +356,7 @@ fn test_server_rejects_clients_without_any_kx_groups() {
 
 #[test]
 fn test_server_rejects_clients_without_any_kx_group_overlap() {
-    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
+    for version_provider in ALL_VERSIONS {
         let (mut client, mut server) = make_pair_for_configs(
             make_client_config_with_kx_groups(
                 KeyType::Rsa2048,

--- a/rustls/tests/process_provider.rs
+++ b/rustls/tests/process_provider.rs
@@ -31,11 +31,11 @@ fn test_process_provider() {
 
 fn test_explicit_choice_required() {
     assert!(CryptoProvider::get_default().is_none());
-    provider::default_provider()
+    provider::DEFAULT_PROVIDER
         .install_default()
         .expect("cannot install");
     CryptoProvider::get_default().expect("provider missing");
-    provider::default_provider()
+    provider::DEFAULT_PROVIDER
         .install_default()
         .expect_err("install succeeded a second time");
     CryptoProvider::get_default().expect("provider missing");

--- a/rustls/tests/quic.rs
+++ b/rustls/tests/quic.rs
@@ -67,7 +67,7 @@ fn test_quic_handshake() {
     }
 
     let kt = KeyType::Rsa2048;
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     let mut client_config = make_client_config(kt, &provider);
     client_config.enable_early_data = true;
     let client_config = Arc::new(client_config);
@@ -273,7 +273,7 @@ fn test_quic_handshake() {
 fn test_quic_rejects_missing_alpn() {
     let client_params = &b"client params"[..];
     let server_params = &b"server params"[..];
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
 
     for &kt in KeyType::all_for_provider(&provider) {
         let client_config = make_client_config(kt, &provider);
@@ -310,7 +310,7 @@ fn test_quic_rejects_missing_alpn() {
 
 #[test]
 fn test_quic_no_tls13_error() {
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls12();
+    let provider = provider::DEFAULT_TLS12_PROVIDER;
     let mut client_config = make_client_config(KeyType::Ed25519, &provider);
     client_config.alpn_protocols = vec!["foo".into()];
     let client_config = Arc::new(client_config);
@@ -337,7 +337,7 @@ fn test_quic_no_tls13_error() {
 
 #[test]
 fn test_quic_invalid_early_data_size() {
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     let mut server_config = make_server_config(KeyType::Ed25519, &provider);
     server_config.alpn_protocols = vec!["foo".into()];
 
@@ -365,7 +365,7 @@ fn test_quic_invalid_early_data_size() {
 
 #[test]
 fn test_quic_server_no_params_received() {
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     let server_config = make_server_config(KeyType::EcdsaP256, &provider);
     let server_config = Arc::new(server_config);
 
@@ -384,7 +384,7 @@ fn test_quic_server_no_params_received() {
 
 #[test]
 fn test_quic_server_no_tls12() {
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     let mut server_config = make_server_config(KeyType::Ed25519, &provider);
     server_config.alpn_protocols = vec!["foo".into()];
     let server_config = Arc::new(server_config);
@@ -436,7 +436,7 @@ fn quic_transfer<L: SideData, R: SideData>(
 fn test_quic_resumption_data_basic() {
     let server_params = b"server params";
     let kt = KeyType::Rsa2048;
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
 
     let mut server_config = make_server_config(kt, &provider);
     server_config.alpn_protocols = vec!["foo".into()];
@@ -474,7 +474,7 @@ fn test_quic_resumption_data_0rtt() {
     let client_params = b"client params";
     let server_params = b"server params";
     let kt = KeyType::Rsa2048;
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
 
     let mut client_config = make_client_config(kt, &provider);
     client_config.alpn_protocols = vec!["foo".into()];
@@ -750,7 +750,7 @@ fn packet_key_api() {
 
 #[test]
 fn test_quic_exporter() {
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     for &kt in KeyType::all_for_provider(&provider) {
         let client_config = make_client_config(kt, &provider);
         let server_config = make_server_config(kt, &provider);
@@ -801,10 +801,7 @@ fn test_quic_exporter() {
 #[test]
 fn test_fragmented_append() {
     // Create a QUIC client connection.
-    let client_config = make_client_config(
-        KeyType::Rsa2048,
-        &provider::DEFAULT_PROVIDER.with_only_tls13(),
-    );
+    let client_config = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_TLS13_PROVIDER);
     let client_config = Arc::new(client_config);
     let mut client = quic::ClientConnection::new(
         client_config.clone(),

--- a/rustls/tests/quic.rs
+++ b/rustls/tests/quic.rs
@@ -67,7 +67,7 @@ fn test_quic_handshake() {
     }
 
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let mut client_config = make_client_config(kt, &provider);
     client_config.enable_early_data = true;
     let client_config = Arc::new(client_config);
@@ -273,7 +273,7 @@ fn test_quic_handshake() {
 fn test_quic_rejects_missing_alpn() {
     let client_params = &b"client params"[..];
     let server_params = &b"server params"[..];
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
 
     for &kt in KeyType::all_for_provider(&provider) {
         let client_config = make_client_config(kt, &provider);
@@ -310,7 +310,7 @@ fn test_quic_rejects_missing_alpn() {
 
 #[test]
 fn test_quic_no_tls13_error() {
-    let provider = provider::default_provider().with_only_tls12();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls12();
     let mut client_config = make_client_config(KeyType::Ed25519, &provider);
     client_config.alpn_protocols = vec!["foo".into()];
     let client_config = Arc::new(client_config);
@@ -337,7 +337,7 @@ fn test_quic_no_tls13_error() {
 
 #[test]
 fn test_quic_invalid_early_data_size() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let mut server_config = make_server_config(KeyType::Ed25519, &provider);
     server_config.alpn_protocols = vec!["foo".into()];
 
@@ -365,7 +365,7 @@ fn test_quic_invalid_early_data_size() {
 
 #[test]
 fn test_quic_server_no_params_received() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let server_config = make_server_config(KeyType::EcdsaP256, &provider);
     let server_config = Arc::new(server_config);
 
@@ -384,7 +384,7 @@ fn test_quic_server_no_params_received() {
 
 #[test]
 fn test_quic_server_no_tls12() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let mut server_config = make_server_config(KeyType::Ed25519, &provider);
     server_config.alpn_protocols = vec!["foo".into()];
     let server_config = Arc::new(server_config);
@@ -436,7 +436,7 @@ fn quic_transfer<L: SideData, R: SideData>(
 fn test_quic_resumption_data_basic() {
     let server_params = b"server params";
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
 
     let mut server_config = make_server_config(kt, &provider);
     server_config.alpn_protocols = vec!["foo".into()];
@@ -474,7 +474,7 @@ fn test_quic_resumption_data_0rtt() {
     let client_params = b"client params";
     let server_params = b"server params";
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
 
     let mut client_config = make_client_config(kt, &provider);
     client_config.alpn_protocols = vec!["foo".into()];
@@ -750,7 +750,7 @@ fn packet_key_api() {
 
 #[test]
 fn test_quic_exporter() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     for &kt in KeyType::all_for_provider(&provider) {
         let client_config = make_client_config(kt, &provider);
         let server_config = make_server_config(kt, &provider);
@@ -803,7 +803,7 @@ fn test_fragmented_append() {
     // Create a QUIC client connection.
     let client_config = make_client_config(
         KeyType::Rsa2048,
-        &provider::default_provider().with_only_tls13(),
+        &provider::DEFAULT_PROVIDER.with_only_tls13(),
     );
     let client_config = Arc::new(client_config);
     let mut client = quic::ClientConnection::new(

--- a/rustls/tests/raw_keys.rs
+++ b/rustls/tests/raw_keys.rs
@@ -13,7 +13,7 @@ use super::provider;
 
 #[test]
 fn successful_raw_key_connection_and_correct_peer_certificates() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let client_config = make_client_config_with_raw_key_support(*kt, &provider);
         let server_config = make_server_config_with_raw_key_support(*kt, &provider);
@@ -53,7 +53,7 @@ fn successful_raw_key_connection_and_correct_peer_certificates() {
 
 #[test]
 fn correct_certificate_type_extensions_from_client_hello() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let client_config = make_client_config_with_raw_key_support(*kt, &provider);
         let mut server_config = make_server_config_with_raw_key_support(*kt, &provider);
@@ -72,7 +72,7 @@ fn correct_certificate_type_extensions_from_client_hello() {
 
 #[test]
 fn only_client_supports_raw_keys() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let client_config_rpk = make_client_config_with_raw_key_support(*kt, &provider);
         let server_config = make_server_config(*kt, &provider);
@@ -98,7 +98,7 @@ fn only_client_supports_raw_keys() {
 
 #[test]
 fn only_server_supports_raw_keys() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let client_config = make_client_config(*kt, &provider.clone().with_only_tls13());
         let server_config_rpk = make_server_config_with_raw_key_support(*kt, &provider);

--- a/rustls/tests/raw_keys.rs
+++ b/rustls/tests/raw_keys.rs
@@ -98,9 +98,9 @@ fn only_client_supports_raw_keys() {
 
 #[test]
 fn only_server_supports_raw_keys() {
-    let provider = provider::DEFAULT_PROVIDER;
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let client_config = make_client_config(*kt, &provider.clone().with_only_tls13());
+        let client_config = make_client_config(*kt, &provider);
         let server_config_rpk = make_server_config_with_raw_key_support(*kt, &provider);
 
         let (mut client, mut server_rpk) = make_pair_for_configs(client_config, server_config_rpk);

--- a/rustls/tests/resolve.rs
+++ b/rustls/tests/resolve.rs
@@ -294,14 +294,8 @@ fn test_client_cert_resolve(
     expected_root_hint_subjects: Vec<Vec<u8>>,
 ) {
     for (version, version_provider) in [
-        (
-            ProtocolVersion::TLSv1_3,
-            &provider::DEFAULT_PROVIDER.with_only_tls13(),
-        ),
-        (
-            ProtocolVersion::TLSv1_2,
-            &provider::DEFAULT_PROVIDER.with_only_tls12(),
-        ),
+        (ProtocolVersion::TLSv1_3, &provider::DEFAULT_TLS13_PROVIDER),
+        (ProtocolVersion::TLSv1_2, &provider::DEFAULT_TLS12_PROVIDER),
     ] {
         println!("{version:?} {key_type:?}:");
 

--- a/rustls/tests/resolve.rs
+++ b/rustls/tests/resolve.rs
@@ -22,8 +22,8 @@ use rustls_test::{
     server_name, transfer, webpki_client_verifier_builder,
 };
 
-use super::{provider, provider_is_aws_lc_rs};
-use crate::common::{all_versions, provider_with_one_suite};
+use super::{ALL_VERSIONS, provider, provider_is_aws_lc_rs};
+use crate::common::provider_with_one_suite;
 
 #[test]
 fn server_cert_resolve_with_sni() {
@@ -204,7 +204,7 @@ fn client_with_sni_disabled_does_not_send_sni() {
         server_config.cert_resolver = Arc::new(ServerCheckNoSni {});
         let server_config = Arc::new(server_config);
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let mut client_config = make_client_config(*kt, &version_provider);
             client_config.enable_sni = false;
 
@@ -414,7 +414,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
     server_config.cert_resolver = Arc::new(resolver);
     let server_config = Arc::new(server_config);
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         let client_config = make_client_config(kt, &version_provider);
         let mut server = ServerConnection::new(server_config.clone()).unwrap();
         let mut client =

--- a/rustls/tests/resume.rs
+++ b/rustls/tests/resume.rs
@@ -18,8 +18,7 @@ use rustls_test::{
     make_pair_for_arc_configs, make_pair_for_configs, make_server_config, transfer,
 };
 
-use super::common::all_versions;
-use super::{COUNTS, CountingLogger, provider};
+use super::{ALL_VERSIONS, COUNTS, CountingLogger, provider};
 
 #[test]
 fn client_only_attempts_resumption_with_compatible_security() {
@@ -29,7 +28,7 @@ fn client_only_attempts_resumption_with_compatible_security() {
     CountingLogger::reset();
 
     let server_config = make_server_config(kt, &provider);
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         let base_client_config = make_client_config(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_configs(base_client_config.clone(), server_config.clone());

--- a/rustls/tests/resume.rs
+++ b/rustls/tests/resume.rs
@@ -94,14 +94,8 @@ fn resumption_combinations() {
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = make_server_config(*kt, &provider);
         for (version, version_provider) in [
-            (
-                ProtocolVersion::TLSv1_2,
-                provider::DEFAULT_PROVIDER.with_only_tls12(),
-            ),
-            (
-                ProtocolVersion::TLSv1_3,
-                provider::DEFAULT_PROVIDER.with_only_tls13(),
-            ),
+            (ProtocolVersion::TLSv1_2, provider::DEFAULT_TLS12_PROVIDER),
+            (ProtocolVersion::TLSv1_3, provider::DEFAULT_TLS13_PROVIDER),
         ] {
             let client_config = make_client_config(*kt, &version_provider);
             let (mut client, mut server) =
@@ -186,17 +180,12 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
     let client_config = Arc::new(client_config);
 
     let server_config_1 = Arc::new(
-        ServerConfig::builder_with_provider(
-            provider
-                .clone()
-                .with_only_tls13()
-                .into(),
-        )
-        .finish(KeyType::Ed25519),
+        ServerConfig::builder_with_provider(provider::DEFAULT_TLS13_PROVIDER.into())
+            .finish(KeyType::Ed25519),
     );
 
     let mut server_config_2 =
-        ServerConfig::builder_with_provider(provider.with_only_tls12().into())
+        ServerConfig::builder_with_provider(provider::DEFAULT_TLS12_PROVIDER.into())
             .finish(KeyType::Ed25519);
     server_config_2.session_storage = Arc::new(rustls::server::NoServerSessionStorage {});
 
@@ -298,7 +287,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
 #[test]
 fn tls13_stateful_resumption() {
     let kt = KeyType::Rsa2048;
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     let client_config = make_client_config(kt, &provider);
     let client_config = Arc::new(client_config);
 
@@ -373,7 +362,7 @@ fn tls13_stateful_resumption() {
 #[test]
 fn tls13_stateless_resumption() {
     let kt = KeyType::Rsa2048;
-    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     let client_config = make_client_config(kt, &provider);
     let client_config = Arc::new(client_config);
 

--- a/rustls/tests/resume.rs
+++ b/rustls/tests/resume.rs
@@ -23,7 +23,7 @@ use super::{COUNTS, CountingLogger, provider};
 
 #[test]
 fn client_only_attempts_resumption_with_compatible_security() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let kt = KeyType::Rsa2048;
     CountingLogger::install();
     CountingLogger::reset();
@@ -90,12 +90,18 @@ fn client_only_attempts_resumption_with_compatible_security() {
 
 #[test]
 fn resumption_combinations() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = make_server_config(*kt, &provider);
         for (version, version_provider) in [
-            (ProtocolVersion::TLSv1_2, provider.clone().with_only_tls12()),
-            (ProtocolVersion::TLSv1_3, provider.clone().with_only_tls13()),
+            (
+                ProtocolVersion::TLSv1_2,
+                provider::DEFAULT_PROVIDER.with_only_tls12(),
+            ),
+            (
+                ProtocolVersion::TLSv1_3,
+                provider::DEFAULT_PROVIDER.with_only_tls13(),
+            ),
         ] {
             let client_config = make_client_config(*kt, &version_provider);
             let (mut client, mut server) =
@@ -173,7 +179,7 @@ fn expected_kx_for_version(version: ProtocolVersion) -> NamedGroup {
 /// https://github.com/rustls/rustls/issues/797
 #[test]
 fn test_client_tls12_no_resume_after_server_downgrade() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut client_config = make_client_config(KeyType::Ed25519, &provider);
     let client_storage = Arc::new(ClientStorage::new());
     client_config.resumption = Resumption::store(client_storage.clone());
@@ -239,7 +245,7 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
 #[test]
 fn test_tls13_client_resumption_does_not_reuse_tickets() {
     let shared_storage = Arc::new(ClientStorage::new());
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
 
     let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
     client_config.resumption = Resumption::store(shared_storage.clone());
@@ -292,7 +298,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
 #[test]
 fn tls13_stateful_resumption() {
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let client_config = make_client_config(kt, &provider);
     let client_config = Arc::new(client_config);
 
@@ -367,7 +373,7 @@ fn tls13_stateful_resumption() {
 #[test]
 fn tls13_stateless_resumption() {
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let client_config = make_client_config(kt, &provider);
     let client_config = Arc::new(client_config);
 
@@ -441,13 +447,13 @@ fn tls13_stateless_resumption() {
 
 #[test]
 fn early_data_not_available() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::default_provider());
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     assert!(client.early_data().is_none());
 }
 
 fn early_data_configs() -> (Arc<ClientConfig>, Arc<ServerConfig>) {
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut client_config = make_client_config(kt, &provider);
     client_config.enable_early_data = true;
     client_config.resumption = Resumption::store(Arc::new(ClientStorage::new()));
@@ -539,7 +545,7 @@ fn early_data_is_available_on_resumption() {
 fn early_data_not_available_on_server_before_client_hello() {
     let mut server = ServerConnection::new(Arc::new(make_server_config(
         KeyType::Rsa2048,
-        &provider::default_provider(),
+        &provider::DEFAULT_PROVIDER,
     )))
     .unwrap();
     assert!(server.early_data().is_none());

--- a/rustls/tests/runners/macros.rs
+++ b/rustls/tests/runners/macros.rs
@@ -21,6 +21,11 @@ macro_rules! provider_ring {
         const fn provider_is_fips() -> bool {
             false
         }
+        #[allow(dead_code)]
+        const ALL_VERSIONS: [rustls::crypto::CryptoProvider; 2] = [
+            provider::DEFAULT_TLS12_PROVIDER,
+            provider::DEFAULT_TLS13_PROVIDER,
+        ];
     };
 }
 
@@ -41,5 +46,10 @@ macro_rules! provider_aws_lc_rs {
         const fn provider_is_fips() -> bool {
             cfg!(feature = "fips")
         }
+        #[allow(dead_code)]
+        const ALL_VERSIONS: [rustls::crypto::CryptoProvider; 2] = [
+            provider::DEFAULT_TLS12_PROVIDER,
+            provider::DEFAULT_TLS13_PROVIDER,
+        ];
     };
 }

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -27,8 +27,7 @@ use webpki::anchor_from_trusted_cert;
 use x509_parser::prelude::FromDer;
 use x509_parser::x509::X509Name;
 
-use super::common::all_versions;
-use super::provider;
+use super::{ALL_VERSIONS, provider};
 
 #[test]
 fn client_can_override_certificate_verification() {
@@ -38,7 +37,7 @@ fn client_can_override_certificate_verification() {
 
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let mut client_config = make_client_config(*kt, &version_provider);
             client_config
                 .dangerous()
@@ -61,7 +60,7 @@ fn client_can_override_certificate_verification_and_reject_certificate() {
 
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let mut client_config = make_client_config(*kt, &version_provider);
             client_config
                 .dangerous()
@@ -151,7 +150,7 @@ fn client_can_override_certificate_verification_and_offer_no_signature_schemes()
 
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let mut client_config = make_client_config(*kt, &version_provider);
             client_config
                 .dangerous()
@@ -179,7 +178,7 @@ fn test_pinned_ocsp_response_given_to_custom_server_cert_verifier() {
     let kt = KeyType::EcdsaP256;
     let provider = provider::DEFAULT_PROVIDER;
 
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         let server_config = ServerConfig::builder_with_provider(provider.clone().into())
             .with_no_client_auth()
             .with_single_cert_with_ocsp(kt.chain(), kt.key(), Arc::from(&ocsp_response[..]))
@@ -303,7 +302,7 @@ fn client_checks_server_certificate_with_given_ip_address() {
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = Arc::new(make_client_config(*kt, &version_provider));
 
             // positive ipv4 case
@@ -343,7 +342,7 @@ fn client_checks_server_certificate_with_given_name() {
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config(*kt, &version_provider);
             let mut client = ClientConnection::new(
                 Arc::new(client_config),
@@ -375,7 +374,7 @@ fn client_check_server_certificate_ee_revoked() {
             .with_crls(crls)
             .only_check_end_entity_revocation();
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config =
                 make_client_config_with_verifier(builder.clone(), &version_provider);
             let mut client =
@@ -416,7 +415,7 @@ fn client_check_server_certificate_ee_unknown_revocation() {
                 .only_check_end_entity_revocation()
                 .allow_unknown_revocation_status();
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_verifier(
                 forbid_unknown_verifier.clone(),
                 &version_provider,
@@ -469,7 +468,7 @@ fn client_check_server_certificate_intermediate_revoked() {
             .only_check_end_entity_revocation()
             .allow_unknown_revocation_status();
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_verifier(
                 full_chain_verifier_builder.clone(),
                 &version_provider,
@@ -522,7 +521,7 @@ fn client_check_server_certificate_ee_crl_expired() {
                 .with_crls(crls)
                 .only_check_end_entity_revocation();
 
-        for version_provider in all_versions(&provider) {
+        for version_provider in ALL_VERSIONS {
             let client_config = make_client_config_with_verifier(
                 enforce_expiration_builder.clone(),
                 &version_provider,

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -85,9 +85,9 @@ fn client_can_override_certificate_verification_and_reject_certificate() {
 
 #[test]
 fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
-    let provider = provider::DEFAULT_PROVIDER;
+    let provider = provider::DEFAULT_TLS12_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
-        let mut client_config = make_client_config(*kt, &provider.clone().with_only_tls12());
+        let mut client_config = make_client_config(*kt, &provider);
         let verifier = Arc::new(MockServerVerifier::rejects_tls12_signatures(
             Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
         ));
@@ -115,9 +115,9 @@ fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
 
 #[test]
 fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
-    let provider = provider::DEFAULT_PROVIDER;
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
-        let mut client_config = make_client_config(*kt, &provider.clone().with_only_tls13());
+        let mut client_config = make_client_config(*kt, &provider);
         let verifier = Arc::new(MockServerVerifier::rejects_tls13_signatures(
             Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
         ));

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -32,7 +32,7 @@ use super::provider;
 
 #[test]
 fn client_can_override_certificate_verification() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
         let verifier = Arc::new(MockServerVerifier::accepts_anything());
 
@@ -53,7 +53,7 @@ fn client_can_override_certificate_verification() {
 
 #[test]
 fn client_can_override_certificate_verification_and_reject_certificate() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
         let verifier = Arc::new(MockServerVerifier::rejects_certificate(
             Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
@@ -85,7 +85,7 @@ fn client_can_override_certificate_verification_and_reject_certificate() {
 
 #[test]
 fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
         let mut client_config = make_client_config(*kt, &provider.clone().with_only_tls12());
         let verifier = Arc::new(MockServerVerifier::rejects_tls12_signatures(
@@ -115,7 +115,7 @@ fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
 
 #[test]
 fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
         let mut client_config = make_client_config(*kt, &provider.clone().with_only_tls13());
         let verifier = Arc::new(MockServerVerifier::rejects_tls13_signatures(
@@ -145,7 +145,7 @@ fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
 
 #[test]
 fn client_can_override_certificate_verification_and_offer_no_signature_schemes() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider).iter() {
         let verifier = Arc::new(MockServerVerifier::offers_no_signature_schemes());
 
@@ -177,7 +177,7 @@ fn client_can_override_certificate_verification_and_offer_no_signature_schemes()
 fn test_pinned_ocsp_response_given_to_custom_server_cert_verifier() {
     let ocsp_response = b"hello-ocsp-world!";
     let kt = KeyType::EcdsaP256;
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
 
     for version_provider in all_versions(&provider) {
         let server_config = ServerConfig::builder_with_provider(provider.clone().into())
@@ -200,7 +200,7 @@ fn test_pinned_ocsp_response_given_to_custom_server_cert_verifier() {
 
 #[test]
 fn client_can_request_certain_trusted_cas() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     // These keys have CAs with different names, which our test needs.
     // They also share the same sigalgs, so the server won't pick one over the other based on sigalgs.
     let key_types = [KeyType::Rsa2048, KeyType::Rsa3072, KeyType::Rsa4096];
@@ -299,7 +299,7 @@ fn client_checks_server_certificate_with_given_ip_address() {
         do_handshake_until_error(&mut client, &mut server)
     }
 
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -339,7 +339,7 @@ fn client_checks_server_certificate_with_given_ip_address() {
 
 #[test]
 fn client_checks_server_certificate_with_given_name() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -365,7 +365,7 @@ fn client_checks_server_certificate_with_given_name() {
 
 #[test]
 fn client_check_server_certificate_ee_revoked() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -396,7 +396,7 @@ fn client_check_server_certificate_ee_revoked() {
 
 #[test]
 fn client_check_server_certificate_ee_unknown_revocation() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -449,7 +449,7 @@ fn client_check_server_certificate_ee_unknown_revocation() {
 
 #[test]
 fn client_check_server_certificate_intermediate_revoked() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -503,7 +503,7 @@ fn client_check_server_certificate_intermediate_revoked() {
 
 #[test]
 fn client_check_server_certificate_ee_crl_expired() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config(*kt, &provider));
 
@@ -560,7 +560,7 @@ fn client_check_server_certificate_ee_crl_expired() {
 /// so isn't used by the other existing verifier tests.
 #[test]
 fn client_check_server_certificate_helper_api() {
-    for kt in KeyType::all_for_provider(&provider::default_provider()) {
+    for kt in KeyType::all_for_provider(&provider::DEFAULT_PROVIDER) {
         let chain = kt.chain();
         let correct_roots = kt.client_root_store();
         let incorrect_roots = match kt {

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -21,8 +21,8 @@ use rustls_test::{
 };
 
 use super::provider::cipher_suite;
-use super::{provider, provider_is_aws_lc_rs, provider_is_fips};
-use crate::common::{all_versions, provider_with_one_suite};
+use super::{ALL_VERSIONS, provider, provider_is_aws_lc_rs, provider_is_fips};
+use crate::common::provider_with_one_suite;
 
 const MAX_ITERATIONS: usize = 100;
 
@@ -127,9 +127,8 @@ fn handshake_config(
 
 #[test]
 fn app_data_client_to_server() {
-    let provider = provider::DEFAULT_PROVIDER;
     let expected: &[_] = b"hello";
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
@@ -162,9 +161,8 @@ fn app_data_client_to_server() {
 
 #[test]
 fn app_data_server_to_client() {
-    let provider = provider::DEFAULT_PROVIDER;
     let expected: &[_] = b"hello";
-    for version_provider in all_versions(&provider) {
+    for version_provider in ALL_VERSIONS {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
@@ -435,7 +433,7 @@ fn run(
 
 #[test]
 fn close_notify_client_to_server() {
-    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
+    for version_provider in ALL_VERSIONS {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
@@ -459,7 +457,7 @@ fn close_notify_client_to_server() {
 
 #[test]
 fn close_notify_server_to_client() {
-    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
+    for version_provider in ALL_VERSIONS {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
@@ -483,7 +481,7 @@ fn close_notify_server_to_client() {
 
 #[test]
 fn full_closure_server_to_client() {
-    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
+    for version_provider in ALL_VERSIONS {
         eprintln!("{version_provider:?}");
         let mut outcome = handshake(version_provider);
         let mut client = outcome.client.take().unwrap();

--- a/rustls/tests/unbuffered.rs
+++ b/rustls/tests/unbuffered.rs
@@ -28,7 +28,7 @@ const MAX_ITERATIONS: usize = 100;
 
 #[test]
 fn tls12_handshake() {
-    let outcome = handshake(provider::default_provider().with_only_tls12());
+    let outcome = handshake(provider::DEFAULT_PROVIDER.with_only_tls12());
 
     assert_eq!(
         outcome.client_transcript, TLS12_CLIENT_TRANSCRIPT,
@@ -43,7 +43,7 @@ fn tls12_handshake() {
 #[test]
 fn tls12_handshake_fragmented() {
     let outcome = handshake_config(
-        provider::default_provider().with_only_tls12(),
+        provider::DEFAULT_PROVIDER.with_only_tls12(),
         |client, server| {
             client.max_fragment_size = Some(512);
             client.cert_decompressors = vec![];
@@ -65,7 +65,7 @@ fn tls12_handshake_fragmented() {
 
 #[test]
 fn tls13_handshake() {
-    let outcome = handshake(provider::default_provider().with_only_tls13());
+    let outcome = handshake(provider::DEFAULT_PROVIDER.with_only_tls13());
 
     assert_eq!(
         outcome.client_transcript, TLS13_CLIENT_TRANSCRIPT,
@@ -80,7 +80,7 @@ fn tls13_handshake() {
 #[test]
 fn tls13_handshake_fragmented() {
     let outcome = handshake_config(
-        provider::default_provider().with_only_tls13(),
+        provider::DEFAULT_PROVIDER.with_only_tls13(),
         |client, server| {
             client.max_fragment_size = Some(512);
             client.cert_decompressors = vec![];
@@ -133,7 +133,7 @@ fn handshake_config(
 
 #[test]
 fn app_data_client_to_server() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let expected: &[_] = b"hello";
     for version_provider in all_versions(&provider) {
         eprintln!("{version_provider:?}");
@@ -168,7 +168,7 @@ fn app_data_client_to_server() {
 
 #[test]
 fn app_data_server_to_client() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let expected: &[_] = b"hello";
     for version_provider in all_versions(&provider) {
         eprintln!("{version_provider:?}");
@@ -203,7 +203,7 @@ fn app_data_server_to_client() {
 
 #[test]
 fn early_data() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let expected: &[_] = b"hello";
 
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
@@ -441,7 +441,7 @@ fn run(
 
 #[test]
 fn close_notify_client_to_server() {
-    for version_provider in all_versions(&provider::default_provider()) {
+    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
@@ -465,7 +465,7 @@ fn close_notify_client_to_server() {
 
 #[test]
 fn close_notify_server_to_client() {
-    for version_provider in all_versions(&provider::default_provider()) {
+    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
@@ -489,7 +489,7 @@ fn close_notify_server_to_client() {
 
 #[test]
 fn full_closure_server_to_client() {
-    for version_provider in all_versions(&provider::default_provider()) {
+    for version_provider in all_versions(&provider::DEFAULT_PROVIDER) {
         eprintln!("{version_provider:?}");
         let mut outcome = handshake(version_provider);
         let mut client = outcome.client.take().unwrap();
@@ -550,7 +550,7 @@ fn junk_after_close_notify_received() {
     ];
 
     for junk in JUNK_DATA {
-        let mut outcome = handshake(provider::default_provider().with_only_tls13());
+        let mut outcome = handshake(provider::DEFAULT_PROVIDER.with_only_tls13());
         let mut client = outcome.client.take().unwrap();
         let mut server = outcome.server.take().unwrap();
 
@@ -589,7 +589,7 @@ fn junk_after_close_notify_received() {
 
 #[test]
 fn queue_close_notify_is_idempotent() {
-    let mut outcome = handshake(provider::default_provider().with_only_tls13());
+    let mut outcome = handshake(provider::DEFAULT_PROVIDER.with_only_tls13());
     let mut client = outcome.client.take().unwrap();
 
     let mut client_send_buf = [0u8; 128];
@@ -609,7 +609,7 @@ fn queue_close_notify_is_idempotent() {
 
 #[test]
 fn refresh_traffic_keys_on_tls12_connection() {
-    let mut outcome = handshake(provider::default_provider().with_only_tls12());
+    let mut outcome = handshake(provider::DEFAULT_PROVIDER.with_only_tls12());
     let mut client = outcome.client.take().unwrap();
 
     match client.process_tls_records(&mut []) {
@@ -631,7 +631,7 @@ fn refresh_traffic_keys_on_tls12_connection() {
 
 #[test]
 fn refresh_traffic_keys_manually() {
-    let mut outcome = handshake(provider::default_provider().with_only_tls13());
+    let mut outcome = handshake(provider::DEFAULT_PROVIDER.with_only_tls13());
     let mut client = outcome.client.take().unwrap();
     let mut server = outcome.server.take().unwrap();
 
@@ -752,11 +752,11 @@ fn refresh_traffic_keys_automatically() {
     const CONFIDENTIALITY_LIMIT_PLUS_ONE: usize = CONFIDENTIALITY_LIMIT + 1;
 
     let client_config = ClientConfig::builder_with_provider(
-        aes_128_gcm_with_1024_confidentiality_limit(provider::default_provider()),
+        aes_128_gcm_with_1024_confidentiality_limit(provider::DEFAULT_PROVIDER),
     )
     .finish(KeyType::Rsa2048);
 
-    let server_config = make_server_config(KeyType::Rsa2048, &provider::default_provider());
+    let server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let mut outcome = run(
         Arc::new(client_config),
         &mut NO_ACTIONS.clone(),
@@ -821,14 +821,14 @@ fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
     const CONFIDENTIALITY_LIMIT: usize = 1024;
     let provider = Arc::new(
         Arc::unwrap_or_clone(aes_128_gcm_with_1024_confidentiality_limit(dbg!(
-            provider::default_provider()
+            provider::DEFAULT_PROVIDER
         )))
         .with_only_tls12(),
     );
 
     let client_config = ClientConfig::builder_with_provider(provider).finish(KeyType::Ed25519);
 
-    let server_config = make_server_config(KeyType::Ed25519, &provider::default_provider());
+    let server_config = make_server_config(KeyType::Ed25519, &provider::DEFAULT_PROVIDER);
     let mut outcome = run(
         Arc::new(client_config),
         &mut NO_ACTIONS.clone(),
@@ -900,7 +900,7 @@ fn tls13_packed_handshake() {
 
     // regression test for https://github.com/rustls/rustls/issues/2040
     let client_config = ClientConfig::builder_with_provider(unsafe_plaintext_crypto_provider(
-        provider::default_provider(),
+        provider::DEFAULT_PROVIDER,
     ))
     .dangerous()
     .with_custom_certificate_verifier(Arc::new(MockServerVerifier::rejects_certificate(
@@ -931,7 +931,7 @@ fn tls13_packed_handshake() {
 fn rejects_junk() {
     let mut server = UnbufferedServerConnection::new(Arc::new(make_server_config(
         KeyType::Rsa2048,
-        &provider::default_provider(),
+        &provider::DEFAULT_PROVIDER,
     )))
     .unwrap();
 
@@ -962,7 +962,7 @@ fn rejects_junk() {
 
 #[test]
 fn read_traffic_not_consumed_too_early() {
-    let mut outcome = handshake(provider::default_provider().with_only_tls13());
+    let mut outcome = handshake(provider::DEFAULT_PROVIDER.with_only_tls13());
     let mut client = outcome.client.take().unwrap();
     let mut server = outcome.server.take().unwrap();
 
@@ -1458,7 +1458,7 @@ fn make_connection_pair(
 #[test]
 fn server_receives_handshake_byte_by_byte() {
     let (mut client, mut server) =
-        make_connection_pair(provider::default_provider().with_only_tls13());
+        make_connection_pair(provider::DEFAULT_PROVIDER.with_only_tls13());
 
     let mut client_hello_buffer = vec![0u8; 2048];
     let UnbufferedStatus { discard, state, .. } = client.process_tls_records(&mut []);
@@ -1492,7 +1492,7 @@ fn server_receives_handshake_byte_by_byte() {
 
 #[test]
 fn server_receives_incorrect_first_handshake_message() {
-    let (_, mut server) = make_connection_pair(provider::default_provider().with_only_tls13());
+    let (_, mut server) = make_connection_pair(provider::DEFAULT_PROVIDER.with_only_tls13());
 
     let mut junk_buffer = [0x16, 0x3, 0x1, 0x0, 0x4, 0xff, 0x0, 0x0, 0x0];
     let junk_buffer_len = junk_buffer.len();
@@ -1531,7 +1531,7 @@ fn test_secret_extraction_enabled() {
     // We support 3 different AEAD algorithms (AES-128-GCM mode, AES-256-GCM, and
     // Chacha20Poly1305), so that's 2*3 = 6 combinations to test.
     let kt = KeyType::Rsa2048;
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     for suite in [
         SupportedCipherSuite::Tls13(cipher_suite::TLS13_AES_128_GCM_SHA256),
         SupportedCipherSuite::Tls13(cipher_suite::TLS13_AES_256_GCM_SHA384),
@@ -1613,7 +1613,7 @@ fn test_secret_extraction_enabled() {
 
 #[test]
 fn kernel_err_on_secret_extraction_not_enabled() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
     let server_config = Arc::new(server_config);
 
@@ -1640,7 +1640,7 @@ fn kernel_err_on_secret_extraction_not_enabled() {
 
 #[test]
 fn kernel_err_on_handshake_not_complete() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.enable_secret_extraction = true;
     let server_config = Arc::new(server_config);
@@ -1665,7 +1665,7 @@ fn kernel_err_on_handshake_not_complete() {
 
 #[test]
 fn kernel_initial_traffic_secrets_match() {
-    let provider = provider::default_provider();
+    let provider = provider::DEFAULT_PROVIDER;
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.enable_secret_extraction = true;
     let server_config = Arc::new(server_config);
@@ -1693,7 +1693,7 @@ fn kernel_initial_traffic_secrets_match() {
 
 #[test]
 fn kernel_key_updates_tls13() {
-    let provider = provider::default_provider().with_only_tls13();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls13();
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.enable_secret_extraction = true;
     let server_config = Arc::new(server_config);
@@ -1729,7 +1729,7 @@ fn kernel_key_updates_tls13() {
 fn kernel_key_updates_tls12() {
     let _ = env_logger::try_init();
 
-    let provider = provider::default_provider().with_only_tls12();
+    let provider = provider::DEFAULT_PROVIDER.with_only_tls12();
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.enable_secret_extraction = true;
     let server_config = Arc::new(server_config);


### PR DESCRIPTION
This is an easier alternative #2652, using `Cow` 🐮 to generalise over borrowed/owned vectors of options. This was both easier to do, and the result is more flexible (because, eg, customising key exchange groups does not mandate allocating for the ciphersuites).