### PR TITLE
Update verifier trait and method names

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -45,7 +45,7 @@ use rustls::pki_types::{
     CertificateDer, EchConfigListBytes, PrivateKeyDer, ServerName, SubjectPublicKeyInfoDer,
 };
 use rustls::server::danger::{
-    ClientCertVerified, ClientCertVerifier, ClientIdentity, SignatureVerificationInput,
+    ClientIdentity, ClientVerified, ClientVerifier, SignatureVerificationInput,
 };
 use rustls::server::{
     ClientHello, ProducesTickets, ServerConfig, ServerConnection, WebPkiClientVerifier,
@@ -388,7 +388,7 @@ fn decode_hex(hex: &str) -> Vec<u8> {
 struct DummyClientAuth {
     mandatory: bool,
     root_hint_subjects: Arc<[DistinguishedName]>,
-    parent: Arc<dyn ClientCertVerifier>,
+    parent: Arc<dyn ClientVerifier>,
 }
 
 impl DummyClientAuth {
@@ -410,7 +410,7 @@ impl DummyClientAuth {
     }
 }
 
-impl ClientCertVerifier for DummyClientAuth {
+impl ClientVerifier for DummyClientAuth {
     fn offer_client_auth(&self) -> bool {
         true
     }
@@ -423,11 +423,8 @@ impl ClientCertVerifier for DummyClientAuth {
         self.root_hint_subjects.clone()
     }
 
-    fn verify_client_cert(
-        &self,
-        _identity: &ClientIdentity<'_>,
-    ) -> Result<ClientCertVerified, Error> {
-        Ok(ClientCertVerified::assertion())
+    fn verify_client_cert(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
+        Ok(ClientVerified::assertion())
     }
 
     fn verify_tls12_signature(

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -29,7 +29,7 @@ use nix::sys::signal::{self, Signal};
 #[cfg(unix)]
 use nix::unistd::Pid;
 use rustls::client::danger::{
-    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdentity,
+    HandshakeSignatureValid, ServerIdentity, ServerVerified, ServerVerifier,
 };
 use rustls::client::{
     ClientConfig, ClientConnection, EchConfig, EchGreaseConfig, EchMode, EchStatus, Resumption,
@@ -453,7 +453,7 @@ impl ClientCertVerifier for DummyClientAuth {
 
 #[derive(Debug)]
 struct DummyServerAuth {
-    parent: Arc<dyn ServerCertVerifier>,
+    parent: Arc<dyn ServerVerifier>,
     ocsp: OcspValidation,
 }
 
@@ -471,15 +471,12 @@ impl DummyServerAuth {
     }
 }
 
-impl ServerCertVerifier for DummyServerAuth {
-    fn verify_server_cert(
-        &self,
-        _identity: &ServerIdentity<'_>,
-    ) -> Result<ServerCertVerified, Error> {
+impl ServerVerifier for DummyServerAuth {
+    fn verify_server_cert(&self, _identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
         if let OcspValidation::Reject = self.ocsp {
             return Err(CertificateError::InvalidOcspResponse.into());
         }
-        Ok(ServerCertVerified::assertion())
+        Ok(ServerVerified::assertion())
     }
 
     fn verify_tls12_signature(

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -472,7 +472,7 @@ impl DummyServerAuth {
 }
 
 impl ServerVerifier for DummyServerAuth {
-    fn verify_server_cert(&self, _identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
+    fn verify_identity(&self, _identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
         if let OcspValidation::Reject = self.ocsp {
             return Err(CertificateError::InvalidOcspResponse.into());
         }

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -411,7 +411,7 @@ impl DummyClientAuth {
 }
 
 impl ClientVerifier for DummyClientAuth {
-    fn verify_client_cert(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
+    fn verify_identity(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
         Ok(ClientVerified::assertion())
     }
 

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -411,18 +411,6 @@ impl DummyClientAuth {
 }
 
 impl ClientVerifier for DummyClientAuth {
-    fn offer_client_auth(&self) -> bool {
-        true
-    }
-
-    fn client_auth_mandatory(&self) -> bool {
-        self.mandatory
-    }
-
-    fn root_hint_subjects(&self) -> Arc<[DistinguishedName]> {
-        self.root_hint_subjects.clone()
-    }
-
     fn verify_client_cert(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
         Ok(ClientVerified::assertion())
     }
@@ -441,6 +429,18 @@ impl ClientVerifier for DummyClientAuth {
     ) -> Result<HandshakeSignatureValid, Error> {
         self.parent
             .verify_tls13_signature(input)
+    }
+
+    fn root_hint_subjects(&self) -> Arc<[DistinguishedName]> {
+        self.root_hint_subjects.clone()
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        self.mandatory
+    }
+
+    fn offer_client_auth(&self) -> bool {
+        true
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -406,7 +406,7 @@ mod danger {
     }
 
     impl rustls::client::danger::ServerVerifier for NoCertificateVerification {
-        fn verify_server_cert(
+        fn verify_identity(
             &self,
             _identity: &ServerIdentity<'_>,
         ) -> Result<rustls::client::danger::ServerVerified, rustls::Error> {

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -405,12 +405,12 @@ mod danger {
         }
     }
 
-    impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+    impl rustls::client::danger::ServerVerifier for NoCertificateVerification {
         fn verify_server_cert(
             &self,
             _identity: &ServerIdentity<'_>,
-        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        ) -> Result<rustls::client::danger::ServerVerified, rustls::Error> {
+            Ok(rustls::client::danger::ServerVerified::assertion())
         }
 
         fn verify_tls12_signature(

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -244,10 +244,6 @@ mod server {
     }
 
     impl ClientVerifier for SimpleRpkClientVerifier {
-        fn root_hint_subjects(&self) -> Arc<[DistinguishedName]> {
-            Arc::from(Vec::new())
-        }
-
         fn verify_client_cert(
             &self,
             identity: &ClientIdentity<'_>,
@@ -274,6 +270,10 @@ mod server {
             input: &SignatureVerificationInput<'_>,
         ) -> Result<HandshakeSignatureValid, Error> {
             verify_tls13_signature(input, &self.supported_algs)
+        }
+
+        fn root_hint_subjects(&self) -> Arc<[DistinguishedName]> {
+            Arc::from(Vec::new())
         }
 
         fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -97,7 +97,7 @@ mod client {
     }
 
     impl ServerVerifier for SimpleRpkServerVerifier {
-        fn verify_server_cert(
+        fn verify_identity(
             &self,
             identity: &ServerIdentity<'_>,
         ) -> Result<ServerVerified, Error> {

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -244,10 +244,7 @@ mod server {
     }
 
     impl ClientVerifier for SimpleRpkClientVerifier {
-        fn verify_client_cert(
-            &self,
-            identity: &ClientIdentity<'_>,
-        ) -> Result<ClientVerified, Error> {
+        fn verify_identity(&self, identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
             let PeerIdentity::RawPublicKey(spki) = identity.identity else {
                 return Err(ApiMisuse::UnverifiableCertificateType.into());
             };

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use rustls::client::WebPkiServerVerifier;
-use rustls::client::danger::ServerCertVerifier;
+use rustls::client::danger::ServerVerifier;
 use rustls::crypto::cipher::{
     AeadKey, InboundOpaqueMessage, InboundPlainMessage, Iv, KeyBlockShape, MessageDecrypter,
     MessageEncrypter, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload,
@@ -49,7 +49,7 @@ pub fn provider() -> crypto::CryptoProvider {
     }
 }
 
-pub fn server_verifier() -> Arc<dyn ServerCertVerifier> {
+pub fn server_verifier() -> Arc<dyn ServerVerifier> {
     // we need one of these, but it doesn't matter what it is
     let mut root_store = RootCertStore::empty();
     root_store.add_parsable_certificates([CertificateDer::from(

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -1112,8 +1112,8 @@ pub struct MockServerVerifier {
 }
 
 impl ServerVerifier for MockServerVerifier {
-    fn verify_server_cert(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
-        println!("verify_server_cert({identity:?})");
+    fn verify_identity(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
+        println!("verify_identity({identity:?})");
         if let Some(expected_ocsp) = &self.expected_ocsp_response {
             assert_eq!(expected_ocsp, identity.ocsp_response);
         }

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -1272,7 +1272,7 @@ impl MockClientVerifier {
 }
 
 impl ClientVerifier for MockClientVerifier {
-    fn verify_client_cert(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
+    fn verify_identity(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
         (self.verified)()
     }
 

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -1272,14 +1272,6 @@ impl MockClientVerifier {
 }
 
 impl ClientVerifier for MockClientVerifier {
-    fn client_auth_mandatory(&self) -> bool {
-        self.mandatory
-    }
-
-    fn root_hint_subjects(&self) -> Arc<[DistinguishedName]> {
-        self.subjects.clone()
-    }
-
     fn verify_client_cert(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
         (self.verified)()
     }
@@ -1311,6 +1303,14 @@ impl ClientVerifier for MockClientVerifier {
             self.parent
                 .verify_tls13_signature(input)
         }
+    }
+
+    fn root_hint_subjects(&self) -> Arc<[DistinguishedName]> {
+        self.subjects.clone()
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        self.mandatory
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -101,7 +101,7 @@ pub(super) mod danger {
         /// Set a custom certificate verifier.
         pub fn with_custom_certificate_verifier(
             self,
-            verifier: Arc<dyn verify::ServerCertVerifier>,
+            verifier: Arc<dyn verify::ServerVerifier>,
         ) -> ConfigBuilder<ClientConfig, WantsClientCert> {
             ConfigBuilder {
                 state: WantsClientCert {
@@ -122,7 +122,7 @@ pub(super) mod danger {
 /// For more information, see the [`ConfigBuilder`] documentation.
 #[derive(Clone)]
 pub struct WantsClientCert {
-    verifier: Arc<dyn verify::ServerCertVerifier>,
+    verifier: Arc<dyn verify::ServerVerifier>,
     client_ech_mode: Option<EchMode>,
 }
 

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -244,7 +244,7 @@ pub struct ClientConfig {
     pub(crate) provider: Arc<CryptoProvider>,
 
     /// How to verify the server certificate chain.
-    pub(super) verifier: Arc<dyn verify::ServerCertVerifier>,
+    pub(super) verifier: Arc<dyn verify::ServerVerifier>,
 
     /// How to decompress the server's certificate chain.
     ///
@@ -476,7 +476,7 @@ pub enum Tls12Resumption {
 /// Container for unsafe APIs
 pub(super) mod danger {
     use super::ClientConfig;
-    use super::verify::ServerCertVerifier;
+    use super::verify::ServerVerifier;
     use crate::sync::Arc;
 
     /// Accessor for dangerous configuration options.
@@ -487,8 +487,8 @@ pub(super) mod danger {
     }
 
     impl DangerousClientConfig<'_> {
-        /// Overrides the default `ServerCertVerifier` with something else.
-        pub fn set_certificate_verifier(&mut self, verifier: Arc<dyn ServerCertVerifier>) {
+        /// Overrides the default `ServerVerifier` with something else.
+        pub fn set_certificate_verifier(&mut self, verifier: Arc<dyn ServerVerifier>) {
             self.cfg.verifier = verifier;
         }
     }

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -321,10 +321,7 @@ mod tests {
 
     impl ServerVerifier for DummyServerVerifier {
         #[cfg_attr(coverage_nightly, coverage(off))]
-        fn verify_identity(
-            &self,
-            _identity: &ServerIdentity<'_>,
-        ) -> Result<ServerVerified, Error> {
+        fn verify_identity(&self, _identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
             unreachable!()
         }
 

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -246,7 +246,7 @@ mod tests {
 
     use super::NoClientSessionStorage;
     use super::provider::cipher_suite;
-    use crate::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+    use crate::client::danger::{HandshakeSignatureValid, ServerVerified, ServerVerifier};
     use crate::client::{ClientSessionStore, ResolvesClientCert};
     use crate::msgs::base::PayloadU16;
     use crate::msgs::enums::NamedGroup;
@@ -264,7 +264,7 @@ mod tests {
         let c = NoClientSessionStorage {};
         let name = ServerName::try_from("example.com").unwrap();
         let now = UnixTime::now();
-        let server_cert_verifier: Arc<dyn ServerCertVerifier> = Arc::new(DummyServerCertVerifier);
+        let server_cert_verifier: Arc<dyn ServerVerifier> = Arc::new(DummyServerVerifier);
         let resolves_client_cert: Arc<dyn ResolvesClientCert> = Arc::new(DummyResolvesClientCert);
 
         c.set_kx_hint(name.clone(), NamedGroup::X25519);
@@ -317,14 +317,14 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct DummyServerCertVerifier;
+    struct DummyServerVerifier;
 
-    impl ServerCertVerifier for DummyServerCertVerifier {
+    impl ServerVerifier for DummyServerVerifier {
         #[cfg_attr(coverage_nightly, coverage(off))]
         fn verify_server_cert(
             &self,
             _identity: &ServerIdentity<'_>,
-        ) -> Result<ServerCertVerified, Error> {
+        ) -> Result<ServerVerified, Error> {
             unreachable!()
         }
 

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -321,7 +321,7 @@ mod tests {
 
     impl ServerVerifier for DummyServerVerifier {
         #[cfg_attr(coverage_nightly, coverage(off))]
-        fn verify_server_cert(
+        fn verify_identity(
             &self,
             _identity: &ServerIdentity<'_>,
         ) -> Result<ServerVerified, Error> {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -41,7 +41,7 @@ use crate::sync::Arc;
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
 use crate::tls13::key_schedule::KeyScheduleEarly;
-use crate::verify::ServerCertVerifier;
+use crate::verify::ServerVerifier;
 
 pub(super) type NextState<'a> = Box<dyn State<ClientConnectionData> + 'a>;
 pub(super) type NextStateOrError<'a> = Result<NextState<'a>, Error>;
@@ -1086,7 +1086,7 @@ impl ClientSessionValue {
 
     fn compatible_config(
         self,
-        server_cert_verifier: &Arc<dyn ServerCertVerifier>,
+        server_cert_verifier: &Arc<dyn ServerVerifier>,
         client_creds: &Arc<dyn ResolvesClientCert>,
     ) -> Option<Self> {
         match &self {

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -308,10 +308,7 @@ mod tests {
     }
 
     impl ServerVerifier for ExpectSha1EcdsaVerifier {
-        fn verify_identity(
-            &self,
-            _identity: &ServerIdentity<'_>,
-        ) -> Result<ServerVerified, Error> {
+        fn verify_identity(&self, _identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
             Ok(ServerVerified::assertion())
         }
 
@@ -502,10 +499,7 @@ mod tests {
         }
 
         #[cfg_attr(coverage_nightly, coverage(off))]
-        fn verify_identity(
-            &self,
-            _identity: &ServerIdentity<'_>,
-        ) -> Result<ServerVerified, Error> {
+        fn verify_identity(&self, _identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
             unreachable!()
         }
 
@@ -539,10 +533,7 @@ mod tests {
 
     impl ServerVerifier for ServerVerifierRequiringRpk {
         #[cfg_attr(coverage_nightly, coverage(off))]
-        fn verify_identity(
-            &self,
-            _identity: &ServerIdentity<'_>,
-        ) -> Result<ServerVerified, Error> {
+        fn verify_identity(&self, _identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
             todo!()
         }
 

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -308,7 +308,7 @@ mod tests {
     }
 
     impl ServerVerifier for ExpectSha1EcdsaVerifier {
-        fn verify_server_cert(
+        fn verify_identity(
             &self,
             _identity: &ServerIdentity<'_>,
         ) -> Result<ServerVerified, Error> {
@@ -502,7 +502,7 @@ mod tests {
         }
 
         #[cfg_attr(coverage_nightly, coverage(off))]
-        fn verify_server_cert(
+        fn verify_identity(
             &self,
             _identity: &ServerIdentity<'_>,
         ) -> Result<ServerVerified, Error> {
@@ -539,7 +539,7 @@ mod tests {
 
     impl ServerVerifier for ServerVerifierRequiringRpk {
         #[cfg_attr(coverage_nightly, coverage(off))]
-        fn verify_server_cert(
+        fn verify_identity(
             &self,
             _identity: &ServerIdentity<'_>,
         ) -> Result<ServerVerified, Error> {

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -41,7 +41,7 @@ mod tests {
     use crate::sign::CertifiedKey;
     use crate::tls13::key_schedule::{derive_traffic_iv, derive_traffic_key};
     use crate::verify::{
-        HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdentity,
+        HandshakeSignatureValid, ServerIdentity, ServerVerified, ServerVerifier,
         SignatureVerificationInput,
     };
     use crate::{DigitallySignedStruct, DistinguishedName, KeyLog};
@@ -307,12 +307,12 @@ mod tests {
         seen_sha1_signature: AtomicBool,
     }
 
-    impl ServerCertVerifier for ExpectSha1EcdsaVerifier {
+    impl ServerVerifier for ExpectSha1EcdsaVerifier {
         fn verify_server_cert(
             &self,
             _identity: &ServerIdentity<'_>,
-        ) -> Result<ServerCertVerified, Error> {
-            Ok(ServerCertVerified::assertion())
+        ) -> Result<ServerVerified, Error> {
+            Ok(ServerVerified::assertion())
         }
 
         fn verify_tls12_signature(
@@ -496,7 +496,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct ServerVerifierWithAuthorityNames(Arc<[DistinguishedName]>);
 
-    impl ServerCertVerifier for ServerVerifierWithAuthorityNames {
+    impl ServerVerifier for ServerVerifierWithAuthorityNames {
         fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>> {
             Some(self.0.clone())
         }
@@ -505,7 +505,7 @@ mod tests {
         fn verify_server_cert(
             &self,
             _identity: &ServerIdentity<'_>,
-        ) -> Result<ServerCertVerified, Error> {
+        ) -> Result<ServerVerified, Error> {
             unreachable!()
         }
 
@@ -537,12 +537,12 @@ mod tests {
     #[derive(Debug)]
     struct ServerVerifierRequiringRpk;
 
-    impl ServerCertVerifier for ServerVerifierRequiringRpk {
+    impl ServerVerifier for ServerVerifierRequiringRpk {
         #[cfg_attr(coverage_nightly, coverage(off))]
         fn verify_server_cert(
             &self,
             _identity: &ServerIdentity<'_>,
-        ) -> Result<ServerCertVerified, Error> {
+        ) -> Result<ServerVerified, Error> {
             todo!()
         }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -184,7 +184,7 @@ mod server_hello {
                     // proof of possession in the prior session.
                     cx.common.peer_identity = Some(resuming.peer_identity().clone());
                     cx.common.handshake_kind = Some(HandshakeKind::Resumed);
-                    let cert_verified = verify::ServerCertVerified::assertion();
+                    let cert_verified = verify::ServerVerified::assertion();
                     let sig_verified = verify::HandshakeSignatureValid::assertion();
 
                     return if must_issue_new_ticket {
@@ -1087,7 +1087,7 @@ struct ExpectNewTicket {
     using_ems: bool,
     transcript: HandshakeHash,
     resuming: bool,
-    cert_verified: verify::ServerCertVerified,
+    cert_verified: verify::ServerVerified,
     sig_verified: verify::HandshakeSignatureValid,
 }
 
@@ -1139,7 +1139,7 @@ struct ExpectCcs {
     transcript: HandshakeHash,
     ticket: Option<NewSessionTicketPayload>,
     resuming: bool,
-    cert_verified: verify::ServerCertVerified,
+    cert_verified: verify::ServerVerified,
     sig_verified: verify::HandshakeSignatureValid,
 }
 
@@ -1200,7 +1200,7 @@ struct ExpectFinished {
     ticket: Option<NewSessionTicketPayload>,
     secrets: ConnectionSecrets,
     resuming: bool,
-    cert_verified: verify::ServerCertVerified,
+    cert_verified: verify::ServerVerified,
     sig_verified: verify::HandshakeSignatureValid,
 }
 
@@ -1337,7 +1337,7 @@ impl State<ClientConnectionData> for ExpectFinished {
 struct ExpectTraffic {
     // only `Some` if `config.enable_secret_extraction` is true
     extracted_secrets: Option<Result<PartiallyExtractedSecrets, Error>>,
-    _cert_verified: verify::ServerCertVerified,
+    _cert_verified: verify::ServerVerified,
     _sig_verified: verify::HandshakeSignatureValid,
     _fin_verified: verify::FinishedMessageVerified,
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -893,7 +893,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
         let cert_verified = st
             .config
             .verifier
-            .verify_server_cert(&ServerIdentity {
+            .verify_identity(&ServerIdentity {
                 identity: &identity,
                 server_name: &st.server_name,
                 ocsp_response: &st.server_cert.ocsp_response,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -599,7 +599,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
 
                 // We *don't* reverify the certificate chain here: resumption is a
                 // continuation of the previous session in terms of security policy.
-                let cert_verified = verify::ServerCertVerified::assertion();
+                let cert_verified = verify::ServerVerified::assertion();
                 let sig_verified = verify::HandshakeSignatureValid::assertion();
                 Ok(Box::new(ExpectFinished {
                     config: self.config,
@@ -1380,7 +1380,7 @@ struct ExpectFinished {
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     client_auth: Option<ClientAuthDetails>,
-    cert_verified: verify::ServerCertVerified,
+    cert_verified: verify::ServerVerified,
     sig_verified: verify::HandshakeSignatureValid,
     ech_retry_configs: Option<Vec<EchConfigPayload>>,
 }
@@ -1533,7 +1533,7 @@ struct ExpectTraffic {
     suite: &'static Tls13CipherSuite,
     key_schedule: KeyScheduleTraffic,
     resumption: KeyScheduleResumption,
-    _cert_verified: verify::ServerCertVerified,
+    _cert_verified: verify::ServerVerified,
     _sig_verified: verify::HandshakeSignatureValid,
     _fin_verified: verify::FinishedMessageVerified,
 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1234,7 +1234,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
         let cert_verified = self
             .config
             .verifier
-            .verify_server_cert(&ServerIdentity {
+            .verify_identity(&ServerIdentity {
                 identity: &identity,
                 server_name: &self.server_name,
                 ocsp_response: &self.server_cert.ocsp_response,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -524,12 +524,12 @@ pub enum CertificateError {
 
     /// The OCSP response provided to the verifier was invalid.
     ///
-    /// This should be returned from [`ServerCertVerifier::verify_server_cert()`]
+    /// This should be returned from [`ServerVerifier::verify_server_cert()`]
     /// when a verifier checks its `ocsp_response` parameter and finds it invalid.
     ///
     /// This maps to [`AlertDescription::BadCertificateStatusResponse`].
     ///
-    /// [`ServerCertVerifier::verify_server_cert()`]: crate::client::danger::ServerCertVerifier::verify_server_cert
+    /// [`ServerVerifier::verify_server_cert()`]: crate::client::danger::ServerVerifier::verify_server_cert
     InvalidOcspResponse,
 
     /// The certificate is valid, but the handshake is rejected for other

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -524,12 +524,12 @@ pub enum CertificateError {
 
     /// The OCSP response provided to the verifier was invalid.
     ///
-    /// This should be returned from [`ServerVerifier::verify_server_cert()`]
+    /// This should be returned from [`ServerVerifier::verify_identity()`]
     /// when a verifier checks its `ocsp_response` parameter and finds it invalid.
     ///
     /// This maps to [`AlertDescription::BadCertificateStatusResponse`].
     ///
-    /// [`ServerVerifier::verify_server_cert()`]: crate::client::danger::ServerVerifier::verify_server_cert
+    /// [`ServerVerifier::verify_identity()`]: crate::client::danger::ServerVerifier::verify_identity
     InvalidOcspResponse,
 
     /// The certificate is valid, but the handshake is rejected for other

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -594,7 +594,7 @@ pub mod client {
     pub use crate::msgs::persist::{Tls12ClientSessionValue, Tls13ClientSessionValue};
     pub use crate::webpki::{
         ServerVerifierBuilder, VerifierBuilderError, WebPkiServerVerifier,
-        verify_server_cert_signed_by_trust_anchor, verify_server_name,
+        verify_identity_signed_by_trust_anchor, verify_server_name,
     };
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -582,7 +582,7 @@ pub mod client {
         pub use super::builder::danger::DangerousClientConfigBuilder;
         pub use super::client_conn::danger::DangerousClientConfig;
         pub use crate::verify::{
-            HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdentity,
+            HandshakeSignatureValid, ServerIdentity, ServerVerified, ServerVerifier,
             SignatureVerificationInput,
         };
     }
@@ -593,7 +593,7 @@ pub mod client {
 
     pub use crate::msgs::persist::{Tls12ClientSessionValue, Tls13ClientSessionValue};
     pub use crate::webpki::{
-        ServerCertVerifierBuilder, VerifierBuilderError, WebPkiServerVerifier,
+        ServerVerifierBuilder, VerifierBuilderError, WebPkiServerVerifier,
         verify_server_cert_signed_by_trust_anchor, verify_server_name,
     };
 }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -628,13 +628,13 @@ pub mod server {
 
     pub use crate::verify::NoClientAuth;
     pub use crate::webpki::{
-        ClientCertVerifierBuilder, ParsedCertificate, VerifierBuilderError, WebPkiClientVerifier,
+        ClientVerifierBuilder, ParsedCertificate, VerifierBuilderError, WebPkiClientVerifier,
     };
 
     /// Dangerous configuration that should be audited and used with extreme care.
     pub mod danger {
         pub use crate::verify::{
-            ClientCertVerified, ClientCertVerifier, ClientIdentity, SignatureVerificationInput,
+            ClientIdentity, ClientVerified, ClientVerifier, SignatureVerificationInput,
         };
     }
 

--- a/rustls/src/manual/implvulns.rs
+++ b/rustls/src/manual/implvulns.rs
@@ -53,7 +53,7 @@ states that look like:
 ```ignore
 struct ExpectTraffic {
    (...)
-    _cert_verified: verify::ServerCertVerified,
+    _cert_verified: verify::ServerVerified,
     _sig_verified: verify::HandshakeSignatureValid,
     _fin_verified: verify::FinishedMessageVerified,
 }

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -13,7 +13,7 @@ use crate::msgs::handshake::{ProtocolName, SessionId};
 use crate::sync::{Arc, Weak};
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
-use crate::verify::{PeerIdentity, ServerCertVerifier};
+use crate::verify::{PeerIdentity, ServerVerifier};
 
 pub(crate) struct Retrieved<T> {
     pub(crate) value: T,
@@ -82,7 +82,7 @@ impl Tls13ClientSessionValue {
         ticket: Arc<PayloadU16>,
         secret: &[u8],
         peer_identity: PeerIdentity,
-        server_cert_verifier: &Arc<dyn ServerCertVerifier>,
+        server_cert_verifier: &Arc<dyn ServerVerifier>,
         client_creds: &Arc<dyn ResolvesClientCert>,
         time_now: UnixTime,
         lifetime_secs: u32,
@@ -164,7 +164,7 @@ impl Tls12ClientSessionValue {
         ticket: Arc<PayloadU16>,
         master_secret: &[u8; 48],
         peer_identity: PeerIdentity,
-        server_cert_verifier: &Arc<dyn ServerCertVerifier>,
+        server_cert_verifier: &Arc<dyn ServerVerifier>,
         client_creds: &Arc<dyn ResolvesClientCert>,
         time_now: UnixTime,
         lifetime_secs: u32,
@@ -223,7 +223,7 @@ pub struct ClientSessionCommon {
     epoch: u64,
     lifetime_secs: u32,
     peer_identity: Arc<PeerIdentity>,
-    server_cert_verifier: Weak<dyn ServerCertVerifier>,
+    server_cert_verifier: Weak<dyn ServerVerifier>,
     client_creds: Weak<dyn ResolvesClientCert>,
 }
 
@@ -233,7 +233,7 @@ impl ClientSessionCommon {
         time_now: UnixTime,
         lifetime_secs: u32,
         peer_identity: PeerIdentity,
-        server_cert_verifier: &Arc<dyn ServerCertVerifier>,
+        server_cert_verifier: &Arc<dyn ServerVerifier>,
         client_creds: &Arc<dyn ResolvesClientCert>,
     ) -> Self {
         Self {
@@ -248,7 +248,7 @@ impl ClientSessionCommon {
 
     pub(crate) fn compatible_config(
         &self,
-        server_cert_verifier: &Arc<dyn ServerCertVerifier>,
+        server_cert_verifier: &Arc<dyn ServerVerifier>,
         client_creds: &Arc<dyn ResolvesClientCert>,
     ) -> bool {
         let same_verifier = Weak::ptr_eq(
@@ -260,7 +260,7 @@ impl ClientSessionCommon {
         match (same_verifier, same_creds) {
             (true, true) => true,
             (false, _) => {
-                crate::log::trace!("resumption not allowed between different ServerCertVerifiers");
+                crate::log::trace!("resumption not allowed between different ServerVerifiers");
                 false
             }
             (_, _) => {

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -9,14 +9,14 @@ use crate::builder::{ConfigBuilder, WantsVerifier};
 use crate::error::Error;
 use crate::sign::{CertifiedKey, SingleCertAndKey};
 use crate::sync::Arc;
-use crate::verify::{ClientCertVerifier, NoClientAuth};
+use crate::verify::{ClientVerifier, NoClientAuth};
 use crate::{NoKeyLog, compress};
 
 impl ConfigBuilder<ServerConfig, WantsVerifier> {
     /// Choose how to verify client certificates.
     pub fn with_client_cert_verifier(
         self,
-        client_cert_verifier: Arc<dyn ClientCertVerifier>,
+        client_cert_verifier: Arc<dyn ClientVerifier>,
     ) -> ConfigBuilder<ServerConfig, WantsServerCert> {
         ConfigBuilder {
             state: WantsServerCert {
@@ -40,7 +40,7 @@ impl ConfigBuilder<ServerConfig, WantsVerifier> {
 /// For more information, see the [`ConfigBuilder`] documentation.
 #[derive(Clone, Debug)]
 pub struct WantsServerCert {
-    verifier: Arc<dyn ClientCertVerifier>,
+    verifier: Arc<dyn ClientVerifier>,
 }
 
 impl ConfigBuilder<ServerConfig, WantsServerCert> {

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -295,7 +295,7 @@ impl<'a> ClientHello<'a> {
 /// Common configuration for a set of server sessions.
 ///
 /// Making one of these is cheap, though one of the inputs may be expensive: gathering trust roots
-/// from the operating system to add to the [`RootCertStore`] passed to a `ClientCertVerifier`
+/// from the operating system to add to the [`RootCertStore`] passed to a `ClientVerifier`
 /// builder may take on the order of a few hundred milliseconds.
 ///
 /// These must be created via the [`ServerConfig::builder()`] or [`ServerConfig::builder_with_provider()`]
@@ -388,7 +388,7 @@ pub struct ServerConfig {
     pub alpn_protocols: Vec<Vec<u8>>,
 
     /// How to verify client certificates.
-    pub(super) verifier: Arc<dyn verify::ClientCertVerifier>,
+    pub(super) verifier: Arc<dyn verify::ClientVerifier>,
 
     /// How to output key material for debugging.  The default
     /// does nothing.

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -499,7 +499,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
                 Some(identity) => {
                     self.config
                         .verifier
-                        .verify_client_cert(&ClientIdentity {
+                        .verify_identity(&ClientIdentity {
                             identity: &identity,
                             now: self.config.current_time()?,
                         })

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1100,7 +1100,7 @@ impl State<ServerConnectionData> for ExpectCertificate {
 
         self.config
             .verifier
-            .verify_client_cert(&ClientIdentity {
+            .verify_identity(&ClientIdentity {
                 identity: &peer_identity,
                 now: self.config.current_time()?,
             })

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -33,7 +33,7 @@ pub trait ServerVerifier: Debug + Send + Sync {
     ///
     /// [Certificate]: https://datatracker.ietf.org/doc/html/rfc8446#section-4.4.2
     /// [`CertificateError::BadEncoding`]: crate::error::CertificateError::BadEncoding
-    fn verify_server_cert(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error>;
+    fn verify_identity(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error>;
 
     /// Verify a signature allegedly by the given server certificate.
     ///

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -119,7 +119,7 @@ pub struct ServerIdentity<'a> {
 
 /// Something that can verify a client certificate chain
 #[allow(unreachable_pub)]
-pub trait ClientCertVerifier: Debug + Send + Sync {
+pub trait ClientVerifier: Debug + Send + Sync {
     /// Returns `true` to enable the server to request a client certificate and
     /// `false` to skip requesting a client certificate. Defaults to `true`.
     fn offer_client_auth(&self) -> bool {
@@ -139,7 +139,7 @@ pub trait ClientCertVerifier: Debug + Send + Sync {
     /// These hint values help the client pick a client certificate it believes the server will
     /// accept. The hints must be DER-encoded X.500 distinguished names, per [RFC 5280 A.1]. They
     /// are sent in the [`certificate_authorities`] extension of a [`CertificateRequest`] message
-    /// when [ClientCertVerifier::offer_client_auth] is true. When an empty list is sent the client
+    /// when [ClientVerifier::offer_client_auth] is true. When an empty list is sent the client
     /// should always provide a client certificate if it has one.
     ///
     /// Generally this list should contain the [`DistinguishedName`] of each root trust
@@ -172,10 +172,7 @@ pub trait ClientCertVerifier: Debug + Send + Sync {
     ///
     /// [InvalidCertificate]: Error#variant.InvalidCertificate
     /// [BadEncoding]: crate::CertificateError#variant.BadEncoding
-    fn verify_client_cert(
-        &self,
-        identity: &ClientIdentity<'_>,
-    ) -> Result<ClientCertVerified, Error>;
+    fn verify_client_cert(&self, identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error>;
 
     /// Verify a signature allegedly by the given client certificate.
     ///
@@ -366,13 +363,13 @@ pub enum SignerPublicKey<'a> {
 ///
 /// In contrast to using
 /// `WebPkiClientVerifier::builder(roots).allow_unauthenticated().build()`, the `NoClientAuth`
-/// `ClientCertVerifier` will not offer client authentication at all, vs offering but not
+/// `ClientVerifier` will not offer client authentication at all, vs offering but not
 /// requiring it.
 #[allow(clippy::exhaustive_structs)]
 #[derive(Debug)]
 pub struct NoClientAuth;
 
-impl ClientCertVerifier for NoClientAuth {
+impl ClientVerifier for NoClientAuth {
     fn offer_client_auth(&self) -> bool {
         false
     }
@@ -381,10 +378,7 @@ impl ClientCertVerifier for NoClientAuth {
         unimplemented!();
     }
 
-    fn verify_client_cert(
-        &self,
-        _identity: &ClientIdentity<'_>,
-    ) -> Result<ClientCertVerified, Error> {
+    fn verify_client_cert(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
         unimplemented!();
     }
 
@@ -478,10 +472,10 @@ impl ServerVerified {
 
 /// Zero-sized marker type representing verification of a client cert chain.
 #[derive(Debug)]
-pub struct ClientCertVerified(());
+pub struct ClientVerified(());
 
-impl ClientCertVerified {
-    /// Make a `ClientCertVerified`
+impl ClientVerified {
+    /// Make a `ClientVerified`
     pub fn assertion() -> Self {
         Self(())
     }
@@ -492,8 +486,8 @@ fn assertions_are_debug() {
     use std::format;
 
     assert_eq!(
-        format!("{:?}", ClientCertVerified::assertion()),
-        "ClientCertVerified(())"
+        format!("{:?}", ClientVerified::assertion()),
+        "ClientVerified(())"
     );
     assert_eq!(
         format!("{:?}", HandshakeSignatureValid::assertion()),

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -128,7 +128,7 @@ pub trait ClientVerifier: Debug + Send + Sync {
     ///
     /// [InvalidCertificate]: Error#variant.InvalidCertificate
     /// [BadEncoding]: crate::CertificateError#variant.BadEncoding
-    fn verify_client_cert(&self, identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error>;
+    fn verify_identity(&self, identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error>;
 
     /// Verify a signature allegedly by the given client certificate.
     ///
@@ -370,7 +370,7 @@ pub enum SignerPublicKey<'a> {
 pub struct NoClientAuth;
 
 impl ClientVerifier for NoClientAuth {
-    fn verify_client_cert(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
+    fn verify_identity(&self, _identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
         unimplemented!();
     }
 

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -24,7 +24,7 @@ use crate::sync::Arc;
 /// Something that can verify a server certificate chain, and verify
 /// signatures made by certificates.
 #[allow(unreachable_pub)]
-pub trait ServerCertVerifier: Debug + Send + Sync {
+pub trait ServerVerifier: Debug + Send + Sync {
     /// Verify the server's identity.
     ///
     /// Note that none of the certificates have been parsed yet, so it is the responsibility of
@@ -33,10 +33,7 @@ pub trait ServerCertVerifier: Debug + Send + Sync {
     ///
     /// [Certificate]: https://datatracker.ietf.org/doc/html/rfc8446#section-4.4.2
     /// [`CertificateError::BadEncoding`]: crate::error::CertificateError::BadEncoding
-    fn verify_server_cert(
-        &self,
-        identity: &ServerIdentity<'_>,
-    ) -> Result<ServerCertVerified, Error>;
+    fn verify_server_cert(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error>;
 
     /// Verify a signature allegedly by the given server certificate.
     ///
@@ -469,11 +466,11 @@ impl FinishedMessageVerified {
 /// Zero-sized marker type representing verification of a server cert chain.
 #[allow(unreachable_pub)]
 #[derive(Debug)]
-pub struct ServerCertVerified(());
+pub struct ServerVerified(());
 
 #[allow(unreachable_pub)]
-impl ServerCertVerified {
-    /// Make a `ServerCertVerified`
+impl ServerVerified {
+    /// Make a `ServerVerified`
     pub fn assertion() -> Self {
         Self(())
     }
@@ -507,7 +504,7 @@ fn assertions_are_debug() {
         "FinishedMessageVerified(())"
     );
     assert_eq!(
-        format!("{:?}", ServerCertVerified::assertion()),
-        "ServerCertVerified(())"
+        format!("{:?}", ServerVerified::assertion()),
+        "ServerVerified(())"
     );
 }

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -231,7 +231,7 @@ impl Context {
         const OCSP_RESPONSE: &[u8] = &[];
 
         self.verifier
-            .verify_server_cert(&ServerIdentity {
+            .verify_identity(&ServerIdentity {
                 identity: &PeerIdentity::X509(CertificateIdentity {
                     end_entity: self.chain[0].clone(),
                     intermediates: self.chain[1..].to_vec(),

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -26,7 +26,7 @@ use pki_types::{CertificateDer, ServerName, UnixTime};
 use webpki_roots;
 
 use crate::crypto::CryptoProvider;
-use crate::verify::{CertificateIdentity, PeerIdentity, ServerCertVerifier, ServerIdentity};
+use crate::verify::{CertificateIdentity, PeerIdentity, ServerIdentity, ServerVerifier};
 use crate::webpki::{RootCertStore, WebPkiServerVerifier};
 
 #[macro_rules_attribute::apply(bench_for_each_provider)]

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -342,21 +342,6 @@ impl WebPkiClientVerifier {
 }
 
 impl ClientVerifier for WebPkiClientVerifier {
-    fn offer_client_auth(&self) -> bool {
-        true
-    }
-
-    fn client_auth_mandatory(&self) -> bool {
-        match self.anonymous_policy {
-            AnonymousClientPolicy::Allow => false,
-            AnonymousClientPolicy::Deny => true,
-        }
-    }
-
-    fn root_hint_subjects(&self) -> Arc<[DistinguishedName]> {
-        self.root_hint_subjects.clone()
-    }
-
     fn verify_client_cert(&self, identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
         let certificates = match identity.identity {
             PeerIdentity::X509(certificates) => certificates,
@@ -408,6 +393,21 @@ impl ClientVerifier for WebPkiClientVerifier {
         input: &SignatureVerificationInput<'_>,
     ) -> Result<HandshakeSignatureValid, Error> {
         verify_tls13_signature(input, &self.supported_algs)
+    }
+
+    fn root_hint_subjects(&self) -> Arc<[DistinguishedName]> {
+        self.root_hint_subjects.clone()
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        match self.anonymous_policy {
+            AnonymousClientPolicy::Allow => false,
+            AnonymousClientPolicy::Deny => true,
+        }
+    }
+
+    fn offer_client_auth(&self) -> bool {
+        true
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -342,7 +342,7 @@ impl WebPkiClientVerifier {
 }
 
 impl ClientVerifier for WebPkiClientVerifier {
-    fn verify_client_cert(&self, identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
+    fn verify_identity(&self, identity: &ClientIdentity<'_>) -> Result<ClientVerified, Error> {
         let certificates = match identity.identity {
             PeerIdentity::X509(certificates) => certificates,
             PeerIdentity::RawPublicKey(_) => {

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -17,7 +17,7 @@ mod verify;
 
 pub use anchors::RootCertStore;
 pub use client_verifier::{ClientCertVerifierBuilder, WebPkiClientVerifier};
-pub use server_verifier::{ServerCertVerifierBuilder, WebPkiServerVerifier};
+pub use server_verifier::{ServerVerifierBuilder, WebPkiServerVerifier};
 // Conditionally exported from crate.
 #[allow(unreachable_pub)]
 pub use verify::{

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -20,9 +20,7 @@ pub use client_verifier::{ClientCertVerifierBuilder, WebPkiClientVerifier};
 pub use server_verifier::{ServerVerifierBuilder, WebPkiServerVerifier};
 // Conditionally exported from crate.
 #[allow(unreachable_pub)]
-pub use verify::{
-    ParsedCertificate, verify_server_cert_signed_by_trust_anchor, verify_server_name,
-};
+pub use verify::{ParsedCertificate, verify_identity_signed_by_trust_anchor, verify_server_name};
 pub use verify::{WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature};
 
 /// An error that can occur when building a certificate verifier.

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -16,7 +16,7 @@ mod server_verifier;
 mod verify;
 
 pub use anchors::RootCertStore;
-pub use client_verifier::{ClientCertVerifierBuilder, WebPkiClientVerifier};
+pub use client_verifier::{ClientVerifierBuilder, WebPkiClientVerifier};
 pub use server_verifier::{ServerVerifierBuilder, WebPkiServerVerifier};
 // Conditionally exported from crate.
 #[allow(unreachable_pub)]

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -10,7 +10,7 @@ use crate::verify::{
     SignatureVerificationInput,
 };
 use crate::webpki::verify::{
-    ParsedCertificate, verify_server_cert_signed_by_trust_anchor_impl, verify_tls12_signature,
+    ParsedCertificate, verify_identity_signed_by_trust_anchor_impl, verify_tls12_signature,
     verify_tls13_signature,
 };
 use crate::webpki::{VerifierBuilderError, parse_crls, verify_server_name};
@@ -229,7 +229,7 @@ impl ServerVerifier for WebPkiServerVerifier {
     /// each certificate in the chain to a root CA (excluding the root itself), or only the
     /// end entity certificate. Similarly, unknown revocation status may be treated as an error
     /// or allowed based on configuration.
-    fn verify_server_cert(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
+    fn verify_identity(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
         let certificates = match identity.identity {
             PeerIdentity::X509(certificates) => certificates,
             PeerIdentity::RawPublicKey(_) => {
@@ -258,7 +258,7 @@ impl ServerVerifier for WebPkiServerVerifier {
 
         // Note: we use the crate-internal `_impl` fn here in order to provide revocation
         // checking information, if applicable.
-        verify_server_cert_signed_by_trust_anchor_impl(
+        verify_identity_signed_by_trust_anchor_impl(
             &cert,
             &self.roots,
             &certificates.intermediates,

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -24,14 +24,14 @@ use crate::verify::{HandshakeSignatureValid, SignatureVerificationInput, SignerP
 /// were sent as part of the server's `Certificate` message. It is in the
 /// same order that the server sent them and may be empty.
 #[allow(dead_code)]
-pub fn verify_server_cert_signed_by_trust_anchor(
+pub fn verify_identity_signed_by_trust_anchor(
     cert: &ParsedCertificate<'_>,
     roots: &RootCertStore,
     intermediates: &[CertificateDer<'_>],
     now: UnixTime,
     supported_algs: &[&dyn SignatureVerificationAlgorithm],
 ) -> Result<(), Error> {
-    verify_server_cert_signed_by_trust_anchor_impl(
+    verify_identity_signed_by_trust_anchor_impl(
         cert,
         roots,
         intermediates,
@@ -44,7 +44,7 @@ pub fn verify_server_cert_signed_by_trust_anchor(
 /// Verify that the `end_entity` has an alternative name matching the `server_name`.
 ///
 /// Note: this only verifies the name and should be used in conjunction with more verification
-/// like [verify_server_cert_signed_by_trust_anchor]
+/// like [verify_identity_signed_by_trust_anchor]
 pub fn verify_server_name(
     cert: &ParsedCertificate<'_>,
     server_name: &ServerName<'_>,
@@ -226,11 +226,11 @@ pub fn verify_tls13_signature(
 ///
 /// `revocation` controls how revocation checking is performed, if at all.
 ///
-/// This function exists to be used by [`verify_server_cert_signed_by_trust_anchor`],
+/// This function exists to be used by [`verify_identity_signed_by_trust_anchor`],
 /// and differs only in providing a `Option<webpki::RevocationOptions>` argument. We
-/// can't include this argument in `verify_server_cert_signed_by_trust_anchor` because
+/// can't include this argument in `verify_identity_signed_by_trust_anchor` because
 /// it will leak the webpki types into Rustls' public API.
-pub(crate) fn verify_server_cert_signed_by_trust_anchor_impl(
+pub(crate) fn verify_identity_signed_by_trust_anchor_impl(
     cert: &ParsedCertificate<'_>,
     roots: &RootCertStore,
     intermediates: &[CertificateDer<'_>],

--- a/rustls/tests/client_cert_verifier.rs
+++ b/rustls/tests/client_cert_verifier.rs
@@ -1,10 +1,10 @@
-//! Tests for configuring and using a [`ClientCertVerifier`] for a server.
+//! Tests for configuring and using a [`ClientVerifier`] for a server.
 
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
 
 use std::sync::Arc;
 
-use rustls::server::danger::ClientCertVerified;
+use rustls::server::danger::ClientVerified;
 use rustls::{
     AlertDescription, CertificateError, ClientConnection, Error, InvalidMessage, PeerIdentity,
     PeerMisbehaved, ServerConfig, ServerConnection,
@@ -21,17 +21,17 @@ use super::common::all_versions;
 use super::provider;
 
 // Client is authorized!
-fn ver_ok() -> Result<ClientCertVerified, Error> {
-    Ok(ClientCertVerified::assertion())
+fn ver_ok() -> Result<ClientVerified, Error> {
+    Ok(ClientVerified::assertion())
 }
 
 // Use when we shouldn't even attempt verification
-fn ver_unreachable() -> Result<ClientCertVerified, Error> {
+fn ver_unreachable() -> Result<ClientVerified, Error> {
     unreachable!()
 }
 
 // Verifier that returns an error that we can expect
-fn ver_err() -> Result<ClientCertVerified, Error> {
+fn ver_err() -> Result<ClientVerified, Error> {
     Err(Error::General("test err".to_string()))
 }
 

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -5,13 +5,13 @@ pub use std::sync::Arc;
 
 use rustls::client::{ServerVerifierBuilder, WebPkiServerVerifier};
 use rustls::crypto::CryptoProvider;
-use rustls::server::{ClientCertVerifierBuilder, WebPkiClientVerifier};
+use rustls::server::{ClientVerifierBuilder, WebPkiClientVerifier};
 use rustls::{RootCertStore, SupportedCipherSuite};
 
 pub fn webpki_client_verifier_builder(
     roots: Arc<RootCertStore>,
     provider: &CryptoProvider,
-) -> ClientCertVerifierBuilder {
+) -> ClientVerifierBuilder {
     if exactly_one_provider() {
         WebPkiClientVerifier::builder(roots)
     } else {

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -3,7 +3,7 @@
 
 pub use std::sync::Arc;
 
-use rustls::client::{ServerCertVerifierBuilder, WebPkiServerVerifier};
+use rustls::client::{ServerVerifierBuilder, WebPkiServerVerifier};
 use rustls::crypto::CryptoProvider;
 use rustls::server::{ClientCertVerifierBuilder, WebPkiClientVerifier};
 use rustls::{RootCertStore, SupportedCipherSuite};
@@ -22,7 +22,7 @@ pub fn webpki_client_verifier_builder(
 pub fn webpki_server_verifier_builder(
     roots: Arc<RootCertStore>,
     provider: &CryptoProvider,
-) -> ServerCertVerifierBuilder {
+) -> ServerVerifierBuilder {
     if exactly_one_provider() {
         WebPkiServerVerifier::builder(roots)
     } else {

--- a/rustls/tests/resume.rs
+++ b/rustls/tests/resume.rs
@@ -83,7 +83,7 @@ fn client_only_attempts_resumption_with_compatible_security() {
             c.borrow()
                 .trace
                 .iter()
-                .any(|item| item == "resumption not allowed between different ServerCertVerifiers")
+                .any(|item| item == "resumption not allowed between different ServerVerifiers")
         }));
     }
 }

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -1,4 +1,4 @@
-//! Tests for configuring and using a [`ServerCertVerifier`] for a client.
+//! Tests for configuring and using a [`ServerVerifier`] for a client.
 
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
 
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use pki_types::UnixTime;
 use rustls::client::danger::{
-    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, ServerIdentity,
+    HandshakeSignatureValid, ServerIdentity, ServerVerified, ServerVerifier,
     SignatureVerificationInput,
 };
 use rustls::client::{WebPkiServerVerifier, verify_server_cert_signed_by_trust_anchor};
@@ -238,7 +238,7 @@ fn client_can_request_certain_trusted_cas() {
                 .build()
                 .unwrap();
 
-        let cas_sending_server_verifier = Arc::new(ServerCertVerifierWithCasExt {
+        let cas_sending_server_verifier = Arc::new(ServerVerifierWithCasExt {
             verifier: server_verifier.clone(),
             ca_names: Arc::from(vec![DistinguishedName::from(
                 key_type
@@ -673,16 +673,13 @@ impl ResolvesServerCert for ResolvesCertChainByCaName {
 }
 
 #[derive(Debug)]
-struct ServerCertVerifierWithCasExt {
-    verifier: Arc<dyn ServerCertVerifier>,
+struct ServerVerifierWithCasExt {
+    verifier: Arc<dyn ServerVerifier>,
     ca_names: Arc<[DistinguishedName]>,
 }
 
-impl ServerCertVerifier for ServerCertVerifierWithCasExt {
-    fn verify_server_cert(
-        &self,
-        identity: &ServerIdentity<'_>,
-    ) -> Result<ServerCertVerified, Error> {
+impl ServerVerifier for ServerVerifierWithCasExt {
+    fn verify_server_cert(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
         self.verifier
             .verify_server_cert(identity)
     }
@@ -717,7 +714,7 @@ impl ServerCertVerifier for ServerCertVerifierWithCasExt {
     }
 
     fn root_hint_subjects(&self) -> Option<Arc<[DistinguishedName]>> {
-        println!("ServerCertVerifierWithCasExt::root_hint_subjects() called!");
+        println!("ServerVerifierWithCasExt::root_hint_subjects() called!");
         Some(self.ca_names.clone())
     }
 }

--- a/rustls/tests/server_cert_verifier.rs
+++ b/rustls/tests/server_cert_verifier.rs
@@ -9,7 +9,7 @@ use rustls::client::danger::{
     HandshakeSignatureValid, ServerIdentity, ServerVerified, ServerVerifier,
     SignatureVerificationInput,
 };
-use rustls::client::{WebPkiServerVerifier, verify_server_cert_signed_by_trust_anchor};
+use rustls::client::{WebPkiServerVerifier, verify_identity_signed_by_trust_anchor};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
 use rustls::sign::{CertifiedKey, CertifiedSigner};
 use rustls::{
@@ -555,7 +555,7 @@ fn client_check_server_certificate_ee_crl_expired() {
     }
 }
 
-/// Simple smoke-test of the webpki verify_server_cert_signed_by_trust_anchor helper API.
+/// Simple smoke-test of the webpki verify_identity_signed_by_trust_anchor helper API.
 /// This public API is intended to be used by consumers implementing their own verifier and
 /// so isn't used by the other existing verifier tests.
 #[test]
@@ -570,7 +570,7 @@ fn client_check_server_certificate_helper_api() {
         .client_root_store();
         // Using the correct trust anchors, we should verify without error.
         assert!(
-            verify_server_cert_signed_by_trust_anchor(
+            verify_identity_signed_by_trust_anchor(
                 &ParsedCertificate::try_from(chain.first().unwrap()).unwrap(),
                 &correct_roots,
                 &[chain.get(1).unwrap().clone()],
@@ -581,7 +581,7 @@ fn client_check_server_certificate_helper_api() {
         );
         // Using the wrong trust anchors, we should get the expected error.
         assert_eq!(
-            verify_server_cert_signed_by_trust_anchor(
+            verify_identity_signed_by_trust_anchor(
                 &ParsedCertificate::try_from(chain.first().unwrap()).unwrap(),
                 &incorrect_roots,
                 &[chain.get(1).unwrap().clone()],
@@ -606,7 +606,7 @@ fn client_check_server_valid_purpose() {
         ],
     };
 
-    let error = verify_server_cert_signed_by_trust_anchor(
+    let error = verify_identity_signed_by_trust_anchor(
         &ParsedCertificate::try_from(chain.first().unwrap()).unwrap(),
         &roots,
         &[chain.get(1).unwrap().clone()],
@@ -679,9 +679,8 @@ struct ServerVerifierWithCasExt {
 }
 
 impl ServerVerifier for ServerVerifierWithCasExt {
-    fn verify_server_cert(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
-        self.verifier
-            .verify_server_cert(identity)
+    fn verify_identity(&self, identity: &ServerIdentity<'_>) -> Result<ServerVerified, Error> {
+        self.verifier.verify_identity(identity)
     }
 
     fn verify_tls12_signature(


### PR DESCRIPTION
These are no longer just for certificates, and the abbrevation in the type name (and method name) was a little unidiomatic.