### PR TITLE
Move `ConnectionCore::process_msg` into `CommonState::process_main_protocol`

### DIFF
--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -117,9 +117,12 @@ impl<Side: SideData> UnbufferedConnectionCommon<Side> {
                         }
                     };
 
-                match self.core.process_msg(msg, state, None) {
+                match self
+                    .core
+                    .common_state
+                    .process_main_protocol(msg, state, &mut self.core.side, None)
+                {
                     Ok(new) => state = new,
-
                     Err(e) => {
                         buffer.queue_discard(buffer_progress.take_discard());
                         self.core.state = Err(e.clone());


### PR DESCRIPTION
`ConnectionCore::process_msg` exclusively modifies `CommonState` internals such that it's entire logic can be contained within `CommonState::process_main_protocol`.

I am hoping to make some progress towards issue #1723 and this arose as a small opportunity to simplify the logic in that direction. 

