### PR TITLE
Privitise `docsrs` cfg flag; fix nightly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
         # keep features in sync with Cargo.toml `[package.metadata.docs.rs]` section
         run: cargo doc --locked --features aws-lc-rs,brotli,custom-provider,hashbrown,log,ring,std,zlib --no-deps --package rustls
         env:
-          RUSTDOCFLAGS: -Dwarnings --cfg=docsrs --html-after-content tag.html
+          RUSTDOCFLAGS: -Dwarnings --cfg=rustls_docsrs --html-after-content tag.html
 
       - name: Generate other pages
         run: |

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -84,7 +84,7 @@ path = "tests/process_provider.rs"
 [package.metadata.docs.rs]
 # all non-default features except fips (cannot build on docs.rs environment)
 features = ["aws-lc-rs", "brotli", "custom-provider", "hashbrown", "log", "ring", "std", "zlib"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "rustls_docsrs"]
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
@@ -97,4 +97,8 @@ allowed_external_types = [
 enum_no_repr_variant_discriminant_changed = "warn"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(bench)", "cfg(coverage_nightly)"] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(bench)",
+  "cfg(coverage_nightly)",
+  "cfg(rustls_docsrs)",
+] }

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -795,8 +795,8 @@ impl From<Vec<u8>> for SharedSecret {
 ///     .unwrap();
 /// # }
 /// ```
-#[cfg(all(feature = "aws-lc-rs", any(feature = "fips", docsrs)))]
-#[cfg_attr(docsrs, doc(cfg(feature = "fips")))]
+#[cfg(all(feature = "aws-lc-rs", any(feature = "fips", rustls_docsrs)))]
+#[cfg_attr(rustls_docsrs, doc(cfg(feature = "fips")))]
 pub fn default_fips_provider() -> CryptoProvider {
     aws_lc_rs::default_provider()
 }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -356,7 +356,7 @@
     clippy::new_without_default
 )]
 // Enable documentation for all features on docs.rs
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(rustls_docsrs, feature(doc_cfg, doc_auto_cfg))]
 // Enable coverage() attr for nightly coverage builds, see
 // <https://github.com/rust-lang/rust/issues/84605>
 // (`coverage_nightly` is a cfg set by `cargo-llvm-cov`)

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -356,7 +356,7 @@
     clippy::new_without_default
 )]
 // Enable documentation for all features on docs.rs
-#![cfg_attr(rustls_docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(rustls_docsrs, feature(doc_cfg))]
 // Enable coverage() attr for nightly coverage builds, see
 // <https://github.com/rust-lang/rust/issues/84605>
 // (`coverage_nightly` is a cfg set by `cargo-llvm-cov`)


### PR DESCRIPTION
cfg is a global namespace, and we don't want to trigger this in dependencies.

Related to https://github.com/rust-lang/rust/pull/138907