### PR TITLE
crypto: allow AeadKeys to be created from 16-byte arrays

### DIFF
--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 use alloc::string::ToString;
-use core::fmt;
+use core::{array, fmt};
 
 use pki_types::FipsStatus;
 use zeroize::Zeroize;
@@ -396,6 +396,15 @@ impl From<[u8; Self::MAX_LEN]> for AeadKey {
     }
 }
 
+impl From<[u8; 16]> for AeadKey {
+    fn from(buf: [u8; 16]) -> Self {
+        Self {
+            buf: array::from_fn(|i| if i < 16 { buf[i] } else { 0 }),
+            used: 16,
+        }
+    }
+}
+
 #[cfg(test)]
 pub(crate) struct FakeAead;
 
@@ -568,5 +577,12 @@ mod tests {
                 maximum: 16
             }))
         ));
+    }
+
+    #[test]
+    fn aead_key_16_bytes() {
+        let bytes = [0xABu8; 16];
+        let key = AeadKey::from(bytes);
+        assert_eq!(key.as_ref(), &bytes);
     }
 }

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -1075,8 +1075,7 @@ pub(crate) fn hkdf_expand_label_aead_key(
     context: &[u8],
 ) -> AeadKey {
     hkdf_expand_label_inner(expander, label, context, key_len, |e, info| {
-        let key: AeadKey = expand(e, info);
-        key.with_length(key_len)
+        expand::<AeadKey, { AeadKey::MAX_LEN }>(e, info).with_length(key_len)
     })
 }
 


### PR DESCRIPTION
Fixes #2853.

Ideally we'd be able to lean harder on `const` constraints here, but unfortunately that's taking its time in getting there.