### PR TITLE
Rework how buffered plaintext is released

### DIFF
--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -280,8 +280,6 @@ impl ConnectionCore<ClientConnectionData> {
             // `start_handshake` won't read plaintext
             plaintext_locator: &Locator::new(&[]),
             received_plaintext: &mut None,
-            // `start_handshake` won't produce plaintext
-            sendable_plaintext: None,
         };
 
         let input = ClientHelloInput::new(name, &extra_exts, &mut cx, config)?;

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1083,8 +1083,7 @@ impl State<ClientConnectionData> for ExpectFinished {
             emit_finished(&st.secrets, &mut st.transcript, cx.common, &proof);
         }
 
-        cx.common
-            .start_traffic(&mut cx.sendable_plaintext);
+        cx.common.start_traffic();
 
         let extracted_secrets = st
             .config

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1300,8 +1300,7 @@ impl State<ClientConnectionData> for ExpectFinished {
         /* Now move to our application traffic keys. */
         let (key_schedule, exporter, resumption) =
             key_schedule_pre_finished.into_traffic(cx.common, st.transcript.current_hash(), &proof);
-        cx.common
-            .start_traffic(&mut cx.sendable_plaintext);
+        cx.common.start_traffic();
         cx.common.peer_identity = Some(st.peer_identity.clone());
         cx.common.exporter = Some(Box::new(exporter));
 

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -959,7 +959,6 @@ impl<Side: SideData> ConnectionCore<Side> {
                 &mut self.side,
                 &locator,
                 &mut plaintext,
-                Some(sendable_plaintext),
             ) {
                 Ok(new) => state = new,
                 Err(e) => {
@@ -969,6 +968,15 @@ impl<Side: SideData> ConnectionCore<Side> {
                     deframer_buffer.discard(buffer_progress.take_discard());
                     return Err(e);
                 }
+            }
+
+            if self
+                .common_state
+                .may_send_application_data
+                && !sendable_plaintext.is_empty()
+            {
+                self.common_state
+                    .send_buffered_plaintext(sendable_plaintext);
             }
 
             if self

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -120,7 +120,6 @@ impl<Side: SideData> UnbufferedConnectionCommon<Side> {
                         &mut self.core.side,
                         &plaintext_locator,
                         &mut received_plaintext,
-                        None,
                     ) {
                     Ok(new) => {
                         buffer.queue_discard(buffer_progress.take_discard());

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -323,7 +323,6 @@ mod buffered {
                 // `ClientHelloInput::from_message` won't read borrowed plaintext
                 plaintext_locator: &Locator::new(&[]),
                 received_plaintext: &mut None,
-                sendable_plaintext: Some(&mut connection.sendable_plaintext),
             };
 
             let sig_schemes = match ClientHelloInput::from_message(&message, false, &mut cx) {
@@ -580,7 +579,6 @@ impl Accepted {
             // `ExpectClientHello::with_input` won't read borrowed plaintext
             plaintext_locator: &Locator::new(&[]),
             received_plaintext: &mut None,
-            sendable_plaintext: Some(&mut self.connection.sendable_plaintext),
         };
 
         let input = ClientHelloInput {

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -66,7 +66,6 @@ fn test_process_client_hello(hello: ClientHelloPayload) -> Result<(), Error> {
             data: &mut ServerConnectionData::default(),
             plaintext_locator: &Locator::new(&[]),
             received_plaintext: &mut None,
-            sendable_plaintext: None,
         },
     )
     .map(|_| ())

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -852,8 +852,7 @@ impl State<ServerConnectionData> for ExpectFinished {
         }
 
         cx.common.peer_identity = self.peer_identity;
-        cx.common
-            .start_traffic(&mut cx.sendable_plaintext);
+        cx.common.start_traffic();
 
         let extracted_secrets = self
             .config

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -352,8 +352,7 @@ mod client_hello {
                 // Application data can be sent immediately after Finished, in one
                 // flight.  However, if client auth is enabled, we don't want to send
                 // application data to an unauthenticated peer.
-                cx.common
-                    .start_outgoing_traffic(&mut cx.sendable_plaintext);
+                cx.common.start_outgoing_traffic();
             }
 
             if doing_client_auth {
@@ -1265,8 +1264,7 @@ impl State<ServerConnectionData> for ExpectFinished {
         flight.finish(cx.common);
 
         // Application data may now flow, even if we have client auth enabled.
-        cx.common
-            .start_traffic(&mut cx.sendable_plaintext);
+        cx.common.start_traffic();
         cx.common.peer_identity = self.peer_identity;
         cx.common.exporter = Some(Box::new(exporter));
 


### PR DESCRIPTION
Instead of ... *all this* ... just have the buffered connection's `process_new_packets()` try to send anything buffered after each state transition.