### PR TITLE
unbuffered: eliminate allocation in unbuffered bulk encrypt path

### DIFF
--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -625,14 +625,16 @@ impl CommonState {
             written += len;
         }
 
+        let mut outgoing_remaining = &mut outgoing_tls[written..];
         for m in fragments {
-            let em = self
+            let (em, new_outgoing_remaining) = self
                 .record_layer
-                .encrypt_outgoing(m)
+                .encrypt_outgoing_into(m, outgoing_remaining)
                 .encode();
 
+            outgoing_remaining = new_outgoing_remaining;
+
             let len = em.len();
-            outgoing_tls[written..written + len].copy_from_slice(&em);
             written += len;
         }
 

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -13,7 +13,8 @@ use crate::enums::{CipherSuite, ProtocolVersion, SignatureScheme};
 use crate::error::Error;
 use crate::msgs::fragmenter::MAX_FRAGMENT_LEN;
 use crate::msgs::message::{
-    InboundPlainMessage, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload,
+    InboundPlainMessage, OutboundOpaqueMessage, OutboundOpaqueMessageBorrowed,
+    OutboundPlainMessage, PrefixedPayload, PrefixedPayloadBorrowed,
 };
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets};
 use crate::tls12::Tls12CipherSuite;
@@ -324,6 +325,33 @@ impl MessageEncrypter for GcmMessageEncrypter {
         Ok(OutboundOpaqueMessage::new(msg.typ, msg.version, payload))
     }
 
+    fn encrypt_into<'a>(
+        &mut self,
+        msg: OutboundPlainMessage<'_>,
+        outgoing_buffer: &'a mut [u8],
+        seq: u64,
+    ) -> Result<OutboundOpaqueMessageBorrowed<'a>, Error> {
+        let total_len = self.encrypted_payload_len(msg.payload.len());
+        let mut payload = PrefixedPayloadBorrowed::with_capacity(outgoing_buffer, total_len)
+            .ok_or(Error::EncryptError)?;
+
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
+        payload.extend_from_slice(&nonce.as_ref()[4..]);
+        payload.extend_from_chunks(&msg.payload);
+
+        self.enc_key
+            .seal_in_place_separate_tag(nonce, aad, &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..])
+            .map(|tag| payload.extend_from_slice(tag.as_ref()))
+            .map_err(|_| Error::EncryptError)?;
+
+        Ok(OutboundOpaqueMessageBorrowed::new(
+            msg.typ,
+            msg.version,
+            payload,
+        ))
+    }
+
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
         payload_len + GCM_EXPLICIT_NONCE_LEN + self.enc_key.algorithm().tag_len()
     }
@@ -401,6 +429,31 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
             .map_err(|_| Error::EncryptError)?;
 
         Ok(OutboundOpaqueMessage::new(msg.typ, msg.version, payload))
+    }
+
+    fn encrypt_into<'a>(
+        &mut self,
+        msg: OutboundPlainMessage<'_>,
+        outgoing_buffer: &'a mut [u8],
+        seq: u64,
+    ) -> Result<OutboundOpaqueMessageBorrowed<'a>, Error> {
+        let total_len = self.encrypted_payload_len(msg.payload.len());
+        let mut payload = PrefixedPayloadBorrowed::with_capacity(outgoing_buffer, total_len)
+            .ok_or(Error::EncryptError)?;
+
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).0);
+        let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
+        payload.extend_from_chunks(&msg.payload);
+
+        self.enc_key
+            .seal_in_place_append_tag(nonce, aad, &mut payload)
+            .map_err(|_| Error::EncryptError)?;
+
+        Ok(OutboundOpaqueMessageBorrowed::new(
+            msg.typ,
+            msg.version,
+            payload,
+        ))
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {

--- a/rustls/src/crypto/aws_lc_rs/tls13.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls13.rs
@@ -12,7 +12,8 @@ use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use crate::enums::{CipherSuite, ContentType, ProtocolVersion};
 use crate::error::Error;
 use crate::msgs::message::{
-    InboundPlainMessage, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload,
+    InboundPlainMessage, OutboundOpaqueMessage, OutboundOpaqueMessageBorrowed,
+    OutboundPlainMessage, PrefixedPayload, PrefixedPayloadBorrowed,
 };
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets};
 use crate::tls13::Tls13CipherSuite;
