### PR TITLE
upgrade to zlib-rs 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,6 +3757,6 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"
+checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ webpki-roots = "1"
 x25519-dalek = "2"
 x509-parser = "0.18"
 zeroize = "1.8"
-zlib-rs = "0.5"
+zlib-rs = "0.6"
 
 [profile.bench]
 codegen-units = 1

--- a/rustls/src/compress.rs
+++ b/rustls/src/compress.rs
@@ -129,8 +129,9 @@ pub struct CompressionFailed;
 
 #[cfg(feature = "zlib")]
 mod feat_zlib_rs {
-    use zlib_rs::c_api::Z_BEST_COMPRESSION;
-    use zlib_rs::{ReturnCode, deflate, inflate};
+    use zlib_rs::{
+        DeflateConfig, InflateConfig, ReturnCode, compress_bound, compress_slice, decompress_slice,
+    };
 
     use super::*;
 
@@ -143,7 +144,7 @@ mod feat_zlib_rs {
     impl CertDecompressor for ZlibRsDecompressor {
         fn decompress(&self, input: &[u8], output: &mut [u8]) -> Result<(), DecompressionFailed> {
             let output_len = output.len();
-            match inflate::uncompress_slice(output, input, inflate::InflateConfig::default()) {
+            match decompress_slice(output, input, InflateConfig::default()) {
                 (output_filled, ReturnCode::Ok) if output_filled.len() == output_len => Ok(()),
                 (_, _) => Err(DecompressionFailed),
             }
@@ -166,12 +167,12 @@ mod feat_zlib_rs {
             input: Vec<u8>,
             level: CompressionLevel,
         ) -> Result<Vec<u8>, CompressionFailed> {
-            let mut output = alloc::vec![0u8; deflate::compress_bound(input.len())];
+            let mut output = alloc::vec![0u8; compress_bound(input.len())];
             let config = match level {
-                CompressionLevel::Interactive => deflate::DeflateConfig::default(),
-                CompressionLevel::Amortized => deflate::DeflateConfig::new(Z_BEST_COMPRESSION),
+                CompressionLevel::Interactive => DeflateConfig::default(),
+                CompressionLevel::Amortized => DeflateConfig::best_compression(),
             };
-            let (output_filled, rc) = deflate::compress_slice(&mut output, &input, config);
+            let (output_filled, rc) = compress_slice(&mut output, &input, config);
             if rc != ReturnCode::Ok {
                 return Err(CompressionFailed);
             }


### PR DESCRIPTION
We're stabilizing our interface in 0.6.0 (it was explicitly marked as unstable before). That means some minor renamings and shuffling things around. 