### PR TITLE
Expose `Side` as `quic::Side`

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -42,7 +42,7 @@ use rustls::pki_types::{
 };
 use rustls::server::danger::{ClientIdentity, ClientVerifier, SignatureVerificationInput};
 use rustls::server::{self, ClientHello, ServerConfig, ServerConnection, WebPkiClientVerifier};
-use rustls::{Connection, DistinguishedName, HandshakeKind, RootCertStore, Side, compress};
+use rustls::{Connection, DistinguishedName, HandshakeKind, RootCertStore, compress};
 
 pub fn main() {
     let mut args: Vec<_> = env::args().collect();
@@ -2161,6 +2161,12 @@ impl rustls::KeyLog for KeyLogMemo {
 struct KeyLogMemoInner {
     client_traffic_secret: Vec<u8>,
     server_traffic_secret: Vec<u8>,
+}
+
+#[derive(Debug, PartialEq)]
+enum Side {
+    Client,
+    Server,
 }
 
 #[derive(Debug, PartialEq)]

--- a/rustls-ring/src/quic.rs
+++ b/rustls-ring/src/quic.rs
@@ -221,9 +221,8 @@ impl quic::Algorithm for KeyBuilder {
 mod tests {
     use std::dbg;
 
-    use rustls::Side;
     use rustls::crypto::tls13::OkmBlock;
-    use rustls::quic::{KeyBuilder, Keys, Version};
+    use rustls::quic::{KeyBuilder, Keys, Side, Version};
 
     use crate::tls13::{TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256};
 

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -8,8 +8,8 @@ use rustls::client::Resumption;
 use rustls::error::{
     AlertDescription, ApiMisuse, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved,
 };
-use rustls::quic::{self, ConnectionCommon};
-use rustls::{HandshakeKind, Side, SideData};
+use rustls::quic::{self, ConnectionCommon, Side};
+use rustls::{HandshakeKind, SideData};
 use rustls_test::{
     ClientStorage, KeyType, encoding, make_client_config, make_server_config, server_name,
 };

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -471,7 +471,7 @@ pub mod unbuffered {
 
 // The public interface is:
 pub use crate::builder::{ConfigBuilder, ConfigSide, WantsVerifier};
-pub use crate::common_state::{CommonState, HandshakeKind, IoState, Side};
+pub use crate::common_state::{CommonState, HandshakeKind, IoState};
 #[cfg(feature = "std")]
 pub use crate::conn::{Connection, Reader, Writer};
 pub use crate::conn::{ConnectionCommon, KeyingMaterialExporter, SideData, kernel};

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use core::fmt::Debug;
 
-use crate::common_state::Side;
+pub use crate::common_state::Side;
 use crate::crypto::cipher::{AeadKey, Iv};
 use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock};
 use crate::error::Error;
@@ -1047,10 +1047,9 @@ mod tests {
     use std::prelude::v1::*;
 
     use super::*;
-    use crate::Side;
     use crate::crypto::TLS13_TEST_SUITE;
     use crate::crypto::tls13::OkmBlock;
-    use crate::quic::{HeaderProtectionKey, Secrets, Version};
+    use crate::quic::{HeaderProtectionKey, Secrets, Side, Version};
 
     #[test]
     fn key_update_test_vector() {


### PR DESCRIPTION
This type is in fact only used publicly in the QUIC API, and placing it in the crate root implies that it is more useful/special than it is.