### PR TITLE
Prefer AES-128-GCM, matching Go

### DIFF
--- a/rustls-aws-lc-rs/src/lib.rs
+++ b/rustls-aws-lc-rs/src/lib.rs
@@ -194,12 +194,12 @@ const SIX_HOURS: Duration = Duration::from_secs(6 * 60 * 60);
 /// This will be [`ALL_TLS12_CIPHER_SUITES`] sans any supported cipher suites that
 /// shouldn't be enabled by most applications.
 pub static DEFAULT_TLS12_CIPHER_SUITES: &[&Tls12CipherSuite] = &[
-    tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     #[cfg(not(feature = "fips"))]
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-    tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     #[cfg(not(feature = "fips"))]
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
@@ -209,26 +209,26 @@ pub static DEFAULT_TLS12_CIPHER_SUITES: &[&Tls12CipherSuite] = &[
 /// This will be [`ALL_TLS13_CIPHER_SUITES`] sans any supported cipher suites that
 /// shouldn't be enabled by most applications.
 pub static DEFAULT_TLS13_CIPHER_SUITES: &[&Tls13CipherSuite] = &[
-    tls13::TLS13_AES_256_GCM_SHA384,
     tls13::TLS13_AES_128_GCM_SHA256,
+    tls13::TLS13_AES_256_GCM_SHA384,
     #[cfg(not(feature = "fips"))]
     tls13::TLS13_CHACHA20_POLY1305_SHA256,
 ];
 
 /// A list of all the TLS1.2 cipher suites supported by the rustls aws-lc-rs provider.
 pub static ALL_TLS12_CIPHER_SUITES: &[&Tls12CipherSuite] = &[
-    tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-    tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
 /// A list of all the TLS1.3 cipher suites supported by the rustls aws-lc-rs provider.
 pub static ALL_TLS13_CIPHER_SUITES: &[&Tls13CipherSuite] = &[
-    tls13::TLS13_AES_256_GCM_SHA384,
     tls13::TLS13_AES_128_GCM_SHA256,
+    tls13::TLS13_AES_256_GCM_SHA384,
     tls13::TLS13_CHACHA20_POLY1305_SHA256,
 ];
 

--- a/rustls-ring/src/lib.rs
+++ b/rustls-ring/src/lib.rs
@@ -145,11 +145,11 @@ pub static DEFAULT_TLS12_CIPHER_SUITES: &[&Tls12CipherSuite] = ALL_TLS12_CIPHER_
 
 /// A list of all the TLS1.2 cipher suites supported by the rustls *ring* provider.
 pub static ALL_TLS12_CIPHER_SUITES: &[&Tls12CipherSuite] = &[
-    tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-    tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
@@ -161,8 +161,8 @@ pub static DEFAULT_TLS13_CIPHER_SUITES: &[&Tls13CipherSuite] = ALL_TLS13_CIPHER_
 
 /// A list of all the TLS1.3 cipher suites supported by the rustls *ring* provider.
 pub static ALL_TLS13_CIPHER_SUITES: &[&Tls13CipherSuite] = &[
-    tls13::TLS13_AES_256_GCM_SHA384,
     tls13::TLS13_AES_128_GCM_SHA256,
+    tls13::TLS13_AES_256_GCM_SHA384,
     tls13::TLS13_CHACHA20_POLY1305_SHA256,
 ];
 

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -39,8 +39,9 @@ use rustls::unbuffered::{
     ConnectionState, EncodeError, UnbufferedConnectionCommon, UnbufferedStatus,
 };
 use rustls::{
-    ClientConfig, ClientConnection, ConfigBuilder, Connection, ConnectionCommon, DistinguishedName,
-    RootCertStore, ServerConfig, ServerConnection, SideData, SupportedCipherSuite, WantsVerifier,
+    ClientConfig, ClientConnection, ConfigBuilder, Connection, ConnectionCommon,
+    ConnectionTrafficSecrets, DistinguishedName, RootCertStore, ServerConfig, ServerConnection,
+    SideData, SupportedCipherSuite, WantsVerifier,
 };
 
 macro_rules! embed_files {
@@ -1375,12 +1376,16 @@ impl RawTls {
 
         let encrypter = match (tx_keys, suite) {
             (
-                rustls::ConnectionTrafficSecrets::Aes256Gcm { key, iv },
+                ConnectionTrafficSecrets::Aes128Gcm { key, iv }
+                | ConnectionTrafficSecrets::Aes256Gcm { key, iv }
+                | ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv },
                 SupportedCipherSuite::Tls13(tls13),
             ) => tls13.aead_alg.encrypter(key, iv),
 
             (
-                rustls::ConnectionTrafficSecrets::Aes256Gcm { key, iv },
+                ConnectionTrafficSecrets::Aes128Gcm { key, iv }
+                | ConnectionTrafficSecrets::Aes256Gcm { key, iv }
+                | ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv },
                 SupportedCipherSuite::Tls12(tls12),
             ) => tls12
                 .aead_alg
@@ -1391,12 +1396,16 @@ impl RawTls {
 
         let decrypter = match (rx_keys, suite) {
             (
-                rustls::ConnectionTrafficSecrets::Aes256Gcm { key, iv },
+                ConnectionTrafficSecrets::Aes128Gcm { key, iv }
+                | ConnectionTrafficSecrets::Aes256Gcm { key, iv }
+                | ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv },
                 SupportedCipherSuite::Tls13(tls13),
             ) => tls13.aead_alg.decrypter(key, iv),
 
             (
-                rustls::ConnectionTrafficSecrets::Aes256Gcm { key, iv },
+                ConnectionTrafficSecrets::Aes128Gcm { key, iv }
+                | ConnectionTrafficSecrets::Aes256Gcm { key, iv }
+                | ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv },
                 SupportedCipherSuite::Tls12(tls12),
             ) => tls12
                 .aead_alg

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -792,14 +792,14 @@ fn test_tls13_exporter_maximum_output_length() {
 
     assert_eq!(
         client.negotiated_cipher_suite(),
-        Some(find_suite(CipherSuite::TLS13_AES_256_GCM_SHA384))
+        Some(find_suite(CipherSuite::TLS13_AES_128_GCM_SHA256))
     );
 
     let client_exporter = client.exporter().unwrap();
     let server_exporter = server.exporter().unwrap();
 
-    let mut maximum_allowed_output_client = [0u8; 255 * 48];
-    let mut maximum_allowed_output_server = [0u8; 255 * 48];
+    let mut maximum_allowed_output_client = [0u8; 255 * 32];
+    let mut maximum_allowed_output_server = [0u8; 255 * 32];
 
     client_exporter
         .derive(
@@ -915,7 +915,7 @@ fn negotiated_ciphersuite_default() {
         do_suite_and_kx_test(
             make_client_config(*kt, &provider),
             make_server_config(*kt, &provider),
-            find_suite(CipherSuite::TLS13_AES_256_GCM_SHA384),
+            find_suite(CipherSuite::TLS13_AES_128_GCM_SHA256),
             expected_kx_for_version(ProtocolVersion::TLSv1_3),
             ProtocolVersion::TLSv1_3,
         );

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1245,9 +1245,9 @@ fn vectored_write_for_client_handshake() {
     {
         let mut pipe = OtherSession::new(&mut server);
         let wrlen = client.write_tls(&mut pipe).unwrap();
-        assert_eq!(wrlen, 154);
+        assert_eq!(wrlen, 138);
         // CCS, finished, then two application data records
-        assert_eq!(pipe.writevs, vec![vec![6, 74, 42, 32]]);
+        assert_eq!(pipe.writevs, vec![vec![6, 58, 42, 32]]);
     }
 
     assert!(!server.is_handshaking());

--- a/rustls/src/manual/defaults.rs
+++ b/rustls/src/manual/defaults.rs
@@ -2,16 +2,6 @@
 
 ## Rationale for defaults
 
-### Why is AES-256 preferred over AES-128?
-
-This is a trade-off between:
-
-1. classical security level: searching a 2^128 key space is as implausible as 2^256.
-2. post-quantum security level: the difference is more meaningful, and AES-256 seems like the conservative choice.
-3. performance: AES-256 is around 40% slower than AES-128, though hardware acceleration typically narrows this gap.
-
-The choice is frankly quite marginal.
-
 ### Why is AES-GCM preferred over chacha20-poly1305?
 
 Hardware support for accelerating AES-GCM is widespread, and hardware-accelerated AES-GCM


### PR DESCRIPTION
Reviewing https://go.dev/blog/tls-cipher-suites because of

- #2252 

this seems like an easy win. Might be nice to backport this to 0.23 as well?