### PR TITLE
Simplify output of negotiated key exchange group

### DIFF
--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -13,7 +13,7 @@ use super::hs::{self, ClientContext};
 use super::{ClientAuthDetails, ServerCertDetails};
 use crate::ConnectionTrafficSecrets;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
-use crate::common_state::{CommonState, HandshakeKind, KxState, Side, State};
+use crate::common_state::{CommonState, HandshakeKind, Side, State};
 use crate::conn::ConnectionRandoms;
 use crate::conn::kernel::{Direction, KernelContext, KernelState};
 use crate::crypto::cipher::Payload;
@@ -818,7 +818,6 @@ impl State<ClientConnectionData> for ExpectServerDone {
         let Some(skxg) = maybe_skxg else {
             return Err(PeerMisbehaved::SelectedUnofferedKxGroup.into());
         };
-        cx.common.kx_state = KxState::Start(skxg);
         let kx = skxg.start()?.into_single();
 
         // 4b.
@@ -844,7 +843,7 @@ impl State<ClientConnectionData> for ExpectServerDone {
             st.randoms,
             suite,
         )?;
-        cx.common.kx_state.complete();
+        cx.common.negotiated_kx_group = Some(skxg);
 
         // 4e. CCS. We are definitely going to switch on encryption.
         emit_ccs(cx.common);

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -7,7 +7,7 @@ use core::fmt;
 use super::connection::ServerConnectionData;
 use super::{ClientHello, ServerConfig};
 use crate::SupportedCipherSuite;
-use crate::common_state::{KxState, State};
+use crate::common_state::State;
 use crate::conn::ConnectionRandoms;
 use crate::crypto::hash::Hash;
 use crate::crypto::kx::{KeyExchangeAlgorithm, NamedGroup, SupportedKxGroup};
@@ -374,7 +374,6 @@ impl ExpectClientHello {
 
         debug!("decided upon suite {suite:?}");
         cx.common.suite = Some(suite.into());
-        cx.common.kx_state = KxState::Start(skxg);
 
         suite
             .server_handler()

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -479,7 +479,7 @@ mod client_hello {
         let (share, kxgroup) = share_and_kxgroup;
         debug_assert_eq!(kxgroup.name(), share.group);
         let ckx = kxgroup.start_and_complete(&share.payload.0)?;
-        cx.common.kx_state.complete();
+        cx.common.negotiated_kx_group = Some(kxgroup);
 
         let extensions = Box::new(ServerExtensions {
             key_share: Some(KeyShareEntry::new(ckx.group, ckx.pub_key)),


### PR DESCRIPTION
There was only a single test that used `KxState::Start`, so replace the whole lot with just writing a field.