### PR TITLE
Rework hybrid key exchange arrangements

### DIFF
--- a/openssl-tests/src/ffdhe.rs
+++ b/openssl-tests/src/ffdhe.rs
@@ -1,7 +1,7 @@
 use num_bigint::BigUint;
 use rustls::crypto::{
-    ActiveKeyExchange, CipherSuiteCommon, KeyExchangeAlgorithm, SharedSecret, SupportedKxGroup,
-    aws_lc_rs as provider,
+    ActiveKeyExchange, CipherSuiteCommon, KeyExchangeAlgorithm, SharedSecret, StartedKeyExchange,
+    SupportedKxGroup, aws_lc_rs as provider,
 };
 use rustls::ffdhe_groups::FfdheGroup;
 use rustls::{CipherSuite, NamedGroup, Tls12CipherSuite};
@@ -13,7 +13,7 @@ pub(crate) const FFDHE2048_GROUP: &dyn SupportedKxGroup =
 pub(crate) struct FfdheKxGroup(pub NamedGroup, pub FfdheGroup<'static>);
 
 impl SupportedKxGroup for FfdheKxGroup {
-    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, rustls::Error> {
+    fn start(&self) -> Result<StartedKeyExchange, rustls::Error> {
         let mut x = vec![0; 64];
         provider::DEFAULT_PROVIDER
             .secure_random
@@ -27,13 +27,13 @@ impl SupportedKxGroup for FfdheKxGroup {
         let x_pub = g.modpow(&x, &p);
         let x_pub = to_bytes_be_with_len(x_pub, group.p.len());
 
-        Ok(Box::new(ActiveFfdheKx {
+        Ok(StartedKeyExchange::Single(Box::new(ActiveFfdheKx {
             x_pub,
             x,
             p,
             group,
             named_group: self.0,
-        }))
+        })))
     }
 
     fn ffdhe_group(&self) -> Option<FfdheGroup<'static>> {

--- a/provider-example/src/kx.rs
+++ b/provider-example/src/kx.rs
@@ -1,7 +1,6 @@
 use alloc::boxed::Box;
 
-use crypto::SupportedKxGroup;
-use rustls::crypto;
+use rustls::crypto::{self, StartedKeyExchange, SupportedKxGroup};
 
 pub(crate) struct KeyExchange {
     priv_key: x25519_dalek::EphemeralSecret,
@@ -33,12 +32,12 @@ pub(crate) const ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[&X25519];
 pub(crate) struct X25519;
 
 impl SupportedKxGroup for X25519 {
-    fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::Error> {
+    fn start(&self) -> Result<StartedKeyExchange, rustls::Error> {
         let priv_key = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
-        Ok(Box::new(KeyExchange {
+        Ok(StartedKeyExchange::Single(Box::new(KeyExchange {
             pub_key: (&priv_key).into(),
             priv_key,
-        }))
+        })))
     }
 
     fn name(&self) -> rustls::NamedGroup {

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -23,8 +23,8 @@ use rustls::crypto::cipher::{
     Tls12AeadAlgorithm, Tls13AeadAlgorithm, UnsupportedOperationError,
 };
 use rustls::crypto::{
-    CipherSuiteCommon, GetRandomFailed, KeyExchangeAlgorithm, WebPkiSupportedAlgorithms, hash,
-    tls12, tls13,
+    CipherSuiteCommon, GetRandomFailed, KeyExchangeAlgorithm, StartedKeyExchange,
+    WebPkiSupportedAlgorithms, hash, tls12, tls13,
 };
 use rustls::pki_types::{
     AlgorithmIdentifier, CertificateDer, InvalidSignature, PrivateKeyDer,
@@ -252,8 +252,8 @@ const KEY_EXCHANGE_GROUP: &dyn crypto::SupportedKxGroup = &KeyExchangeGroup;
 struct KeyExchangeGroup;
 
 impl crypto::SupportedKxGroup for KeyExchangeGroup {
-    fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, Error> {
-        Ok(Box::new(ActiveKeyExchange))
+    fn start(&self) -> Result<StartedKeyExchange, Error> {
+        Ok(StartedKeyExchange::Single(Box::new(ActiveKeyExchange)))
     }
 
     fn name(&self) -> NamedGroup {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1003,7 +1003,7 @@ impl State<ClientConnectionData> for ExpectServerDone<'_> {
             ));
         };
         cx.common.kx_state = KxState::Start(skxg);
-        let kx = skxg.start()?;
+        let kx = skxg.start()?.into_single();
 
         // 4b.
         let mut transcript = st.transcript;

--- a/rustls/src/crypto/aws_lc_rs/pq/hybrid.rs
+++ b/rustls/src/crypto/aws_lc_rs/pq/hybrid.rs
@@ -2,7 +2,10 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use super::INVALID_KEY_SHARE;
-use crate::crypto::{ActiveKeyExchange, CompletedKeyExchange, SharedSecret, SupportedKxGroup};
+use crate::crypto::{
+    ActiveKeyExchange, CompletedKeyExchange, HybridKeyExchange, SharedSecret, StartedKeyExchange,
+    SupportedKxGroup,
+};
 use crate::{Error, NamedGroup};
 
 /// A generalization of hybrid key exchange.
@@ -15,21 +18,21 @@ pub(crate) struct Hybrid {
 }
 
 impl SupportedKxGroup for Hybrid {
-    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
-        let classical = self.classical.start()?;
-        let post_quantum = self.post_quantum.start()?;
+    fn start(&self) -> Result<StartedKeyExchange, Error> {
+        let classical = self.classical.start()?.into_single();
+        let post_quantum = self.post_quantum.start()?.into_single();
 
         let combined_pub_key = self
             .layout
             .concat(post_quantum.pub_key(), classical.pub_key());
 
-        Ok(Box::new(ActiveHybrid {
+        Ok(StartedKeyExchange::Hybrid(Box::new(ActiveHybrid {
             classical,
             post_quantum,
             name: self.name,
             layout: self.layout,
             combined_pub_key,
-        }))
+        })))
     }
 
     fn start_and_complete(&self, client_share: &[u8]) -> Result<CompletedKeyExchange, Error> {
@@ -113,24 +116,30 @@ impl ActiveKeyExchange for ActiveHybrid {
         Ok(SharedSecret::from(secret))
     }
 
-    /// Allow the classical computation to be offered and selected separately.
-    fn hybrid_component(&self) -> Option<(NamedGroup, &[u8])> {
-        Some((self.classical.group(), self.classical.pub_key()))
-    }
-
-    fn complete_hybrid_component(
-        self: Box<Self>,
-        peer_pub_key: &[u8],
-    ) -> Result<SharedSecret, Error> {
-        self.classical.complete(peer_pub_key)
-    }
-
     fn pub_key(&self) -> &[u8] {
         &self.combined_pub_key
     }
 
     fn group(&self) -> NamedGroup {
         self.name
+    }
+}
+
+impl HybridKeyExchange for ActiveHybrid {
+    fn component(&self) -> (NamedGroup, &[u8]) {
+        (self.classical.group(), self.classical.pub_key())
+    }
+
+    fn complete_component(self: Box<Self>, peer_pub_key: &[u8]) -> Result<SharedSecret, Error> {
+        self.classical.complete(peer_pub_key)
+    }
+
+    fn into_key_exchange(self: Box<Self>) -> Box<dyn ActiveKeyExchange> {
+        self
+    }
+
+    fn as_key_exchange(&self) -> &(dyn ActiveKeyExchange + 'static) {
+        self
     }
 }
 

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -52,7 +52,8 @@ mod tests {
     use super::super::*;
     use crate::common_state::KxState;
     use crate::crypto::{
-        ActiveKeyExchange, CryptoProvider, KeyExchangeAlgorithm, SupportedKxGroup,
+        ActiveKeyExchange, CryptoProvider, KeyExchangeAlgorithm, StartedKeyExchange,
+        SupportedKxGroup,
     };
     use crate::enums::CertificateType;
     use crate::ffdhe_groups::FfdheGroup;
@@ -304,8 +305,8 @@ mod tests {
             NamedGroup::FFDHE2048
         }
 
-        fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
-            Ok(Box::new(ActiveFakeFfdhe))
+        fn start(&self) -> Result<StartedKeyExchange, Error> {
+            Ok(StartedKeyExchange::Single(Box::new(ActiveFakeFfdhe)))
         }
     }
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -387,7 +387,7 @@ mod client_hello {
         signer: Box<dyn Signer>,
         randoms: &ConnectionRandoms,
     ) -> Result<Box<dyn ActiveKeyExchange>, Error> {
-        let kx = selected_group.start()?;
+        let kx = selected_group.start()?.into_single();
         let kx_params = ServerKeyExchangeParams::new(&*kx);
 
         let mut msg = Vec::new();


### PR DESCRIPTION
Have an enum that allows `SupportedKxGroup::start()` to return more specific trait types, and then trace that through everywhere.

`HybridKeyExchange` is an extension to `ActiveKeyExchange` that adds the hybrid key exchange parts.

This is the final TODO for, and therefore fixes #2119