### PR TITLE
Proof of concept of a reader-writer split (#2761)

### DIFF
--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -41,7 +41,7 @@ mod buffered {
 
     /// This represents a single TLS client connection.
     pub struct ClientConnection {
-        inner: ConnectionCommon<ClientConnectionData>,
+        pub(crate) inner: ConnectionCommon<ClientConnectionData>,
     }
 
     impl fmt::Debug for ClientConnection {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1205,6 +1205,23 @@ impl State<ClientConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
+    fn handle_for_split_traffic(
+        &mut self,
+        cx: &mut ClientContext<'_>,
+        message: Message<'_>,
+    ) -> Result<(), Error> {
+        match message.payload {
+            MessagePayload::ApplicationData(payload) => cx.receive_plaintext(payload),
+            payload => {
+                return Err(inappropriate_message(
+                    &payload,
+                    &[ContentType::ApplicationData],
+                ));
+            }
+        }
+        Ok(())
+    }
+
     fn into_external_state(
         mut self: Box<Self>,
     ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1205,8 +1205,8 @@ impl State<ClientConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
-    fn into_traffic(self: Box<Self>) -> Result<Box<dyn TrafficState>, Error> {
-        Ok(self)
+    fn into_traffic(self: Box<Self>) -> Result<TrafficState, Error> {
+        Ok(TrafficState::Tls12)
     }
 
     fn into_external_state(
@@ -1218,12 +1218,6 @@ impl State<ClientConnectionData> for ExpectTraffic {
                 "call of into_external_state() only allowed with enable_secret_extraction",
             )),
         }
-    }
-}
-
-impl TrafficState for ExpectTraffic {
-    fn handle_unexpected(&self, payload: &MessagePayload<'_>) -> Error {
-        inappropriate_message(payload, &[ContentType::ApplicationData])
     }
 }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1205,21 +1205,8 @@ impl State<ClientConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
-    fn handle_for_split_traffic(
-        &mut self,
-        cx: &mut ClientContext<'_>,
-        message: Message<'_>,
-    ) -> Result<(), Error> {
-        match message.payload {
-            MessagePayload::ApplicationData(payload) => cx.receive_plaintext(payload),
-            payload => {
-                return Err(inappropriate_message(
-                    &payload,
-                    &[ContentType::ApplicationData],
-                ));
-            }
-        }
-        Ok(())
+    fn handle_other_for_split_traffic(&self, payload: &MessagePayload<'_>) -> Error {
+        inappropriate_message(payload, &[ContentType::ApplicationData])
     }
 
     fn into_external_state(

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1583,6 +1583,33 @@ impl State<ClientConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
+    fn handle_for_split_traffic(
+        &mut self,
+        cx: &mut ClientContext<'_>,
+        message: Message<'_>,
+    ) -> Result<(), Error> {
+        match message.payload {
+            MessagePayload::ApplicationData(payload) => cx.receive_plaintext(payload),
+            MessagePayload::Handshake {
+                parsed: HandshakeMessagePayload(HandshakePayload::NewSessionTicketTls13(new_ticket)),
+                ..
+            } => self.handle_new_ticket_tls13(cx, &new_ticket)?,
+            MessagePayload::Handshake {
+                parsed: HandshakeMessagePayload(HandshakePayload::KeyUpdate(key_update)),
+                ..
+            } => self.handle_key_update(cx.common, &key_update)?,
+            payload => {
+                return Err(inappropriate_handshake_message(
+                    &payload,
+                    &[ContentType::ApplicationData, ContentType::Handshake],
+                    &[HandshakeType::NewSessionTicket, HandshakeType::KeyUpdate],
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     fn send_key_update_request(&mut self, common: &mut CommonState) -> Result<(), Error> {
         self.key_schedule
             .request_key_update_and_update_encrypter(common)

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1583,8 +1583,15 @@ impl State<ClientConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
-    fn into_traffic(self: Box<Self>) -> Result<Box<dyn TrafficState>, Error> {
-        Ok(self)
+    fn into_traffic(self: Box<Self>) -> Result<TrafficState, Error> {
+        Ok(TrafficState::Tls13 {
+            decryption_secret: self
+                .key_schedule
+                .current_server_traffic_secret,
+            encryption_secret: self
+                .key_schedule
+                .current_client_traffic_secret,
+        })
     }
 
     fn send_key_update_request(&mut self, common: &mut CommonState) -> Result<(), Error> {
@@ -1600,35 +1607,6 @@ impl State<ClientConnectionData> for ExpectTraffic {
                 .extract_secrets(Side::Client)?,
             self,
         ))
-    }
-}
-
-impl TrafficState for ExpectTraffic {
-    fn handle_unexpected(&self, payload: &MessagePayload<'_>) -> Error {
-        inappropriate_handshake_message(
-            payload,
-            &[ContentType::ApplicationData, ContentType::Handshake],
-            &[HandshakeType::NewSessionTicket, HandshakeType::KeyUpdate],
-        )
-    }
-
-    fn handle_key_update(
-        &mut self,
-        common_state: &mut CommonState,
-        key_update: KeyUpdateRequest,
-    ) -> Result<(), Error> {
-        self.handle_key_update(common_state, &key_update)
-    }
-
-    fn send_key_update(&mut self, common: &mut CommonState, request: bool) {
-        if request {
-            let _ = self
-                .key_schedule
-                .request_key_update_and_update_encrypter(common);
-        } else {
-            self.key_schedule
-                .update_encrypter_and_notify(common);
-        }
     }
 }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1612,22 +1612,6 @@ impl TrafficState for ExpectTraffic {
         )
     }
 
-    fn handle_tls13_session_ticket(
-        &mut self,
-        common_state: &mut CommonState,
-        new_ticket: NewSessionTicketPayloadTls13,
-    ) -> Result<(), Error> {
-        let mut kcx = KernelContext {
-            peer_identity: common_state.peer_identity.as_ref(),
-            protocol: common_state.protocol,
-            quic: &common_state.quic,
-        };
-        common_state.tls13_tickets_received = common_state
-            .tls13_tickets_received
-            .saturating_add(1);
-        self.handle_new_ticket_impl(&mut kcx, &new_ticket)
-    }
-
     fn handle_key_update(
         &mut self,
         common_state: &mut CommonState,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1636,10 +1636,15 @@ impl TrafficState for ExpectTraffic {
         self.handle_key_update(common_state, &key_update)
     }
 
-    fn send_key_update_request(&mut self, common: &mut CommonState) {
-        let _ = self
-            .key_schedule
-            .request_key_update_and_update_encrypter(common);
+    fn send_key_update(&mut self, common: &mut CommonState, request: bool) {
+        if request {
+            let _ = self
+                .key_schedule
+                .request_key_update_and_update_encrypter(common);
+        } else {
+            self.key_schedule
+                .update_encrypter_and_notify(common);
+        }
     }
 }
 

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -835,10 +835,10 @@ pub(crate) trait State<Side>: Send + Sync {
 
     fn handle_tls13_session_ticket_for_split_traffic(
         &mut self,
-        cx: &mut Context<'_, Side>,
+        common_state: &mut CommonState,
         new_ticket: NewSessionTicketPayloadTls13,
     ) -> Result<(), Error> {
-        let _ = cx;
+        let _ = common_state;
         let payload = MessagePayload::Handshake {
             parsed: HandshakeMessagePayload(HandshakePayload::NewSessionTicketTls13(new_ticket)),
             encoded: Payload::Borrowed(&[]),
@@ -848,10 +848,10 @@ pub(crate) trait State<Side>: Send + Sync {
 
     fn handle_key_update_for_split_traffic(
         &mut self,
-        cx: &mut Context<'_, Side>,
+        common_state: &mut CommonState,
         key_update: KeyUpdateRequest,
     ) -> Result<(), Error> {
-        let _ = cx;
+        let _ = common_state;
         let payload = MessagePayload::Handshake {
             parsed: HandshakeMessagePayload(HandshakePayload::KeyUpdate(key_update)),
             encoded: Payload::Borrowed(&[]),

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -40,7 +40,7 @@ pub struct CommonState {
     pub(crate) early_exporter: Option<Box<dyn Exporter>>,
     pub(crate) aligned_handshake: Option<HandshakeAlignedProof>,
     pub(crate) may_send_application_data: bool,
-    may_receive_application_data: bool,
+    pub(crate) may_receive_application_data: bool,
     pub(crate) early_traffic: bool,
     sent_fatal_alert: bool,
     /// If we signaled end of stream.
@@ -59,7 +59,7 @@ pub struct CommonState {
     pub(crate) protocol: Protocol,
     pub(crate) quic: quic::Quic,
     pub(crate) enable_secret_extraction: bool,
-    temper_counters: TemperCounters,
+    pub(crate) temper_counters: TemperCounters,
     pub(crate) refresh_traffic_keys_pending: bool,
     pub(crate) fips: bool,
     pub(crate) tls13_tickets_received: u32,
@@ -634,7 +634,7 @@ impl CommonState {
         Ok(self.write_fragments(outgoing_tls, [].into_iter()))
     }
 
-    fn send_warning_alert_no_log(&mut self, desc: AlertDescription) {
+    pub(crate) fn send_warning_alert_no_log(&mut self, desc: AlertDescription) {
         let m = Message::build_alert(AlertLevel::Warning, desc);
         self.send_msg(m, self.record_layer.is_encrypting());
     }
@@ -963,7 +963,7 @@ enum Limit {
 
 /// Tracking technically-allowed protocol actions
 /// that we limit to avoid denial-of-service vectors.
-struct TemperCounters {
+pub(crate) struct TemperCounters {
     allowed_warning_alerts: u8,
     allowed_renegotiation_requests: u8,
     allowed_key_update_requests: u8,
@@ -981,7 +981,7 @@ impl TemperCounters {
         }
     }
 
-    fn received_renegotiation_request(&mut self) -> Result<(), Error> {
+    pub(crate) fn received_renegotiation_request(&mut self) -> Result<(), Error> {
         match self.allowed_renegotiation_requests {
             0 => Err(PeerMisbehaved::TooManyRenegotiationRequests.into()),
             _ => {
@@ -1001,7 +1001,7 @@ impl TemperCounters {
         }
     }
 
-    fn received_tls13_change_cipher_spec(&mut self) -> Result<(), Error> {
+    pub(crate) fn received_tls13_change_cipher_spec(&mut self) -> Result<(), Error> {
         match self.allowed_middlebox_ccs {
             0 => Err(PeerMisbehaved::IllegalMiddleboxChangeCipherSpec.into()),
             _ => {

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -831,6 +831,15 @@ pub(crate) trait State<Side>: Send + Sync {
         message: Message<'m>,
     ) -> Result<Box<dyn State<Side>>, Error>;
 
+    fn handle_for_split_traffic(
+        &mut self,
+        cx: &mut Context<'_, Side>,
+        message: Message<'_>,
+    ) -> Result<(), Error> {
+        let _ = (cx, message);
+        Err(Error::HandshakeNotComplete)
+    }
+
     fn send_key_update_request(&mut self, _common: &mut CommonState) -> Result<(), Error> {
         Err(Error::HandshakeNotComplete)
     }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -879,8 +879,8 @@ pub(crate) trait TrafficState {
 
     fn handle_unexpected(&self, payload: &MessagePayload<'_>) -> Error;
 
-    fn send_key_update_request(&mut self, common_state: &mut CommonState) {
-        let _ = common_state;
+    fn send_key_update(&mut self, common_state: &mut CommonState, request: bool) {
+        let _ = (common_state, request);
     }
 
     fn handle_decrypt_error(&self) {}
@@ -1024,7 +1024,7 @@ impl TemperCounters {
         }
     }
 
-    fn received_key_update_request(&mut self) -> Result<(), Error> {
+    pub(crate) fn received_key_update_request(&mut self) -> Result<(), Error> {
         match self.allowed_key_update_requests {
             0 => Err(PeerMisbehaved::TooManyKeyUpdateRequests.into()),
             _ => {

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -44,7 +44,7 @@ pub struct CommonState {
     pub(crate) may_send_application_data: bool,
     pub(crate) may_receive_application_data: bool,
     pub(crate) early_traffic: bool,
-    sent_fatal_alert: bool,
+    pub(crate) sent_fatal_alert: bool,
     /// If we signaled end of stream.
     pub(crate) has_sent_close_notify: bool,
     /// If the peer has signaled end of stream.

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -19,9 +19,7 @@ use crate::msgs::codec::Codec;
 use crate::msgs::deframer::{Delocator, HandshakeAlignedProof, Locator};
 use crate::msgs::enums::{AlertLevel, KeyUpdateRequest};
 use crate::msgs::fragmenter::MessageFragmenter;
-use crate::msgs::handshake::{
-    HandshakeMessagePayload, HandshakePayload, NewSessionTicketPayloadTls13, ProtocolName,
-};
+use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload, ProtocolName};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::quic;
 use crate::suites::{PartiallyExtractedSecrets, SupportedCipherSuite};
@@ -851,19 +849,6 @@ pub(crate) trait State<Side>: Send + Sync {
 }
 
 pub(crate) trait TrafficState {
-    fn handle_tls13_session_ticket(
-        &mut self,
-        common_state: &mut CommonState,
-        new_ticket: NewSessionTicketPayloadTls13,
-    ) -> Result<(), Error> {
-        let _ = common_state;
-        let payload = MessagePayload::Handshake {
-            parsed: HandshakeMessagePayload(HandshakePayload::NewSessionTicketTls13(new_ticket)),
-            encoded: Payload::Borrowed(&[]),
-        };
-        return Err(self.handle_unexpected(&payload));
-    }
-
     fn handle_key_update(
         &mut self,
         common_state: &mut CommonState,

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -1004,7 +1004,7 @@ pub(crate) struct TemperCounters {
 }
 
 impl TemperCounters {
-    fn received_warning_alert(&mut self) -> Result<(), Error> {
+    pub(crate) fn received_warning_alert(&mut self) -> Result<(), Error> {
         match self.allowed_warning_alerts {
             0 => Err(PeerMisbehaved::TooManyWarningAlertsReceived.into()),
             _ => {

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -54,7 +54,7 @@ pub struct CommonState {
     message_fragmenter: MessageFragmenter,
     pub(crate) received_plaintext: ChunkVecBuffer,
     pub(crate) sendable_tls: ChunkVecBuffer,
-    queued_key_update_message: Option<Vec<u8>>,
+    pub(crate) queued_key_update_message: Option<Vec<u8>>,
 
     /// Protocol whose key schedule should be used. Unused for TLS < 1.3.
     pub(crate) protocol: Protocol,

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -51,7 +51,7 @@ pub struct CommonState {
     #[cfg(feature = "std")]
     pub(crate) has_seen_eof: bool,
     pub(crate) peer_identity: Option<Identity<'static>>,
-    message_fragmenter: MessageFragmenter,
+    pub(crate) message_fragmenter: MessageFragmenter,
     pub(crate) received_plaintext: ChunkVecBuffer,
     pub(crate) sendable_tls: ChunkVecBuffer,
     pub(crate) queued_key_update_message: Option<Vec<u8>>,
@@ -965,7 +965,7 @@ pub(crate) enum Protocol {
     Quic,
 }
 
-enum Limit {
+pub(crate) enum Limit {
     #[cfg(feature = "std")]
     Yes,
     No,

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -458,7 +458,7 @@ impl ConnectionRandoms {
 /// [`StreamOwned`]: crate::StreamOwned
 pub struct ConnectionCommon<Side: SideData> {
     pub(crate) core: ConnectionCore<Side>,
-    deframer_buffer: DeframerVecBuffer,
+    pub(crate) deframer_buffer: DeframerVecBuffer,
     pub(crate) sendable_plaintext: ChunkVecBuffer,
 }
 

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -22,6 +22,7 @@ use crate::vecbuf::ChunkVecBuffer;
 
 // pub so that it can be re-exported from the crate root
 pub mod kernel;
+pub mod split;
 pub(crate) mod unbuffered;
 
 #[cfg(feature = "std")]

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -10,7 +10,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::client::ClientConnection;
+use crate::{
+    ConnectionCommon,
+    client::{ClientConnection, ClientConnectionData},
+};
 
 //----------- split ----------------------------------------------------------
 
@@ -25,7 +28,9 @@ pub fn split_client(conn: ClientConnection) -> (ClientReader, ClientWriter) {
         "the connection must be post-handshake"
     );
 
-    let conn = Arc::new(Mutex::new(conn));
+    let ClientConnection { inner } = conn;
+
+    let conn = Arc::new(Mutex::new(inner));
     (
         ClientReader { conn: conn.clone() },
         ClientWriter { conn: conn.clone() },
@@ -37,7 +42,7 @@ pub fn split_client(conn: ClientConnection) -> (ClientReader, ClientWriter) {
 /// The reading half of a client-side TLS connection.
 pub struct ClientReader {
     /// The underlying connection.
-    conn: Arc<Mutex<ClientConnection>>,
+    conn: Arc<Mutex<ConnectionCommon<ClientConnectionData>>>,
 }
 
 impl ClientReader {
@@ -95,7 +100,7 @@ impl io::Read for PlaintextReader<'_> {
 /// The writing half of a client-side TLS connection.
 pub struct ClientWriter {
     /// The underlying connection.
-    conn: Arc<Mutex<ClientConnection>>,
+    conn: Arc<Mutex<ConnectionCommon<ClientConnectionData>>>,
 }
 
 impl ClientWriter {

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -1138,30 +1138,6 @@ impl Writer {
         }
     }
 
-    // CommonState::buffer_plaintext()
-    fn buffer_plaintext(
-        info: &ConnectionInfo,
-        sendable_tls: &mut ChunkVecBuffer,
-        refresh_traffic_keys_pending: &mut bool,
-        message_fragmenter: &mut MessageFragmenter,
-        message_encrypter: &mut dyn MessageEncrypter,
-        write_seq: &mut u64,
-        write_seq_max: u64,
-        payload: OutboundChunks<'_>,
-    ) -> usize {
-        Self::send_appdata_encrypt(
-            info,
-            sendable_tls,
-            message_fragmenter,
-            refresh_traffic_keys_pending,
-            message_encrypter,
-            write_seq,
-            write_seq_max,
-            payload,
-            Limit::Yes,
-        )
-    }
-
     // CommonState::send_msg_encrypt()
     fn send_msg_encrypt(
         info: &ConnectionInfo,
@@ -1338,15 +1314,16 @@ impl io::Write for PlaintextWriter<'_> {
             return Ok(0);
         }
 
-        let len = Writer::buffer_plaintext(
+        let len = Writer::send_appdata_encrypt(
             &self.writer.info,
             &mut self.writer.sendable_tls,
-            &mut self.writer.refresh_traffic_keys_pending,
             &mut self.writer.message_fragmenter,
+            &mut self.writer.refresh_traffic_keys_pending,
             &mut *self.writer.message_encrypter,
             &mut self.writer.write_seq,
             self.writer.write_seq_max,
             buf.into(),
+            Limit::Yes,
         );
         Writer::maybe_refresh_traffic_keys(
             &self.writer.info,
@@ -1381,15 +1358,16 @@ impl io::Write for PlaintextWriter<'_> {
             }
         };
 
-        let len = Writer::buffer_plaintext(
+        let len = Writer::send_appdata_encrypt(
             &self.writer.info,
             &mut self.writer.sendable_tls,
-            &mut self.writer.refresh_traffic_keys_pending,
             &mut self.writer.message_fragmenter,
+            &mut self.writer.refresh_traffic_keys_pending,
             &mut *self.writer.message_encrypter,
             &mut self.writer.write_seq,
             self.writer.write_seq_max,
             payload,
+            Limit::Yes,
         );
         Writer::maybe_refresh_traffic_keys(
             &self.writer.info,

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -7,18 +7,26 @@
 
 use std::{
     boxed::Box,
-    io,
+    io, mem,
     ops::Deref,
     sync::{Arc, Mutex},
     vec::Vec,
 };
 
 use crate::{
-    ConnectionCommon,
+    CommonState, ConnectionCommon, Error, IoState,
     client::{ClientConnection, ClientConnectionData},
-    conn::{ConnectionCore, connection::PlaintextSink},
-    crypto::cipher::OutboundChunks,
-    msgs::deframer::DeframerVecBuffer,
+    common_state::State,
+    conn::{
+        ALLOWED_CONSECUTIVE_EMPTY_FRAGMENTS_MAX, ConnectionCore, InboundUnborrowedMessage,
+        connection::PlaintextSink,
+    },
+    crypto::cipher::{Decrypted, InboundPlainMessage, OutboundChunks},
+    enums::{ContentType, ProtocolVersion},
+    error::{AlertDescription, PeerMisbehaved},
+    msgs::deframer::{
+        BufferProgress, DeframerIter, DeframerVecBuffer, Delocator, HandshakeDeframer, Locator,
+    },
     vecbuf::ChunkVecBuffer,
 };
 
@@ -38,20 +46,36 @@ pub fn split_client(conn: ClientConnection) -> (ClientReader, ClientWriter) {
     let ClientConnection {
         inner:
             ConnectionCommon {
-                core,
+                core:
+                    ConnectionCore {
+                        state,
+                        side,
+                        common_state,
+                        hs_deframer,
+                        seen_consecutive_empty_fragments,
+                    },
                 deframer_buffer,
                 sendable_plaintext,
             },
     } = conn;
 
-    let conn = Arc::new(Mutex::new(core));
+    let state = Arc::new(Mutex::new(state));
+    let common_state = Arc::new(Mutex::new(common_state));
+
     (
         ClientReader {
-            core: conn.clone(),
+            state: state.clone(),
+            common_state: common_state.clone(),
+            side,
+
             deframer_buffer,
+            hs_deframer,
+            seen_consecutive_empty_fragments,
         },
         ClientWriter {
-            core: conn.clone(),
+            state: state.clone(),
+            common_state: common_state.clone(),
+
             sendable_plaintext,
         },
     )
@@ -61,11 +85,23 @@ pub fn split_client(conn: ClientConnection) -> (ClientReader, ClientWriter) {
 
 /// The reading half of a client-side TLS connection.
 pub struct ClientReader {
-    /// The underlying connection.
-    core: Arc<Mutex<ConnectionCore<ClientConnectionData>>>,
+    state: Arc<Mutex<Result<Box<dyn State<ClientConnectionData>>, Error>>>,
+    common_state: Arc<Mutex<CommonState>>,
+
+    side: ClientConnectionData,
+    /// Side-specific data about the connection.
 
     /// A buffer of received TLS frames to coalesce.
     deframer_buffer: DeframerVecBuffer,
+
+    /// De-framing state specific to handshake messages.
+    hs_deframer: HandshakeDeframer,
+
+    /// The number of consecutive empty fragments we've received.
+    ///
+    /// We limit consecutive empty fragments to avoid a route for the peer to
+    /// send us significant but fruitless traffic.
+    seen_consecutive_empty_fragments: u8,
 }
 
 impl ClientReader {
@@ -76,13 +112,20 @@ impl ClientReader {
 
     /// Receive TLS messages from the network.
     pub fn recv_tls(&mut self, rd: &mut dyn io::Read) -> io::Result<Received> {
-        let mut core = self.core.lock().unwrap();
+        let mut state = self.state.lock().unwrap();
+        let mut common_state = self.common_state.lock().unwrap();
+
         let mut total = 0;
         let mut eof = false;
         let mut sendable_plaintext = ChunkVecBuffer::new(None);
 
-        while !eof && core.common_state.wants_read() {
-            match Self::read_tls(&mut core, &mut self.deframer_buffer, rd) {
+        while !eof && common_state.wants_read() {
+            match Self::read_tls(
+                &mut common_state,
+                &mut self.hs_deframer,
+                &mut self.deframer_buffer,
+                rd,
+            ) {
                 Ok(0) => eof = true,
                 Ok(n) => total += n,
 
@@ -96,8 +139,16 @@ impl ClientReader {
                 Err(err) => return Err(err),
             }
 
-            core.process_new_packets(&mut self.deframer_buffer, &mut sendable_plaintext)
-                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+            Self::process_new_packets(
+                &mut state,
+                &mut common_state,
+                &mut self.side,
+                &mut self.hs_deframer,
+                &mut self.seen_consecutive_empty_fragments,
+                &mut self.deframer_buffer,
+                &mut sendable_plaintext,
+            )
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
         }
 
         let writer_action = WriterAction {
@@ -120,30 +171,333 @@ impl ClientReader {
 
     // ConnectionCommon::read_tls()
     fn read_tls(
-        core: &mut ConnectionCore<ClientConnectionData>,
+        common_state: &mut CommonState,
+        hs_deframer: &mut HandshakeDeframer,
         deframer_buffer: &mut DeframerVecBuffer,
         rd: &mut dyn io::Read,
     ) -> io::Result<usize> {
-        if core
-            .common_state
+        if common_state
             .received_plaintext
             .is_full()
         {
             return Err(io::Error::other("received plaintext buffer full"));
         }
 
-        if core
-            .common_state
-            .has_received_close_notify
-        {
+        if common_state.has_received_close_notify {
             return Ok(0);
         }
 
-        let res = deframer_buffer.read(rd, core.hs_deframer.is_active());
+        let res = deframer_buffer.read(rd, hs_deframer.is_active());
         if let Ok(0) = res {
-            core.common_state.has_seen_eof = true;
+            common_state.has_seen_eof = true;
         }
         res
+    }
+
+    // ConnectionCore::process_new_packets()
+    fn process_new_packets(
+        state_: &mut Result<Box<dyn State<ClientConnectionData>>, Error>,
+        common_state: &mut CommonState,
+        side: &mut ClientConnectionData,
+        hs_deframer: &mut HandshakeDeframer,
+        seen_consecutive_empty_fragments: &mut u8,
+        deframer_buffer: &mut DeframerVecBuffer,
+        sendable_plaintext: &mut ChunkVecBuffer,
+    ) -> Result<IoState, Error> {
+        let mut state = match mem::replace(state_, Err(Error::HandshakeNotComplete)) {
+            Ok(state) => state,
+            Err(e) => {
+                *state_ = Err(e.clone());
+                return Err(e);
+            }
+        };
+
+        // Should `InboundPlainMessage` resolve to plaintext application
+        // data it will be allocated within `plaintext` and written to
+        // `CommonState.received_plaintext` buffer.
+        //
+        // TODO `CommonState.received_plaintext` should be hoisted into
+        // `ConnectionCommon`
+        let mut plaintext = None;
+        let mut buffer_progress = hs_deframer.progress();
+
+        loop {
+            let buffer = deframer_buffer.filled_mut();
+            let locator = Locator::new(buffer);
+            let res = Self::deframe(
+                common_state,
+                hs_deframer,
+                seen_consecutive_empty_fragments,
+                Some(&*state),
+                buffer,
+                &mut buffer_progress,
+            );
+
+            let opt_msg = match res {
+                Ok(opt_msg) => opt_msg,
+                Err(e) => {
+                    *state_ = Err(e.clone());
+                    deframer_buffer.discard(buffer_progress.take_discard());
+                    return Err(e);
+                }
+            };
+
+            let Some(msg) = opt_msg else {
+                break;
+            };
+
+            match common_state.process_main_protocol(
+                msg,
+                state,
+                side,
+                &locator,
+                &mut plaintext,
+                Some(sendable_plaintext),
+            ) {
+                Ok(new) => state = new,
+                Err(e) => {
+                    *state_ = Err(e.clone());
+                    deframer_buffer.discard(buffer_progress.take_discard());
+                    return Err(e);
+                }
+            }
+
+            if common_state.has_received_close_notify {
+                // "Any data received after a closure alert has been received MUST be ignored."
+                // -- <https://datatracker.ietf.org/doc/html/rfc8446#section-6.1>
+                // This is data that has already been accepted in `read_tls`.
+                buffer_progress.add_discard(deframer_buffer.filled().len());
+                break;
+            }
+
+            if let Some(payload) = plaintext.take() {
+                let payload = payload.reborrow(&Delocator::new(buffer));
+                common_state
+                    .received_plaintext
+                    .append(payload.into_vec());
+            }
+
+            deframer_buffer.discard(buffer_progress.take_discard());
+        }
+
+        deframer_buffer.discard(buffer_progress.take_discard());
+        *state_ = Ok(state);
+        Ok(common_state.current_io_state())
+    }
+
+    // ConnectionCore::deframe()
+    fn deframe<'b>(
+        common_state: &mut CommonState,
+        hs_deframer: &mut HandshakeDeframer,
+        seen_consecutive_empty_fragments: &mut u8,
+        state: Option<&dyn State<ClientConnectionData>>,
+        buffer: &'b mut [u8],
+        buffer_progress: &mut BufferProgress,
+    ) -> Result<Option<InboundPlainMessage<'b>>, Error> {
+        // before processing any more of `buffer`, return any extant messages from `hs_deframer`
+        if hs_deframer.has_message_ready() {
+            Ok(Self::take_handshake_message(
+                hs_deframer,
+                buffer,
+                buffer_progress,
+            ))
+        } else {
+            Self::process_more_input(
+                common_state,
+                hs_deframer,
+                seen_consecutive_empty_fragments,
+                state,
+                buffer,
+                buffer_progress,
+            )
+        }
+    }
+
+    // ConnectionCore::take_handshake_message()
+    fn take_handshake_message<'b>(
+        hs_deframer: &mut HandshakeDeframer,
+        buffer: &'b mut [u8],
+        buffer_progress: &mut BufferProgress,
+    ) -> Option<InboundPlainMessage<'b>> {
+        hs_deframer
+            .iter(buffer)
+            .next()
+            .map(|(message, discard)| {
+                buffer_progress.add_discard(discard);
+                message
+            })
+    }
+
+    // ConnectionCore::process_more_input()
+    fn process_more_input<'b>(
+        common_state: &mut CommonState,
+        hs_deframer: &mut HandshakeDeframer,
+        seen_consecutive_empty_fragments: &mut u8,
+        state: Option<&dyn State<ClientConnectionData>>,
+        buffer: &'b mut [u8],
+        buffer_progress: &mut BufferProgress,
+    ) -> Result<Option<InboundPlainMessage<'b>>, Error> {
+        let version_is_tls13 = matches!(
+            common_state.negotiated_version,
+            Some(ProtocolVersion::TLSv1_3)
+        );
+
+        let locator = Locator::new(buffer);
+
+        loop {
+            let mut iter = DeframerIter::new(&mut buffer[buffer_progress.processed()..]);
+
+            let (message, processed) = loop {
+                let message = match iter.next().transpose() {
+                    Ok(Some(message)) => message,
+                    Ok(None) => return Ok(None),
+                    Err(err) => return Err(Self::handle_deframe_error(common_state, err, state)),
+                };
+
+                let allowed_plaintext = match message.typ {
+                    // CCS messages are always plaintext.
+                    ContentType::ChangeCipherSpec => true,
+                    // Alerts are allowed to be plaintext if-and-only-if:
+                    // * The negotiated protocol version is TLS 1.3. - In TLS 1.2 it is unambiguous when
+                    //   keying changes based on the CCS message. Only TLS 1.3 requires these heuristics.
+                    // * We have not yet decrypted any messages from the peer - if we have we don't
+                    //   expect any plaintext.
+                    // * The payload size is indicative of a plaintext alert message.
+                    ContentType::Alert
+                        if version_is_tls13
+                            && !common_state
+                                .record_layer
+                                .has_decrypted()
+                            && message.payload.len() <= 2 =>
+                    {
+                        true
+                    }
+                    // In other circumstances, we expect all messages to be encrypted.
+                    _ => false,
+                };
+
+                if allowed_plaintext && !hs_deframer.is_active() {
+                    break (message.into_plain_message(), iter.bytes_consumed());
+                }
+
+                let message = match common_state
+                    .record_layer
+                    .decrypt_incoming(message)
+                {
+                    // failed decryption during trial decryption is not allowed to be
+                    // interleaved with partial handshake data.
+                    Ok(None) if hs_deframer.aligned().is_none() => {
+                        return Err(
+                            PeerMisbehaved::RejectedEarlyDataInterleavedWithHandshakeMessage.into(),
+                        );
+                    }
+
+                    // failed decryption during trial decryption.
+                    Ok(None) => continue,
+
+                    Ok(Some(message)) => message,
+
+                    Err(err) => return Err(Self::handle_deframe_error(common_state, err, state)),
+                };
+
+                let Decrypted {
+                    want_close_before_decrypt,
+                    plaintext,
+                } = message;
+
+                if want_close_before_decrypt {
+                    common_state.send_close_notify();
+                }
+
+                break (plaintext, iter.bytes_consumed());
+            };
+
+            if hs_deframer.aligned().is_none() && message.typ != ContentType::Handshake {
+                // "Handshake messages MUST NOT be interleaved with other record
+                // types.  That is, if a handshake message is split over two or more
+                // records, there MUST NOT be any other records between them."
+                // https://www.rfc-editor.org/rfc/rfc8446#section-5.1
+                return Err(PeerMisbehaved::MessageInterleavedWithHandshakeMessage.into());
+            }
+
+            match message.payload.len() {
+                0 => {
+                    if *seen_consecutive_empty_fragments == ALLOWED_CONSECUTIVE_EMPTY_FRAGMENTS_MAX
+                    {
+                        return Err(PeerMisbehaved::TooManyEmptyFragments.into());
+                    }
+                    *seen_consecutive_empty_fragments += 1;
+                }
+                _ => {
+                    *seen_consecutive_empty_fragments = 0;
+                }
+            };
+
+            buffer_progress.add_processed(processed);
+
+            // do an end-run around the borrow checker, converting `message` (containing
+            // a borrowed slice) to an unborrowed one (containing a `Range` into the
+            // same buffer).  the reborrow happens inside the branch that returns the
+            // message.
+            //
+            // is fixed by -Zpolonius
+            // https://github.com/rust-lang/rfcs/blob/master/text/2094-nll.md#problem-case-3-conditional-control-flow-across-functions
+            let unborrowed = InboundUnborrowedMessage::unborrow(&locator, message);
+
+            if unborrowed.typ != ContentType::Handshake {
+                let message = unborrowed.reborrow(&Delocator::new(buffer));
+                buffer_progress.add_discard(processed);
+                return Ok(Some(message));
+            }
+
+            let message = unborrowed.reborrow(&Delocator::new(buffer));
+            hs_deframer.input_message(message, &locator, buffer_progress.processed());
+            hs_deframer.coalesce(buffer)?;
+
+            common_state.aligned_handshake = hs_deframer.aligned();
+
+            if hs_deframer.has_message_ready() {
+                // trial decryption finishes with the first handshake message after it started.
+                common_state
+                    .record_layer
+                    .finish_trial_decryption();
+
+                return Ok(Self::take_handshake_message(
+                    hs_deframer,
+                    buffer,
+                    buffer_progress,
+                ));
+            }
+        }
+    }
+
+    // ConnectionCore::handle_deframe_error()
+    fn handle_deframe_error(
+        common_state: &mut CommonState,
+        error: Error,
+        state: Option<&dyn State<ClientConnectionData>>,
+    ) -> Error {
+        match error {
+            error @ Error::InvalidMessage(_) => {
+                if common_state.is_quic() {
+                    common_state.quic.alert = Some(AlertDescription::DecodeError);
+                    error
+                } else {
+                    common_state.send_fatal_alert(AlertDescription::DecodeError, error)
+                }
+            }
+            Error::PeerSentOversizedRecord => {
+                common_state.send_fatal_alert(AlertDescription::RecordOverflow, error)
+            }
+            Error::DecryptError => {
+                if let Some(state) = state {
+                    state.handle_decrypt_error();
+                }
+                common_state.send_fatal_alert(AlertDescription::BadRecordMac, error)
+            }
+
+            error => error,
+        }
     }
 }
 
@@ -164,8 +518,8 @@ pub struct PlaintextReader<'a> {
 
 impl io::Read for PlaintextReader<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut core = self.reader.core.lock().unwrap();
-        let common = &mut core.common_state;
+        let mut common_state = self.reader.common_state.lock().unwrap();
+        let common = &mut *common_state;
         crate::Reader {
             received_plaintext: &mut common.received_plaintext,
             has_received_close_notify: common.has_received_close_notify,
@@ -179,8 +533,8 @@ impl io::Read for PlaintextReader<'_> {
 
 /// The writing half of a client-side TLS connection.
 pub struct ClientWriter {
-    /// The underlying connection.
-    core: Arc<Mutex<ConnectionCore<ClientConnectionData>>>,
+    state: Arc<Mutex<Result<Box<dyn State<ClientConnectionData>>, Error>>>,
+    common_state: Arc<Mutex<CommonState>>,
 
     /// A buffer of plaintext to encrypt and send.
     sendable_plaintext: ChunkVecBuffer,
@@ -204,10 +558,10 @@ impl ClientWriter {
 
     /// Send prepared TLS messages over the network.
     pub fn send_tls(&mut self, wr: &mut dyn io::Write) -> io::Result<usize> {
-        let mut core = self.core.lock().unwrap();
+        let mut common_state = self.common_state.lock().unwrap();
         let mut total = 0;
-        while core.common_state.wants_write() {
-            match Self::write_tls(&mut core, wr) {
+        while common_state.wants_write() {
+            match Self::write_tls(&mut common_state, wr) {
                 Ok(0) => return Ok(total),
                 Ok(n) => total += n,
 
@@ -225,13 +579,29 @@ impl ClientWriter {
     }
 
     // ConnectionCommon::write_tls()
-    fn write_tls(
-        core: &mut ConnectionCore<ClientConnectionData>,
-        wr: &mut dyn io::Write,
-    ) -> io::Result<usize> {
-        core.common_state
-            .sendable_tls
-            .write_to(wr)
+    fn write_tls(common_state: &mut CommonState, wr: &mut dyn io::Write) -> io::Result<usize> {
+        common_state.sendable_tls.write_to(wr)
+    }
+
+    // ConnectionCore::maybe_refresh_traffic_keys()
+    fn maybe_refresh_traffic_keys(
+        state: &mut Result<Box<dyn State<ClientConnectionData>>, Error>,
+        common_state: &mut CommonState,
+    ) {
+        if mem::take(&mut common_state.refresh_traffic_keys_pending) {
+            let _ = Self::refresh_traffic_keys(state, common_state);
+        }
+    }
+
+    // ConnectionCore::refresh_traffic_keys()
+    fn refresh_traffic_keys(
+        state: &mut Result<Box<dyn State<ClientConnectionData>>, Error>,
+        common_state: &mut CommonState,
+    ) -> Result<(), Error> {
+        match state {
+            Ok(st) => st.send_key_update_request(common_state),
+            Err(e) => Err(e.clone()),
+        }
     }
 }
 
@@ -243,11 +613,10 @@ pub struct PlaintextWriter<'a> {
 
 impl PlaintextSink for PlaintextWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut core = self.writer.core.lock().unwrap();
-        let len = core
-            .common_state
-            .buffer_plaintext(buf.into(), &mut self.writer.sendable_plaintext);
-        core.maybe_refresh_traffic_keys();
+        let mut state = self.writer.state.lock().unwrap();
+        let mut common_state = self.writer.common_state.lock().unwrap();
+        let len = common_state.buffer_plaintext(buf.into(), &mut self.writer.sendable_plaintext);
+        ClientWriter::maybe_refresh_traffic_keys(&mut state, &mut common_state);
         Ok(len)
     }
 
@@ -266,11 +635,10 @@ impl PlaintextSink for PlaintextWriter<'_> {
             }
         };
 
-        let mut core = self.writer.core.lock().unwrap();
-        let len = core
-            .common_state
-            .buffer_plaintext(payload, &mut self.writer.sendable_plaintext);
-        core.maybe_refresh_traffic_keys();
+        let mut state = self.writer.state.lock().unwrap();
+        let mut common_state = self.writer.common_state.lock().unwrap();
+        let len = common_state.buffer_plaintext(payload, &mut self.writer.sendable_plaintext);
+        ClientWriter::maybe_refresh_traffic_keys(&mut state, &mut common_state);
         Ok(len)
     }
 

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -4,3 +4,151 @@
 //! handshakes.  It separates the read and write halves of the connection into
 //! [`Reader`] and [`Writer`] respectively.  These halves can be used fairly
 //! independently, making it easier to pipeline and maximize throughput.
+
+use std::{
+    io,
+    sync::{Arc, Mutex},
+};
+
+use crate::client::ClientConnection;
+
+//----------- split ----------------------------------------------------------
+
+/// Split a [`ClientConnection`] into reader-writer halves.
+///
+/// # Panics
+///
+/// Panics if `conn.is_handshaking()`.
+pub fn split_client(conn: ClientConnection) -> (ClientReader, ClientWriter) {
+    assert!(
+        !conn.is_handshaking(),
+        "the connection must be post-handshake"
+    );
+
+    let conn = Arc::new(Mutex::new(conn));
+    (
+        ClientReader { conn: conn.clone() },
+        ClientWriter { conn: conn.clone() },
+    )
+}
+
+//----------- Reader ---------------------------------------------------------
+
+/// The reading half of a client-side TLS connection.
+pub struct ClientReader {
+    /// The underlying connection.
+    conn: Arc<Mutex<ClientConnection>>,
+}
+
+impl ClientReader {
+    /// A reader for plaintext data.
+    pub fn reader(&mut self) -> PlaintextReader<'_> {
+        PlaintextReader { reader: self }
+    }
+
+    /// Receive TLS messages from the network.
+    pub fn recv_tls(&mut self, rd: &mut dyn io::Read) -> io::Result<usize> {
+        let mut conn = self.conn.lock().unwrap();
+        let mut total = 0;
+        let mut eof = false;
+        while !eof && conn.wants_read() {
+            match conn.read_tls(rd) {
+                Ok(0) => eof = true,
+                Ok(n) => total += n,
+
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                    if total != 0 {
+                        return Ok(total);
+                    } else {
+                        return Err(err);
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+
+            conn.process_new_packets()
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        }
+        Ok(total)
+    }
+}
+
+/// A reader of plaintext data from a [`ClientReader`].
+pub struct PlaintextReader<'a> {
+    /// The underlying reader.
+    reader: &'a mut ClientReader,
+}
+
+impl io::Read for PlaintextReader<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.reader
+            .conn
+            .lock()
+            .unwrap()
+            .reader()
+            .read(buf)
+    }
+}
+
+//----------- Writer ---------------------------------------------------------
+
+/// The writing half of a client-side TLS connection.
+pub struct ClientWriter {
+    /// The underlying connection.
+    conn: Arc<Mutex<ClientConnection>>,
+}
+
+impl ClientWriter {
+    /// A writer for plaintext data.
+    pub fn writer(&mut self) -> PlaintextWriter<'_> {
+        PlaintextWriter { writer: self }
+    }
+
+    /// Send prepared TLS messages over the network.
+    pub fn send_tls(&mut self, wr: &mut dyn io::Write) -> io::Result<usize> {
+        let mut conn = self.conn.lock().unwrap();
+        let mut total = 0;
+        while conn.wants_write() {
+            match conn.write_tls(wr) {
+                Ok(0) => return Ok(total),
+                Ok(n) => total += n,
+
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                    if total != 0 {
+                        return Ok(total);
+                    } else {
+                        return Err(err);
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(total)
+    }
+}
+
+/// A writer of plaintext data into a [`ClientWriter`].
+pub struct PlaintextWriter<'a> {
+    /// The underlying writer.
+    writer: &'a mut ClientWriter,
+}
+
+impl io::Write for PlaintextWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.writer
+            .conn
+            .lock()
+            .unwrap()
+            .writer()
+            .write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer
+            .conn
+            .lock()
+            .unwrap()
+            .writer()
+            .flush()
+    }
+}

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -116,7 +116,7 @@ pub fn split(conn: impl Into<Connection>) -> Result<(Reader, Writer), Error> {
         handshake_kind: common_state.handshake_kind.unwrap(),
         side: common_state.side,
         suite: common_state.suite.unwrap(),
-        alpn_protocol: common_state.alpn_protocol.clone(),
+        _alpn_protocol: common_state.alpn_protocol.clone(),
         peer_identity: common_state
             .peer_identity
             .clone()
@@ -152,26 +152,28 @@ pub fn split(conn: impl Into<Connection>) -> Result<(Reader, Writer), Error> {
 }
 
 /// Immutable information about a connection.
-struct ConnectionInfo {
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ConnectionInfo {
     /// The TLS protocol version in use.
-    version: ProtocolVersion,
+    pub version: ProtocolVersion,
 
     /// Which kind of handshake was performed.
     ///
     /// Relevant for resumptions.
-    handshake_kind: HandshakeKind,
+    pub handshake_kind: HandshakeKind,
 
     /// Which side of the connection this is.
-    side: Side,
+    pub side: Side,
 
     /// The cipher suite in use.
-    suite: SupportedCipherSuite,
+    pub suite: SupportedCipherSuite,
 
     /// The negotiated ALPN protocol, if any.
-    alpn_protocol: Option<ProtocolName>,
+    _alpn_protocol: Option<ProtocolName>,
 
     /// The identity of the peer.
-    peer_identity: Identity<'static>,
+    pub peer_identity: Identity<'static>,
 }
 
 impl ConnectionInfo {
@@ -225,6 +227,11 @@ pub struct Reader {
 }
 
 impl Reader {
+    /// Information about the connection.
+    pub fn info(&self) -> &ConnectionInfo {
+        &self.info
+    }
+
     /// A reader for plaintext data.
     pub fn reader(&mut self) -> PlaintextReader<'_> {
         PlaintextReader { reader: self }
@@ -866,6 +873,11 @@ pub struct Writer {
 }
 
 impl Writer {
+    /// Information about the connection.
+    pub fn info(&self) -> &ConnectionInfo {
+        &self.info
+    }
+
     /// A writer for plaintext data.
     pub fn writer(&mut self) -> PlaintextWriter<'_> {
         PlaintextWriter { writer: self }

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -685,11 +685,12 @@ impl Reader {
             .map(|()| None),
 
             MessagePayload::Handshake {
-                parsed: HandshakeMessagePayload(HandshakePayload::NewSessionTicketTls13(new_ticket)),
+                parsed: HandshakeMessagePayload(HandshakePayload::NewSessionTicketTls13(_)),
                 ..
-            } if info.is_tls13() && info.side == Side::Client => state
-                .handle_tls13_session_ticket(common_state, new_ticket)
-                .map(|()| None),
+            } if info.is_tls13() && info.side == Side::Client => {
+                // TODO: Restore support for session tickets
+                Ok(None)
+            }
 
             MessagePayload::Handshake {
                 parsed: HandshakeMessagePayload(HandshakePayload::KeyUpdate(key_update)),
@@ -698,6 +699,7 @@ impl Reader {
                 Self::handle_key_update(common_state, state, writer_action, key_update)
                     .map(|()| None)
             }
+
             other => Err(state.handle_unexpected(&other)),
         };
 

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -6,13 +6,20 @@
 //! independently, making it easier to pipeline and maximize throughput.
 
 use std::{
+    boxed::Box,
     io,
+    ops::Deref,
     sync::{Arc, Mutex},
+    vec::Vec,
 };
 
 use crate::{
     ConnectionCommon,
     client::{ClientConnection, ClientConnectionData},
+    conn::{ConnectionCore, connection::PlaintextSink},
+    crypto::cipher::OutboundChunks,
+    msgs::deframer::DeframerVecBuffer,
+    vecbuf::ChunkVecBuffer,
 };
 
 //----------- split ----------------------------------------------------------
@@ -28,12 +35,25 @@ pub fn split_client(conn: ClientConnection) -> (ClientReader, ClientWriter) {
         "the connection must be post-handshake"
     );
 
-    let ClientConnection { inner } = conn;
+    let ClientConnection {
+        inner:
+            ConnectionCommon {
+                core,
+                deframer_buffer,
+                sendable_plaintext,
+            },
+    } = conn;
 
-    let conn = Arc::new(Mutex::new(inner));
+    let conn = Arc::new(Mutex::new(core));
     (
-        ClientReader { conn: conn.clone() },
-        ClientWriter { conn: conn.clone() },
+        ClientReader {
+            core: conn.clone(),
+            deframer_buffer,
+        },
+        ClientWriter {
+            core: conn.clone(),
+            sendable_plaintext,
+        },
     )
 }
 
@@ -42,7 +62,10 @@ pub fn split_client(conn: ClientConnection) -> (ClientReader, ClientWriter) {
 /// The reading half of a client-side TLS connection.
 pub struct ClientReader {
     /// The underlying connection.
-    conn: Arc<Mutex<ConnectionCommon<ClientConnectionData>>>,
+    core: Arc<Mutex<ConnectionCore<ClientConnectionData>>>,
+
+    /// A buffer of received TLS frames to coalesce.
+    deframer_buffer: DeframerVecBuffer,
 }
 
 impl ClientReader {
@@ -52,18 +75,20 @@ impl ClientReader {
     }
 
     /// Receive TLS messages from the network.
-    pub fn recv_tls(&mut self, rd: &mut dyn io::Read) -> io::Result<usize> {
-        let mut conn = self.conn.lock().unwrap();
+    pub fn recv_tls(&mut self, rd: &mut dyn io::Read) -> io::Result<Received> {
+        let mut core = self.core.lock().unwrap();
         let mut total = 0;
         let mut eof = false;
-        while !eof && conn.wants_read() {
-            match conn.read_tls(rd) {
+        let mut sendable_plaintext = ChunkVecBuffer::new(None);
+
+        while !eof && core.common_state.wants_read() {
+            match Self::read_tls(&mut core, &mut self.deframer_buffer, rd) {
                 Ok(0) => eof = true,
                 Ok(n) => total += n,
 
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
                     if total != 0 {
-                        return Ok(total);
+                        break;
                     } else {
                         return Err(err);
                     }
@@ -71,11 +96,64 @@ impl ClientReader {
                 Err(err) => return Err(err),
             }
 
-            conn.process_new_packets()
+            core.process_new_packets(&mut self.deframer_buffer, &mut sendable_plaintext)
                 .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
         }
-        Ok(total)
+
+        let writer_action = WriterAction {
+            sendable_plaintext: (!sendable_plaintext.is_empty()).then(|| {
+                let mut buffer = (0..sendable_plaintext.len())
+                    .map(|_| 0u8)
+                    .collect::<Box<[u8]>>();
+                sendable_plaintext
+                    .read(&mut buffer)
+                    .expect("just moving data");
+                buffer
+            }),
+        };
+
+        Ok(Received {
+            bytes_read: total,
+            writer_action: Some(writer_action).filter(|a| !a.is_empty()),
+        })
     }
+
+    // ConnectionCommon::read_tls()
+    fn read_tls(
+        core: &mut ConnectionCore<ClientConnectionData>,
+        deframer_buffer: &mut DeframerVecBuffer,
+        rd: &mut dyn io::Read,
+    ) -> io::Result<usize> {
+        if core
+            .common_state
+            .received_plaintext
+            .is_full()
+        {
+            return Err(io::Error::other("received plaintext buffer full"));
+        }
+
+        if core
+            .common_state
+            .has_received_close_notify
+        {
+            return Ok(0);
+        }
+
+        let res = deframer_buffer.read(rd, core.hs_deframer.is_active());
+        if let Ok(0) = res {
+            core.common_state.has_seen_eof = true;
+        }
+        res
+    }
+}
+
+/// The output of [`Reader::recv_tls()`].
+pub struct Received {
+    /// The number of bytes read.
+    pub bytes_read: usize,
+
+    /// An action the writer should take, if any.
+    pub writer_action: Option<WriterAction>,
 }
 
 /// A reader of plaintext data from a [`ClientReader`].
@@ -86,12 +164,14 @@ pub struct PlaintextReader<'a> {
 
 impl io::Read for PlaintextReader<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.reader
-            .conn
-            .lock()
-            .unwrap()
-            .reader()
-            .read(buf)
+        let mut core = self.reader.core.lock().unwrap();
+        let common = &mut core.common_state;
+        crate::Reader {
+            received_plaintext: &mut common.received_plaintext,
+            has_received_close_notify: common.has_received_close_notify,
+            has_seen_eof: common.has_seen_eof,
+        }
+        .read(buf)
     }
 }
 
@@ -100,7 +180,10 @@ impl io::Read for PlaintextReader<'_> {
 /// The writing half of a client-side TLS connection.
 pub struct ClientWriter {
     /// The underlying connection.
-    conn: Arc<Mutex<ConnectionCommon<ClientConnectionData>>>,
+    core: Arc<Mutex<ConnectionCore<ClientConnectionData>>>,
+
+    /// A buffer of plaintext to encrypt and send.
+    sendable_plaintext: ChunkVecBuffer,
 }
 
 impl ClientWriter {
@@ -109,12 +192,22 @@ impl ClientWriter {
         PlaintextWriter { writer: self }
     }
 
+    /// Enact a [`WriterAction`] sent by the [`Reader`].
+    pub fn enact(&mut self, action: WriterAction) {
+        let WriterAction { sendable_plaintext } = action;
+
+        if let Some(sendable_plaintext) = sendable_plaintext {
+            self.sendable_plaintext
+                .append(sendable_plaintext.into_vec());
+        }
+    }
+
     /// Send prepared TLS messages over the network.
     pub fn send_tls(&mut self, wr: &mut dyn io::Write) -> io::Result<usize> {
-        let mut conn = self.conn.lock().unwrap();
+        let mut core = self.core.lock().unwrap();
         let mut total = 0;
-        while conn.wants_write() {
-            match conn.write_tls(wr) {
+        while core.common_state.wants_write() {
+            match Self::write_tls(&mut core, wr) {
                 Ok(0) => return Ok(total),
                 Ok(n) => total += n,
 
@@ -130,6 +223,16 @@ impl ClientWriter {
         }
         Ok(total)
     }
+
+    // ConnectionCommon::write_tls()
+    fn write_tls(
+        core: &mut ConnectionCore<ClientConnectionData>,
+        wr: &mut dyn io::Write,
+    ) -> io::Result<usize> {
+        core.common_state
+            .sendable_tls
+            .write_to(wr)
+    }
 }
 
 /// A writer of plaintext data into a [`ClientWriter`].
@@ -138,22 +241,68 @@ pub struct PlaintextWriter<'a> {
     writer: &'a mut ClientWriter,
 }
 
-impl io::Write for PlaintextWriter<'_> {
+impl PlaintextSink for PlaintextWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.writer
-            .conn
-            .lock()
-            .unwrap()
-            .writer()
-            .write(buf)
+        let mut core = self.writer.core.lock().unwrap();
+        let len = core
+            .common_state
+            .buffer_plaintext(buf.into(), &mut self.writer.sendable_plaintext);
+        core.maybe_refresh_traffic_keys();
+        Ok(len)
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        let payload_owner: Vec<&[u8]>;
+        let payload = match bufs.len() {
+            0 => return Ok(0),
+            1 => OutboundChunks::Single(bufs[0].deref()),
+            _ => {
+                payload_owner = bufs
+                    .iter()
+                    .map(|io_slice| io_slice.deref())
+                    .collect();
+
+                OutboundChunks::new(&payload_owner)
+            }
+        };
+
+        let mut core = self.writer.core.lock().unwrap();
+        let len = core
+            .common_state
+            .buffer_plaintext(payload, &mut self.writer.sendable_plaintext);
+        core.maybe_refresh_traffic_keys();
+        Ok(len)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.writer
-            .conn
-            .lock()
-            .unwrap()
-            .writer()
-            .flush()
+        Ok(())
+    }
+}
+
+impl io::Write for PlaintextWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        crate::Writer::new(self).write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        crate::Writer::new(self).flush()
+    }
+}
+
+/// An action commanded by the [`Reader`].
+pub struct WriterAction {
+    /// A buffer to append to `sendable_plaintext`.
+    sendable_plaintext: Option<Box<[u8]>>,
+}
+
+impl WriterAction {
+    /// Whether this action is a no-op.
+    fn is_empty(&self) -> bool {
+        matches!(
+            self,
+            Self {
+                sendable_plaintext: None,
+            }
+        )
     }
 }

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -1,0 +1,6 @@
+//! A split reader-writer interface.
+//!
+//! This module offers an alternative API for TLS connections with completed
+//! handshakes.  It separates the read and write halves of the connection into
+//! [`Reader`] and [`Writer`] respectively.  These halves can be used fairly
+//! independently, making it easier to pipeline and maximize throughput.

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -18,10 +18,7 @@ use crate::{
     SupportedCipherSuite,
     client::ClientConnection,
     common_state::{TrafficState, UnborrowedPayload},
-    conn::{
-        ALLOWED_CONSECUTIVE_EMPTY_FRAGMENTS_MAX, ConnectionCore, InboundUnborrowedMessage,
-        connection::PlaintextSink,
-    },
+    conn::{ALLOWED_CONSECUTIVE_EMPTY_FRAGMENTS_MAX, ConnectionCore, InboundUnborrowedMessage},
     crypto::{
         Identity,
         cipher::{Decrypted, InboundPlainMessage, OutboundChunks},
@@ -869,7 +866,7 @@ pub struct PlaintextWriter<'a> {
     writer: &'a mut Writer,
 }
 
-impl PlaintextSink for PlaintextWriter<'_> {
+impl io::Write for PlaintextWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         // Ignore if a fatal error has been enqueued.
         if self.writer.enqueued_fatal_error {
@@ -912,16 +909,6 @@ impl PlaintextSink for PlaintextWriter<'_> {
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
-    }
-}
-
-impl io::Write for PlaintextWriter<'_> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        crate::Writer::new(self).write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        crate::Writer::new(self).flush()
     }
 }
 

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -19,7 +19,7 @@ mod outbound;
 pub use outbound::{OutboundChunks, OutboundOpaqueMessage, OutboundPlainMessage, PrefixedPayload};
 
 mod record_layer;
-pub(crate) use record_layer::{Decrypted, PreEncryptAction, RecordLayer};
+pub(crate) use record_layer::{Decrypted, DirectionState, PreEncryptAction, RecordLayer};
 
 /// Factory trait for building `MessageEncrypter` and `MessageDecrypter` for a TLS1.3 cipher suite.
 pub trait Tls13AeadAlgorithm: Send + Sync {

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -10,7 +10,7 @@ use crate::log::trace;
 use crate::msgs::deframer::HandshakeAlignedProof;
 
 #[derive(PartialEq)]
-enum DirectionState {
+pub(crate) enum DirectionState {
     /// No keying material.
     Invalid,
 
@@ -23,19 +23,19 @@ enum DirectionState {
 
 /// Record layer that tracks decryption and encryption keys.
 pub(crate) struct RecordLayer {
-    message_encrypter: Box<dyn MessageEncrypter>,
-    message_decrypter: Box<dyn MessageDecrypter>,
-    write_seq_max: u64,
-    write_seq: u64,
-    read_seq: u64,
-    has_decrypted: bool,
-    encrypt_state: DirectionState,
-    decrypt_state: DirectionState,
+    pub(crate) message_encrypter: Box<dyn MessageEncrypter>,
+    pub(crate) message_decrypter: Box<dyn MessageDecrypter>,
+    pub(crate) write_seq_max: u64,
+    pub(crate) write_seq: u64,
+    pub(crate) read_seq: u64,
+    pub(crate) has_decrypted: bool,
+    pub(crate) encrypt_state: DirectionState,
+    pub(crate) decrypt_state: DirectionState,
 
     // Message encrypted with other keys may be encountered, so failures
     // should be swallowed by the caller.  This struct tracks the amount
     // of message size this is allowed for.
-    trial_decryption_len: Option<usize>,
+    pub(crate) trial_decryption_len: Option<usize>,
 }
 
 impl RecordLayer {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -474,7 +474,7 @@ pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier};
 pub use crate::common_state::{CommonState, HandshakeKind, IoState, Side};
 #[cfg(feature = "std")]
 pub use crate::conn::{Connection, Reader, Writer};
-pub use crate::conn::{ConnectionCommon, KeyingMaterialExporter, SideData, kernel};
+pub use crate::conn::{ConnectionCommon, KeyingMaterialExporter, SideData, kernel, split};
 pub use crate::error::Error;
 pub use crate::key_log::{KeyLog, NoKeyLog};
 #[cfg(feature = "std")]

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -70,7 +70,7 @@ mod buffered {
     /// Send TLS-protected data to the peer using the `io::Write` trait implementation.
     /// Read data from the peer using the `io::Read` trait implementation.
     pub struct ServerConnection {
-        pub(super) inner: ConnectionCommon<ServerConnectionData>,
+        pub(crate) inner: ConnectionCommon<ServerConnectionData>,
     }
 
     impl ServerConnection {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -914,8 +914,8 @@ impl State<ServerConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
-    fn into_traffic(self: Box<Self>) -> Result<Box<dyn TrafficState>, Error> {
-        Ok(self)
+    fn into_traffic(self: Box<Self>) -> Result<TrafficState, Error> {
+        Ok(TrafficState::Tls12)
     }
 
     fn into_external_state(
@@ -927,12 +927,6 @@ impl State<ServerConnectionData> for ExpectTraffic {
                 "call of into_external_state() only allowed with enable_secret_extraction",
             )),
         }
-    }
-}
-
-impl TrafficState for ExpectTraffic {
-    fn handle_unexpected(&self, payload: &MessagePayload<'_>) -> Error {
-        inappropriate_message(&payload, &[ContentType::ApplicationData])
     }
 }
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -912,21 +912,8 @@ impl State<ServerConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
-    fn handle_for_split_traffic(
-        &mut self,
-        cx: &mut ServerContext<'_>,
-        message: Message<'_>,
-    ) -> Result<(), Error> {
-        match message.payload {
-            MessagePayload::ApplicationData(payload) => cx.receive_plaintext(payload),
-            payload => {
-                return Err(inappropriate_message(
-                    &payload,
-                    &[ContentType::ApplicationData],
-                ));
-            }
-        }
-        Ok(())
+    fn handle_other_for_split_traffic(&self, payload: &MessagePayload<'_>) -> Error {
+        inappropriate_message(&payload, &[ContentType::ApplicationData])
     }
 
     fn into_external_state(

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -912,6 +912,23 @@ impl State<ServerConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
+    fn handle_for_split_traffic(
+        &mut self,
+        cx: &mut ServerContext<'_>,
+        message: Message<'_>,
+    ) -> Result<(), Error> {
+        match message.payload {
+            MessagePayload::ApplicationData(payload) => cx.receive_plaintext(payload),
+            payload => {
+                return Err(inappropriate_message(
+                    &payload,
+                    &[ContentType::ApplicationData],
+                ));
+            }
+        }
+        Ok(())
+    }
+
     fn into_external_state(
         mut self: Box<Self>,
     ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error> {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1413,6 +1413,29 @@ impl State<ServerConnectionData> for ExpectTraffic {
         Ok(self)
     }
 
+    fn handle_for_split_traffic(
+        &mut self,
+        cx: &mut ServerContext<'_>,
+        message: Message<'_>,
+    ) -> Result<(), Error> {
+        match message.payload {
+            MessagePayload::ApplicationData(payload) => cx.receive_plaintext(payload),
+            MessagePayload::Handshake {
+                parsed: HandshakeMessagePayload(HandshakePayload::KeyUpdate(key_update)),
+                ..
+            } => self.handle_key_update(cx.common, &key_update)?,
+            payload => {
+                return Err(inappropriate_handshake_message(
+                    &payload,
+                    &[ContentType::ApplicationData, ContentType::Handshake],
+                    &[HandshakeType::KeyUpdate],
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     fn send_key_update_request(&mut self, common: &mut CommonState) -> Result<(), Error> {
         self.key_schedule
             .request_key_update_and_update_encrypter(common)

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1450,10 +1450,15 @@ impl TrafficState for ExpectTraffic {
         )
     }
 
-    fn send_key_update_request(&mut self, common: &mut CommonState) {
-        let _ = self
-            .key_schedule
-            .request_key_update_and_update_encrypter(common);
+    fn send_key_update(&mut self, common: &mut CommonState, request: bool) {
+        if request {
+            let _ = self
+                .key_schedule
+                .request_key_update_and_update_encrypter(common);
+        } else {
+            self.key_schedule
+                .update_encrypter_and_notify(common);
+        }
     }
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1415,10 +1415,10 @@ impl State<ServerConnectionData> for ExpectTraffic {
 
     fn handle_key_update_for_split_traffic(
         &mut self,
-        cx: &mut ServerContext<'_>,
+        common_state: &mut CommonState,
         key_update: KeyUpdateRequest,
     ) -> Result<(), Error> {
-        self.handle_key_update(cx.common, &key_update)
+        self.handle_key_update(common_state, &key_update)
     }
 
     fn handle_other_for_split_traffic(&self, payload: &MessagePayload<'_>) -> Error {

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -582,8 +582,8 @@ impl KeyScheduleTrafficWithClientFinishedPending {
 /// to be available.
 pub(crate) struct KeyScheduleTraffic {
     ks: KeyScheduleSuite,
-    current_client_traffic_secret: OkmBlock,
-    current_server_traffic_secret: OkmBlock,
+    pub(crate) current_client_traffic_secret: OkmBlock,
+    pub(crate) current_server_traffic_secret: OkmBlock,
 }
 
 impl KeyScheduleTraffic {
@@ -825,12 +825,12 @@ impl Deref for KeySchedule {
 /// This is a component part of `KeySchedule`, and groups operations
 /// that do not depend on the root key schedule secret.
 #[derive(Clone, Copy)]
-struct KeyScheduleSuite {
+pub(crate) struct KeyScheduleSuite {
     suite: &'static Tls13CipherSuite,
 }
 
 impl KeyScheduleSuite {
-    fn set_encrypter(&self, secret: &OkmBlock, common: &mut CommonState) {
+    pub(crate) fn set_encrypter(&self, secret: &OkmBlock, common: &mut CommonState) {
         let expander = self
             .suite
             .hkdf_provider
@@ -846,7 +846,7 @@ impl KeyScheduleSuite {
             );
     }
 
-    fn set_decrypter(
+    pub(crate) fn set_decrypter(
         &self,
         secret: &OkmBlock,
         common: &mut CommonState,
@@ -894,7 +894,7 @@ impl KeyScheduleSuite {
     }
 
     /// Derive the next application traffic secret, returning it.
-    fn derive_next(&self, base_key: &OkmBlock) -> OkmBlock {
+    pub(crate) fn derive_next(&self, base_key: &OkmBlock) -> OkmBlock {
         let expander = self
             .suite
             .hkdf_provider


### PR DESCRIPTION
This is a proof of concept adding module `rustls::split`, an alternative (currently buffered) API which splits a post-handshake TLS connection into a `Reader` and `Writer`.  It demonstrates a possible API and implementation for #2761.

## The API

The `split()` function can split a TLS 1.2/1.3 client/server connection with a completed handshake into `(Reader, Writer)`.  These types can be used independently, e.g. from different threads or asynchronous tasks.  It is sometimes necessary to communicate between them (e.g. to send alerts to a misbehaving peer, or if the peer requests we update our encryption keys).  But this happens quite rarely, and the user can implement that communication using their own synchronization mechanisms (e.g. mutexes or channels).

`Reader` implements the reader-side functionality of `ConnectionCommon`.  It offers `recv_tls()` to read from the underlying stream (equivalent to `read_tls()` + `process_new_packets()`) and `reader()` to access buffered plaintext data.  The most important difference is that `recv_tls()` can return a `WriterAction`, which the user must communicate to the `Writer`.

`Writer` implements the writer-side functionality of `ConnectionCommon`.  It offers `send_tls()` (i.e. `write_tls()`) and `writer()`.  In addition, it has an `enact()` method to consume a `WriterAction` from the reader.

## Justification

Splitting the reader and writer can make life a lot easier for request-response protocols.  Even though TLS is an ordered stream protocol, the read and write halves of a connection are not ordered wrt each other.  Instead of sending a single request, waiting for a response, and then repeating, implementations can write as many requests as I/O allows and wait for the responses to arrive.  In theory, this could significantly improve throughput, especially for connections and requests with high latency; but testing it with `rustls` has been difficult.

With this API, it is possible that `WriterAction`s are somewhat delayed.  Is this a correctness issue?  I would argue not.  A TLS peer's delayed response to a message could occur because of a delayed `WriterAction`, or simply delays in the network; the two are indistinguishable.  As long as `WriterAction`s are processed relatively quickly, and sent to the right `Writer` in the right order, it will be fine.  The improvement in throughput (which can now be benchmarked, with this PR) is adequate justification in my eyes.

## Defensive Measures

Firstly, I want to emphasize the low-level nature of this API.  Even with the unbuffered API we have today, implementation error on the user's part can lead to problems.  The same is true here.  We can still implement defensive measures to mitigate this, but an impossible-to-misuse API is unnecessary and unwarranted.

It is important to ensure that all `WriterAction`s are sent to the right `Writer` in the right order.  I am ignoring timeliness.

- I have already implemented some defensive measures with `#[must_use]` annotations on `Received` and `WriterAction`; these mitigate the possibility of the `WriterAction` being dropped or ignored. 
- To ensure ordering, `WriterAction`s could include a simple monotonic counter.
- Ensuring that they reach the _right_ `Writer` is more difficult; one way would be to maintain an `Arc` internally (as the current code does), include it in the `WriterAction`, and test `Arc::ptr_eq`.

## Implementation

The `rustls::split` module inlines the state and methods of `ClientConnection` / `ServerConnection`, `ConnectionCommon, `ConnectionCore`, `Box<dyn State>`, `CommonState`, and `RecordLayer`.  These types combined reader and writer state and could not be used; I chose to duplicate their code rather than to break the existing codebase.  The only changes to them are to make some items `pub(crate)` so that I can access them.

This has resulted in a 1500-line module that combines all the important post-handshake TLS logic.  It's not pretty, but it does have some benefits; every step in the process is visible at a glance and it's easier to simplify control flow.  IMO, in-place encryption/decryption would be much easier to implement on this, than on the existing code; #2758 would not have been hindered the way it was.

It should be possible to refactor this module and split up its data into smaller types again; but I suspect `ConnectionCommon` etc. are not the ideal layout.  But I don't want to put too much more effort into this right now; it's good enough to judge the API concretely and to benchmark.  I don't want to waste my time if you (the maintainers) think a different approach is necessary.

## Testing

Some basic initial testing shows that this code works!  I was able to modify `simpleclient` and I can happily talk to `rust-lang.org`.  I'll try to find tests that focus on post-handshake state, and perhaps look at BoGo.

This code needs to be integrated with `rustls`' benchmarking suite.  I need to investigate that and figure out how to measure the maximum throughput of a request-response connection, with and without the reader-writer split.  Suggestions for alternative benchmarking approaches are welcome.

## Future Direction

If this approach seems feasible, I would like to make this implementation unbuffered.  Now that all of the different layers of TLS logic are in one place, it's much easier to implement in-place encryption/decryption and wipe out all allocations from the hot path.

The code is only applicable to connections that have finished their handshakes.  The handshaking process is significantly more complicated and would be incredibly difficult to implement like this.  The core idea behind this PR is that readers and writers don't communicate that much; but that's not true during a handshake.  I don't know if or how `ClientConnection` etc. can be implemented in terms of this code.  Still, this module is already useful for users of long-lived connections; they can trade extra handshaking work for better post-handshake performance.

The code currently lacks support for TLS 1.3 session tickets.  This made my life way easier, as I could then define `Reader` and `Writer` as simple concrete types.  Session ticket support will require distinguishing client and server types, as well as TLS 1.2 and TLS 1.3 use.  It doesn't sound fun, but it will be necessary.

## Commit History / Review

I've left the commit history as-is for now.  I'm happy to try to clean it up if merging this PR is on the table.  While the overall diff is +1508 -40, the sum of diffs across commits is +2712 -1234; a lot of refactoring happened in-place.  It may be possible to review the commits in order, but I'm sure that won't be fun.  I've tried to mark down where functions come from (e.g. `ConnectionCore` vs `CommonState`), but it might not always be clear.  A lot of QUIC and handshake related logic have also been removed.

Sorry about the huge chunk of code to review.  I know y'all have limited time.  I would suggest prioritizing the API and judging whether this design is feasible.  We can talk further once I have some benchmarks.