### PR TITLE
Withdraw separate QUIC alert API

### DIFF
--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -488,8 +488,9 @@ impl CommonState {
     pub(crate) fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool) {
         {
             if let Protocol::Quic = self.protocol {
-                if let MessagePayload::Alert(alert) = m.payload {
-                    self.quic.alert = Some(alert.description);
+                if let MessagePayload::Alert(_) = m.payload {
+                    // alerts are sent out-of-band in QUIC mode
+                    return;
                 } else {
                     debug_assert!(
                         matches!(


### PR DESCRIPTION
The corresponding quinn change for this is simply:

```patch
diff --git a/quinn-proto/src/crypto/rustls.rs b/quinn-proto/src/crypto/rustls.rs
index 48891fd8..cc9313e1 100644
--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -105,7 +105,7 @@ impl crypto::Session for TlsSession {

     fn read_handshake(&mut self, buf: &[u8]) -> Result<bool, TransportError> {
         self.inner.read_hs(buf).map_err(|e| {
-            if let Some(alert) = self.inner.alert() {
+            if let Some(alert) = AlertDescription::try_from(&e).ok() {
                 TransportError {
                     code: TransportErrorCode::crypto(alert.into()),
                     frame: None,
```