### PR TITLE
Support encryption for QUIC multipath

### DIFF
--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -731,6 +731,25 @@ pub trait PacketKey: Send + Sync {
         payload: &mut [u8],
     ) -> Result<Tag, Error>;
 
+    /// Encrypts a multipath QUIC packet
+    ///
+    /// Takes a `path_id` and `packet_number`, used to derive the nonce; the packet `header`, which is used as
+    /// the additional authenticated data; and the `payload`. The authentication tag is returned if
+    /// encryption succeeds.
+    ///
+    /// Fails if and only if the payload is longer than allowed by the cipher suite's AEAD algorithm.
+    ///
+    /// See <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-11.html#name-nonce-calculation>.
+    fn encrypt_in_place_for_path(
+        &self,
+        _path_id: u32,
+        _packet_number: u64,
+        _header: &[u8],
+        _payload: &mut [u8],
+    ) -> Result<Tag, Error> {
+        Err(Error::EncryptError)
+    }
+
     /// Decrypt a QUIC packet
     ///
     /// Takes the packet `header`, which is used as the additional authenticated data, and the
@@ -744,6 +763,26 @@ pub trait PacketKey: Send + Sync {
         header: &[u8],
         payload: &'a mut [u8],
     ) -> Result<&'a [u8], Error>;
+
+    /// Decrypt a multipath QUIC packet
+    ///
+    /// Takes a `path_id` and `packet_number`, used to derive the nonce; the packet `header`, which is used as
+    /// the additional authenticated data; and the `payload`. The authentication tag is returned if
+    /// encryption succeeds.
+    ///
+    /// If the return value is `Ok`, the decrypted payload can be found in `payload`, up to the
+    /// length found in the return value.
+    ///
+    /// See <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-11.html#name-nonce-calculation>.
+    fn decrypt_in_place_for_path<'a>(
+        &self,
+        _path_id: u32,
+        _packet_number: u64,
+        _header: &[u8],
+        _payload: &'a mut [u8],
+    ) -> Result<&'a [u8], Error> {
+        Err(Error::DecryptError)
+    }
 
     /// Tag length for the underlying AEAD algorithm
     fn tag_len(&self) -> usize;


### PR DESCRIPTION
https://datatracker.ietf.org/doc/draft-ietf-quic-multipath/ defines new semantics to encrypt QUIC packets.  It uses both the packet number and path ID, so packets for different paths can be encrypted independently.

This is a version of #2312 without breaking any existing APIs.  Differences from that PR are as minimal as possible.  Anyone using this will have to deal with a small breaking change when upgrading to rustls 0.24, but this is a straight forward API change to deal with.

This is used in the multipath implementation for Quinn, which is being developed here: https://github.com/n0-computer/quinn/tree/multipath-quinn-0.11.x.  While not yet perfect, this work is now functional and can be used to use QUIC Multipath in Quinn connections.  Support for this API by a released rustls version would help being able to publish crates for this.