### PR TITLE
Support variable-length IVs in cipher operations

### DIFF
--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -580,7 +580,7 @@ mod tests {
 
             // Derive Encrypter
             let key = derive_traffic_key(expander.as_ref(), cipher_suite.aead_alg);
-            let iv = derive_traffic_iv(expander.as_ref());
+            let iv = derive_traffic_iv(expander.as_ref(), cipher_suite.aead_alg.iv_len());
             cipher_suite.aead_alg.encrypter(key, iv)
         }
     }

--- a/rustls/src/crypto/aws_lc_rs/quic.rs
+++ b/rustls/src/crypto/aws_lc_rs/quic.rs
@@ -133,7 +133,7 @@ impl quic::PacketKey for PacketKey {
     ) -> Result<quic::Tag, Error> {
         let aad = aead::Aad::from(header);
         let nonce_value = Nonce::quic(path_id, &self.iv, packet_number);
-        let nonce = aead::Nonce::assume_unique_for_key(nonce_value.0);
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_value.to_array()?);
         let tag = self
             .key
             .seal_in_place_separate_tag(nonce, aad, payload)
@@ -161,7 +161,7 @@ impl quic::PacketKey for PacketKey {
         let payload_len = payload.len();
         let aad = aead::Aad::from(header);
         let nonce_value = Nonce::quic(path_id, &self.iv, packet_number);
-        let nonce = aead::Nonce::assume_unique_for_key(nonce_value.0);
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_value.to_array()?);
         self.key
             .open_in_place(nonce, aad, payload)
             .map_err(|_| Error::DecryptError)?;

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -202,7 +202,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
         );
         Box::new(ChaCha20Poly1305MessageDecrypter {
             dec_key,
-            dec_offset: Iv::copy(iv),
+            dec_offset: Iv::new(iv).expect("IV length validated by key_block_shape"),
         })
     }
 
@@ -212,7 +212,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
         );
         Box::new(ChaCha20Poly1305MessageEncrypter {
             enc_key,
-            enc_offset: Iv::copy(enc_iv),
+            enc_offset: Iv::new(enc_iv).expect("IV length validated by key_block_shape"),
         })
     }
 
@@ -234,7 +234,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
         debug_assert_eq!(aead::NONCE_LEN, iv.len());
         Ok(ConnectionTrafficSecrets::Chacha20Poly1305 {
             key,
-            iv: Iv::new(iv[..].try_into().unwrap()),
+            iv: Iv::new(iv).expect("IV length validated by key_block_shape"),
         })
     }
 
@@ -311,7 +311,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = PrefixedPayload::with_capacity(total_len);
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
         payload.extend_from_slice(&nonce.as_ref()[4..]);
         payload.extend_from_chunks(&msg.payload);
@@ -359,7 +359,8 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
             return Err(Error::DecryptError);
         }
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.dec_offset, seq).0);
+        let nonce =
+            aead::Nonce::assume_unique_for_key(Nonce::new(&self.dec_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(
             seq,
             msg.typ,
@@ -392,7 +393,8 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = PrefixedPayload::with_capacity(total_len);
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).0);
+        let nonce =
+            aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
         payload.extend_from_chunks(&msg.payload);
 
@@ -423,7 +425,7 @@ fn gcm_iv(write_iv: &[u8], explicit: &[u8]) -> Iv {
     iv[..4].copy_from_slice(write_iv);
     iv[4..].copy_from_slice(explicit);
 
-    Iv::new(iv)
+    Iv::new(&iv).expect("IV length is NONCE_LEN, which is within MAX_LEN")
 }
 
 struct Tls12Prf(&'static tls_prf::Algorithm);

--- a/rustls/src/crypto/aws_lc_rs/tls13.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls13.rs
@@ -231,7 +231,7 @@ impl MessageEncrypter for AeadMessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = PrefixedPayload::with_capacity(total_len);
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(total_len));
         payload.extend_from_chunks(&msg.payload);
         payload.extend_from_slice(&msg.typ.to_array());
@@ -265,7 +265,7 @@ impl MessageDecrypter for AeadMessageDecrypter {
             return Err(Error::DecryptError);
         }
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(payload.len()));
         let plain_len = self
             .dec_key
@@ -292,7 +292,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = PrefixedPayload::with_capacity(total_len);
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(total_len));
         payload.extend_from_chunks(&msg.payload);
         payload.extend_from_slice(&msg.typ.to_array());
