### PR TITLE
fix: only add ocsp in `ServerConfig` if `ocsp` parameter is not empty

### DIFF
--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -90,7 +90,9 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
         ocsp: Arc<[u8]>,
     ) -> Result<ServerConfig, Error> {
         let mut credentials = Credentials::from_der(identity, key_der, self.crypto_provider())?;
-        credentials.ocsp = Some(ocsp);
+        if !ocsp.is_empty() {
+            credentials.ocsp = Some(ocsp);
+        }
         self.with_server_credential_resolver(Arc::new(SingleCredential::from(credentials)))
     }
 


### PR DESCRIPTION
Fixes rustls/rustls#2732

Quick fix to the function `ConfigBuilder::with_single_cert_with_ocsp` to set the ocsp configuration
only if the given parameter is not 0-length.