### PR TITLE
Introduce public API type for ALPN protocols

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -30,7 +30,9 @@ use rustls::crypto::{
     Credentials, CryptoProvider, Identity, SelectedCredential, SignatureScheme, Signer, SigningKey,
     SingleCredential, aws_lc_rs,
 };
-use rustls::enums::{CertificateCompressionAlgorithm, CertificateType, ProtocolVersion};
+use rustls::enums::{
+    ApplicationProtocol, CertificateCompressionAlgorithm, CertificateType, ProtocolVersion,
+};
 use rustls::error::{
     AlertDescription, CertificateError, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved,
 };
@@ -1332,12 +1334,12 @@ fn make_server_cfg(opts: &Options, key_log: &Arc<KeyLogMemo>) -> Arc<ServerConfi
         cfg.alpn_protocols = opts
             .protocols
             .iter()
-            .map(|proto| proto.as_bytes().to_vec())
+            .map(|proto| ApplicationProtocol::from(proto.as_bytes()).to_owned())
             .collect::<Vec<_>>();
     }
 
     if opts.reject_alpn {
-        cfg.alpn_protocols = vec![b"invalid".to_vec()];
+        cfg.alpn_protocols = vec![ApplicationProtocol::from(b"invalid")];
     }
 
     if opts.enable_early_data {
@@ -1511,7 +1513,7 @@ fn make_client_cfg(opts: &Options, key_log: &Arc<KeyLogMemo>) -> Arc<ClientConfi
         cfg.alpn_protocols = opts
             .protocols
             .iter()
-            .map(|proto| proto.as_bytes().to_vec())
+            .map(|proto| ApplicationProtocol::from(proto.as_bytes()).to_owned())
             .collect();
     }
 

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -30,7 +30,7 @@ use mio::net::TcpStream;
 use rustls::RootCertStore;
 use rustls::crypto::kx::SupportedKxGroup;
 use rustls::crypto::{CryptoProvider, Identity, aws_lc_rs as provider};
-use rustls::enums::ProtocolVersion;
+use rustls::enums::{ApplicationProtocol, ProtocolVersion};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 
@@ -503,7 +503,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     config.alpn_protocols = args
         .proto
         .iter()
-        .map(|proto| proto.as_bytes().to_vec())
+        .map(|proto| ApplicationProtocol::from(proto.as_bytes()).to_owned())
         .collect();
     config.max_fragment_size = args.max_frag_size;
 

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -30,7 +30,7 @@ use log::{debug, error};
 use mio::net::{TcpListener, TcpStream};
 use rustls::RootCertStore;
 use rustls::crypto::{CryptoProvider, Identity, aws_lc_rs as provider};
-use rustls::enums::ProtocolVersion;
+use rustls::enums::{ApplicationProtocol, ProtocolVersion};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use rustls::server::WebPkiClientVerifier;
@@ -666,7 +666,11 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
         config.max_early_data_size = args.max_early_data;
     }
 