@@ -329,7 +329,7 @@ impl MessageDecrypter for GcmMessageDecrypter {
             return Err(Error::DecryptError);
         }
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(payload.len()));
         let plain_len = self
             .dec_key

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use zeroize::Zeroize;
 
 use crate::enums::{ContentType, ProtocolVersion};
-use crate::error::Error;
+use crate::error::{ApiMisuse, Error};
 use crate::msgs::codec;
 pub use crate::msgs::message::{
     BorrowedPayload, InboundOpaqueMessage, InboundPlainMessage, OutboundChunks,
@@ -23,6 +23,11 @@ pub trait Tls13AeadAlgorithm: Send + Sync {
 
     /// The length of key in bytes required by `encrypter()` and `decrypter()`.
     fn key_len(&self) -> usize;
+
+    /// The length of IV in bytes required by `encrypter()` and `decrypter()`.
+    fn iv_len(&self) -> usize {
+        NONCE_LEN
+    }
 
     /// Convert the key material from `key`/`iv`, into a `ConnectionTrafficSecrets` item.
     ///
@@ -174,44 +179,64 @@ impl dyn MessageDecrypter {
 }
 
 /// A write or read IV.
-#[derive(Default)]
-pub struct Iv([u8; NONCE_LEN]);
+#[derive(Default, Clone)]
+pub struct Iv {
+    buf: [u8; Self::MAX_LEN],
+    used: usize,
+}
 
 impl Iv {
-    /// Create a new `Iv` from a byte array, of precisely `NONCE_LEN` bytes.
-    pub fn new(value: [u8; NONCE_LEN]) -> Self {
-        Self(value)
+    /// Create a new `Iv` from a byte slice.
+    ///
+    /// Returns an error if the length of `value` exceeds [`Self::MAX_LEN`].
+    pub fn new(value: &[u8]) -> Result<Self, Error> {
+        if value.len() > Self::MAX_LEN {
+            return Err(ApiMisuse::IvLengthExceedsMaximum {
+                actual: value.len(),
+                maximum: Self::MAX_LEN,
+            }
+            .into());
+        }
+        let mut buf = [0u8; Self::MAX_LEN];
+        buf[..value.len()].copy_from_slice(value);
+        Ok(Self {
+            buf,
+            used: value.len(),
+        })
     }
 
-    /// Create a new `Iv` from a byte slice, of precisely `NONCE_LEN` bytes.
-    pub fn copy(value: &[u8]) -> Self {
-        debug_assert_eq!(value.len(), NONCE_LEN);
-        let mut iv = Self::new(Default::default());
-        iv.0.copy_from_slice(value);
-        iv
+    /// Return the IV length.
+    #[expect(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.used
     }
+
+    /// Maximum supported IV length.
+    pub const MAX_LEN: usize = 16;
 }
 
 impl From<[u8; NONCE_LEN]> for Iv {
     fn from(bytes: [u8; NONCE_LEN]) -> Self {
-        Self(bytes)
+        Self::new(&bytes).expect("NONCE_LEN is within MAX_LEN")
     }
 }
 
 impl AsRef<[u8]> for Iv {
     fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
+        &self.buf[..self.used]
     }
 }
 
 /// A nonce.  This is unique for all messages on a connection.
-#[expect(clippy::exhaustive_structs)]
-pub struct Nonce(pub [u8; NONCE_LEN]);
+pub struct Nonce {
+    buf: [u8; Iv::MAX_LEN],
+    len: usize,
+}
 
 impl Nonce {
     /// Combine an `Iv` and sequence number to produce a unique nonce.
     ///
-    /// This is `iv ^ seq` where `seq` is encoded as a 96-bit big-endian integer.
+    /// This is `iv ^ seq` where `seq` is encoded as a big-endian integer.
     #[inline]
     pub fn new(iv: &Iv, seq: u64) -> Self {
         Self::new_inner(None, iv, seq)
@@ -219,29 +244,72 @@ impl Nonce {
 
     /// Creates a unique nonce based on the multipath `path_id`, the `iv` and packet number `pn`.
     ///
-    /// The nonce is computed as the XOR between the `iv` and the 96-bit big-endian integer formed
+    /// The nonce is computed as the XOR between the `iv` and the big-endian integer formed
     /// by concatenating `path_id` (or 0) and `pn`.
     pub fn quic(path_id: Option<u32>, iv: &Iv, pn: u64) -> Self {
         Self::new_inner(path_id, iv, pn)
     }
 
-    /// Creates a unique nonce based on the `iv` and sequence number `seq`.
+    /// Creates a unique nonce based on the iv and sequence number seq.
     #[inline]
     fn new_inner(path_id: Option<u32>, iv: &Iv, seq: u64) -> Self {
-        let mut seq_bytes = [0u8; NONCE_LEN];
-        codec::put_u64(seq, &mut seq_bytes[4..]);
-        if let Some(path_id) = path_id {
-            seq_bytes[0..4].copy_from_slice(&path_id.to_be_bytes());
+        let iv_len = iv.len();
+        let mut buf = [0u8; Iv::MAX_LEN];
+
+        if iv_len >= 8 {
+            codec::put_u64(seq, &mut buf[iv_len - 8..iv_len]);
+            if let Some(path_id) = path_id {
+                if iv_len >= 12 {
+                    buf[iv_len - 12..iv_len - 8].copy_from_slice(&path_id.to_be_bytes());
+                }
+            }
+        } else {
+            let seq_bytes = seq.to_be_bytes();
+            buf[..iv_len].copy_from_slice(&seq_bytes[8 - iv_len..]);
         }
 
-        seq_bytes
+        buf[..iv_len]
             .iter_mut()
-            .zip(iv.0.iter())
-            .for_each(|(s, iv)| {
-                *s ^= *iv;
-            });
+            .zip(iv.as_ref())
+            .for_each(|(s, iv)| *s ^= *iv);
 
-        Self(seq_bytes)
+        Self { buf, len: iv_len }
+    }
+
+    /// Convert to a fixed-size array of length `N`.
+    ///
+    /// Returns an error if the nonce length is not `N`.
+    ///
+    /// For standard nonces, use `nonce.to_array::<NONCE_LEN>()?` or just `nonce.to_array()?`
+    /// which defaults to `NONCE_LEN`.
+    pub fn to_array<const N: usize>(&self) -> Result<[u8; N], Error> {
+        if self.len != N {
+            return Err(ApiMisuse::NonceArraySizeMismatch {
+                expected: N,
+                actual: self.len,
+            }
+            .into());
+        }
+        Ok(self.buf[..N]
+            .try_into()
+            .expect("nonce buffer conversion failed"))
+    }
+
+    /// Return the nonce value.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    /// Return the nonce length.
+    #[expect(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl AsRef<[u8]> for Nonce {
+    fn as_ref(&self) -> &[u8] {
+        &self.buf[..self.len]
     }
 }
 
@@ -376,7 +444,134 @@ mod tests {
         const PN: u64 = 54321;
         const IV: [u8; 16] = 0x6b26114b9cba2b63a9e8dd4fu128.to_be_bytes();
         const EXPECTED_NONCE: [u8; 16] = 0x6b2611489cba2b63a9e8097eu128.to_be_bytes();
-        let nonce = Nonce::quic(Some(PATH_ID), &Iv::copy(&IV[4..]), PN).0;
-        assert_eq!(EXPECTED_NONCE[4..], nonce);
+        let nonce = Nonce::quic(Some(PATH_ID), &Iv::new(&IV[4..]).unwrap(), PN);
+        assert_eq!(&EXPECTED_NONCE[4..], nonce.as_bytes());
+    }
+
+    #[test]
+    fn iv_len() {
+        let iv = Iv::new(&[1u8; NONCE_LEN]).unwrap();
+        assert_eq!(iv.len(), NONCE_LEN);
+
+        let short_iv = Iv::new(&[1u8, 2, 3]).unwrap();
+        assert_eq!(short_iv.len(), 3);
+
+        let empty_iv = Iv::new(&[]).unwrap();
+        assert_eq!(empty_iv.len(), 0);
+    }
+
+    #[test]
+    fn iv_as_ref() {
+        let iv_data = [1u8, 2, 3, 4, 5];
+        let iv = Iv::new(&iv_data).unwrap();
+        let iv_ref: &[u8] = iv.as_ref();
+        assert_eq!(iv_ref, &iv_data);
+    }
+
+    #[test]
+    fn nonce_with_short_iv() {
+        let short_iv = Iv::new(&[0xAA, 0xBB, 0xCC, 0xDD]).unwrap();
+        let seq = 0x1122334455667788u64;
+        let nonce = Nonce::new(&short_iv, seq);
+
+        // The nonce should XOR the last 4 bytes of seq with the IV
+        assert_eq!(nonce.len(), 4);
+        let seq_bytes = seq.to_be_bytes();
+        let expected = [
+            0xAA ^ seq_bytes[4],
+            0xBB ^ seq_bytes[5],
+            0xCC ^ seq_bytes[6],
+            0xDD ^ seq_bytes[7],
+        ];
+        assert_eq!(nonce.as_bytes(), &expected);
+    }
+
+    #[test]
+    fn nonce_len() {
+        let iv = Iv::new(&[1u8; NONCE_LEN]).unwrap();
+        let nonce = Nonce::new(&iv, 42);
+        assert_eq!(nonce.len(), NONCE_LEN);
+
+        let short_iv = Iv::new(&[1u8, 2]).unwrap();
+        let short_nonce = Nonce::new(&short_iv, 42);
+        assert_eq!(short_nonce.len(), 2);
+    }
+
+    #[test]
+    fn nonce_as_ref() {
+        let iv = Iv::new(&[1u8; NONCE_LEN]).unwrap();
+        let nonce = Nonce::new(&iv, 42);
+        let nonce_ref: &[u8] = nonce.as_ref();
+        assert_eq!(nonce_ref.len(), NONCE_LEN);
+    }
+
+    #[test]
+    fn nonce_to_array_correct_size() {
+        let iv = Iv::new(&[1u8; NONCE_LEN]).unwrap();
+        let nonce = Nonce::new(&iv, 42);
+        let array: [u8; NONCE_LEN] = nonce.to_array().unwrap();
+        assert_eq!(array.len(), NONCE_LEN);
+    }
+
+    #[test]
+    fn nonce_to_array_wrong_size() {
+        let iv = Iv::new(&[1u8; NONCE_LEN]).unwrap();
+        let nonce = Nonce::new(&iv, 42);
+        let result: Result<[u8; 16], Error> = nonce.to_array();
+        assert!(matches!(
+            result,
+            Err(Error::ApiMisuse(ApiMisuse::NonceArraySizeMismatch {
+                expected: 16,
+                actual: NONCE_LEN
+            }))
+        ));
+    }
+
+    #[test]
+    fn nonce_to_array_variable_length_error() {
+        // Create an IV with a non-standard length (8 bytes instead of 12)
+        let short_iv = Iv::new(&[0xAAu8; 8]).unwrap();
+        let nonce = Nonce::new(&short_iv, 42);
+
+        // Attempting to convert to standard NONCE_LEN should fail
+        let result: Result<[u8; NONCE_LEN], Error> = nonce.to_array();
+        if let Err(Error::ApiMisuse(ApiMisuse::NonceArraySizeMismatch { expected, actual })) =
+            result
+        {
+            assert_eq!(expected, NONCE_LEN);
+            assert_eq!(actual, 8);
+        } else {
+            panic!("Expected Error::ApiMisuse(NonceArraySizeMismatch)");
+        }
+
+        // But converting to the correct length should work
+        let result_correct: Result<[u8; 8], Error> = nonce.to_array();
+        assert!(result_correct.is_ok());
+    }
+
+    #[test]
+    fn nonce_xor_with_iv() {
+        let iv_data = [0xFFu8; NONCE_LEN];
+        let iv = Iv::new(&iv_data).unwrap();
+        let seq = 0x0000000000000001u64;
+        let nonce = Nonce::new(&iv, seq);
+
+        // The last byte should be 0xFF XOR 0x01 = 0xFE
+        let nonce_bytes = nonce.as_bytes();
+        assert_eq!(nonce_bytes[NONCE_LEN - 1], 0xFE);
+    }
+
+    #[test]
+    fn iv_length_exceeds_maximum() {
+        let too_long_iv = [0xAAu8; Iv::MAX_LEN + 1];
+        let result = Iv::new(&too_long_iv);
+
+        assert!(matches!(
+            result,
+            Err(Error::ApiMisuse(ApiMisuse::IvLengthExceedsMaximum {
+                actual: 17,
+                maximum: 16
+            }))
+        ));
     }
 }

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -133,7 +133,7 @@ impl quic::PacketKey for PacketKey {
     ) -> Result<quic::Tag, Error> {
         let aad = aead::Aad::from(header);
         let nonce_value = Nonce::quic(path_id, &self.iv, packet_number);
-        let nonce = aead::Nonce::assume_unique_for_key(nonce_value.0);
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_value.to_array()?);
         let tag = self
             .key
             .seal_in_place_separate_tag(nonce, aad, payload)
@@ -161,7 +161,7 @@ impl quic::PacketKey for PacketKey {
         let payload_len = payload.len();
         let aad = aead::Aad::from(header);
         let nonce_value = Nonce::quic(path_id, &self.iv, packet_number);
-        let nonce = aead::Nonce::assume_unique_for_key(nonce_value.0);
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_value.to_array()?);
         self.key
             .open_in_place(nonce, aad, payload)
             .map_err(|_| Error::DecryptError)?;

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -186,7 +186,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
         );
         Box::new(ChaCha20Poly1305MessageDecrypter {
             dec_key,
-            dec_offset: Iv::copy(iv),
+            dec_offset: Iv::new(iv).expect("IV length validated by key_block_shape"),
         })
     }
 
@@ -196,7 +196,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
         );
         Box::new(ChaCha20Poly1305MessageEncrypter {
             enc_key,
-            enc_offset: Iv::copy(enc_iv),
+            enc_offset: Iv::new(enc_iv).expect("IV length validated by key_block_shape"),
         })
     }
 
