### PR TITLE
Align initializer order with declaration order

### DIFF
--- a/rustls/.clippy.toml
+++ b/rustls/.clippy.toml
@@ -1,4 +1,5 @@
 upper-case-acronyms-aggressive = true
+check-inconsistent-struct-field-initializers = true
 
 disallowed-types = [
   { path = "std::sync::Arc", reason = "must use Arc from sync module to support downstream forks targeting architectures without atomic ptrs" },

--- a/rustls/src/client/config.rs
+++ b/rustls/src/client/config.rs
@@ -743,12 +743,6 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
         }
 
         Ok(ClientConfig {
-            domain: SecurityDomain::new(
-                self.provider,
-                client_auth_cert_resolver,
-                self.state.verifier,
-                self.time_provider,
-            ),
             alpn_protocols: Vec::new(),
             resumption: Resumption::default(),
             max_fragment_size: None,
@@ -757,9 +751,15 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             enable_secret_extraction: false,
             enable_early_data: false,
             require_ems: cfg!(feature = "fips"),
+            domain: SecurityDomain::new(
+                self.provider,
+                client_auth_cert_resolver,
+                self.state.verifier,
+                self.time_provider,
+            ),
+            cert_decompressors: compress::default_cert_decompressors().to_vec(),
             cert_compressors: compress::default_cert_compressors().to_vec(),
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),
-            cert_decompressors: compress::default_cert_decompressors().to_vec(),
             ech_mode: self.state.client_ech_mode,
         })
     }

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -451,8 +451,8 @@ pub(super) struct EarlyData {
 impl EarlyData {
     fn new() -> Self {
         Self {
-            left: 0,
             state: EarlyDataState::Disabled,
+            left: 0,
         }
     }
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -132,8 +132,8 @@ impl ClientAuthDetails {
     ) -> Self {
         let server_hello = CredentialRequest {
             negotiated_type,
-            signature_schemes,
             root_hint_subjects: root_hint_subjects.unwrap_or_default(),
+            signature_schemes,
         };
 
         if let Some(credentials) = resolver.resolve(&server_hello) {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -991,13 +991,13 @@ impl State<ClientConnectionData> for ExpectCcs {
 
         Ok(Box::new(ExpectFinished {
             config: self.config,
-            secrets: self.secrets,
             resuming_session: self.resuming_session,
             session_id: self.session_id,
             session_key: self.session_key,
             using_ems: self.using_ems,
             transcript: self.transcript,
             ticket: self.ticket,
+            secrets: self.secrets,
             resuming: self.resuming,
             cert_verified: self.cert_verified,
             sig_verified: self.sig_verified,

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -26,10 +26,10 @@ pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: &Tls12CipherSuite = &T
         confidentiality_limit: u64::MAX,
     },
     protocol_version: TLS12_VERSION,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
     kx: KeyExchangeAlgorithm::ECDHE,
     sign: TLS12_ECDSA_SCHEMES,
     aead_alg: &ChaCha20Poly1305,
-    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
 };
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
@@ -40,10 +40,10 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: &Tls12CipherSuite = &Tls
         confidentiality_limit: u64::MAX,
     },
     protocol_version: TLS12_VERSION,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
     kx: KeyExchangeAlgorithm::ECDHE,
     sign: TLS12_RSA_SCHEMES,
     aead_alg: &ChaCha20Poly1305,
-    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
 };
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
@@ -54,10 +54,10 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: &Tls12CipherSuite = &Tls12Ciph
         confidentiality_limit: 1 << 24,
     },
     protocol_version: TLS12_VERSION,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
     kx: KeyExchangeAlgorithm::ECDHE,
     sign: TLS12_RSA_SCHEMES,
     aead_alg: &AES128_GCM,
-    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
 };
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -68,10 +68,10 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: &Tls12CipherSuite = &Tls12Ciph
         confidentiality_limit: 1 << 24,
     },
     protocol_version: TLS12_VERSION,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA384),
     kx: KeyExchangeAlgorithm::ECDHE,
     sign: TLS12_RSA_SCHEMES,
     aead_alg: &AES256_GCM,
-    prf_provider: &Tls12Prf(&tls_prf::P_SHA384),
 };
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
@@ -82,10 +82,10 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: &Tls12CipherSuite = &Tls12Ci
         confidentiality_limit: 1 << 24,
     },
     protocol_version: TLS12_VERSION,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
     kx: KeyExchangeAlgorithm::ECDHE,
     sign: TLS12_ECDSA_SCHEMES,
     aead_alg: &AES128_GCM,
