### PR TITLE
tlsserver-mio: fix lint with better style

### DIFF
--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -364,13 +364,9 @@ impl OpenConnection {
             .register(&mut self.socket, self.token, event_set)
             .unwrap();
 
-        if self.back.is_some() {
+        if let Some(back) = &mut self.back {
             registry
-                .register(
-                    self.back.as_mut().unwrap(),
-                    self.token,
-                    mio::Interest::READABLE,
-                )
+                .register(back, self.token, mio::Interest::READABLE)
                 .unwrap();
         }
     }


### PR DESCRIPTION
(fix for 1.93 clippy)