### PR TITLE
crypto: drop SigningKey::algorithm() method

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -44,7 +44,7 @@ use rustls::crypto::{
 };
 use rustls::enums::{
     AlertDescription, CertificateCompressionAlgorithm, CertificateType, ProtocolVersion,
-    SignatureAlgorithm, SignatureScheme,
+    SignatureScheme,
 };
 use rustls::error::{CertificateError, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use rustls::internal::msgs::codec::Codec;
@@ -543,10 +543,6 @@ impl SigningKey for FixedSignatureSchemeSigningKey {
 
     fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
         self.key.public_key()
-    }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
-        self.key.algorithm()
     }
 }
 

--- a/provider-example/src/sign.rs
+++ b/provider-example/src/sign.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use pkcs8::{DecodePrivateKey, EncodePublicKey};
 use rustls::crypto::{Signer, SigningKey};
-use rustls::enums::{SignatureAlgorithm, SignatureScheme};
+use rustls::enums::SignatureScheme;
 use rustls::pki_types::{PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer};
 use signature::{RandomizedSigner, SignatureEncoding};
 
@@ -44,10 +44,6 @@ impl SigningKey for EcdsaSigningKeyP256 {
                 .ok()?
                 .into_vec(),
         ))
-    }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
-        SignatureAlgorithm::ECDSA
     }
 }
 

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -26,9 +26,7 @@ use rustls::crypto::{
     self, CipherSuiteCommon, Credentials, GetRandomFailed, Identity, KeyExchangeAlgorithm,
     SelectedCredential, StartedKeyExchange, WebPkiSupportedAlgorithms, hash, tls12, tls13,
 };
-use rustls::enums::{
-    CipherSuite, ContentType, ProtocolVersion, SignatureAlgorithm, SignatureScheme,
-};
+use rustls::enums::{CipherSuite, ContentType, ProtocolVersion, SignatureScheme};
 use rustls::error::{PeerIncompatible, PeerMisbehaved};
 use rustls::pki_types::{
     AlgorithmIdentifier, CertificateDer, InvalidSignature, PrivateKeyDer,
@@ -500,10 +498,6 @@ impl crypto::SigningKey for SigningKey {
 
     fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
         None
-    }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
-        SignatureAlgorithm::ECDSA
     }
 }
 

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -14,8 +14,7 @@ use rustls::crypto::{
     Credentials, CryptoProvider, Identity, SelectedCredential, Signer, SigningKey,
 };
 use rustls::enums::{
-    AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureAlgorithm,
-    SignatureScheme,
+    AlertDescription, CipherSuite, ContentType, HandshakeType, ProtocolVersion, SignatureScheme,
 };
 use rustls::error::{ApiMisuse, CertificateError, Error, InconsistentKeys, PeerMisbehaved};
 use rustls::internal::msgs::base::Payload;
@@ -652,10 +651,6 @@ impl SigningKey for SigningKeyNoneSpki {
     fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
         None
     }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
-        unimplemented!("Not meant to be called during tests")
-    }
 }
 
 /// Represents a SigningKey that returns Some for its SPKI.
@@ -676,10 +671,6 @@ impl SigningKey for SigningKeySomeSpki {
     }
 
     fn choose_scheme(&self, _offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
-        unimplemented!("Not meant to be called during tests")
-    }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
         unimplemented!("Not meant to be called during tests")
     }
 }

--- a/rustls/src/crypto/aws_lc_rs/sign.rs
+++ b/rustls/src/crypto/aws_lc_rs/sign.rs
@@ -11,7 +11,7 @@ use pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, SubjectPublicKeyInfoDer, alg_
 #[cfg(any(test, bench))]
 use crate::crypto::CryptoProvider;
 use crate::crypto::signer::{Signer, SigningKey, public_key_to_spki};
-use crate::enums::{SignatureAlgorithm, SignatureScheme};
+use crate::enums::SignatureScheme;
 use crate::error::Error;
 use crate::sync::Arc;
 