@@ -218,7 +218,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
         debug_assert_eq!(aead::NONCE_LEN, iv.len());
         Ok(ConnectionTrafficSecrets::Chacha20Poly1305 {
             key,
-            iv: Iv::new(iv[..].try_into().unwrap()),
+            iv: Iv::new(iv).expect("IV length validated by key_block_shape"),
         })
     }
 
@@ -292,7 +292,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = PrefixedPayload::with_capacity(total_len);
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
         payload.extend_from_slice(&nonce.as_ref()[4..]);
         payload.extend_from_chunks(&msg.payload);
@@ -340,7 +340,8 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
             return Err(Error::DecryptError);
         }
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.dec_offset, seq).0);
+        let nonce =
+            aead::Nonce::assume_unique_for_key(Nonce::new(&self.dec_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(
             seq,
             msg.typ,
@@ -373,7 +374,8 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = PrefixedPayload::with_capacity(total_len);
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).0);
+        let nonce =
+            aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
         payload.extend_from_chunks(&msg.payload);
 
@@ -404,5 +406,5 @@ fn gcm_iv(write_iv: &[u8], explicit: &[u8]) -> Iv {
     iv[..4].copy_from_slice(write_iv);
     iv[4..].copy_from_slice(explicit);
 
-    Iv::new(iv)
+    Iv::new(&iv).expect("IV length is NONCE_LEN, which is within MAX_LEN")
 }

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -207,7 +207,7 @@ impl MessageEncrypter for Tls13MessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = PrefixedPayload::with_capacity(total_len);
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(total_len));
         payload.extend_from_chunks(&msg.payload);
         payload.extend_from_slice(&msg.typ.to_array());
