### PR TITLE
Expose constructors for OtherError

### DIFF
--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -60,6 +60,12 @@ impl rustls::crypto::KeyProvider for Provider {
         &self,
         key_der: PrivateKeyDer<'static>,
     ) -> Result<Box<dyn rustls::sign::SigningKey>, rustls::Error> {
+        let PrivateKeyDer::Pkcs8(key_der) = key_der else {
+            return Err(rustls::Error::General(
+                "only PKCS#8 private keys are supported".into(),
+            ));
+        };
+
         Ok(Box::new(
             sign::EcdsaSigningKeyP256::try_from(key_der).map_err(|err| {
                 #[cfg(feature = "std")]

--- a/rustls/src/crypto/aws_lc_rs/hpke.rs
+++ b/rustls/src/crypto/aws_lc_rs/hpke.rs
@@ -19,7 +19,6 @@ use crate::crypto::hpke::{
 use crate::crypto::tls13::{HkdfExpander, HkdfPrkExtract, HkdfUsingHmac, expand};
 use crate::msgs::enums::{HpkeAead, HpkeKdf, HpkeKem};
 use crate::msgs::handshake::HpkeSymmetricCipherSuite;
-use crate::sync::Arc;
 use crate::{Error, OtherError};
 
 /// Default [RFC 9180] Hybrid Public Key Encryption (HPKE) suites supported by aws-lc-rs cryptography.
@@ -925,7 +924,7 @@ impl<const KDF_LEN: usize> Drop for KemSharedSecret<KDF_LEN> {
 }
 
 fn key_rejected_err(e: aws_lc_rs::error::KeyRejected) -> Error {
-    Error::Other(OtherError(Arc::new(e)))
+    Error::Other(OtherError::new(e))
 }
 
 // The `cipher::chacha::KEY_LEN` const is not exported, so we copy it here:

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -13,7 +13,6 @@ use crate::crypto::{CryptoProvider, KeyProvider, SecureRandom, SupportedKxGroup}
 use crate::enums::SignatureScheme;
 use crate::rand::GetRandomFailed;
 use crate::sign::SigningKey;
-use crate::sync::Arc;
 use crate::webpki::WebPkiSupportedAlgorithms;
 use crate::{Error, OtherError, Tls12CipherSuite, Tls13CipherSuite};
 
@@ -300,7 +299,7 @@ pub(super) fn fips() -> bool {
 }
 
 pub(super) fn unspecified_err(e: aws_lc_rs::error::Unspecified) -> Error {
-    Error::Other(OtherError(Arc::new(e)))
+    Error::Other(OtherError::new(e))
 }
 
 #[cfg(test)]

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -7,7 +7,6 @@ use webpki::{CertRevocationList, InvalidNameContext, OwnedCertRevocationList};
 use crate::error::{
     CertRevocationListError, CertificateError, Error, ExtendedKeyPurpose, OtherError,
 };
-use crate::sync::Arc;
 
 mod anchors;
 mod client_verifier;
@@ -118,7 +117,7 @@ fn pki_error(error: webpki::Error) -> Error {
             .into()
         }
 
-        _ => CertificateError::Other(OtherError(Arc::new(error))).into(),
+        _ => CertificateError::Other(OtherError::new(error)).into(),
     }
 }
 
@@ -148,7 +147,7 @@ fn crl_error(e: webpki::Error) -> CertRevocationListError {
         UnsupportedIndirectCrl => CertRevocationListError::UnsupportedIndirectCrl,
         UnsupportedRevocationReason => CertRevocationListError::UnsupportedRevocationReason,
 
-        _ => CertRevocationListError::Other(OtherError(Arc::new(e))),
+        _ => CertRevocationListError::Other(OtherError::new(e)),
     }
 }
 


### PR DESCRIPTION
These cannot be a blanket `From` impls because that conflicts with an implementation in `core`.

Replaces

- #2694 

Follow up from

- #2692