### PR TITLE
Use fmt `finish_non_exhaustive()` when appropriate

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -1422,7 +1422,7 @@ impl Debug for ClientCacheWithSpecificKxHints {
         // Note: we omit self.storage here as it may contain sensitive data.
         f.debug_struct("ClientCacheWithoutKxHints")
             .field("delay", &self.delay)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/rustls-aws-lc-rs/src/hpke.rs
+++ b/rustls-aws-lc-rs/src/hpke.rs
@@ -457,7 +457,8 @@ impl<const KEY_SIZE: usize, const KDF_SIZE: usize> HpkeSealer for Sealer<KEY_SIZ
 
 impl<const KEY_SIZE: usize, const KDF_SIZE: usize> Debug for Sealer<KEY_SIZE, KDF_SIZE> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Sealer").finish()
+        f.debug_struct("Sealer")
+            .finish_non_exhaustive()
     }
 }
 
@@ -510,7 +511,8 @@ impl<const KEY_SIZE: usize, const KDF_SIZE: usize> HpkeOpener for Opener<KEY_SIZ
 
 impl<const KEY_SIZE: usize, const KDF_SIZE: usize> Debug for Opener<KEY_SIZE, KDF_SIZE> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Opener").finish()
+        f.debug_struct("Opener")
+            .finish_non_exhaustive()
     }
 }
 

--- a/rustls-aws-lc-rs/src/sign.rs
+++ b/rustls-aws-lc-rs/src/sign.rs
@@ -90,7 +90,8 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaSigningKey {
 
 impl Debug for RsaSigningKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RsaSigningKey").finish()
+        f.debug_struct("RsaSigningKey")
+            .finish_non_exhaustive()
     }
 }
 