@@ -241,7 +241,7 @@ impl MessageDecrypter for Tls13MessageDecrypter {
             return Err(Error::DecryptError);
         }
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).0);
+        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(payload.len()));
         let plain_len = self
             .dec_key

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -1212,6 +1212,31 @@ pub enum ApiMisuse {
 
     /// A verifier or resolver implementation signalled that it does not support any certificate types.
     NoSupportedCertificateTypes,
+
+    /// [`Nonce::to_array()`][] called with incorrect array size.
+    ///
+    /// The nonce length does not match the requested array size `N`.
+    ///
+    /// [`Nonce::to_array()`]: crate::crypto::cipher::Nonce::to_array()
+    NonceArraySizeMismatch {
+        /// The expected array size (type parameter N)
+        expected: usize,
+        /// The actual nonce length
+        actual: usize,
+    },
+
+    /// [`Iv::new()`][] called with a value that exceeds the maximum IV length.
+    ///
+    /// The IV length must not exceed [`Iv::MAX_LEN`][].
+    ///
+    /// [`Iv::new()`]: crate::crypto::cipher::Iv::new()
+    /// [`Iv::MAX_LEN`]: crate::crypto::cipher::Iv::MAX_LEN
+    IvLengthExceedsMaximum {
+        /// The actual IV length provided
+        actual: usize,
+        /// The maximum allowed IV length
+        maximum: usize,
+    },
 }
 
 impl fmt::Display for ApiMisuse {


### PR DESCRIPTION
Allow the `Iv` and `Nonce` types to support a variable length instead of a hardcoded size of 12 bytes.

The current built-in AEADs use a 96 bit nonce, but other AEADs may have different requirements.