### PR TITLE
Fix unconditionally used underscore bindings

### DIFF
--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -115,33 +115,33 @@ mod cache {
 
         fn set_tls12_session(
             &self,
-            _server_name: ServerName<'static>,
-            _value: persist::Tls12ClientSessionValue,
+            server_name: ServerName<'static>,
+            value: persist::Tls12ClientSessionValue,
         ) {
             self.servers
                 .lock()
                 .unwrap()
-                .get_or_insert_default_and_edit(_server_name.clone(), |data| {
-                    data.tls12 = Some(_value)
+                .get_or_insert_default_and_edit(server_name.clone(), |data| {
+                    data.tls12 = Some(value)
                 });
         }
 
         fn tls12_session(
             &self,
-            _server_name: &ServerName<'_>,
+            server_name: &ServerName<'_>,
         ) -> Option<persist::Tls12ClientSessionValue> {
             self.servers
                 .lock()
                 .unwrap()
-                .get(_server_name)
+                .get(server_name)
                 .and_then(|sd| sd.tls12.as_ref().cloned())
         }
 
-        fn remove_tls12_session(&self, _server_name: &ServerName<'static>) {
+        fn remove_tls12_session(&self, server_name: &ServerName<'static>) {
             self.servers
                 .lock()
                 .unwrap()
-                .get_mut(_server_name)
+                .get_mut(server_name)
                 .and_then(|data| data.tls12.take());
         }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -444,9 +444,9 @@ impl ClientHelloInput {
     ) -> Result<Self, Error> {
         let mut resuming = ClientSessionValue::retrieve(&server_name, &config, cx);
         let session_id = match &mut resuming {
-            Some(_resuming) => {
+            Some(resuming) => {
                 debug!("Resuming session");
-                match &mut _resuming.value {
+                match &mut resuming.value {
                     ClientSessionValue::Tls12(inner) => {
                         // If we have a ticket, we use the sessionid as a signal that
                         // we're  doing an abbreviated handshake.  See section 3.4 in

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1132,7 +1132,7 @@ impl State<ClientConnectionData> for ExpectFinished {
 
         // Constant-time verification of this is relatively unimportant: they only
         // get one chance.  But it can't hurt.
-        let _fin_verified =
+        let fin_verified =
             match ConstantTimeEq::ct_eq(&expect_verify_data[..], finished.bytes()).into() {
                 true => verify::FinishedMessageVerified::assertion(),
                 false => {
@@ -1169,7 +1169,7 @@ impl State<ClientConnectionData> for ExpectFinished {
             extracted_secrets,
             _cert_verified: st.cert_verified,
             _sig_verified: st.sig_verified,
-            _fin_verified,
+            _fin_verified: fin_verified,
         }))
     }
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -815,7 +815,7 @@ impl State<ServerConnectionData> for ExpectFinished {
         let vh = self.transcript.current_hash();
         let expect_verify_data = self.secrets.client_verify_data(&vh);
 
-        let _fin_verified =
+        let fin_verified =
             match ConstantTimeEq::ct_eq(&expect_verify_data[..], finished.bytes()).into() {
                 true => verify::FinishedMessageVerified::assertion(),
                 false => {
@@ -879,7 +879,7 @@ impl State<ServerConnectionData> for ExpectFinished {
 
         Ok(Box::new(ExpectTraffic {
             extracted_secrets,
-            _fin_verified,
+            _fin_verified: fin_verified,
         }))
     }
 }

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -330,7 +330,7 @@ impl KeyScheduleHandshake {
 
         let before_finished =
             KeyScheduleBeforeFinished::new(self.ks, hs_hash, key_log, client_random);
-        let (_client_secret, server_secret) = (
+        let (client_secret, server_secret) = (
             &before_finished.current_client_traffic_secret,
             &before_finished.current_server_traffic_secret,
         );
@@ -341,7 +341,7 @@ impl KeyScheduleHandshake {
 
         if common.is_quic() {
             common.quic.traffic_secrets = Some(quic::Secrets::new(
-                _client_secret.clone(),
+                client_secret.clone(),
                 server_secret.clone(),
                 before_finished.ks.suite,
                 before_finished.ks.suite.quic.unwrap(),


### PR DESCRIPTION
The need for these fell away after the demise of the `quic` and `tls12` crate features.