### PR TITLE
ci: bring back integration tests for cross-compiled targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,6 +420,7 @@ jobs:
         if: ${{ matrix.target != 'i686-unknown-linux-gnu' }}
         run: cargo add --dev --features bindgen 'aws-lc-sys@>0.20' --package rustls --verbose
       - run: cross test --package rustls --target ${{ matrix.target }}
+      - run: cross test --package rustls-test --features aws-lc-rs --target ${{ matrix.target }}
 
   semver:
     name: Check semver compatibility


### PR DESCRIPTION
In

- https://github.com/rustls/rustls/pull/2728

I moved the integration tests out of the rustls crate and into rustls-test. However, the cross-compiled target workflow in CI explicitly uses `-p rustls`, so it was not testing as much as before. Restore the previous behavior.