### PR TITLE
Enqueue key update message on demand

### DIFF
--- a/rustls/src/msgs/message/mod.rs
+++ b/rustls/src/msgs/message/mod.rs
@@ -181,15 +181,6 @@ impl Message<'_> {
         }
     }
 
-    pub fn build_key_update_notify() -> Self {
-        Self {
-            version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::handshake(HandshakeMessagePayload(
-                HandshakePayload::KeyUpdate(KeyUpdateRequest::UpdateNotRequested),
-            )),
-        }
-    }
-
     pub fn build_key_update_request() -> Self {
         Self {
             version: ProtocolVersion::TLSv1_3,


### PR DESCRIPTION
I am hoping to make progress towards in-place encryption in the unbuffered pipeline and this change resulted as a minor improvement along the way.

Currently the key update notify message is separately allocated in `CommonState` where it is encrypted and later written to the `CommonState.sendable_tls` buffer.

The critical issue with this approach is `CommonState::enqueue_key_update_notification` seems to only be called within a receive context where, if in-place encryption is implemented, it will not have access to the outgoing buffer.

This PR moves the initialization of the key update message into `CommonState::perhaps_write_key_update` and simultaneously removes the separate allocation within `CommonState`.