### PR TITLE
Owned states

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -8,26 +8,15 @@ use crate::sign::CertifiedSigner;
 use crate::{SignatureScheme, compress};
 
 #[derive(Debug)]
-pub(super) struct ServerCertDetails<'a> {
-    pub(super) cert_chain: CertificateChain<'a>,
+pub(super) struct ServerCertDetails {
+    pub(super) cert_chain: CertificateChain<'static>,
     pub(super) ocsp_response: Vec<u8>,
 }
 
-impl<'a> ServerCertDetails<'a> {
-    pub(super) fn new(cert_chain: CertificateChain<'a>, ocsp_response: Vec<u8>) -> Self {
+impl ServerCertDetails {
+    pub(super) fn new(cert_chain: CertificateChain<'static>, ocsp_response: Vec<u8>) -> Self {
         Self {
             cert_chain,
-            ocsp_response,
-        }
-    }
-
-    pub(super) fn into_owned(self) -> ServerCertDetails<'static> {
-        let Self {
-            cert_chain,
-            ocsp_response,
-        } = self;
-        ServerCertDetails {
-            cert_chain: cert_chain.into_owned(),
             ocsp_response,
         }
     }

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -9,12 +9,12 @@ use crate::{SignatureScheme, compress};
 
 #[derive(Debug)]
 pub(super) struct ServerCertDetails {
-    pub(super) cert_chain: CertificateChain<'static>,
+    pub(super) cert_chain: CertificateChain,
     pub(super) ocsp_response: Vec<u8>,
 }
 
 impl ServerCertDetails {
-    pub(super) fn new(cert_chain: CertificateChain<'static>, ocsp_response: Vec<u8>) -> Self {
+    pub(super) fn new(cert_chain: CertificateChain, ocsp_response: Vec<u8>) -> Self {
         Self {
             cert_chain,
             ocsp_response,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -43,8 +43,8 @@ use crate::tls13::Tls13CipherSuite;
 use crate::tls13::key_schedule::KeyScheduleEarly;
 use crate::verify::ServerCertVerifier;
 
-pub(super) type NextState<'a> = Box<dyn State<ClientConnectionData> + 'a>;
-pub(super) type NextStateOrError<'a> = Result<NextState<'a>, Error>;
+pub(super) type NextState = Box<dyn State<ClientConnectionData>>;
+pub(super) type NextStateOrError = Result<NextState, Error>;
 pub(super) type ClientContext<'a> = crate::common_state::Context<'a, ClientConnectionData>;
 
 pub(crate) struct ExpectServerHello {
@@ -69,7 +69,7 @@ impl ExpectServerHello {
         server_hello: &ServerHelloPayload,
         message: &Message<'_>,
         cx: &mut ClientContext<'_>,
-    ) -> NextStateOrError<'static>
+    ) -> NextStateOrError
     where
         CryptoProvider: Borrow<[&'static T]>,
         SupportedCipherSuite: From<&'static T>,
@@ -155,14 +155,7 @@ impl ExpectServerHello {
 }
 
 impl State<ClientConnectionData> for ExpectServerHello {
-    fn handle<'m>(
-        self: Box<Self>,
-        cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> NextStateOrError {
         let server_hello =
             require_handshake_msg!(m, HandshakeType::ServerHello, HandshakePayload::ServerHello)?;
         trace!("We got ServerHello {server_hello:#?}");
@@ -212,10 +205,6 @@ impl State<ClientConnectionData> for ExpectServerHello {
             }
         }
     }
-
-    fn into_owned(self: Box<Self>) -> NextState<'static> {
-        self
-    }
 }
 
 struct ExpectServerHelloOrHelloRetryRequest {
@@ -224,7 +213,7 @@ struct ExpectServerHelloOrHelloRetryRequest {
 }
 
 impl ExpectServerHelloOrHelloRetryRequest {
-    fn into_expect_server_hello(self) -> NextState<'static> {
+    fn into_expect_server_hello(self) -> NextState {
         Box::new(self.next)
     }
 
@@ -232,7 +221,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         mut self,
         cx: &mut ClientContext<'_>,
         m: Message<'_>,
-    ) -> NextStateOrError<'static> {
+    ) -> NextStateOrError {
         let hrr = require_handshake_msg!(
             m,
             HandshakeType::HelloRetryRequest,
@@ -414,14 +403,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
 }
 
 impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
-    fn handle<'m>(
-        self: Box<Self>,
-        cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> NextStateOrError {
         match m.payload {
             MessagePayload::Handshake {
                 parsed: HandshakeMessagePayload(HandshakePayload::ServerHello(..)),
@@ -439,10 +421,6 @@ impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
                 &[HandshakeType::ServerHello, HandshakeType::HelloRetryRequest],
             )),
         }
-    }
-
-    fn into_owned(self: Box<Self>) -> NextState<'static> {
-        self
     }
 }
 
@@ -520,7 +498,7 @@ impl ClientHelloInput {
         self,
         extra_exts: ClientExtensionsInput<'static>,
         cx: &mut ClientContext<'_>,
-    ) -> NextStateOrError<'static> {
+    ) -> NextStateOrError {
         let mut transcript_buffer = HandshakeHashBuffer::new();
         if self
             .config
@@ -574,7 +552,7 @@ fn emit_client_hello_for_retry(
     mut input: ClientHelloInput,
     cx: &mut ClientContext<'_>,
     mut ech_state: Option<EchState>,
-) -> NextStateOrError<'static> {
+) -> NextStateOrError {
     let config = &input.config;
     // Defense in depth: the ECH state should be None if ECH is disabled based on config
     // builder semantics.
@@ -1116,5 +1094,5 @@ pub(crate) trait ClientHandler<T>: fmt::Debug + Sealed + Send + Sync {
         message: &Message<'_>,
         st: ExpectServerHello,
         cx: &mut ClientContext<'_>,
-    ) -> NextStateOrError<'static>;
+    ) -> NextStateOrError;
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -261,8 +261,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
             m,
             HandshakeType::Certificate,
             HandshakePayload::Certificate
-        )?
-        .into_owned();
+        )?;
 
         if self.may_send_cert_status {
             Ok(Box::new(ExpectCertificateStatusOrServerKx {
@@ -303,7 +302,7 @@ struct ExpectCertificateStatusOrServerKx {
     using_ems: bool,
     transcript: HandshakeHash,
     suite: &'static Tls12CipherSuite,
-    server_cert_chain: CertificateChain<'static>,
+    server_cert_chain: CertificateChain,
     must_issue_new_ticket: bool,
 }
 
@@ -363,7 +362,7 @@ struct ExpectCertificateStatus {
     using_ems: bool,
     transcript: HandshakeHash,
     suite: &'static Tls12CipherSuite,
-    server_cert_chain: CertificateChain<'static>,
+    server_cert_chain: CertificateChain,
     must_issue_new_ticket: bool,
 }
 
@@ -473,7 +472,7 @@ impl State<ClientConnectionData> for ExpectServerKx {
 
 fn emit_certificate(
     transcript: &mut HandshakeHash,
-    cert_chain: CertificateChain<'static>,
+    cert_chain: CertificateChain,
     common: &mut CommonState,
 ) {
     let cert = Message {

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -83,7 +83,7 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
         message: &Message<'_>,
         st: ExpectServerHello,
         cx: &mut ClientContext<'_>,
-    ) -> hs::NextStateOrError<'static> {
+    ) -> hs::NextStateOrError {
         // Start our handshake hash, and input the server-hello.
         let mut transcript = st
             .transcript_buffer
@@ -504,14 +504,11 @@ struct ExpectEncryptedExtensions {
 }
 
 impl State<ClientConnectionData> for ExpectEncryptedExtensions {
-    fn handle<'m>(
+    fn handle(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+        m: Message<'_>,
+    ) -> hs::NextStateOrError {
         let exts = require_handshake_msg!(
             m,
             HandshakeType::EncryptedExtensions,
@@ -651,10 +648,6 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
             }
         }
     }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
-    }
 }
 
 fn check_cert_type(
@@ -688,14 +681,7 @@ struct ExpectCertificateOrCompressedCertificateOrCertReq {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrCertReq {
-    fn handle<'m>(
-        self: Box<Self>,
-        cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::Handshake {
                 parsed: HandshakeMessagePayload(HandshakePayload::CertificateTls13(..)),
@@ -754,10 +740,6 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrC
             )),
         }
     }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
-    }
 }
 
 struct ExpectCertificateOrCompressedCertificate {
@@ -773,14 +755,7 @@ struct ExpectCertificateOrCompressedCertificate {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificate {
-    fn handle<'m>(
-        self: Box<Self>,
-        cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::Handshake {
                 parsed: HandshakeMessagePayload(HandshakePayload::CertificateTls13(..)),
@@ -823,10 +798,6 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificate {
             )),
         }
     }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
-    }
 }
 
 struct ExpectCertificateOrCertReq {
@@ -841,14 +812,7 @@ struct ExpectCertificateOrCertReq {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
-    fn handle<'m>(
-        self: Box<Self>,
-        cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::Handshake {
                 parsed: HandshakeMessagePayload(HandshakePayload::CertificateTls13(..)),
@@ -891,10 +855,6 @@ impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
             )),
         }
     }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
