### PR TITLE
Enable all features by default in rustls-test crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ ring = "0.17"
 rsa = { version = "0.9", features = ["sha2"], default-features = false }
 rustc-hash = "2"
 rustls-graviola = { version = "0.3" }
-rustls-test = { path = "rustls-test/" }
+rustls-test = { path = "rustls-test/", default-features = false }
 rustls-fuzzing-provider = { path = "rustls-fuzzing-provider/" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -17,7 +17,7 @@ rustc-hash = { workspace = true }
 rustls = { path = "../rustls" }
 rustls-aws-lc-rs = { path = "../rustls-aws-lc-rs" }
 rustls-ring = { path = "../rustls-ring" }
-rustls-test = { workspace = true }
+rustls-test = { workspace = true, default-features = false }
 rustls-fuzzing-provider = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/rustls-bench/Cargo.toml
+++ b/rustls-bench/Cargo.toml
@@ -10,7 +10,7 @@ rustls = { path = "../rustls" }
 rustls-aws-lc-rs = { path = "../rustls-aws-lc-rs", optional = true }
 rustls-ring = { path = "../rustls-ring", optional = true }
 rustls-graviola = { workspace = true, optional = true }
-rustls-test = { workspace = true }
+rustls-test = { workspace = true, default-features = false }
 
 [features]
 default = []

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -23,7 +23,7 @@ webpki = { workspace = true }
 criterion = { workspace = true }
 env_logger = { workspace = true }
 rcgen = { workspace = true }
-rustls-test = { workspace = true }
+rustls-test = { workspace = true, default-features = false }
 webpki-roots = { workspace = true }
 
 [[bench]]

--- a/rustls-ring/Cargo.toml
+++ b/rustls-ring/Cargo.toml
@@ -23,7 +23,7 @@ webpki = { workspace = true, features = ["ring"] }
 
 [dev-dependencies]
 bencher = { workspace = true }
-rustls-test = { workspace = true }
+rustls-test = { workspace = true, default-features = false }
 
 [[bench]]
 name = "benchmarks"

--- a/rustls-test/Cargo.toml
+++ b/rustls-test/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 publish = false
 
 [features]
+default = ["aws-lc-rs", "brotli", "log", "ring", "zlib"]
 aws-lc-rs = ["dep:rustls-aws-lc-rs"]
 brotli = ["rustls/brotli"]
 fips = ["rustls-aws-lc-rs/fips"]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -40,7 +40,7 @@ env_logger = { workspace = true }
 log = { workspace = true }
 macro_rules_attribute = { workspace = true }
 rcgen = { workspace = true }
-rustls-test = { workspace = true }
+rustls-test = { workspace = true, default-features = false }
 time = { workspace = true }
 webpki-roots = { workspace = true }
 


### PR DESCRIPTION
Because I can't enable all features across the workspace (due to conflicts between aws-lc-rs fips and unstable), I set `rust-analyzer.cargo.features` to `[]` to use default features. However, this disabled all diagnostics for integration tests in rustls-test, which are gated on provider features.