@@ -249,6 +250,32 @@ impl MessageEncrypter for AeadMessageEncrypter {
         ))
     }
 
+    fn encrypt_into<'a>(
+        &mut self,
+        msg: OutboundPlainMessage<'_>,
+        outgoing_buffer: &'a mut [u8],
+        seq: u64,
+    ) -> Result<OutboundOpaqueMessageBorrowed<'a>, Error> {
+        let total_len = self.encrypted_payload_len(msg.payload.len());
+        let mut payload = PrefixedPayloadBorrowed::with_capacity(outgoing_buffer, total_len)
+            .ok_or(Error::EncryptError)?;
+
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let aad = aead::Aad::from(make_tls13_aad(total_len));
+        payload.extend_from_chunks(&msg.payload);
+        payload.extend_from_slice(&msg.typ.to_array());
+
+        self.enc_key
+            .seal_in_place_append_tag(nonce, aad, &mut payload)
+            .map_err(|_| Error::EncryptError)?;
+
+        Ok(OutboundOpaqueMessageBorrowed::new(
+            ContentType::ApplicationData,
+            ProtocolVersion::TLSv1_2,
+            payload,
+        ))
+    }
+
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
         payload_len + 1 + self.enc_key.algorithm().tag_len()
     }
@@ -302,6 +329,32 @@ impl MessageEncrypter for GcmMessageEncrypter {
             .map_err(|_| Error::EncryptError)?;
 
         Ok(OutboundOpaqueMessage::new(
+            ContentType::ApplicationData,
+            ProtocolVersion::TLSv1_2,
+            payload,
+        ))
+    }
+
+    fn encrypt_into<'a>(
+        &mut self,
+        msg: OutboundPlainMessage<'_>,
+        outgoing_buffer: &'a mut [u8],
+        seq: u64,
+    ) -> Result<OutboundOpaqueMessageBorrowed<'a>, Error> {
+        let total_len = self.encrypted_payload_len(msg.payload.len());
+        let mut payload = PrefixedPayloadBorrowed::with_capacity(outgoing_buffer, total_len)
+            .ok_or(Error::EncryptError)?;
+
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let aad = aead::Aad::from(make_tls13_aad(total_len));
+        payload.extend_from_chunks(&msg.payload);
+        payload.extend_from_slice(&msg.typ.to_array());
+
+        self.enc_key
+            .seal_in_place_append_tag(nonce, aad, &mut payload)
+            .map_err(|_| Error::EncryptError)?;
+
+        Ok(OutboundOpaqueMessageBorrowed::new(
             ContentType::ApplicationData,
             ProtocolVersion::TLSv1_2,
             payload,

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -7,6 +7,7 @@ use zeroize::Zeroize;
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::Error;
 use crate::msgs::codec;
+use crate::msgs::message::OutboundOpaqueMessageBorrowed;
 pub use crate::msgs::message::{
     BorrowedPayload, InboundOpaqueMessage, InboundPlainMessage, OutboundChunks,
     OutboundOpaqueMessage, OutboundPlainMessage, PlainMessage, PrefixedPayload,
@@ -155,6 +156,23 @@ pub trait MessageEncrypter: Send + Sync {
         msg: OutboundPlainMessage<'_>,
         seq: u64,
     ) -> Result<OutboundOpaqueMessage, Error>;
+
+    /// Encrypt the given TLS message `msg` directly into the outgoing
+    /// buffer, using the sequence number `seq` which can
+    /// be used to derive a unique [`Nonce`].
+    ///
+    /// Can be overridden by the provider to provide zero-allocation and
+    /// zero-copy encrypt.
+    fn encrypt_into<'a>(
+        &mut self,
+        msg: OutboundPlainMessage<'_>,
+        outgoing_buffer: &'a mut [u8],
+        seq: u64,
+    ) -> Result<OutboundOpaqueMessageBorrowed<'a>, Error> {
+        let em = self.encrypt(msg, seq)?;
+        em.copy_to_borrowed(outgoing_buffer)
+            .ok_or(Error::EncryptError)
+    }
 
     /// Return the length of the ciphertext that results from encrypting plaintext of
     /// length `payload_len`

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -11,7 +11,8 @@ use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use crate::enums::{CipherSuite, ContentType, ProtocolVersion};
 use crate::error::Error;
 use crate::msgs::message::{
-    InboundPlainMessage, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload,
+    InboundPlainMessage, OutboundOpaqueMessage, OutboundOpaqueMessageBorrowed,
+    OutboundPlainMessage, PrefixedPayload, PrefixedPayloadBorrowed,
 };
 use crate::suites::{CipherSuiteCommon, ConnectionTrafficSecrets};
 use crate::tls13::Tls13CipherSuite;
@@ -219,6 +220,32 @@ impl MessageEncrypter for Tls13MessageEncrypter {
             ContentType::ApplicationData,
             // Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
             // protocol version, see https://www.rfc-editor.org/rfc/rfc8446#section-5.1
+            ProtocolVersion::TLSv1_2,
+            payload,
+        ))
+    }
+
+    fn encrypt_into<'a>(
+        &mut self,
+        msg: OutboundPlainMessage<'_>,
+        outgoing_buffer: &'a mut [u8],
+        seq: u64,
+    ) -> Result<OutboundOpaqueMessageBorrowed<'a>, Error> {
+        let total_len = self.encrypted_payload_len(msg.payload.len());
+        let mut payload = PrefixedPayloadBorrowed::with_capacity(outgoing_buffer, total_len)
+            .ok_or(Error::EncryptError)?;
+
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let aad = aead::Aad::from(make_tls13_aad(total_len));
+        payload.extend_from_chunks(&msg.payload);
+        payload.extend_from_slice(&msg.typ.to_array());
+
+        self.enc_key
+            .seal_in_place_append_tag(nonce, aad, &mut payload)
+            .map_err(|_| Error::EncryptError)?;
+
+        Ok(OutboundOpaqueMessageBorrowed::new(
+            ContentType::ApplicationData,
             ProtocolVersion::TLSv1_2,
             payload,
         ))