-    }
 }
 
 // TLS1.3 version of CertificateRequest handling.  We then move to expecting the server
@@ -913,14 +873,11 @@ struct ExpectCertificateRequest {
 }
 
 impl State<ClientConnectionData> for ExpectCertificateRequest {
-    fn handle<'m>(
+    fn handle(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+        m: Message<'_>,
+    ) -> hs::NextStateOrError {
         let certreq = &require_handshake_msg!(
             m,
             HandshakeType::CertificateRequest,
@@ -1010,10 +967,6 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
             })
         })
     }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
-    }
 }
 
 struct ExpectCompressedCertificate {
@@ -1029,14 +982,11 @@ struct ExpectCompressedCertificate {
 }
 
 impl State<ClientConnectionData> for ExpectCompressedCertificate {
-    fn handle<'m>(
+    fn handle(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+        m: Message<'_>,
+    ) -> hs::NextStateOrError {
         self.transcript.add_message(&m);
         let compressed_cert = require_handshake_msg_move!(
             m,
@@ -1115,10 +1065,6 @@ impl State<ClientConnectionData> for ExpectCompressedCertificate {
         })
         .handle(cx, m)
     }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
-    }
 }
 
 struct ExpectCertificate {
@@ -1135,14 +1081,11 @@ struct ExpectCertificate {
 }
 
 impl State<ClientConnectionData> for ExpectCertificate {
-    fn handle<'m>(
+    fn handle(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+        m: Message<'_>,
+    ) -> hs::NextStateOrError {
         if !self.message_already_in_transcript {
             self.transcript.add_message(&m);
         }
@@ -1181,35 +1124,28 @@ impl State<ClientConnectionData> for ExpectCertificate {
             expected_certificate_type: self.expected_certificate_type,
         }))
     }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
