### PR TITLE
Attach handshake alignment proof to state machine input

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -202,7 +202,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         )?;
         trace!("Got HRR {hrr:?}");
 
-        let proof = cx.common.check_aligned_handshake()?;
+        let proof = input.check_aligned_handshake()?;
 
         // We always send a key share when TLS 1.3 is enabled.
         let offered_key_share = self.next.offered_key_share.unwrap();

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -767,8 +767,10 @@ impl<Side: SideData> ConnectionCommon<Side> {
             Some(Ok(msg)) => {
                 self.deframer_buffer
                     .discard(buffer_progress.take_discard());
-                self.core.common_state.aligned_handshake = self.core.hs_deframer.aligned();
-                Ok(Some(Input { message: msg }))
+                Ok(Some(Input {
+                    message: msg,
+                    aligned_handshake: self.core.hs_deframer.aligned(),
+                }))
             }
             Some(Err(err)) => Err(err.into()),
             None => Ok(None),
@@ -957,6 +959,7 @@ impl<Side: SideData> ConnectionCore<Side> {
 
             match self.common_state.process_main_protocol(
                 msg,
+                self.hs_deframer.aligned(),
                 state,
                 &mut self.side,
                 &locator,
@@ -1160,8 +1163,6 @@ impl<Side: SideData> ConnectionCore<Side> {
             self.hs_deframer
                 .input_message(message, &locator, buffer_progress.processed());
             self.hs_deframer.coalesce(buffer)?;
-
-            self.common_state.aligned_handshake = self.hs_deframer.aligned();
 
             if self.hs_deframer.has_message_ready() {
                 // trial decryption finishes with the first handshake message after it started.

--- a/rustls/src/conn/unbuffered.rs
+++ b/rustls/src/conn/unbuffered.rs
@@ -116,6 +116,7 @@ impl<Side: SideData> UnbufferedConnectionCommon<Side> {
                     .common_state
                     .process_main_protocol(
                         msg,
+                        self.core.hs_deframer.aligned(),
                         state,
                         &mut self.core.side,
                         &plaintext_locator,

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -438,7 +438,6 @@ mod connection {
                 .hs_deframer
                 .coalesce(self.deframer_buffer.filled_mut())?;
 
-            self.core.common_state.aligned_handshake = self.core.hs_deframer.aligned();
             self.core
                 .process_new_packets(&mut self.deframer_buffer, &mut self.sendable_plaintext)?;
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -560,7 +560,7 @@ impl<'a> ClientHelloInput<'a> {
         }
 
         // No handshake messages should follow this one in this flight.
-        let proof = cx.common.check_aligned_handshake()?;
+        let proof = input.check_aligned_handshake()?;
 
         if done_retry {
             let ch_sni = client_hello

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -59,7 +59,10 @@ fn test_process_client_hello(hello: ClientHelloPayload) -> Result<(), Error> {
     };
 
     ClientHelloInput::from_input(
-        &Input { message: m },
+        &Input {
+            message: m,
+            aligned_handshake: None,
+        },
         false,
         &mut Context {
             common: &mut CommonState::new(Side::Server),


### PR DESCRIPTION
Instead of repeatedly stuffing the proof into `CommonState::aligned_handshake` (which is long-lived), pass it into each state transition. This introduces an `Input` type which bundles together the message and handshake alignment proof.