### PR TITLE
Allow trivial casts

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -11,7 +11,6 @@
     clippy::use_self,
     clippy::upper_case_acronyms,
     elided_lifetimes_in_paths,
-    trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
     unused_import_braces,

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -5,7 +5,6 @@
     clippy::use_self,
     clippy::upper_case_acronyms,
     elided_lifetimes_in_paths,
-    trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
     unused_import_braces,
@@ -313,13 +312,11 @@ fn all_benchmarks_params() -> Vec<BenchmarkParams> {
     for (provider, ticketer, provider_name) in [
         (
             derandomize(ring::default_provider()),
-            #[allow(trivial_casts)]
             &(ring_ticketer as fn() -> Arc<dyn rustls::server::ProducesTickets>),
             "ring",
         ),
         (
             derandomize(aws_lc_rs::default_provider()),
-            #[allow(trivial_casts)]
             &(aws_lc_rs_ticketer as fn() -> Arc<dyn rustls::server::ProducesTickets>),
             "aws_lc_rs",
         ),
@@ -378,7 +375,6 @@ fn all_benchmarks_params() -> Vec<BenchmarkParams> {
         }
     }
 
-    #[allow(trivial_casts)] // false positive
     let make_ticketer = &((|| Arc::new(rustls_fuzzing_provider::Ticketer))
         as fn() -> Arc<dyn rustls::server::ProducesTickets>);
 

--- a/openssl-tests/src/lib.rs
+++ b/openssl-tests/src/lib.rs
@@ -6,7 +6,6 @@
     clippy::use_self,
     clippy::upper_case_acronyms,
     elided_lifetimes_in_paths,
-    trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
     unused_import_braces,

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -6,7 +6,6 @@
     clippy::use_self,
     clippy::upper_case_acronyms,
     elided_lifetimes_in_paths,
-    trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
     unused_import_braces,

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -9,7 +9,6 @@
     clippy::use_self,
     clippy::upper_case_acronyms,
     elided_lifetimes_in_paths,
-    trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
     unused_import_braces,

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -5,7 +5,6 @@
     clippy::use_self,
     clippy::upper_case_acronyms,
     elided_lifetimes_in_paths,
-    trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
     unused_import_braces,

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -5,7 +5,6 @@
     clippy::use_self,
     clippy::upper_case_acronyms,
     elided_lifetimes_in_paths,
-    trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
     unused_import_braces,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -331,7 +331,6 @@
     clippy::upper_case_acronyms,
     elided_lifetimes_in_paths,
     missing_docs,
-    trivial_casts,
     trivial_numeric_casts,
     unnameable_types,
     unreachable_pub,


### PR DESCRIPTION
This is:

- Unknown to have triggered any true positives
- Has a number of false positives already ignored
- Triggers on trait object casts (`Box::new(..) as Box<dyn ..>`) for which there appears no better solution