-    }
 }
 
 // --- TLS1.3 CertificateVerify ---
-struct ExpectCertificateVerify<'a> {
+struct ExpectCertificateVerify {
     config: Arc<ClientConfig>,
     server_name: ServerName<'static>,
     randoms: ConnectionRandoms,
     suite: &'static Tls13CipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
-    server_cert: ServerCertDetails<'a>,
+    server_cert: ServerCertDetails,
     client_auth: Option<ClientAuthDetails>,
     ech_retry_configs: Option<Vec<EchConfigPayload>>,
     expected_certificate_type: CertificateType,
 }
 
-impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
-    fn handle<'m>(
+impl State<ClientConnectionData> for ExpectCertificateVerify {
+    fn handle(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+        m: Message<'_>,
+    ) -> hs::NextStateOrError {
         let cert_verify = require_handshake_msg!(
             m,
             HandshakeType::CertificateVerify,
@@ -1275,21 +1211,6 @@ impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
             sig_verified,
             ech_retry_configs: self.ech_retry_configs,
         }))
-    }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        Box::new(ExpectCertificateVerify {
-            config: self.config,
-            server_name: self.server_name,
-            randoms: self.randoms,
-            suite: self.suite,
-            transcript: self.transcript,
-            key_schedule: self.key_schedule,
-            server_cert: self.server_cert.into_owned(),
-            client_auth: self.client_auth,
-            ech_retry_configs: self.ech_retry_configs,
-            expected_certificate_type: self.expected_certificate_type,
-        })
     }
 }
 