-    config.alpn_protocols = args.proto.clone();
+    config.alpn_protocols = args
+        .proto
+        .iter()
+        .map(|bytes| ApplicationProtocol::from(bytes.as_slice()).to_owned())
+        .collect();
 
     Arc::new(config)
 }

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -284,7 +284,7 @@ fn test_quic_rejects_missing_alpn() {
         let client_config = Arc::new(client_config);
 
         let mut server_config = make_server_config(kt, &provider);
-        server_config.alpn_protocols = vec!["foo".into()];
+        server_config.alpn_protocols = vec![b"foo".into()];
         let server_config = Arc::new(server_config);
 
         let mut client = quic::ClientConnection::new(
@@ -313,7 +313,7 @@ fn test_quic_rejects_missing_alpn() {
 fn test_quic_no_tls13_error() {
     let provider = provider::DEFAULT_TLS12_PROVIDER;
     let mut client_config = make_client_config(KeyType::Ed25519, &provider);
-    client_config.alpn_protocols = vec!["foo".into()];
+    client_config.alpn_protocols = vec![b"foo".into()];
     let client_config = Arc::new(client_config);
 
     assert!(
@@ -327,7 +327,7 @@ fn test_quic_no_tls13_error() {
     );
 
     let mut server_config = make_server_config(KeyType::Ed25519, &provider);
-    server_config.alpn_protocols = vec!["foo".into()];
+    server_config.alpn_protocols = vec![b"foo".into()];
     let server_config = Arc::new(server_config);
 
     assert!(
@@ -340,7 +340,7 @@ fn test_quic_no_tls13_error() {
 fn test_quic_invalid_early_data_size() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let mut server_config = make_server_config(KeyType::Ed25519, &provider);
-    server_config.alpn_protocols = vec!["foo".into()];
+    server_config.alpn_protocols = vec![b"foo".into()];
 
     let cases = [
         (None, true),
@@ -417,7 +417,7 @@ fn test_quic_server_no_params_received() {
 fn test_quic_server_no_tls12() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let mut server_config = make_server_config(KeyType::Ed25519, &provider);
-    server_config.alpn_protocols = vec!["foo".into()];
+    server_config.alpn_protocols = vec![b"foo".into()];
     let server_config = Arc::new(server_config);
 
     let mut server =
@@ -475,7 +475,7 @@ fn test_quic_resumption_data_basic() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
 
     let mut server_config = make_server_config(kt, &provider);
-    server_config.alpn_protocols = vec!["foo".into()];
+    server_config.alpn_protocols = vec![b"foo".into()];
     server_config.max_early_data_size = 0xffff_ffff;
     server_config.ticketer = Some(
         provider
@@ -518,13 +518,13 @@ fn test_quic_resumption_data_0rtt() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
 
     let mut client_config = make_client_config(kt, &provider);
-    client_config.alpn_protocols = vec!["foo".into()];
+    client_config.alpn_protocols = vec![b"foo".into()];
     client_config.enable_early_data = true;
     client_config.resumption = Resumption::store(Arc::new(ClientStorage::new()));
     let client_config = Arc::new(client_config);
 
     let mut server_config = make_server_config(kt, &provider);
-    server_config.alpn_protocols = vec!["foo".into()];
+    server_config.alpn_protocols = vec![b"foo".into()];
     server_config.max_early_data_size = 0xffff_ffff;
     server_config.ticketer = Some(
         provider

--- a/rustls-test/tests/api/resolve.rs
+++ b/rustls-test/tests/api/resolve.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use pki_types::{CertificateDer, DnsName};
 use rustls::client::{ClientCredentialResolver, CredentialRequest};
 use rustls::crypto::{CipherSuite, Credentials, Identity, SelectedCredential, SignatureScheme};
-use rustls::enums::{CertificateType, ProtocolVersion};
+use rustls::enums::{ApplicationProtocol, CertificateType, ProtocolVersion};
 use rustls::error::{CertificateError, Error, PeerMisbehaved};
 use rustls::server::{ClientHello, ServerCredentialResolver, ServerNameResolver};
 use rustls::{
@@ -53,7 +53,10 @@ fn server_cert_resolve_with_alpn() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let mut client_config = make_client_config(*kt, &provider);
-        client_config.alpn_protocols = vec!["foo".into(), "bar".into()];
+        client_config.alpn_protocols = vec![
+            ApplicationProtocol::from(b"foo"),
+            ApplicationProtocol::from(b"bar"),
+        ];
 
         let mut server_config = make_server_config(*kt, &provider);
         server_config.cert_resolver = Arc::new(ServerCheckCertResolve {

--- a/rustls/src/client/config.rs
+++ b/rustls/src/client/config.rs
@@ -18,7 +18,7 @@ use crate::crypto::{
     CipherSuite, Credentials, CryptoProvider, Identity, SelectedCredential, SignatureScheme,
     SingleCredential, hash,
 };
-use crate::enums::{CertificateType, ProtocolVersion};
+use crate::enums::{ApplicationProtocol, CertificateType, ProtocolVersion};
 use crate::error::{ApiMisuse, Error};
 use crate::key_log::NoKeyLog;
 use crate::msgs::persist;
@@ -62,7 +62,7 @@ use crate::{DistinguishedName, DynHasher, KeyLog, compress, verify};
 pub struct ClientConfig {
     /// Which ALPN protocols we include in our client hello.
     /// If empty, no ALPN extension is sent.
-    pub alpn_protocols: Vec<Vec<u8>>,
+    pub alpn_protocols: Vec<ApplicationProtocol<'static>>,
 
     /// How and when the client can resume a previous session.
     ///

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 use core::{fmt, mem};
 
@@ -11,6 +10,7 @@ use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 #[cfg(doc)]
 use crate::crypto;
+use crate::enums::ApplicationProtocol;
 use crate::error::Error;
 use crate::kernel::KernelConnection;
 use crate::log::trace;
@@ -22,7 +22,6 @@ use crate::unbuffered::{EncryptError, TransmitTlsData};
 
 #[cfg(feature = "std")]
 mod buffered {
-    use alloc::vec::Vec;
     use core::fmt;
     use core::ops::{Deref, DerefMut};
     use std::io;
@@ -35,6 +34,7 @@ mod buffered {
     use crate::client::config::ClientConfig;
     use crate::common_state::Protocol;
     use crate::conn::{ConnectionCommon, ConnectionCore};
+    use crate::enums::ApplicationProtocol;
     use crate::error::Error;
     use crate::suites::ExtractedSecrets;
     use crate::sync::Arc;
@@ -56,14 +56,14 @@ mod buffered {
         /// we behave in the TLS protocol, `name` is the
         /// name of the server we want to talk to.
         pub fn new(config: Arc<ClientConfig>, name: ServerName<'static>) -> Result<Self, Error> {
-            Self::new_with_alpn(config.clone(), name, config.alpn_protocols.clone())
+            Self::new_with_alpn(config.clone(), name, &config.alpn_protocols)
         }
 
         /// Make a new ClientConnection with custom ALPN protocols.
         pub fn new_with_alpn(
             config: Arc<ClientConfig>,
             name: ServerName<'static>,
-            alpn_protocols: Vec<Vec<u8>>,
+            alpn_protocols: &[ApplicationProtocol<'_>],
         ) -> Result<Self, Error> {
             Ok(Self {
                 inner: ConnectionCommon::from(ConnectionCore::for_client(
@@ -308,7 +308,7 @@ impl UnbufferedClientConnection {
         Self::new_with_extensions(
             config.clone(),
             name,
-            ClientExtensionsInput::from_alpn(config.alpn_protocols.clone()),
+            ClientExtensionsInput::from_alpn(&config.alpn_protocols),
         )
     }
 
@@ -316,7 +316,7 @@ impl UnbufferedClientConnection {
     pub fn new_with_alpn(
         config: Arc<ClientConfig>,
         name: ServerName<'static>,
-        alpn_protocols: Vec<Vec<u8>>,
+        alpn_protocols: &[ApplicationProtocol<'_>],
     ) -> Result<Self, Error> {
         Self::new_with_extensions(
             config,

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -1,5 +1,110 @@
 #![expect(missing_docs)]
 
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplicationProtocol<'a> {
+    AcmeTls1,
+    DoT,
+    DoQ,
+    Ftp,
+    Http09,
+    Http10,
+    Http11,
+    Http2,
+    Http3,
+    Imap,
+    Mqtt,
+    Pop3,
+    Postgresql,
+    WebRtc,
+    Other(Cow<'a, [u8]>),
+}
+
+impl<'a> ApplicationProtocol<'a> {
+    fn new(data: Cow<'a, [u8]>) -> Self {
+        match data.as_ref() {
+            b"acme-tls/1" => Self::AcmeTls1,
+            b"dot" => Self::DoT,
+            b"doq" => Self::DoQ,
+            b"ftp" => Self::Ftp,
+            b"http/0.9" => Self::Http09,
+            b"http/1.0" => Self::Http10,
+            b"http/1.1" => Self::Http11,
+            b"h2" => Self::Http2,
+            b"h3" => Self::Http3,
+            b"imap" => Self::Imap,
+            b"mqtt" => Self::Mqtt,
+            b"pop3" => Self::Pop3,
+            b"postgresql" => Self::Postgresql,
+            b"webrtc" => Self::WebRtc,
+            _r => Self::Other(data),
+        }
+    }
+
+    pub fn to_owned(&self) -> ApplicationProtocol<'static> {
+        match self {
+            Self::AcmeTls1 => ApplicationProtocol::AcmeTls1,
+            Self::DoT => ApplicationProtocol::DoT,
+            Self::DoQ => ApplicationProtocol::DoQ,
+            Self::Ftp => ApplicationProtocol::Ftp,
+            Self::Http09 => ApplicationProtocol::Http09,
+            Self::Http10 => ApplicationProtocol::Http10,
+            Self::Http11 => ApplicationProtocol::Http11,
+            Self::Http2 => ApplicationProtocol::Http2,
+            Self::Http3 => ApplicationProtocol::Http3,
+            Self::Imap => ApplicationProtocol::Imap,
+            Self::Mqtt => ApplicationProtocol::Mqtt,
+            Self::Pop3 => ApplicationProtocol::Pop3,
+            Self::Postgresql => ApplicationProtocol::Postgresql,
+            Self::WebRtc => ApplicationProtocol::WebRtc,
+            Self::Other(data) => ApplicationProtocol::Other(Cow::Owned(data.to_vec())),
+        }
+    }
+}
+
+impl From<Vec<u8>> for ApplicationProtocol<'static> {
+    fn from(data: Vec<u8>) -> Self {
+        Self::new(Cow::Owned(data))
+    }
+}
+
+impl<'a, const N: usize> From<&'a [u8; N]> for ApplicationProtocol<'a> {
+    fn from(data: &'a [u8; N]) -> Self {
+        ApplicationProtocol::from(&data[..])
+    }
+}
+
+impl<'a> From<&'a [u8]> for ApplicationProtocol<'a> {
+    fn from(data: &'a [u8]) -> Self {
+        Self::new(Cow::Borrowed(data))
+    }
+}
+
+impl AsRef<[u8]> for ApplicationProtocol<'_> {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::AcmeTls1 => b"acme-tls/1",
+            Self::DoT => b"dot",
+            Self::DoQ => b"doq",
+            Self::Ftp => b"ftp",
+            Self::Http09 => b"http/0.9",
+            Self::Http10 => b"http/1.0",
+            Self::Http11 => b"http/1.1",
+            Self::Http2 => b"h2",
+            Self::Http3 => b"h3",
+            Self::Imap => b"imap",
+            Self::Mqtt => b"mqtt",
+            Self::Pop3 => b"pop3",
+            Self::Postgresql => b"postgresql",
+            Self::WebRtc => b"webrtc",
+            Self::Other(data) => data.as_ref(),
+        }
+    }
+}
+
 enum_builder! {
     /// The `HandshakeType` TLS protocol enum.  Values in this enum are taken
     /// from the various RFCs covering TLS, and are listed by IANA.

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -17,8 +17,8 @@ use crate::crypto::{
     CipherSuite, GetRandomFailed, SecureRandom, SelectedCredential, SignatureScheme,
 };
 use crate::enums::{
-    CertificateCompressionAlgorithm, CertificateType, EchClientHelloType, HandshakeType,
-    ProtocolVersion,
+    ApplicationProtocol, CertificateCompressionAlgorithm, CertificateType, EchClientHelloType,
+    HandshakeType, ProtocolVersion,
 };
 use crate::error::InvalidMessage;
 use crate::log::warn;
@@ -787,13 +787,15 @@ pub(crate) struct ClientExtensionsInput<'a> {
 }
 
 impl ClientExtensionsInput<'_> {
-    pub(crate) fn from_alpn(alpn_protocols: Vec<Vec<u8>>) -> ClientExtensionsInput<'static> {
+    pub(crate) fn from_alpn(
+        alpn_protocols: &[ApplicationProtocol<'_>],
+    ) -> ClientExtensionsInput<'static> {
         let protocols = match alpn_protocols.is_empty() {
             true => None,
             false => Some(
                 alpn_protocols
-                    .into_iter()
-                    .map(ProtocolName::from)
+                    .iter()
+                    .map(|p| ProtocolName::from(p.as_ref().to_vec()))
                     .collect::<Vec<_>>(),
             ),
         };

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -27,7 +27,7 @@ mod connection {
     use crate::common_state::{CommonState, DEFAULT_BUFFER_LIMIT, Protocol};
     use crate::conn::{ConnectionCore, KeyingMaterialExporter, SideData};
     use crate::crypto::cipher::{EncodedMessage, Payload};
-    use crate::enums::{ContentType, ProtocolVersion};
+    use crate::enums::{ApplicationProtocol, ContentType, ProtocolVersion};
     use crate::error::{ApiMisuse, Error};
     use crate::msgs::deframer::{DeframerVecBuffer, Locator};
     use crate::msgs::handshake::{
@@ -129,7 +129,7 @@ mod connection {
                 quic_version,
                 name,
                 params,
-                config.alpn_protocols.clone(),
+                &config.alpn_protocols,
             )
         }
 
@@ -139,7 +139,7 @@ mod connection {
             quic_version: Version,
             name: ServerName<'static>,
             params: Vec<u8>,
-            alpn_protocols: Vec<Vec<u8>>,
+            alpn_protocols: &[ApplicationProtocol<'_>],
         ) -> Result<Self, Error> {
             let suites = &config.provider().tls13_cipher_suites;
             if suites.is_empty() {

--- a/rustls/src/server/config.rs
+++ b/rustls/src/server/config.rs
@@ -15,7 +15,7 @@ use crate::crypto::{
     CipherSuite, Credentials, CryptoProvider, Identity, SelectedCredential, SignatureScheme,
     SingleCredential, TicketProducer,
 };
-use crate::enums::{CertificateType, ProtocolVersion};
+use crate::enums::{ApplicationProtocol, CertificateType, ProtocolVersion};
 use crate::error::{Error, PeerMisbehaved};
 use crate::msgs::handshake::{ProtocolName, ServerNamePayload};
 use crate::sync::Arc;
@@ -118,7 +118,7 @@ pub struct ServerConfig {
 
     /// Protocol names we support, most preferred first.
     /// If empty we don't do ALPN at all.
-    pub alpn_protocols: Vec<Vec<u8>>,
+    pub alpn_protocols: Vec<ApplicationProtocol<'static>>,
 
     /// How to verify client certificates.
     pub(super) verifier: Arc<dyn ClientVerifier>,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -86,9 +86,9 @@ impl<'a> ExtensionProcessing<'a> {
                 .find(|ours| {
                     their_protocols
                         .iter()
-                        .any(|theirs| theirs.as_ref() == ours.as_slice())
+                        .any(|theirs| theirs.as_ref() == ours.as_ref())
                 })
-                .map(|bytes| ProtocolName::from(bytes.clone()))
+                .map(|proto| ProtocolName::from(proto.as_ref().to_vec()))
             {
                 debug!("Chosen ALPN protocol {selected_protocol:?}");
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -25,7 +25,7 @@ use crate::msgs::codec::Codec;
 use crate::msgs::deframer::HandshakeAlignedProof;
 use crate::msgs::handshake::{
     CertificateChain, ClientKeyExchangeParams, HandshakeMessagePayload, HandshakePayload,
-    NewSessionTicketPayload, NewSessionTicketPayloadTls13, SessionId,
+    NewSessionTicketPayload, NewSessionTicketPayloadTls13, ProtocolName, SessionId,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -724,7 +724,10 @@ fn get_server_connection_value_tls12(
             cx.data.sni.as_ref(),
             secrets.suite().common.suite,
             peer_identity.cloned(),
-            cx.common.alpn_protocol.clone(),
+            cx.common
+                .alpn_protocol
+                .as_ref()
+                .map(|p| ProtocolName::from(p.as_ref().to_vec())),
             cx.data.resumption_data.clone(),
             time_now,
         ),


### PR DESCRIPTION
Here's a first take. Happy to iterate more pending discussion.

Well-known variants cribbed from https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids, relying on my own opinion for what's useful with rustls in 2026.