### PR TITLE
Add the rustls version in provider crate dependencies

### DIFF
--- a/rustls-aws-lc-rs/Cargo.toml
+++ b/rustls-aws-lc-rs/Cargo.toml
@@ -20,7 +20,7 @@ unstable = ["aws-lc-rs/unstable"]
 [dependencies]
 aws-lc-rs = { workspace = true, features = ["prebuilt-nasm"] }
 pki-types = { workspace = true }
-rustls = { path = "../rustls", default-features = false }
+rustls = { path = "../rustls", version = "0.24.0-dev.0", default-features = false }
 subtle = { workspace = true }
 zeroize = { workspace = true }
 

--- a/rustls-ring/Cargo.toml
+++ b/rustls-ring/Cargo.toml
@@ -16,7 +16,7 @@ std = ["rustls/std"]
 
 [dependencies]
 pki-types = { workspace = true }
-rustls = { path = "../rustls", default-features = false }
+rustls = { path = "../rustls", version = "0.24.0-dev.0", default-features = false }
 ring = { workspace = true }
 subtle = { workspace = true }
 


### PR DESCRIPTION
This is a prerequisite for publishing.