### PR TITLE
Deduplicate outgoing

### DIFF
--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -382,12 +382,11 @@ impl CommonState {
         {
             PreEncryptAction::Nothing => {}
 
-            // Close connection once we start to run out of
-            // sequence space.
+            // Close connection once we start to run out of sequence space.
             PreEncryptAction::RefreshOrClose => {
                 match self.negotiated_version {
                     Some(ProtocolVersion::TLSv1_3) => {
-                        // driven by caller, as we don't have the `State` here
+                        // Driven by caller, as we don't have the `State` here.
                         self.refresh_traffic_keys_pending = true;
                     }
                     _ => {
@@ -400,11 +399,9 @@ impl CommonState {
                 }
             }
 
-            // Refuse to wrap counter at all costs.  This
+            // Refuse to wrap counter at all costs. This
             // is basically untestable unfortunately.
-            PreEncryptAction::Refuse => {
-                return Err(EncryptError::EncryptExhausted);
-            }
+            PreEncryptAction::Refuse => return Err(EncryptError::EncryptExhausted),
         };
 
         Ok(self.encrypt_state.encrypt_outgoing(m))


### PR DESCRIPTION
As before I am hoping to make progress towards a proposal for in-place encryption and this PR arose as an opportunity to simplify things along the way.

`CommonState::write_plaintext` and `CommonState::send_appdata_encrypt` largely share the same internal logic but duplicate most of their implementations, this PR re-organizes the internals such that they may be shared generically.