@@ -126,7 +127,7 @@ impl Debug for RsaSigner {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("RsaSigner")
             .field("scheme", &self.scheme)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -247,7 +248,7 @@ impl Debug for EcdsaSigner {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("EcdsaSigner")
             .field("scheme", &self.scheme)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -317,7 +318,7 @@ impl Debug for Ed25519Signer {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Ed25519Signer")
             .field("scheme", &self.scheme)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -369,7 +370,7 @@ mod tests {
         let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256, .. }"
         );
 
         assert!(
@@ -385,7 +386,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             format!("{s:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256, .. }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP256_SHA256);
         // nb. signature is variable length and asn.1-encoded
@@ -425,7 +426,7 @@ mod tests {
         let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384, .. }"
         );
 
         assert!(
@@ -441,7 +442,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             format!("{s:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384, .. }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP384_SHA384);
         // nb. signature is variable length and asn.1-encoded
@@ -481,7 +482,7 @@ mod tests {
         let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP521_SHA512 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP521_SHA512, .. }"
         );
 
         assert!(
@@ -501,7 +502,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             format!("{s:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP521_SHA512 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP521_SHA512, .. }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP521_SHA512);
         // nb. signature is variable length and asn.1-encoded
@@ -528,7 +529,7 @@ mod tests {
             PrivatePkcs8KeyDer::from(&include_bytes!("../../rustls/src/testdata/eddsakey.der")[..]);
 
         let k = Ed25519Signer::try_from(&key).unwrap();
-        assert_eq!(format!("{k:?}"), "Ed25519Signer { scheme: ED25519 }");
+        assert_eq!(format!("{k:?}"), "Ed25519Signer { scheme: ED25519, .. }");
 
         assert!(
             k.choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA256])
@@ -541,7 +542,7 @@ mod tests {
         let s = k
             .choose_scheme(&[SignatureScheme::ED25519])
             .unwrap();
-        assert_eq!(format!("{s:?}"), "Ed25519Signer { scheme: ED25519 }");
+        assert_eq!(format!("{s:?}"), "Ed25519Signer { scheme: ED25519, .. }");
         assert_eq!(s.scheme(), SignatureScheme::ED25519);
         assert_eq!(s.sign(b"hello").unwrap().len(), 64);
     }
@@ -573,7 +574,7 @@ mod tests {
         ));
 
         let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
-        assert_eq!(format!("{k:?}"), "RsaSigningKey");
+        assert_eq!(format!("{k:?}"), "RsaSigningKey { .. }");
 
         assert!(
             k.choose_scheme(&[SignatureScheme::ECDSA_NISTP256_SHA256])
@@ -587,7 +588,7 @@ mod tests {
         let s = k
             .choose_scheme(&[SignatureScheme::RSA_PSS_SHA256])
             .unwrap();
-        assert_eq!(format!("{s:?}"), "RsaSigner { scheme: RSA_PSS_SHA256 }");
+        assert_eq!(format!("{s:?}"), "RsaSigner { scheme: RSA_PSS_SHA256, .. }");
         assert_eq!(s.scheme(), SignatureScheme::RSA_PSS_SHA256);
         assert_eq!(s.sign(b"hello").unwrap().len(), 256);
 

--- a/rustls-ring/src/sign.rs
+++ b/rustls-ring/src/sign.rs
@@ -90,7 +90,8 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaSigningKey {
 
 impl Debug for RsaSigningKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RsaSigningKey").finish()
+        f.debug_struct("RsaSigningKey")
+            .finish_non_exhaustive()
     }
 }
 
@@ -126,7 +127,7 @@ impl Debug for RsaSigner {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("RsaSigner")
             .field("scheme", &self.scheme)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -280,7 +281,7 @@ impl Debug for EcdsaSigner {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("EcdsaSigner")
             .field("scheme", &self.scheme)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -350,7 +351,7 @@ impl Debug for Ed25519Signer {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Ed25519Signer")
             .field("scheme", &self.scheme)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -448,7 +449,7 @@ mod tests {
         let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256, .. }"
         );
 
         assert!(
@@ -464,7 +465,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             format!("{s:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP256_SHA256, .. }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP256_SHA256);
         // nb. signature is variable length and asn.1-encoded
@@ -504,7 +505,7 @@ mod tests {
         let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
         assert_eq!(
             format!("{k:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384, .. }"
         );
 
         assert!(
@@ -520,7 +521,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             format!("{s:?}"),
-            "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384 }"
+            "EcdsaSigner { scheme: ECDSA_NISTP384_SHA384, .. }"
         );
         assert_eq!(s.scheme(), SignatureScheme::ECDSA_NISTP384_SHA384);
         // nb. signature is variable length and asn.1-encoded
@@ -547,7 +548,7 @@ mod tests {
             PrivatePkcs8KeyDer::from(&include_bytes!("../../rustls/src/testdata/eddsakey.der")[..]);
 
         let k = Ed25519Signer::try_from(&key).unwrap();
-        assert_eq!(format!("{k:?}"), "Ed25519Signer { scheme: ED25519 }");
+        assert_eq!(format!("{k:?}"), "Ed25519Signer { scheme: ED25519, .. }");
 
         assert!(
             k.choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA256])
@@ -560,7 +561,7 @@ mod tests {
         let s = k
             .choose_scheme(&[SignatureScheme::ED25519])
             .unwrap();
-        assert_eq!(format!("{s:?}"), "Ed25519Signer { scheme: ED25519 }");
+        assert_eq!(format!("{s:?}"), "Ed25519Signer { scheme: ED25519, .. }");
         assert_eq!(s.scheme(), SignatureScheme::ED25519);
         assert_eq!(s.sign(b"hello").unwrap().len(), 64);
     }
@@ -592,7 +593,7 @@ mod tests {
         ));
 
         let k = load_key(&DEFAULT_PROVIDER, key.clone_key()).unwrap();
-        assert_eq!(format!("{k:?}"), "RsaSigningKey");
+        assert_eq!(format!("{k:?}"), "RsaSigningKey { .. }");
 
         assert!(
             k.choose_scheme(&[SignatureScheme::ECDSA_NISTP256_SHA256])
@@ -606,7 +607,7 @@ mod tests {
         let s = k
             .choose_scheme(&[SignatureScheme::RSA_PSS_SHA256])
             .unwrap();
-        assert_eq!(format!("{s:?}"), "RsaSigner { scheme: RSA_PSS_SHA256 }");
+        assert_eq!(format!("{s:?}"), "RsaSigner { scheme: RSA_PSS_SHA256, .. }");
         assert_eq!(s.scheme(), SignatureScheme::RSA_PSS_SHA256);
         assert_eq!(s.sign(b"hello").unwrap().len(), 256);
 

--- a/rustls-ring/src/ticketer.rs
+++ b/rustls-ring/src/ticketer.rs
@@ -151,7 +151,7 @@ impl Debug for AeadTicketer {
         // Note: we deliberately omit the key from the debug output.
         f.debug_struct("AeadTicketer")
             .field("alg", &self.alg)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -198,7 +198,7 @@ mod tests {
 
         let t = AeadTicketer::new().unwrap();
 
-        let expect = format!("AeadTicketer {{ alg: {TICKETER_AEAD:?} }}");
+        let expect = format!("AeadTicketer {{ alg: {TICKETER_AEAD:?}, .. }}");
         assert_eq!(format!("{t:?}"), expect);
         assert_eq!(t.lifetime(), Duration::ZERO);
     }

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -150,7 +150,7 @@ impl<Side: ConfigSide, State: fmt::Debug> fmt::Debug for ConfigBuilder<Side, Sta
 
         f.debug_struct(&format!("ConfigBuilder<{name}, _>",))
             .field("state", &self.state)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -48,7 +48,7 @@ mod buffered {
     impl fmt::Debug for ClientConnection {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("ClientConnection")
-                .finish()
+                .finish_non_exhaustive()
         }
     }
 

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -174,7 +174,7 @@ mod cache {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             // Note: we omit self.servers as it may contain sensitive data.
             f.debug_struct("ClientSessionMemoryCache")
-                .finish()
+                .finish_non_exhaustive()
         }
     }
 }

--- a/rustls/src/key_log_file.rs
+++ b/rustls/src/key_log_file.rs
@@ -67,7 +67,7 @@ impl Debug for KeyLogFileInner {
         f.debug_struct("KeyLogFileInner")
             // Note: we omit self.buf deliberately as it may contain key data.
             .field("file", &self.file)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -219,7 +219,7 @@ mod connection {
     impl Debug for ClientConnection {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("quic::ClientConnection")
-                .finish()
+                .finish_non_exhaustive()
         }
     }
 
@@ -351,7 +351,7 @@ mod connection {
     impl Debug for ServerConnection {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("quic::ServerConnection")
-                .finish()
+                .finish_non_exhaustive()
         }
     }
 

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -174,7 +174,7 @@ mod buffered {
     impl Debug for ServerConnection {
         fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
             f.debug_struct("ServerConnection")
-                .finish()
+                .finish_non_exhaustive()
         }
     }
 
@@ -358,7 +358,8 @@ mod buffered {
 
     impl Debug for AcceptedAlert {
         fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-            f.debug_struct("AcceptedAlert").finish()
+            f.debug_struct("AcceptedAlert")
+                .finish_non_exhaustive()
         }
     }
 
@@ -591,7 +592,8 @@ impl Accepted {
 #[cfg(feature = "std")]
 impl Debug for Accepted {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Accepted").finish()
+        f.debug_struct("Accepted")
+            .finish_non_exhaustive()
     }
 }
 

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -90,7 +90,7 @@ mod cache {
     impl Debug for ServerSessionMemoryCache {
         fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
             f.debug_struct("ServerSessionMemoryCache")
-                .finish()
+                .finish_non_exhaustive()
         }
     }
 

--- a/rustls/src/tls12.rs
+++ b/rustls/src/tls12.rs
@@ -139,7 +139,7 @@ impl fmt::Debug for Tls12CipherSuite {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Tls12CipherSuite")
             .field("suite", &self.common.suite)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -132,7 +132,7 @@ impl fmt::Debug for Tls13CipherSuite {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Tls13CipherSuite")
             .field("suite", &self.common.suite)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
As a general stylistic point, most manual `fmt::Debug` impls should use `finish_non_exhaustive()` as they are there to omit a non-Debug or sensitive field.