--- a/rustls/src/msgs/message/mod.rs
+++ b/rustls/src/msgs/message/mod.rs
@@ -13,8 +13,10 @@ pub use inbound::{BorrowedPayload, InboundOpaqueMessage, InboundPlainMessage};
 mod outbound;
 use alloc::vec::Vec;
 
-pub(crate) use outbound::read_opaque_message_header;
+#[allow(unused_imports)]
+pub(crate) use outbound::PrefixedPayloadBorrowed;
 pub use outbound::{OutboundChunks, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload};
+pub(crate) use outbound::{OutboundOpaqueMessageBorrowed, read_opaque_message_header};
 
 #[non_exhaustive]
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
This PR eliminates allocations in the unbuffered API bulk encrypt path without modifying the public API. This is achieved by adding an `encrypt_into` method on the `MessageEncrypter` trait that writes the encrypted record directly into a caller-provided buffer.

To be less intrusive, I introduced the structs `PrefixedPayloadBorrowed` and `OutboundOpaqueMessageBorrowed` alongside their owned counterparts. This temporarily duplicates some logic but leaves the original encrypt path untouched.

## Benchmarks

Hardware: AMD Ryzen 7 5800XT  
Command: `BENCH_MULTIPLIER=32 taskset -c 4 ./target/release/rustls-bench --api=unbuffered bulk TLS13_AES_128_GCM_SHA256`

| Allocator | Version     | Throughput (MB/s) | Δ vs prev |
|-----------|-------------|-------------------|-----------|
| system    | prev        | 5022.06           | —         |
| system    | zero-alloc  | 5253.56           | +4.6%     |
| jemalloc  | prev        | 5024.51           | —         |
| jemalloc  | zero-alloc  | 5243.84           | +4.4%     |

Across both allocators, throughput improved by ~4-5%.

## Motivation
Beyond the modest throughput increase, removing allocations in this path:
- Reduces fragmentation caused by frequent allocation of variable-sized records, improving long-run consistency.
- Reduces allocator contention under load.
- Provides a foundation for future zero-copy optimizations.

## Follow-up
- **Zero-copy encrypt:** Once crypto providers expose an out-of-place API, we can eliminate the intermediate copy. In local experiments with aws-lc-rs, this yielded 15–35% higher throughput depending on machine, with even better multi-core scaling due to reduced DRAM traffic.