@@ -1386,14 +1307,7 @@ struct ExpectFinished {
 }
 
 impl State<ClientConnectionData> for ExpectFinished {
-    fn handle<'m>(
-        self: Box<Self>,
-        cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> hs::NextStateOrError {
         let mut st = *self;
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
@@ -1517,10 +1431,6 @@ impl State<ClientConnectionData> for ExpectFinished {
             false => Box::new(st),
         })
     }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
-    }
 }
 
 // -- Traffic transit state (TLS1.3) --
@@ -1630,14 +1540,11 @@ impl ExpectTraffic {
 }
 
 impl State<ClientConnectionData> for ExpectTraffic {
-    fn handle<'m>(
+    fn handle(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+        m: Message<'_>,
+    ) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx
                 .common
@@ -1676,10 +1583,6 @@ impl State<ClientConnectionData> for ExpectTraffic {
             self,
         ))
     }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
-    }
 }
 
 impl KernelState for ExpectTraffic {
@@ -1703,14 +1606,11 @@ impl KernelState for ExpectTraffic {
 struct ExpectQuicTraffic(ExpectTraffic);
 
 impl State<ClientConnectionData> for ExpectQuicTraffic {
-    fn handle<'m>(
+    fn handle(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
-        m: Message<'m>,
-    ) -> hs::NextStateOrError<'m>
-    where
-        Self: 'm,
-    {
+        m: Message<'_>,
+    ) -> hs::NextStateOrError {
         let nst = require_handshake_msg!(
             m,
             HandshakeType::NewSessionTicket,
@@ -1730,10 +1630,6 @@ impl State<ClientConnectionData> for ExpectQuicTraffic {
                 .extract_secrets(Side::Client)?,
             self,
         ))
-    }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
     }
 }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1104,12 +1104,8 @@ impl State<ClientConnectionData> for ExpectCertificate {
         }
 
         let end_entity_ocsp = cert_chain.end_entity_ocsp().to_vec();
-        let server_cert = ServerCertDetails::new(
-            cert_chain
-                .into_certificate_chain()
-                .into_owned(),
-            end_entity_ocsp,
-        );
+        let server_cert =
+            ServerCertDetails::new(cert_chain.into_certificate_chain(), end_entity_ocsp);
 
         Ok(Box::new(ExpectCertificateVerify {
             config: self.config,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -1195,15 +1195,8 @@ impl State<ServerConnectionData> for Accepting {
         self: Box<Self>,
         _cx: &mut hs::ServerContext<'_>,
         _m: Message<'m>,
-    ) -> Result<Box<dyn State<ServerConnectionData> + 'm>, Error>
-    where
-        Self: 'm,
-    {
+    ) -> Result<Box<dyn State<ServerConnectionData>>, Error> {
         Err(Error::Unreachable("unreachable state"))
-    }
-
-    fn into_owned(self: Box<Self>) -> hs::NextState<'static> {
-        self
     }
 }
 


### PR DESCRIPTION
Following up on https://github.com/rustls/rustls/pull/2676#pullrequestreview-3268000058:

> One thing we can look at in the future is when/how `CertificatePayloadTls13::into_owned` is called, and if it is perhaps keep an `Arc<[CertificateDer]>` in there instead.

Not quite there yet but these seem like improvements.