@@ -63,10 +63,6 @@ impl SigningKey for RsaSigningKey {
             self.key.public_key(),
         ))
     }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
-        SignatureAlgorithm::RSA
-    }
 }
 
 impl TryFrom<&PrivateKeyDer<'_>> for RsaSigningKey {
@@ -96,9 +92,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaSigningKey {
 
 impl Debug for RsaSigningKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RsaSigningKey")
-            .field("algorithm", &self.algorithm())
-            .finish()
+        f.debug_struct("RsaSigningKey").finish()
     }
 }
 
@@ -201,10 +195,6 @@ impl SigningKey for EcdsaSigner {
 
         Some(public_key_to_spki(&id, self.key.public_key()))
     }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
-        self.scheme.algorithm()
-    }
 }
 
 impl Signer for EcdsaSigner {
@@ -290,10 +280,6 @@ impl SigningKey for Ed25519Signer {
 
     fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
         Some(public_key_to_spki(&alg_id::ED25519, self.key.public_key()))
-    }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
-        self.scheme.algorithm()
     }
 }
 
@@ -386,7 +372,6 @@ mod tests {
             format!("{k:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256 }"
         );
-        assert_eq!(k.algorithm(), SignatureAlgorithm::ECDSA);
 
         assert!(
             k.choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA256])
@@ -442,7 +427,6 @@ mod tests {
             format!("{k:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384 }"
         );
-        assert_eq!(k.algorithm(), SignatureAlgorithm::ECDSA);
 
         assert!(
             k.choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA256])
@@ -498,7 +482,6 @@ mod tests {
             format!("{k:?}"),
             "EcdsaSigner { scheme: ECDSA_NISTP521_SHA512 }"
         );
-        assert_eq!(k.algorithm(), SignatureAlgorithm::ECDSA);
 
         assert!(
             k.choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA256])
@@ -543,7 +526,6 @@ mod tests {
 
         let k = Ed25519Signer::try_from(&key).unwrap();
         assert_eq!(format!("{k:?}"), "Ed25519Signer { scheme: ED25519 }");
-        assert_eq!(k.algorithm(), SignatureAlgorithm::ED25519);
 
         assert!(
             k.choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA256])
@@ -587,8 +569,7 @@ mod tests {
         ));
 
         let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
-        assert_eq!(format!("{k:?}"), "RsaSigningKey { algorithm: RSA }");
-        assert_eq!(k.algorithm(), SignatureAlgorithm::RSA);
+        assert_eq!(format!("{k:?}"), "RsaSigningKey");
 
         assert!(
             k.choose_scheme(&[SignatureScheme::ECDSA_NISTP256_SHA256])

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -8,7 +8,7 @@ use pki_types::{AlgorithmIdentifier, CertificateDer, PrivateKeyDer, SubjectPubli
 use super::CryptoProvider;
 use crate::client::{ClientCredentialResolver, CredentialRequest};
 use crate::common_state::CommonState;
-use crate::enums::{AlertDescription, CertificateType, SignatureAlgorithm, SignatureScheme};
+use crate::enums::{AlertDescription, CertificateType, SignatureScheme};
 use crate::error::{ApiMisuse, Error, InconsistentKeys, InvalidMessage, PeerIncompatible};
 use crate::msgs::codec::{Codec, Reader};
 use crate::server::{ClientHello, ParsedCertificate, ServerCredentialResolver};
@@ -395,9 +395,6 @@ pub trait SigningKey: Debug + Send + Sync {
     /// If an implementation does not have the ability to derive this,
     /// it can return `None`.
     fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>>;
-
-    /// What kind of key we have.
-    fn algorithm(&self) -> SignatureAlgorithm;
 }
 
 /// A thing that can sign a message.


### PR DESCRIPTION
This is no longer used. I think this was enabled by

- #2688