### PR TITLE
Withdraw `reject_early_data()` API

### DIFF
--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -174,40 +174,6 @@ fn test_quic_handshake() {
         .unwrap()
         .unwrap();
     assert!(client.is_early_data_accepted());
-    // 0-RTT rejection
-    {
-        let client_config = (*client_config).clone();
-        let mut client = quic::ClientConnection::new(
-            Arc::new(client_config),
-            quic::Version::V1,
-            server_name("localhost"),
-            client_params.into(),
-        )
-        .unwrap();
-
-        let mut server = quic::ServerConnection::new(
-            server_config.clone(),
-            quic::Version::V1,
-            server_params.into(),
-        )
-        .unwrap();
-        server.reject_early_data();
-
-        step(&mut client, &mut server).unwrap();
-        assert_eq!(client.quic_transport_parameters(), Some(server_params));
-        assert!(client.zero_rtt_keys().is_some());
-        assert!(server.zero_rtt_keys().is_none());
-        step(&mut server, &mut client)
-            .unwrap()
-            .unwrap();
-        step(&mut client, &mut server)
-            .unwrap()
-            .unwrap();
-        step(&mut server, &mut client)
-            .unwrap()
-            .unwrap();
-        assert!(!client.is_early_data_accepted());
-    }
 
     // failed handshake
     let mut client = quic::ClientConnection::new(

--- a/rustls-test/tests/api/resume.rs
+++ b/rustls-test/tests/api/resume.rs
@@ -545,41 +545,6 @@ fn early_data_not_available_on_server_before_client_hello() {
 }
 
 #[test]
-fn early_data_can_be_rejected_by_server() {
-    let (client_config, server_config) = early_data_configs();
-
-    let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake(&mut client, &mut server);
-
-    let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    assert!(client.early_data().is_some());
-    assert_eq!(
-        client
-            .early_data()
-            .unwrap()
-            .bytes_left(),
-        1234
-    );
-    client
-        .early_data()
-        .unwrap()
-        .flush()
-        .unwrap();
-    assert_eq!(
-        client
-            .early_data()
-            .unwrap()
-            .write(b"hello")
-            .unwrap(),
-        5
-    );
-    server.reject_early_data();
-    do_handshake(&mut client, &mut server);
-
-    assert!(!client.is_early_data_accepted());
-}
-
-#[test]
 fn early_data_is_limited_on_client() {
     let (client_config, server_config) = early_data_configs();
 

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -271,15 +271,6 @@ mod connection {
             Ok(Self { inner })
         }
 
-        /// Explicitly discard early data, notifying the client
-        ///
-        /// Useful if invariants encoded in `received_resumption_data()` cannot be respected.
-        ///
-        /// Must be called while `is_handshaking` is true.
-        pub fn reject_early_data(&mut self) {
-            self.inner.core.reject_early_data()
-        }
-
         /// Retrieves the server name, if any, used to select the certificate and
         /// private key.
         ///

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -134,15 +134,6 @@ mod buffered {
             self.inner.core.side.resumption_data = data.into();
         }
 
-        /// Explicitly discard early data, notifying the client
-        ///
-        /// Useful if invariants encoded in `received_resumption_data()` cannot be respected.
-        ///
-        /// Must be called while `is_handshaking` is true.
-        pub fn reject_early_data(&mut self) {
-            self.inner.core.reject_early_data()
-        }
-
         /// Returns an `io::Read` implementer you can read bytes from that are
         /// received from a client as TLS1.3 0RTT/"early" data, during the handshake.
         ///
@@ -734,15 +725,6 @@ impl ConnectionCore<ServerConnectionData> {
             ServerConnectionData::default(),
             common,
         ))
-    }
-
-    #[cfg(feature = "std")]
-    pub(crate) fn reject_early_data(&mut self) {
-        assert!(
-            self.common_state.is_handshaking(),
-            "cannot retroactively reject early data"
-        );
-        self.side.early_data.reject();
     }
 }
 


### PR DESCRIPTION
It seems the only callers of this are in our tests.