### PR TITLE
Support P256+SHA512 and P384+SHA512 signatures in certificates

### DIFF
--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -208,8 +208,10 @@ pub static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgori
     all: &[
         webpki_algs::ECDSA_P256_SHA256,
         webpki_algs::ECDSA_P256_SHA384,
+        webpki_algs::ECDSA_P256_SHA512,
         webpki_algs::ECDSA_P384_SHA256,
         webpki_algs::ECDSA_P384_SHA384,
+        webpki_algs::ECDSA_P384_SHA512,
         webpki_algs::ECDSA_P521_SHA256,
         webpki_algs::ECDSA_P521_SHA384,
         webpki_algs::ECDSA_P521_SHA512,
@@ -336,6 +338,8 @@ pub(super) fn unspecified_err(e: aws_lc_rs::error::Unspecified) -> Error {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     #[cfg(feature = "fips")]
     #[test]
     fn default_suites_are_fips() {
@@ -361,6 +365,27 @@ mod tests {
         assert_eq!(
             super::DEFAULT_TLS13_CIPHER_SUITES,
             super::ALL_TLS13_CIPHER_SUITES
+        );
+    }
+
+    #[test]
+    fn certificate_sig_algs() {
+        // `all` should not contain duplicates (not incorrect, but a waste of time)
+        assert_eq!(
+            super::SUPPORTED_SIG_ALGS
+                .all
+                .iter()
+                .map(|alg| {
+                    (
+                        alg.public_key_alg_id()
+                            .as_ref()
+                            .to_vec(),
+                        alg.signature_alg_id().as_ref().to_vec(),
+                    )
+                })
+                .collect::<HashSet<_>>()
+                .len(),
+            super::SUPPORTED_SIG_ALGS.all.len(),
         );
     }
 }


### PR DESCRIPTION
This allows P256+SHA512 and P384+SHA512 signatures in certificates, when using the aws-lc-rs provider.

Previously, [0.23.32](https://github.com/rustls/rustls/releases/tag/v%2F0.23.32) added support for these in TLS1.2 handshake signatures. This was the topic of #2661 and #2477.

Note that (eg) [Mozilla's Root Store Policy](https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/#512-ecdsa) disallows such certificates. However, the reported case is a private CA, though the [documentation for that CA](https://dn42.dev/services/Automatic-CA#validation-process) also specifies that RSA keys are to be used? It's vibe certificates all the way down.

fixes #2825 