-    prf_provider: &Tls12Prf(&tls_prf::P_SHA256),
 };
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
@@ -96,10 +96,10 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: &Tls12CipherSuite = &Tls12Ci
         confidentiality_limit: 1 << 24,
     },
     protocol_version: TLS12_VERSION,
+    prf_provider: &Tls12Prf(&tls_prf::P_SHA384),
     kx: KeyExchangeAlgorithm::ECDHE,
     sign: TLS12_ECDSA_SCHEMES,
     aead_alg: &AES256_GCM,
-    prf_provider: &Tls12Prf(&tls_prf::P_SHA384),
 };
 
 static TLS12_ECDSA_SCHEMES: &[SignatureScheme] = &[

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -55,8 +55,8 @@ impl<'a> EncodedMessage<Payload<'a>> {
     /// Convert into an unencrypted [`EncodedMessage<OutboundOpaque>`] (without decrypting).
     pub fn into_unencrypted_opaque(self) -> EncodedMessage<OutboundOpaque> {
         EncodedMessage {
-            version: self.version,
             typ: self.typ,
+            version: self.version,
             payload: OutboundOpaque::from(self.payload.bytes()),
         }
     }
@@ -64,8 +64,8 @@ impl<'a> EncodedMessage<Payload<'a>> {
     /// Borrow as an [`EncodedMessage<OutboundPlain<'a>>`].
     pub fn borrow_outbound(&'a self) -> EncodedMessage<OutboundPlain<'a>> {
         EncodedMessage {
-            version: self.version,
             typ: self.typ,
+            version: self.version,
             payload: self.payload.bytes().into(),
         }
     }
@@ -151,8 +151,8 @@ impl EncodedMessage<OutboundPlain<'_>> {
         let mut payload = OutboundOpaque::with_capacity(self.payload.len());
         payload.extend_from_chunks(&self.payload);
         EncodedMessage {
-            version: self.version,
             typ: self.typ,
+            version: self.version,
             payload,
         }
     }

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -135,8 +135,8 @@ impl HandshakeHash {
             HandshakeMessagePayload::build_handshake_hash(old_hash.as_ref());
 
         HandshakeHashBuffer {
-            client_auth_enabled: self.client_auth.is_some(),
             buffer: old_handshake_hash_msg.get_encoding(),
+            client_auth_enabled: self.client_auth.is_some(),
         }
     }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -118,8 +118,8 @@ impl From<[u8; 32]> for Random {
 
 #[derive(Copy, Clone)]
 pub(crate) struct SessionId {
-    len: usize,
     data: [u8; 32],
+    len: usize,
 }
 
 impl fmt::Debug for SessionId {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -913,12 +913,12 @@ impl Keys {
             .extract_from_secret(Some(salt), client_dst_connection_id);
 
         let secrets = Secrets {
-            version,
             client: hkdf_expand_label_block(hs_secret.as_ref(), CLIENT_LABEL, &[]),
             server: hkdf_expand_label_block(hs_secret.as_ref(), SERVER_LABEL, &[]),
             suite,
             quic,
             side,
+            version,
         };
         Self::new(&secrets)
     }

--- a/rustls/src/server/config.rs
+++ b/rustls/src/server/config.rs
@@ -410,13 +410,13 @@ impl<'a> ClientHello<'a> {
             server_name: sni.map(Cow::Borrowed),
             signature_schemes: &input.sig_schemes,
             alpn: input.client_hello.protocols.as_ref(),
-            client_cert_types: input
-                .client_hello
-                .client_certificate_types
-                .as_deref(),
             server_cert_types: input
                 .client_hello
                 .server_certificate_types
+                .as_deref(),
+            client_cert_types: input
+                .client_hello
+                .client_certificate_types
                 .as_deref(),
             cipher_suites: &input.client_hello.cipher_suites,
             // We adhere to the TLS 1.2 RFC by not exposing this to the cert resolver if TLS version is 1.2
@@ -668,8 +668,6 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
         self.provider.consistency_check()?;
         Ok(ServerConfig {
             provider: self.provider,
-            verifier: self.state.verifier,
-            cert_resolver,
             ignore_client_order: false,
             max_fragment_size: None,
             #[cfg(feature = "std")]
@@ -677,7 +675,9 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             #[cfg(not(feature = "std"))]
             session_storage: Arc::new(handy::NoServerSessionStorage {}),
             ticketer: None,
+            cert_resolver,
             alpn_protocols: Vec::new(),
+            verifier: self.state.verifier,
             key_log: Arc::new(NoKeyLog {}),
             enable_secret_extraction: false,
             max_early_data_size: 0,

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -586,8 +586,8 @@ impl Accepted {
         };
 
         let input = ClientHelloInput {
-            client_hello: Self::client_hello_payload(&self.message),
             message: &self.message,
+            client_hello: Self::client_hello_payload(&self.message),
             sig_schemes: self.sig_schemes,
             proof,
         };

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -488,8 +488,8 @@ mod client_hello {
 
         let extensions = Box::new(ServerExtensions {
             key_share: Some(KeyShareEntry::new(ckx.group, ckx.pub_key)),
-            selected_version: Some(ProtocolVersion::TLSv1_3),
             preshared_key: chosen_psk_idx.map(|idx| idx as u16),
+            selected_version: Some(ProtocolVersion::TLSv1_3),
             ..Default::default()
         });
 
@@ -695,6 +695,14 @@ mod client_hello {
                         .verifier
                         .supported_verify_schemes(),
                 ),
+                authority_names: match config
+                    .verifier
+                    .root_hint_subjects()
+                    .as_ref()
+                {
+                    [] => None,
+                    authorities => Some(authorities.to_vec()),
+                },
                 certificate_compression_algorithms: match config.cert_decompressors.as_slice() {
                     &[] => None,
                     decomps => Some(
@@ -703,14 +711,6 @@ mod client_hello {
                             .map(|decomp| decomp.algorithm())
                             .collect(),
                     ),
-                },
-                authority_names: match config
-                    .verifier
-                    .root_hint_subjects()
-                    .as_ref()
-                {
-                    [] => None,
-                    authorities => Some(authorities.to_vec()),
                 },
             },
         };
@@ -1003,9 +1003,9 @@ impl State<ServerConnectionData> for ExpectCertificate {
                 self.transcript.abandon_client_auth();
                 return Ok(Box::new(ExpectFinished {
                     config: self.config,
+                    transcript: self.transcript,
                     suite: self.suite,
                     key_schedule: self.key_schedule,
-                    transcript: self.transcript,
                     send_tickets: self.send_tickets,
                 }));
             }
@@ -1022,8 +1022,8 @@ impl State<ServerConnectionData> for ExpectCertificate {
 
         Ok(Box::new(ExpectCertificateVerify {
             config: self.config,
-            suite: self.suite,
             transcript: self.transcript,
+            suite: self.suite,
             key_schedule: self.key_schedule,
             peer_identity: peer_identity.into_owned(),
             send_tickets: self.send_tickets,
@@ -1068,9 +1068,9 @@ impl State<ServerConnectionData> for ExpectCertificateVerify {
         self.transcript.add_message(&m);
         Ok(Box::new(ExpectFinished {
             config: self.config,
+            transcript: self.transcript,
             suite: self.suite,
             key_schedule: self.key_schedule,
-            transcript: self.transcript,
             send_tickets: self.send_tickets,
         }))
     }
@@ -1114,9 +1114,9 @@ impl State<ServerConnectionData> for ExpectEarlyData {
                 self.transcript.add_message(&m);
                 Ok(Box::new(ExpectFinished {
                     config: self.config,
+                    transcript: self.transcript,
                     suite: self.suite,
                     key_schedule: self.key_schedule,
-                    transcript: self.transcript,
                     send_tickets: self.send_tickets,
                 }))
             }

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -77,7 +77,7 @@ impl Tls13CipherSuite {
     /// Returns a `quic::Suite` for the ciphersuite, if supported.
     pub fn quic_suite(&'static self) -> Option<crate::quic::Suite> {
         self.quic
-            .map(|quic| crate::quic::Suite { quic, suite: self })
+            .map(|quic| crate::quic::Suite { suite: self, quic })
     }
 }
 

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -44,14 +44,15 @@ impl ClientVerifierBuilder {
         roots: Arc<RootCertStore>,
         supported_algs: WebPkiSupportedAlgorithms,
     ) -> Self {
+        let root_hint_subjects = roots.subjects();
         Self {
-            root_hint_subjects: roots.subjects(),
             roots,
+            root_hint_subjects,
             crls: Vec::new(),
-            anon_policy: AnonymousClientPolicy::Deny,
             revocation_check_depth: RevocationCheckDepth::Chain,
             unknown_revocation_policy: UnknownStatusPolicy::Deny,
             revocation_expiration_policy: ExpirationPolicy::Ignore,
+            anon_policy: AnonymousClientPolicy::Deny,
             supported_algs,
         }
     }


### PR DESCRIPTION
This PR clears up `clippy::inconsistent_struct_constructor` lints but does not enable the lint on an ongoing basis because it seems like a bit of a pain in the ass. WDYT? There are a couple of places where a new binding is needed.