### PR TITLE
S3FIFO Cache

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -461,10 +461,6 @@ pub mod time_provider;
 /// APIs abstracting over locking primitives.
 pub mod lock;
 
-mod hash_set {
-    pub(crate) use std::collections::HashSet;
-}
-
 mod hash_map {
     pub(crate) use std::collections::HashMap;
 }


### PR DESCRIPTION
Related: #1503, #1200

Thea ideal to implement cache in s3fifo was initial mentioned by @djc in https://github.com/rustls/rustls/issues/1200#issuecomment-1714609882

--- 

I can not compile for this repo to run additional benchmark, dependency is kind of messy.
> I've benchmarked this using a custom microbenchmark ([repo](https://github.com/aochagavia/rustls-cache-bench)) in https://github.com/rustls/rustls/issues/1200#issuecomment-1714082722

Outdate benchmark:

<details>

Would like to share some of benchmark on my machine. M1Pro 10c 32G

`> rustls-bench handshake TLS13_AES_256_GCM_SHA38`

Basline 257e511ce879e8f785484528cc78fdf2d83ec182
```bash
handshakes      TLSv1_3 Rsa2048 TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       6966.17 handshakes/s
handshakes      TLSv1_3 Rsa2048 TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       1649.87 handshakes/s
handshakes-unbuffered   TLSv1_3 Rsa2048 TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       7071.62handshakes/s
handshakes-unbuffered   TLSv1_3 Rsa2048 TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       1646.93handshakes/s
handshakes      TLSv1_3 EcdsaP256       TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       3908.12handshakes/s
handshakes      TLSv1_3 EcdsaP256       TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       8346.22handshakes/s
handshakes-unbuffered   TLSv1_3 EcdsaP256       TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume      3863.44  handshakes/s
handshakes-unbuffered   TLSv1_3 EcdsaP256       TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume      8284.81  handshakes/s
handshakes      TLSv1_3 Ed25519 TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       5116.57 handshakes/s
handshakes      TLSv1_3 Ed25519 TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       9550.34 handshakes/s
handshakes-unbuffered   TLSv1_3 Ed25519 TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       5036.99handshakes/s
handshakes-unbuffered   TLSv1_3 Ed25519 TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       9496.43handshakes/s
```

PR
```bash
handshakes      TLSv1_3 Rsa2048 TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       7587.90 handshakes/s
handshakes      TLSv1_3 Rsa2048 TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       1736.19 handshakes/s
handshakes-unbuffered   TLSv1_3 Rsa2048 TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       7532.33handshakes/s
handshakes-unbuffered   TLSv1_3 Rsa2048 TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       1721.51handshakes/s
handshakes      TLSv1_3 EcdsaP256       TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       4635.09handshakes/s
handshakes      TLSv1_3 EcdsaP256       TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       10245.13handshakes/s
handshakes-unbuffered   TLSv1_3 EcdsaP256       TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume      4645.36  handshakes/s
handshakes-unbuffered   TLSv1_3 EcdsaP256       TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume      10239.77 handshakes/s
handshakes      TLSv1_3 Ed25519 TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       5981.90 handshakes/s
handshakes      TLSv1_3 Ed25519 TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       11503.03       handshakes/s
handshakes-unbuffered   TLSv1_3 Ed25519 TLS13_AES_256_GCM_SHA384        client  server-auth     no-resume       6008.96handshakes/s
handshakes-unbuffered   TLSv1_3 Ed25519 TLS13_AES_256_GCM_SHA384        server  server-auth     no-resume       11559.65handshakes/s
```
</details>

--- 

Additional work would like to be

- rewrite `.lock()` to `.try_lock()` (? early return None not wait to a value may changed the expected behavior
- rewrite `Mutex<Cache<T>>` to `[Mutex<Cache<T>>]` for better lock contention optimization

Happy to receive any feedback so I(we) can move this forward
