### PR TITLE
Add `HandshakeKind::ResumedWithHelloRetryRequest`

### DIFF
--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -597,7 +597,12 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
                 }
 
                 cx.common.peer_identity = Some(resuming_session.peer_identity().clone());
-                cx.common.handshake_kind = Some(HandshakeKind::Resumed);
+                cx.common.handshake_kind = Some(match cx.common.handshake_kind {
+                    Some(HandshakeKind::FullWithHelloRetryRequest) => {
+                        HandshakeKind::ResumedWithHelloRetryRequest
+                    }
+                    _ => HandshakeKind::Resumed,
+                });
 
                 // We *don't* reverify the certificate chain here: resumption is a
                 // continuation of the previous session in terms of security policy.

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -778,7 +778,7 @@ pub enum HandshakeKind {
     /// A full TLS1.3 handshake, with an extra round-trip for a `HelloRetryRequest`.
     ///
     /// The server can respond with a `HelloRetryRequest` if the initial `ClientHello`
-    /// is unacceptable for several reasons, the most likely if no supported key
+    /// is unacceptable for several reasons, the most likely being if no supported key
     /// shares were offered by the client.
     FullWithHelloRetryRequest,
 
@@ -788,6 +788,13 @@ pub enum HandshakeKind {
     /// full ones, but can only happen when the peers have previously done a full
     /// handshake together, and then remember data about it.
     Resumed,
+
+    /// A resumed handshake, with an extra round-trip for a `HelloRetryRequest`.
+    ///
+    /// The server can respond with a `HelloRetryRequest` if the initial `ClientHello`
+    /// is unacceptable for several reasons, but this does not prevent the client
+    /// from resuming.
+    ResumedWithHelloRetryRequest,
 }
 
 /// Values of this structure are returned from [`Connection::process_new_packets`]

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -312,7 +312,10 @@ mod client_hello {
                     .handshake_kind
                     .get_or_insert(HandshakeKind::Full);
             } else {
-                cx.common.handshake_kind = Some(HandshakeKind::Resumed);
+                cx.common.handshake_kind = match st.done_retry {
+                    true => Some(HandshakeKind::ResumedWithHelloRetryRequest),
+                    false => Some(HandshakeKind::Resumed),
+                };
             }
 
             let mut ocsp_response = signer.ocsp.as_deref();


### PR DESCRIPTION
The impetus for this is a later PR, where this clarifies a test.

But, more generally, I kind of expect it would be useful for downstream users to hook up `handshake_kind()` to monitoring/metrics, and this change improves the resolution of that.