### PR TITLE
Split supported verification algorithms off from provider

### DIFF
--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
-use rustls::crypto::{CryptoProvider, TicketProducer};
+use rustls::crypto::{CryptoProvider, TicketProducer, WebPkiSupportedAlgorithms};
 use rustls_test::KeyType;
 
 use crate::Side;
@@ -88,6 +88,8 @@ pub(crate) struct BenchmarkParams {
     ///
     /// The choice of cipher suite is baked into this.
     pub provider: Arc<CryptoProvider>,
+    /// Which signature verification algorithms to use.
+    pub verify_algs: WebPkiSupportedAlgorithms,
     /// How to make a suitable [`rustls::crypto::TicketProducer`].
     pub ticketer: &'static fn() -> Arc<dyn TicketProducer>,
     /// Where to get keys for server auth
@@ -102,6 +104,7 @@ impl BenchmarkParams {
     /// Create a new set of benchmark params
     pub(crate) const fn new(
         provider: Arc<CryptoProvider>,
+        verify_algs: WebPkiSupportedAlgorithms,
         ticketer: &'static fn() -> Arc<dyn TicketProducer>,
         auth_key: AuthKeySource,
         label: String,
@@ -109,6 +112,7 @@ impl BenchmarkParams {
     ) -> Self {
         Self {
             provider,
+            verify_algs,
             ticketer,
             auth_key,
             label,

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -46,6 +46,7 @@ use rustls::crypto::hpke::Hpke;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, EchConfigListBytes, ServerName};
 use rustls::{ClientConfig, RootCertStore};
+use rustls_aws_lc_rs::SUPPORTED_SIG_ALGS;
 use rustls_aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
 use rustls_util::{KeyLogFile, Stream};
 
@@ -116,7 +117,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Construct a rustls client config with a TLS1.3-only provider, and ECH enabled.
     let mut config = ClientConfig::builder(rustls_aws_lc_rs::DEFAULT_TLS13_PROVIDER.into())
         .with_ech(ech_mode)
-        .with_root_certificates(root_store)
+        .with_root_certificates(root_store, SUPPORTED_SIG_ALGS)
         .with_no_client_auth()?;
 
     // Allow using SSLKEYLOGFILE.

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use rustls::crypto::CryptoProvider;
 use rustls::{ClientConfig, RootCertStore};
-use rustls_aws_lc_rs as provider;
+use rustls_aws_lc_rs::{self as provider, SUPPORTED_SIG_ALGS};
 use rustls_util::Stream;
 
 fn main() {
@@ -21,7 +21,7 @@ fn main() {
 
     let config = Arc::new(
         ClientConfig::builder(PROVIDER.into())
-            .with_root_certificates(root_store)
+            .with_root_certificates(root_store, SUPPORTED_SIG_ALGS)
             .with_no_client_auth()
             .unwrap(),
     );

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -18,7 +18,7 @@ use rustls::RootCertStore;
 use rustls::crypto::{CryptoProvider, Identity};
 use rustls::pki_types::{CertificateRevocationListDer, PrivatePkcs8KeyDer};
 use rustls::server::{Acceptor, ClientHello, ServerConfig, WebPkiClientVerifier};
-use rustls_aws_lc_rs::DEFAULT_PROVIDER;
+use rustls_aws_lc_rs::{DEFAULT_PROVIDER, SUPPORTED_SIG_ALGS};
 use rustls_util::KeyLogFile;
 
 fn main() {
@@ -205,7 +205,7 @@ impl TestPki {
 
         // Construct a fresh verifier using the test PKI roots, and the updated CRL.
         let verifier = Arc::new(
-            WebPkiClientVerifier::builder(self.roots.clone(), &self.provider)
+            WebPkiClientVerifier::builder(self.roots.clone(), SUPPORTED_SIG_ALGS)
                 .with_crls([CertificateRevocationListDer::from(crl)])
                 .build()
                 .unwrap(),

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, ServerName};
 use rustls::{ClientConfig, RootCertStore};
-use rustls_aws_lc_rs::DEFAULT_PROVIDER;
+use rustls_aws_lc_rs::{DEFAULT_PROVIDER, SUPPORTED_SIG_ALGS};
 use rustls_util::{KeyLogFile, Stream};
 
 fn start_connection(config: &Arc<ClientConfig>, domain_name: &str, port: u16) {
@@ -105,7 +105,7 @@ fn main() {
     }
 
     let mut config = ClientConfig::builder(Arc::new(DEFAULT_PROVIDER))
-        .with_root_certificates(root_store)
+        .with_root_certificates(root_store, SUPPORTED_SIG_ALGS)
         .with_no_client_auth()
         .unwrap();
 

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -13,6 +13,7 @@ use std::net::TcpStream;
 use std::sync::Arc;
 
 use rustls::{ClientConfig, RootCertStore};
+use rustls_aws_lc_rs::SUPPORTED_SIG_ALGS;
 use rustls_util::{KeyLogFile, Stream};
 
 fn main() {
@@ -21,7 +22,7 @@ fn main() {
     };
 
     let mut config = ClientConfig::builder(rustls_aws_lc_rs::DEFAULT_PROVIDER.into())
-        .with_root_certificates(root_store)
+        .with_root_certificates(root_store, SUPPORTED_SIG_ALGS)
         .with_no_client_auth()
         .unwrap();
 

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -605,18 +605,24 @@ fn make_config(args: &Args) -> Arc<ServerConfig> {
         let crls = load_crls(args.crl.iter());
         if args.require_auth {
             Arc::new(
-                WebPkiClientVerifier::builder(client_auth_roots.into(), &provider)
-                    .with_crls(crls)
-                    .build()
-                    .unwrap(),
+                WebPkiClientVerifier::builder(
+                    client_auth_roots.into(),
+                    provider::SUPPORTED_SIG_ALGS,
+                )
+                .with_crls(crls)
+                .build()
+                .unwrap(),
             )
         } else {
             Arc::new(
-                WebPkiClientVerifier::builder(client_auth_roots.into(), &provider)
-                    .with_crls(crls)
-                    .allow_unauthenticated()
-                    .build()
-                    .unwrap(),
+                WebPkiClientVerifier::builder(
+                    client_auth_roots.into(),
+                    provider::SUPPORTED_SIG_ALGS,
+                )
+                .with_crls(crls)
+                .allow_unauthenticated()
+                .build()
+                .unwrap(),
             )
         }
     } else {

--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -11,7 +11,7 @@ use rustls::unbuffered::{
     WriteTraffic,
 };
 use rustls::{ClientConfig, RootCertStore};
-use rustls_aws_lc_rs::DEFAULT_PROVIDER;
+use rustls_aws_lc_rs::{DEFAULT_PROVIDER, SUPPORTED_SIG_ALGS};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let config = ClientConfig::builder(Arc::new(DEFAULT_PROVIDER))
-        .with_root_certificates(root_store)
+        .with_root_certificates(root_store, SUPPORTED_SIG_ALGS)
         .with_no_client_auth()?;
 
     let config = Arc::new(config);

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -12,7 +12,7 @@ use rustls::unbuffered::{
     WriteTraffic,
 };
 use rustls::{ClientConfig, RootCertStore};
-use rustls_aws_lc_rs::DEFAULT_PROVIDER;
+use rustls_aws_lc_rs::{DEFAULT_PROVIDER, SUPPORTED_SIG_ALGS};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let root_store = RootCertStore {
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let mut config = ClientConfig::builder(Arc::new(DEFAULT_PROVIDER))
-        .with_root_certificates(root_store)
+        .with_root_certificates(root_store, SUPPORTED_SIG_ALGS)
         .with_no_client_auth()?;
     config.enable_early_data = SEND_EARLY_DATA;
 

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -9,7 +9,7 @@ use rustls::crypto::{CryptoProvider, Identity};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 use rustls::{ClientConfig, RootCertStore, ServerConfig, ServerConnection};
-use rustls_aws_lc_rs as provider;
+use rustls_aws_lc_rs::{self as provider, SUPPORTED_SIG_ALGS};
 
 use crate::ffdhe::{self, FFDHE2048_GROUP};
 use crate::utils::verify_openssl3_available;
@@ -125,7 +125,7 @@ fn test_rustls_client_with_ffdhe_kx(iters: usize) {
             // OpenSSL 3 does not support RFC 7919 with TLS 1.2: https://github.com/openssl/openssl/issues/10971
             FFDHE_TLS13_PROVIDER.into(),
         )
-        .with_root_certificates(root_ca())
+        .with_root_certificates(root_ca(), SUPPORTED_SIG_ALGS)
         .with_no_client_auth()
         .unwrap(),
     );

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -95,7 +95,7 @@ mod client {
         fn new(trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>) -> Self {
             Self {
                 trusted_spki,
-                supported_algs: provider::DEFAULT_PROVIDER.signature_verification_algorithms,
+                supported_algs: provider::SUPPORTED_SIG_ALGS,
             }
         }
     }
@@ -247,7 +247,7 @@ mod server {
         pub(crate) fn new(trusted_spki: Vec<SubjectPublicKeyInfoDer<'static>>) -> Self {
             Self {
                 trusted_spki,
-                supported_algs: provider::DEFAULT_PROVIDER.signature_verification_algorithms,
+                supported_algs: provider::SUPPORTED_SIG_ALGS,
             }
         }
     }

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -3,7 +3,7 @@ use std::net::TcpStream;
 use std::sync::Arc;
 
 use rustls::{ClientConfig, RootCertStore};
-use rustls_provider_example::provider;
+use rustls_provider_example::{SUPPORTED_SIG_ALGS, provider};
 use rustls_util::Stream;
 
 fn main() {
@@ -17,7 +17,7 @@ fn main() {
 
     let config = Arc::new(
         ClientConfig::builder(provider().into())
-            .with_root_certificates(root_store)
+            .with_root_certificates(root_store, SUPPORTED_SIG_ALGS)
             .with_no_client_auth()
             .unwrap(),
     );

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -42,13 +42,13 @@ mod ticketer;
 #[cfg(feature = "std")]
 use ticketer::AeadTicketer;
 mod verify;
+pub use verify::SUPPORTED_SIG_ALGS;
 
 pub fn provider() -> CryptoProvider {
     CryptoProvider {
         tls12_cipher_suites: Cow::Borrowed(ALL_TLS12_CIPHER_SUITES),
         tls13_cipher_suites: Cow::Borrowed(ALL_TLS13_CIPHER_SUITES),
         kx_groups: Cow::Borrowed(kx::ALL_KX_GROUPS),
-        signature_verification_algorithms: verify::ALGORITHMS,
         secure_random: &Provider,
         key_provider: &Provider,
         ticketer_factory: &Provider,

--- a/provider-example/src/verify.rs
+++ b/provider-example/src/verify.rs
@@ -6,7 +6,7 @@ use rustls::pki_types::{
     AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm, alg_id,
 };
 
-pub(crate) static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+pub static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[RSA_PSS_SHA256, RSA_PKCS1_SHA256],
     mapping: &[
         (SignatureScheme::RSA_PSS_SHA256, &[RSA_PSS_SHA256]),

--- a/rustls-aws-lc-rs/src/lib.rs
+++ b/rustls-aws-lc-rs/src/lib.rs
@@ -92,7 +92,6 @@ pub const DEFAULT_PROVIDER: CryptoProvider = CryptoProvider {
     tls12_cipher_suites: Cow::Borrowed(DEFAULT_TLS12_CIPHER_SUITES),
     tls13_cipher_suites: Cow::Borrowed(DEFAULT_TLS13_CIPHER_SUITES),
     kx_groups: Cow::Borrowed(DEFAULT_KX_GROUPS),
-    signature_verification_algorithms: SUPPORTED_SIG_ALGS,
     secure_random: &AwsLcRs,
     key_provider: &AwsLcRs,
     ticketer_factory: &AwsLcRs,

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -31,7 +31,6 @@ pub const PROVIDER: crypto::CryptoProvider = crypto::CryptoProvider {
     tls12_cipher_suites: Cow::Borrowed(&[TLS_FUZZING_SUITE]),
     tls13_cipher_suites: Cow::Borrowed(&[TLS13_FUZZING_SUITE]),
     kx_groups: Cow::Borrowed(&[KEY_EXCHANGE_GROUP]),
-    signature_verification_algorithms: VERIFY_ALGORITHMS,
     secure_random: &Provider,
     key_provider: &Provider,
     ticketer_factory: &Provider,
@@ -55,7 +54,7 @@ pub fn server_verifier() -> Arc<dyn ServerVerifier> {
     )]);
 
     Arc::new(
-        WebPkiServerVerifier::builder(root_store.into(), &PROVIDER)
+        WebPkiServerVerifier::builder(root_store.into(), VERIFY_ALGORITHMS)
             .build()
             .unwrap(),
     )

--- a/rustls-ring/src/lib.rs
+++ b/rustls-ring/src/lib.rs
@@ -62,7 +62,6 @@ pub const DEFAULT_PROVIDER: CryptoProvider = CryptoProvider {
     tls12_cipher_suites: Cow::Borrowed(DEFAULT_TLS12_CIPHER_SUITES),
     tls13_cipher_suites: Cow::Borrowed(DEFAULT_TLS13_CIPHER_SUITES),
     kx_groups: Cow::Borrowed(DEFAULT_KX_GROUPS),
-    signature_verification_algorithms: SUPPORTED_SIG_ALGS,
     secure_random: &Ring,
     key_provider: &Ring,
     ticketer_factory: &Ring,
@@ -191,7 +190,7 @@ pub mod cipher_suite {
 
 /// A `WebPkiSupportedAlgorithms` value that reflects webpki's capabilities when
 /// compiled against *ring*.
-static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+pub static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[
         ECDSA_P256_SHA256,
         ECDSA_P256_SHA384,

--- a/rustls-test/tests/api/crypto.rs
+++ b/rustls-test/tests/api/crypto.rs
@@ -27,7 +27,7 @@ fn key_log_for_tls12() {
 
     let provider = provider::DEFAULT_TLS12_PROVIDER;
     let kt = KeyType::Rsa2048;
-    let mut client_config = make_client_config(kt, &provider);
+    let mut client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.key_log = client_key_log.clone();
     let client_config = Arc::new(client_config);
 
@@ -64,7 +64,7 @@ fn key_log_for_tls13() {
 
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let kt = KeyType::Rsa2048;
-    let mut client_config = make_client_config(kt, &provider);
+    let mut client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.key_log = client_key_log.clone();
     let client_config = Arc::new(client_config);
 
@@ -207,7 +207,7 @@ fn test_secret_extraction_enabled() {
         server_config.enable_secret_extraction = true;
         let server_config = Arc::new(server_config);
 
-        let mut client_config = make_client_config(kt, &provider);
+        let mut client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider);
         client_config.enable_secret_extraction = true;
 
         let (mut client, mut server) =
@@ -263,7 +263,7 @@ fn test_secret_extract_produces_correct_variant() {
         server_config.enable_secret_extraction = true;
         let server_config = Arc::new(server_config);
 
-        let mut client_config = ClientConfig::builder(provider).finish(kt);
+        let mut client_config = ClientConfig::builder(provider).finish(kt, provider::SUPPORTED_SIG_ALGS);
         client_config.enable_secret_extraction = true;
 
         let (mut client, mut server) =
@@ -329,7 +329,7 @@ fn test_secret_extraction_disabled_or_too_early() {
         server_config.enable_secret_extraction = server_enable;
         let server_config = Arc::new(server_config);
 
-        let mut client_config = make_client_config(kt, &provider);
+        let mut client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider);
         client_config.enable_secret_extraction = client_enable;
 
         let client_config = Arc::new(client_config);
@@ -370,7 +370,7 @@ fn test_secret_extraction_disabled_or_too_early() {
 
 #[test]
 fn test_refresh_traffic_keys_during_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Ed25519, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     assert_eq!(
         client
             .refresh_traffic_keys()
@@ -387,7 +387,7 @@ fn test_refresh_traffic_keys_during_handshake() {
 
 #[test]
 fn test_refresh_traffic_keys() {
-    let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Ed25519, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     fn check_both_directions(client: &mut ClientConnection, server: &mut ServerConnection) {
@@ -432,7 +432,7 @@ fn test_automatic_refresh_traffic_keys() {
     const KEY_UPDATE_SIZE: usize = encrypted_size(5);
     let provider = aes_128_gcm_with_1024_confidentiality_limit(provider::DEFAULT_PROVIDER);
 
-    let client_config = ClientConfig::builder(provider.clone()).finish(KeyType::Ed25519);
+    let client_config = ClientConfig::builder(provider.clone()).finish(KeyType::Ed25519, provider::SUPPORTED_SIG_ALGS);
     let server_config = ServerConfig::builder(provider).finish(KeyType::Ed25519);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -491,7 +491,7 @@ fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
         )))
     });
 
-    let client_config = ClientConfig::builder(provider.clone()).finish(KeyType::Ed25519);
+    let client_config = ClientConfig::builder(provider.clone()).finish(KeyType::Ed25519, provider::SUPPORTED_SIG_ALGS);
     let server_config = ServerConfig::builder(provider).finish(KeyType::Ed25519);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);

--- a/rustls-test/tests/api/ffdhe.rs
+++ b/rustls-test/tests/api/ffdhe.rs
@@ -33,7 +33,7 @@ fn config_builder_for_client_rejects_cipher_suites_without_compatible_kx_groups(
     };
 
     let build_err = ClientConfig::builder(bad_crypto_provider.into())
-        .with_root_certificates(KeyType::EcdsaP256.client_root_store())
+        .with_root_certificates(KeyType::EcdsaP256.client_root_store(), provider::SUPPORTED_SIG_ALGS)
         .with_no_client_auth()
         .unwrap_err()
         .to_string();
@@ -66,7 +66,7 @@ fn ffdhe_ciphersuite() {
             &ffdhe_provider(),
             expected_cipher_suite,
         ));
-        let client_config = ClientConfig::builder(provider.clone()).finish(KeyType::Rsa2048);
+        let client_config = ClientConfig::builder(provider.clone()).finish(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS);
         let server_config = ServerConfig::builder(provider).finish(KeyType::Rsa2048);
         do_suite_and_kx_test(
             client_config,
@@ -92,7 +92,7 @@ fn server_avoids_dhe_cipher_suites_when_client_has_no_known_dhe_in_groups_ext() 
         }
         .into(),
     )
-    .finish(KeyType::Rsa2048);
+    .finish(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS);
 
     let server_config = ServerConfig::builder(
         CryptoProvider {
@@ -229,7 +229,7 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             _ => unreachable!(),
         };
         let client_config = ClientConfig::builder(provider.into())
-            .finish(KeyType::Rsa2048)
+            .finish(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS)
             .into();
 
         let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -35,7 +35,7 @@ fn buffered_client_data_sent() {
     ));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
 
@@ -58,7 +58,7 @@ fn buffered_server_data_sent() {
     ));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
 
@@ -81,7 +81,7 @@ fn buffered_both_data_sent() {
     ));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
 
@@ -114,7 +114,7 @@ fn buffered_both_data_sent() {
 
 #[test]
 fn server_respects_buffer_limit_pre_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     server.set_buffer_limit(Some(32));
 
@@ -142,7 +142,7 @@ fn server_respects_buffer_limit_pre_handshake() {
 
 #[test]
 fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     server.set_buffer_limit(Some(32));
 
@@ -166,7 +166,7 @@ fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
 
 #[test]
 fn server_respects_buffer_limit_post_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     // this test will vary in behaviour depending on the default suites
     do_handshake(&mut client, &mut server);
@@ -195,7 +195,7 @@ fn server_respects_buffer_limit_post_handshake() {
 
 #[test]
 fn client_respects_buffer_limit_pre_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     client.set_buffer_limit(Some(32));
 
@@ -223,7 +223,7 @@ fn client_respects_buffer_limit_pre_handshake() {
 
 #[test]
 fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     client.set_buffer_limit(Some(32));
 
@@ -247,7 +247,7 @@ fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
 
 #[test]
 fn client_respects_buffer_limit_post_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     do_handshake(&mut client, &mut server);
     client.set_buffer_limit(Some(48));
@@ -276,7 +276,7 @@ fn client_respects_buffer_limit_post_handshake() {
 #[test]
 fn client_detects_broken_write_vectored_impl() {
     // see https://github.com/rustls/rustls/issues/2316
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     let err = client
         .write_tls(&mut BrokenWriteVectored)
         .unwrap_err();
@@ -304,7 +304,7 @@ fn client_detects_broken_write_vectored_impl() {
 
 #[test]
 fn buf_read() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     do_handshake(&mut client, &mut server);
 
@@ -337,35 +337,35 @@ fn buf_read() {
 
 #[test]
 fn server_read_returns_wouldblock_when_no_data() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     assert!(matches!(server.reader().read(&mut [0u8; 1]),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn client_read_returns_wouldblock_when_no_data() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     assert!(matches!(client.reader().read(&mut [0u8; 1]),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn server_fill_buf_returns_wouldblock_when_no_data() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     assert!(matches!(server.reader().fill_buf(),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn client_fill_buf_returns_wouldblock_when_no_data() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     assert!(matches!(client.reader().fill_buf(),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn new_server_returns_initial_io_state() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     let io_state = server.process_new_packets().unwrap();
     println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
@@ -375,7 +375,7 @@ fn new_server_returns_initial_io_state() {
 
 #[test]
 fn new_client_returns_initial_io_state() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     let io_state = client.process_new_packets().unwrap();
     println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
@@ -385,7 +385,7 @@ fn new_client_returns_initial_io_state() {
 
 #[test]
 fn client_complete_io_for_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     assert!(client.is_handshaking());
     let (rdlen, wrlen) = client
@@ -398,7 +398,7 @@ fn client_complete_io_for_handshake() {
 
 #[test]
 fn buffered_client_complete_io_for_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     assert!(client.is_handshaking());
     let (rdlen, wrlen) = client
@@ -411,7 +411,7 @@ fn buffered_client_complete_io_for_handshake() {
 
 #[test]
 fn client_complete_io_for_handshake_eof() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     let mut input = io::Cursor::new(Vec::new());
 
     assert!(client.is_handshaking());
@@ -425,7 +425,7 @@ fn client_complete_io_for_handshake_eof() {
 fn client_complete_io_for_write() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         do_handshake(&mut client, &mut server);
 
@@ -453,7 +453,7 @@ fn client_complete_io_for_write() {
 
 #[test]
 fn client_complete_io_with_nonblocking_io() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     // absolutely no progress writing ClientHello
     assert_eq!(
@@ -465,7 +465,7 @@ fn client_complete_io_with_nonblocking_io() {
     );
 
     // a little progress writing ClientHello
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     assert_eq!(
         client
             .complete_io(&mut TestNonBlockIo {
@@ -477,7 +477,7 @@ fn client_complete_io_with_nonblocking_io() {
     );
 
     // complete writing ClientHello
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     assert_eq!(
         client
             .complete_io(&mut TestNonBlockIo {
@@ -490,7 +490,7 @@ fn client_complete_io_with_nonblocking_io() {
     );
 
     // complete writing ClientHello, partial read of ServerHello
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     let (rd, wr) = dbg!(client.complete_io(&mut TestNonBlockIo {
         writes: vec![4096],
         reads: vec![vec![ContentType::Handshake.into()]],
@@ -500,7 +500,7 @@ fn client_complete_io_with_nonblocking_io() {
     assert!(wr > 1);
 
     // data phase:
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     // read
@@ -548,7 +548,7 @@ fn client_complete_io_with_nonblocking_io() {
 fn buffered_client_complete_io_for_write() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         do_handshake(&mut client, &mut server);
 
@@ -578,7 +578,7 @@ fn buffered_client_complete_io_for_write() {
 fn client_complete_io_for_read() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         do_handshake(&mut client, &mut server);
 
@@ -600,7 +600,7 @@ fn client_complete_io_for_read() {
 fn server_complete_io_for_handshake() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         assert!(server.is_handshaking());
         let (rdlen, wrlen) = server
@@ -614,7 +614,7 @@ fn server_complete_io_for_handshake() {
 
 #[test]
 fn server_complete_io_for_handshake_eof() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     let mut input = io::Cursor::new(Vec::new());
 
     assert!(server.is_handshaking());
@@ -628,7 +628,7 @@ fn server_complete_io_for_handshake_eof() {
 fn server_complete_io_for_write() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         do_handshake(&mut client, &mut server);
 
@@ -657,7 +657,7 @@ fn server_complete_io_for_write() {
 fn server_complete_io_for_write_eof() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         do_handshake(&mut client, &mut server);
 
@@ -714,7 +714,7 @@ impl<const N: usize> Read for EofWriter<N> {
 fn server_complete_io_for_read() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         do_handshake(&mut client, &mut server);
 
@@ -734,7 +734,7 @@ fn server_complete_io_for_read() {
 
 #[test]
 fn server_complete_io_for_handshake_ending_with_alert() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::SUPPORTED_SIG_ALGS, provider::DEFAULT_PROVIDER);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
     assert!(server.is_handshaking());
@@ -771,7 +771,7 @@ enum StreamKind {
 fn test_client_stream_write(stream_kind: StreamKind) {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
         let data = b"hello";
         {
             let mut pipe = OtherSession::new(&mut server);
@@ -788,7 +788,7 @@ fn test_client_stream_write(stream_kind: StreamKind) {
 fn test_server_stream_write(stream_kind: StreamKind) {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
         let data = b"hello";
         {
             let mut pipe = OtherSession::new(&mut client);
@@ -840,7 +840,7 @@ fn test_stream_read(read_kind: ReadKind, mut stream: impl BufRead, data: &[u8]) 
 fn test_client_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
         let data = b"world";
         server.writer().write_all(data).unwrap();
 
@@ -861,7 +861,7 @@ fn test_client_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
 fn test_server_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let (mut client, mut server) = make_pair(*kt, &provider);
+        let (mut client, mut server) = make_pair(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
         let data = b"world";
         client.writer().write_all(data).unwrap();
 
@@ -881,7 +881,7 @@ fn test_server_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
 
 #[test]
 fn test_client_write_and_vectored_write_equivalence() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     const N: usize = 1000;
@@ -934,7 +934,7 @@ impl Write for FailsWrites {
 
 #[test]
 fn stream_write_reports_underlying_io_error_before_plaintext_processed() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     let mut pipe = FailsWrites {
@@ -954,7 +954,7 @@ fn stream_write_reports_underlying_io_error_before_plaintext_processed() {
 
 #[test]
 fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     let mut pipe = FailsWrites {
@@ -972,7 +972,7 @@ fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
 
 #[test]
 fn client_stream_handshake_error() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::SUPPORTED_SIG_ALGS, provider::DEFAULT_PROVIDER);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
     {
@@ -995,7 +995,7 @@ fn client_stream_handshake_error() {
 
 #[test]
 fn client_streamowned_handshake_error() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::SUPPORTED_SIG_ALGS, provider::DEFAULT_PROVIDER);
     let (client, mut server) = make_pair_for_configs(client_config, server_config);
 
     let pipe = OtherSession::new_fails(&mut server);
@@ -1018,7 +1018,7 @@ fn client_streamowned_handshake_error() {
 
 #[test]
 fn server_stream_handshake_error() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::SUPPORTED_SIG_ALGS, provider::DEFAULT_PROVIDER);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
     client
@@ -1041,7 +1041,7 @@ fn server_stream_handshake_error() {
 
 #[test]
 fn server_streamowned_handshake_error() {
-    let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
+    let (client_config, server_config) = make_disjoint_suite_configs(provider::SUPPORTED_SIG_ALGS, provider::DEFAULT_PROVIDER);
     let (mut client, server) = make_pair_for_configs(client_config, server_config);
 
     client
@@ -1062,7 +1062,7 @@ fn server_streamowned_handshake_error() {
 
 #[test]
 fn vectored_write_for_server_appdata() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     server
@@ -1087,7 +1087,7 @@ fn vectored_write_for_server_appdata() {
 
 #[test]
 fn vectored_write_for_client_appdata() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     client
@@ -1116,7 +1116,7 @@ fn vectored_write_for_server_handshake_with_half_rtt_data() {
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
     server_config.send_half_rtt_data = true;
     let (mut client, mut server) = make_pair_for_configs(
-        make_client_config_with_auth(KeyType::Rsa2048, &provider),
+        make_client_config_with_auth(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider),
         server_config,
     );
 
@@ -1158,7 +1158,7 @@ fn vectored_write_for_server_handshake_with_half_rtt_data() {
 
 fn check_half_rtt_does_not_work(server_config: ServerConfig) {
     let (mut client, mut server) = make_pair_for_configs(
-        make_client_config_with_auth(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER),
+        make_client_config_with_auth(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER),
         server_config,
     );
 
@@ -1206,6 +1206,7 @@ fn check_half_rtt_does_not_work(server_config: ServerConfig) {
 fn vectored_write_for_server_handshake_no_half_rtt_with_client_auth() {
     let mut server_config = make_server_config_with_mandatory_client_auth(
         KeyType::Rsa2048,
+        provider::SUPPORTED_SIG_ALGS,
         &provider::DEFAULT_PROVIDER,
     );
     server_config.send_half_rtt_data = true; // ask even though it will be ignored
@@ -1221,7 +1222,7 @@ fn vectored_write_for_server_handshake_no_half_rtt_by_default() {
 
 #[test]
 fn vectored_write_for_client_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     client
         .writer()
@@ -1258,7 +1259,7 @@ fn vectored_write_for_client_handshake() {
 
 #[test]
 fn vectored_write_with_slow_client() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
 
     client.set_buffer_limit(Some(32));
 
@@ -1322,7 +1323,7 @@ fn test_client_mtu_reduction() {
 
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let mut client_config = make_client_config(*kt, &provider);
+        let mut client_config = make_client_config(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
         client_config.max_fragment_size = Some(64);
         let mut client = Arc::new(client_config)
             .connect(server_name("localhost"))
@@ -1342,7 +1343,7 @@ fn test_server_mtu_reduction() {
     server_config.max_fragment_size = Some(64);
     server_config.send_half_rtt_data = true;
     let (mut client, mut server) = make_pair_for_configs(
-        make_client_config(KeyType::Rsa2048, &provider),
+        make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider),
         server_config,
     );
 
@@ -1388,7 +1389,7 @@ fn test_server_mtu_reduction() {
 
 fn check_client_max_fragment_size(size: usize) -> Option<Error> {
     let provider = provider::DEFAULT_PROVIDER;
-    let mut client_config = make_client_config(KeyType::Ed25519, &provider);
+    let mut client_config = make_client_config(KeyType::Ed25519, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.max_fragment_size = Some(size);
     Arc::new(client_config)
         .connect(server_name("localhost"))
@@ -1426,7 +1427,7 @@ fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
             // no hidden significance to these numbers
             for frag_size in [37, 61, 101, 257] {
                 println!("test kt={kt:?} version={version_provider:?} frag={frag_size:?}");
-                let mut client_config = make_client_config(*kt, &version_provider);
+                let mut client_config = make_client_config(*kt, provider::SUPPORTED_SIG_ALGS, &version_provider);
                 client_config.max_fragment_size = Some(frag_size);
                 let mut server_config = make_server_config(*kt, &provider);
                 server_config.max_fragment_size = Some(frag_size);
@@ -1456,7 +1457,7 @@ fn test_acceptor() {
     use rustls::server::Acceptor;
 
     let provider = provider::DEFAULT_PROVIDER;
-    let client_config = Arc::new(make_client_config(KeyType::Ed25519, &provider));
+    let client_config = Arc::new(make_client_config(KeyType::Ed25519, provider::SUPPORTED_SIG_ALGS, &provider));
     let mut client = client_config
         .connect(server_name("localhost"))
         .build()
@@ -1567,7 +1568,7 @@ fn test_acceptor_rejected_handshake() {
     use rustls::server::Acceptor;
 
     let client_config =
-        ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into()).finish(KeyType::Ed25519);
+        ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into()).finish(KeyType::Ed25519, provider::SUPPORTED_SIG_ALGS);
     let mut client = Arc::new(client_config)
         .connect(server_name("localhost"))
         .build()
@@ -1627,7 +1628,7 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
         .unwrap(),
     );
 
-    let client_config = Arc::new(make_client_config(kt, &provider));
+    let client_config = Arc::new(make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider));
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
 
     if let Some(limit) = limit {
@@ -1708,13 +1709,13 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
 
 #[test]
 fn server_flush_does_nothing() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     assert!(matches!(server.writer().flush(), Ok(())));
 }
 
 #[test]
 fn client_flush_does_nothing() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     assert!(matches!(client.writer().flush(), Ok(())));
 }
 
@@ -1722,10 +1723,10 @@ fn client_flush_does_nothing() {
 fn server_close_notify() {
     let provider = provider::DEFAULT_PROVIDER;
     let kt = KeyType::Rsa2048;
-    let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
+    let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, provider::SUPPORTED_SIG_ALGS, &provider));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config_with_auth(kt, &version_provider);
+        let client_config = make_client_config_with_auth(kt, provider::SUPPORTED_SIG_ALGS, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
         do_handshake(&mut client, &mut server);
@@ -1762,10 +1763,10 @@ fn server_close_notify() {
 fn client_close_notify() {
     let provider = provider::DEFAULT_PROVIDER;
     let kt = KeyType::Rsa2048;
-    let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
+    let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, provider::SUPPORTED_SIG_ALGS, &provider));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config_with_auth(kt, &version_provider);
+        let client_config = make_client_config_with_auth(kt, provider::SUPPORTED_SIG_ALGS, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
         do_handshake(&mut client, &mut server);
@@ -1805,7 +1806,7 @@ fn server_closes_uncleanly() {
     let server_config = Arc::new(make_server_config(kt, &provider));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(kt, &version_provider);
+        let client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
         do_handshake(&mut client, &mut server);
@@ -1851,7 +1852,7 @@ fn client_closes_uncleanly() {
     let server_config = Arc::new(make_server_config(kt, &provider));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(kt, &version_provider);
+        let client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
         do_handshake(&mut client, &mut server);
@@ -1925,7 +1926,7 @@ fn test_complete_io_errors_if_close_notify_received_too_early() {
 
 #[test]
 fn test_complete_io_with_no_io_needed() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
     client
         .writer()
@@ -1963,7 +1964,7 @@ fn test_complete_io_with_no_io_needed() {
 
 #[test]
 fn test_junk_after_close_notify_received() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
     client
         .writer()
@@ -2006,7 +2007,7 @@ fn test_junk_after_close_notify_received() {
 
 #[test]
 fn test_data_after_close_notify_is_ignored() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
     client
@@ -2038,7 +2039,7 @@ fn test_data_after_close_notify_is_ignored() {
 
 #[test]
 fn test_close_notify_sent_prior_to_handshake_complete() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     client.send_close_notify();
     assert_eq!(
         do_handshake_until_error(&mut client, &mut server),
@@ -2050,7 +2051,7 @@ fn test_close_notify_sent_prior_to_handshake_complete() {
 
 #[test]
 fn test_subsequent_close_notify_ignored() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     client.send_close_notify();
     assert!(transfer(&mut client, &mut server) > 0);
 
@@ -2061,7 +2062,7 @@ fn test_subsequent_close_notify_ignored() {
 
 #[test]
 fn test_second_close_notify_after_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
     client.send_close_notify();
     assert!(transfer(&mut client, &mut server) > 0);
@@ -2074,7 +2075,7 @@ fn test_second_close_notify_after_handshake() {
 
 #[test]
 fn test_read_tls_artificial_eof_after_close_notify() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
     client.send_close_notify();
     assert!(transfer(&mut client, &mut server) > 0);

--- a/rustls-test/tests/api/kx.rs
+++ b/rustls-test/tests/api/kx.rs
@@ -27,7 +27,7 @@ fn test_client_config_keyshare() {
     let provider = provider::DEFAULT_PROVIDER;
     let kx_groups = vec![provider::kx_group::SECP384R1];
     let client_config =
-        make_client_config_with_kx_groups(KeyType::Rsa2048, kx_groups.clone(), &provider);
+        make_client_config_with_kx_groups(KeyType::Rsa2048, kx_groups.clone(), provider::SUPPORTED_SIG_ALGS, &provider);
     let server_config = make_server_config_with_kx_groups(KeyType::Rsa2048, kx_groups, &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     do_handshake_until_error(&mut client, &mut server).unwrap();
@@ -39,6 +39,7 @@ fn test_client_config_keyshare_mismatch() {
     let client_config = make_client_config_with_kx_groups(
         KeyType::Rsa2048,
         vec![provider::kx_group::SECP384R1],
+        provider::SUPPORTED_SIG_ALGS,
         &provider,
     );
     let server_config = make_server_config_with_kx_groups(
@@ -67,6 +68,7 @@ fn exercise_all_key_exchange_methods() {
             let client_config = make_client_config_with_kx_groups(
                 KeyType::Rsa2048,
                 vec![*kx_group],
+                provider::SUPPORTED_SIG_ALGS,
                 &version_provider,
             );
             let server_config = make_server_config_with_kx_groups(
@@ -88,6 +90,7 @@ fn test_client_sends_helloretryrequest() {
     let mut client_config = make_client_config_with_kx_groups(
         KeyType::Rsa2048,
         vec![provider::kx_group::SECP384R1, provider::kx_group::X25519],
+        provider::SUPPORTED_SIG_ALGS,
         &provider,
     );
 
@@ -204,6 +207,7 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     let mut client_config_1 = make_client_config_with_kx_groups(
         KeyType::Rsa2048,
         vec![provider::kx_group::SECP256R1],
+        provider::SUPPORTED_SIG_ALGS,
         &provider,
     );
     client_config_1.resumption = Resumption::store(shared_storage.clone());
@@ -213,6 +217,7 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     let mut client_config_2 = make_client_config_with_kx_groups(
         KeyType::Rsa2048,
         vec![provider::kx_group::SECP384R1],
+        provider::SUPPORTED_SIG_ALGS,
         &provider,
     );
     client_config_2.resumption = Resumption::store(shared_storage.clone());
@@ -263,6 +268,7 @@ fn test_client_sends_share_for_less_preferred_group() {
     let mut client_config_1 = make_client_config_with_kx_groups(
         KeyType::Rsa2048,
         vec![provider::kx_group::SECP384R1],
+        provider::SUPPORTED_SIG_ALGS,
         &provider,
     );
     client_config_1.resumption = Resumption::store(shared_storage.clone());
@@ -272,6 +278,7 @@ fn test_client_sends_share_for_less_preferred_group() {
     let mut client_config_2 = make_client_config_with_kx_groups(
         KeyType::Rsa2048,
         vec![provider::kx_group::X25519, provider::kx_group::SECP384R1],
+        provider::SUPPORTED_SIG_ALGS,
         &provider,
     );
     client_config_2.resumption = Resumption::store(shared_storage.clone());
@@ -319,7 +326,7 @@ fn test_client_sends_share_for_less_preferred_group() {
 
 #[test]
 fn test_server_rejects_clients_without_any_kx_groups() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_PROVIDER);
     server
         .read_tls(
             &mut encoding::message_framing(
@@ -355,6 +362,7 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
             make_client_config_with_kx_groups(
                 KeyType::Rsa2048,
                 vec![provider::kx_group::X25519],
+                provider::SUPPORTED_SIG_ALGS,
                 &version_provider,
             ),
             ServerConfig::builder(
@@ -391,12 +399,12 @@ fn hybrid_kx_component_share_offered_but_server_chooses_something_else() {
         }
         .into(),
     )
-    .finish(kt);
+    .finish(kt, provider::SUPPORTED_SIG_ALGS);
     let provider = provider::DEFAULT_PROVIDER;
     let server_config = make_server_config(kt, &provider);
 
     let (mut client_1, mut server) = make_pair_for_configs(client_config, server_config);
-    let (mut client_2, _) = make_pair(kt, &provider);
+    let (mut client_2, _) = make_pair(kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
     // client_2 supplies the ClientHello, client_1 receives the ServerHello
     transfer(&mut client_2, &mut server);

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -70,7 +70,7 @@ fn test_quic_handshake() {
 
     let kt = KeyType::Rsa2048;
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let mut client_config = make_client_config(kt, &provider);
+    let mut client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.enable_early_data = true;
     let client_config = Arc::new(client_config);
     let mut server_config = make_server_config(kt, &provider);
@@ -246,7 +246,7 @@ fn test_quic_rejects_missing_alpn() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
 
     for &kt in KeyType::all_for_provider(&provider) {
-        let client_config = make_client_config(kt, &provider);
+        let client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider);
         let client_config = Arc::new(client_config);
 
         let mut server_config = make_server_config(kt, &provider);
@@ -278,7 +278,7 @@ fn test_quic_rejects_missing_alpn() {
 #[test]
 fn test_quic_no_tls13_error() {
     let provider = provider::DEFAULT_TLS12_PROVIDER;
-    let mut client_config = make_client_config(KeyType::Ed25519, &provider);
+    let mut client_config = make_client_config(KeyType::Ed25519, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.alpn_protocols = vec![b"foo".into()];
     let client_config = Arc::new(client_config);
 
@@ -487,7 +487,7 @@ fn test_quic_resumption_data_0rtt() {
     let kt = KeyType::Rsa2048;
     let provider = provider::DEFAULT_TLS13_PROVIDER;
 
-    let mut client_config = make_client_config(kt, &provider);
+    let mut client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.alpn_protocols = vec![b"foo".into()];
     client_config.enable_early_data = true;
     client_config.resumption = Resumption::store(Arc::new(ClientStorage::new()));
@@ -770,7 +770,7 @@ fn packet_key_api() {
 fn test_quic_exporter() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     for &kt in KeyType::all_for_provider(&provider) {
-        let client_config = make_client_config(kt, &provider);
+        let client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider);
         let server_config = make_server_config(kt, &provider);
 
         let mut server =
@@ -819,7 +819,7 @@ fn test_quic_exporter() {
 #[test]
 fn test_fragmented_append() {
     // Create a QUIC client connection.
-    let client_config = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_TLS13_PROVIDER);
+    let client_config = make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider::DEFAULT_TLS13_PROVIDER);
     let client_config = Arc::new(client_config);
     let mut client = quic::ClientConnection::new(
         client_config,

--- a/rustls-test/tests/api/raw_keys.rs
+++ b/rustls-test/tests/api/raw_keys.rs
@@ -17,8 +17,8 @@ use super::provider;
 fn successful_raw_key_connection_and_correct_peer_certificates() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let client_config = make_client_config_with_raw_key_support(*kt, &provider);
-        let server_config = make_server_config_with_raw_key_support(*kt, &provider);
+        let client_config = make_client_config_with_raw_key_support(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
+        let server_config = make_server_config_with_raw_key_support(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
         do_handshake(&mut client, &mut server);
@@ -57,8 +57,8 @@ fn successful_raw_key_connection_and_correct_peer_certificates() {
 fn correct_certificate_type_extensions_from_client_hello() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let client_config = make_client_config_with_raw_key_support(*kt, &provider);
-        let mut server_config = make_server_config_with_raw_key_support(*kt, &provider);
+        let client_config = make_client_config_with_raw_key_support(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
+        let mut server_config = make_server_config_with_raw_key_support(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         server_config.cert_resolver = Arc::new(ServerCheckCertResolve {
             expected_client_cert_types: Some(vec![CertificateType::RawPublicKey]),
@@ -76,7 +76,7 @@ fn correct_certificate_type_extensions_from_client_hello() {
 fn only_client_supports_raw_keys() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let client_config_rpk = make_client_config_with_raw_key_support(*kt, &provider);
+        let client_config_rpk = make_client_config_with_raw_key_support(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
         let server_config = make_server_config(*kt, &provider);
 
         let (mut client_rpk, mut server) = make_pair_for_configs(client_config_rpk, server_config);
@@ -102,8 +102,8 @@ fn only_client_supports_raw_keys() {
 fn only_server_supports_raw_keys() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let client_config = make_client_config(*kt, &provider);
-        let server_config_rpk = make_server_config_with_raw_key_support(*kt, &provider);
+        let client_config = make_client_config(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
+        let server_config_rpk = make_server_config_with_raw_key_support(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         let (mut client, mut server_rpk) = make_pair_for_configs(client_config, server_config_rpk);
 

--- a/rustls-test/tests/api/resolve.rs
+++ b/rustls-test/tests/api/resolve.rs
@@ -29,7 +29,7 @@ use super::{ALL_VERSIONS, provider, provider_is_aws_lc_rs};
 fn server_cert_resolve_with_sni() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let client_config = Arc::new(make_client_config(*kt, &provider));
+        let client_config = Arc::new(make_client_config(*kt, provider::SUPPORTED_SIG_ALGS, &provider));
         let mut server_config = make_server_config(*kt, &provider);
 
         server_config.cert_resolver = Arc::new(ServerCheckCertResolve {
@@ -52,7 +52,7 @@ fn server_cert_resolve_with_sni() {
 fn server_cert_resolve_with_alpn() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let mut client_config = make_client_config(*kt, &provider);
+        let mut client_config = make_client_config(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
         client_config.alpn_protocols = vec![
             ApplicationProtocol::from(b"foo"),
             ApplicationProtocol::from(b"bar"),
@@ -79,7 +79,7 @@ fn server_cert_resolve_with_alpn() {
 fn server_cert_resolve_with_named_groups() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let client_config = make_client_config(*kt, &provider);
+        let client_config = make_client_config(*kt, provider::SUPPORTED_SIG_ALGS, &provider);
 
         let mut server_config = make_server_config(*kt, &provider);
         server_config.cert_resolver = Arc::new(ServerCheckCertResolve {
@@ -103,7 +103,7 @@ fn server_cert_resolve_with_named_groups() {
 fn client_trims_terminating_dot() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
-        let client_config = Arc::new(make_client_config(*kt, &provider));
+        let client_config = Arc::new(make_client_config(*kt, provider::SUPPORTED_SIG_ALGS, &provider));
         let mut server_config = make_server_config(*kt, &provider);
 
         server_config.cert_resolver = Arc::new(ServerCheckCertResolve {
@@ -130,7 +130,7 @@ fn check_sigalgs_reduced_by_ciphersuite(
     let client_config = ClientConfig::builder(
         provider_with_one_suite(&provider::DEFAULT_PROVIDER, find_suite(suite)).into(),
     )
-    .finish(kt);
+    .finish(kt, provider::SUPPORTED_SIG_ALGS);
 
     let mut server_config = make_server_config(kt, &provider::DEFAULT_PROVIDER);
 
@@ -215,7 +215,7 @@ fn client_with_sni_disabled_does_not_send_sni() {
         let server_config = Arc::new(server_config);
 
         for version_provider in ALL_VERSIONS {
-            let mut client_config = make_client_config(*kt, &version_provider);
+            let mut client_config = make_client_config(*kt, provider::SUPPORTED_SIG_ALGS, &version_provider);
             client_config.enable_sni = false;
 
             let mut client = Arc::new(client_config)
@@ -311,7 +311,7 @@ fn test_client_cert_resolve(
         println!("{version:?} {key_type:?}:");
 
         let client_config = ClientConfig::builder(version_provider.clone().into())
-            .add_root_certs(key_type)
+            .add_root_certs(key_type, provider::SUPPORTED_SIG_ALGS)
             .with_client_credential_resolver(Arc::new(ClientCheckCertResolve::new(
                 1,
                 expected_root_hint_subjects.clone(),
@@ -365,7 +365,7 @@ fn client_cert_resolve_default() {
     let provider = provider::DEFAULT_PROVIDER;
     for key_type in KeyType::all_for_provider(&provider) {
         let server_config = Arc::new(make_server_config_with_mandatory_client_auth(
-            *key_type, &provider,
+            *key_type, provider::SUPPORTED_SIG_ALGS, &provider,
         ));
 
         // In a default configuration we expect that the verifier's trust anchors are used
@@ -383,7 +383,7 @@ fn client_cert_resolve_server_no_hints() {
     let provider = provider::DEFAULT_PROVIDER;
     for key_type in KeyType::all_for_provider(&provider) {
         // Build a verifier with no hint subjects.
-        let verifier = webpki_client_verifier_builder(key_type.client_root_store(), &provider)
+        let verifier = webpki_client_verifier_builder(key_type.client_root_store(), provider::SUPPORTED_SIG_ALGS)
             .clear_root_hint_subjects();
         let server_config = make_server_config_with_client_verifier(*key_type, verifier, &provider);
         let expected_root_hint_subjects = Vec::default(); // no hints expected.
@@ -403,7 +403,7 @@ fn client_cert_resolve_server_added_hint() {
         let expected_hint_subjects = vec![key_type.ca_distinguished_name(), extra_name.clone()];
         // Create a verifier that adds the extra_name as a hint subject in addition to the ones
         // from the root cert store.
-        let verifier = webpki_client_verifier_builder(key_type.client_root_store(), &provider)
+        let verifier = webpki_client_verifier_builder(key_type.client_root_store(), provider::SUPPORTED_SIG_ALGS)
             .add_root_hint_subjects([extra_name.clone()].into_iter());
         let server_config = make_server_config_with_client_verifier(*key_type, verifier, &provider);
         test_client_cert_resolve(*key_type, server_config.into(), expected_hint_subjects);
@@ -421,7 +421,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
     let server_config = Arc::new(server_config);
 
     for version_provider in ALL_VERSIONS {
-        let client_config = Arc::new(make_client_config(kt, &version_provider));
+        let client_config = Arc::new(make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &version_provider));
         let mut server = ServerConnection::new(server_config.clone()).unwrap();
         let mut client = client_config
             .connect(server_name("thisdoesNOTexist.com"))
@@ -459,7 +459,7 @@ fn sni_resolver_works() {
     let server_config = Arc::new(server_config);
 
     let mut server1 = ServerConnection::new(server_config.clone()).unwrap();
-    let mut client1 = Arc::new(make_client_config(kt, &provider))
+    let mut client1 = Arc::new(make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider))
         .connect(server_name("localhost"))
         .build()
         .unwrap();
@@ -467,7 +467,7 @@ fn sni_resolver_works() {
     assert_eq!(err, Ok(()));
 
     let mut server2 = ServerConnection::new(server_config).unwrap();
-    let mut client2 = Arc::new(make_client_config(kt, &provider))
+    let mut client2 = Arc::new(make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider))
         .connect(server_name("notlocalhost"))
         .build()
         .unwrap();
@@ -523,7 +523,7 @@ fn sni_resolver_lower_cases_configured_names() {
     let server_config = Arc::new(server_config);
 
     let mut server1 = ServerConnection::new(server_config).unwrap();
-    let mut client1 = Arc::new(make_client_config(kt, &provider))
+    let mut client1 = Arc::new(make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider))
         .connect(server_name("localhost"))
         .build()
         .unwrap();
@@ -552,7 +552,7 @@ fn sni_resolver_lower_cases_queried_names() {
     let server_config = Arc::new(server_config);
 
     let mut server1 = ServerConnection::new(server_config).unwrap();
-    let mut client1 = Arc::new(make_client_config(kt, &provider))
+    let mut client1 = Arc::new(make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider))
         .connect(server_name("LOCALHOST"))
         .build()
         .unwrap();

--- a/rustls-test/tests/api/unbuffered.rs
+++ b/rustls-test/tests/api/unbuffered.rs
@@ -114,7 +114,8 @@ fn handshake_config(
     editor: impl Fn(&mut ClientConfig, &mut ServerConfig),
 ) -> Outcome {
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config =
+        make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider);
     editor(&mut client_config, &mut server_config);
 
     run(
@@ -131,7 +132,11 @@ fn app_data_client_to_server() {
     for version_provider in ALL_VERSIONS {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(
+            KeyType::Rsa2048,
+            provider::SUPPORTED_SIG_ALGS,
+            &version_provider,
+        );
 
         let mut client_actions = Actions {
             app_data_to_send: Some(expected),
@@ -165,7 +170,11 @@ fn app_data_server_to_client() {
     for version_provider in ALL_VERSIONS {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(
+            KeyType::Rsa2048,
+            provider::SUPPORTED_SIG_ALGS,
+            &version_provider,
+        );
 
         let mut server_actions = Actions {
             app_data_to_send: Some(expected),
@@ -202,7 +211,8 @@ fn early_data() {
     server_config.max_early_data_size = 128;
     let server_config = Arc::new(server_config);
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config =
+        make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.enable_early_data = true;
     let client_config = Arc::new(client_config);
 
@@ -436,7 +446,11 @@ fn close_notify_client_to_server() {
     for version_provider in ALL_VERSIONS {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(
+            KeyType::Rsa2048,
+            provider::SUPPORTED_SIG_ALGS,
+            &version_provider,
+        );
 
         let mut client_actions = Actions {
             send_close_notify: true,
@@ -460,7 +474,11 @@ fn close_notify_server_to_client() {
     for version_provider in ALL_VERSIONS {
         eprintln!("{version_provider:?}");
         let server_config = make_server_config(KeyType::Rsa2048, &version_provider);
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(
+            KeyType::Rsa2048,
+            provider::SUPPORTED_SIG_ALGS,
+            &version_provider,
+        );
 
         let mut server_actions = Actions {
             send_close_notify: true,
@@ -744,7 +762,7 @@ fn refresh_traffic_keys_automatically() {
     let client_config = ClientConfig::builder(aes_128_gcm_with_1024_confidentiality_limit(
         provider::DEFAULT_PROVIDER,
     ))
-    .finish(KeyType::Rsa2048);
+    .finish(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS);
 
     let server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     let mut outcome = run(
@@ -816,7 +834,8 @@ fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
         )))
     });
 
-    let client_config = ClientConfig::builder(provider).finish(KeyType::Ed25519);
+    let client_config =
+        ClientConfig::builder(provider).finish(KeyType::Ed25519, provider::SUPPORTED_SIG_ALGS);
 
     let server_config = make_server_config(KeyType::Ed25519, &provider::DEFAULT_PROVIDER);
     let mut outcome = run(
@@ -1381,7 +1400,8 @@ fn make_connection_pair(
     provider: CryptoProvider,
 ) -> (UnbufferedClientConnection, UnbufferedServerConnection) {
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
-    let client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let client_config =
+        make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider);
 
     let client =
         UnbufferedClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
@@ -1487,7 +1507,7 @@ fn test_secret_extraction_enabled() {
         server_config.enable_secret_extraction = true;
         let server_config = Arc::new(server_config);
 
-        let mut client_config = make_client_config(kt, &provider);
+        let mut client_config = make_client_config(kt, provider::SUPPORTED_SIG_ALGS, &provider);
         client_config.enable_secret_extraction = true;
 
         let mut outcome = run(
@@ -1550,7 +1570,8 @@ fn kernel_err_on_secret_extraction_not_enabled() {
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
     let server_config = Arc::new(server_config);
 
-    let client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let client_config =
+        make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider);
     let client_config = Arc::new(client_config);
 
     let mut server = UnbufferedServerConnection::new(server_config).unwrap();
@@ -1578,7 +1599,8 @@ fn kernel_err_on_handshake_not_complete() {
     server_config.enable_secret_extraction = true;
     let server_config = Arc::new(server_config);
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config =
+        make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.enable_secret_extraction = true;
     let client_config = Arc::new(client_config);
 
@@ -1603,7 +1625,8 @@ fn kernel_initial_traffic_secrets_match() {
     server_config.enable_secret_extraction = true;
     let server_config = Arc::new(server_config);
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config =
+        make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.enable_secret_extraction = true;
     let client_config = Arc::new(client_config);
 
@@ -1631,7 +1654,8 @@ fn kernel_key_updates_tls13() {
     server_config.enable_secret_extraction = true;
     let server_config = Arc::new(server_config);
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config =
+        make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.enable_secret_extraction = true;
     let client_config = Arc::new(client_config);
 
@@ -1667,7 +1691,8 @@ fn kernel_key_updates_tls12() {
     server_config.enable_secret_extraction = true;
     let server_config = Arc::new(server_config);
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config =
+        make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &provider);
     client_config.enable_secret_extraction = true;
     let client_config = Arc::new(client_config);
 

--- a/rustls-test/tests/key_log_file_env/tests.rs
+++ b/rustls-test/tests/key_log_file_env/tests.rs
@@ -43,7 +43,7 @@ fn exercise_key_log_file_for_client() {
         unsafe { env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt") };
 
         for version_provider in ALL_VERSIONS {
-            let mut client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+            let mut client_config = make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &version_provider);
             client_config.key_log = Arc::new(KeyLogFile::new());
 
             let (mut client, mut server) =
@@ -69,7 +69,7 @@ fn exercise_key_log_file_for_server() {
         let server_config = Arc::new(server_config);
 
         for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+            let client_config = make_client_config(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
 

--- a/rustls-test/tests/process_provider.rs
+++ b/rustls-test/tests/process_provider.rs
@@ -28,5 +28,5 @@ fn test_explicit_choice_required() {
     let provider = CryptoProvider::get_default().expect("provider missing");
 
     // does not panic
-    ClientConfig::builder(provider.clone()).finish(KeyType::Rsa2048);
+    ClientConfig::builder(provider.clone()).finish(KeyType::Rsa2048, provider::SUPPORTED_SIG_ALGS);
 }

--- a/rustls/src/client/config.rs
+++ b/rustls/src/client/config.rs
@@ -21,7 +21,7 @@ use crate::crypto;
 use crate::crypto::kx::NamedGroup;
 use crate::crypto::{CipherSuite, CryptoProvider, SelectedCredential, SignatureScheme, hash};
 #[cfg(feature = "webpki")]
-use crate::crypto::{Credentials, Identity, SingleCredential};
+use crate::crypto::{Credentials, Identity, SingleCredential, WebPkiSupportedAlgorithms};
 use crate::enums::{ApplicationProtocol, CertificateType, ProtocolVersion};
 use crate::error::{ApiMisuse, Error};
 use crate::key_log::NoKeyLog;
@@ -639,12 +639,10 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
     pub fn with_root_certificates(
         self,
         root_store: impl Into<Arc<webpki::RootCertStore>>,
+        supported: WebPkiSupportedAlgorithms,
     ) -> ConfigBuilder<ClientConfig, WantsClientCert> {
-        let algorithms = self
-            .provider
-            .signature_verification_algorithms;
         self.with_webpki_verifier(
-            WebPkiServerVerifier::new_without_revocation(root_store, algorithms).into(),
+            WebPkiServerVerifier::new_without_revocation(root_store, supported).into(),
         )
     }
 

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -11,7 +11,7 @@ use pki_types::{CertificateDer, FipsStatus, ServerName};
 use crate::client::{ClientConfig, Resumption, Tls12Resumption};
 use crate::crypto::cipher::{EncodedMessage, MessageEncrypter, Payload};
 use crate::crypto::kx::{self, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup};
-use crate::crypto::test_provider::FakeKeyExchangeGroup;
+use crate::crypto::test_provider::{FakeKeyExchangeGroup, VERIFY_ALGORITHMS};
 use crate::crypto::tls13::OkmBlock;
 use crate::crypto::{
     CipherSuite, Credentials, CryptoProvider, Identity, SignatureScheme, SingleCredential,
@@ -41,7 +41,7 @@ use crate::{DigitallySignedStruct, DistinguishedName, KeyLog, RootCertStore};
 #[test]
 fn test_no_session_ticket_request_on_tls_1_3() {
     let mut config = ClientConfig::builder(Arc::new(tls13_only(TEST_PROVIDER.clone())))
-        .with_root_certificates(roots())
+        .with_root_certificates(roots(), VERIFY_ALGORITHMS)
         .with_no_client_auth()
         .unwrap();
     config.resumption =
@@ -54,7 +54,7 @@ fn test_no_session_ticket_request_on_tls_1_3() {
 fn test_no_renegotiation_scsv_on_tls_1_3() {
     let ch = client_hello_sent_for_config(
         ClientConfig::builder(Arc::new(tls13_only(TEST_PROVIDER.clone())))
-            .with_root_certificates(roots())
+            .with_root_certificates(roots(), VERIFY_ALGORITHMS)
             .with_no_client_auth()
             .unwrap(),
     )
@@ -72,7 +72,7 @@ fn test_client_does_not_offer_sha1() {
         tls13_only(TEST_PROVIDER.clone()),
     ] {
         let config = ClientConfig::builder(Arc::new(provider))
-            .with_root_certificates(roots())
+            .with_root_certificates(roots(), VERIFY_ALGORITHMS)
             .with_no_client_auth()
             .unwrap();
         let ch = client_hello_sent_for_config(config).unwrap();
@@ -90,7 +90,7 @@ fn test_client_does_not_offer_sha1() {
 #[test]
 fn test_client_rejects_hrr_with_varied_session_id() {
     let config = ClientConfig::builder(Arc::new(TEST_PROVIDER.clone()))
-        .with_root_certificates(roots())
+        .with_root_certificates(roots(), VERIFY_ALGORITHMS)
         .with_no_client_auth()
         .unwrap();
     let mut conn = Arc::new(config)
@@ -127,7 +127,7 @@ fn test_client_rejects_hrr_with_varied_session_id() {
 #[test]
 fn test_client_rejects_no_extended_master_secret_extension_when_require_ems_or_fips() {
     let mut config = ClientConfig::builder(Arc::new(TEST_PROVIDER.clone()))
-        .with_root_certificates(roots())
+        .with_root_certificates(roots(), VERIFY_ALGORITHMS)
         .with_no_client_auth()
         .unwrap();
     if !matches!(config.provider().fips(), FipsStatus::Unvalidated) {
@@ -614,7 +614,7 @@ impl KeyLog for FakeServerCrypto {
 fn hybrid_kx_component_share_offered_if_supported_separately() {
     let ch = client_hello_sent_for_config(
         ClientConfig::builder(Arc::new(HYBRID_PROVIDER.clone()))
-            .with_root_certificates(roots())
+            .with_root_certificates(roots(), VERIFY_ALGORITHMS)
             .with_no_client_auth()
             .unwrap(),
     )
@@ -638,7 +638,7 @@ fn hybrid_kx_component_share_not_offered_unless_supported_separately() {
     };
     let ch = client_hello_sent_for_config(
         ClientConfig::builder(provider.into())
-            .with_root_certificates(roots())
+            .with_root_certificates(roots(), VERIFY_ALGORITHMS)
             .with_no_client_auth()
             .unwrap(),
     )

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -207,15 +207,6 @@ pub struct CryptoProvider {
     /// The `SupportedKxGroup` type carries both configuration and implementation.
     pub kx_groups: Cow<'static, [&'static dyn SupportedKxGroup]>,
 
-    /// List of signature verification algorithms for use with webpki.
-    ///
-    /// These are used for both certificate chain verification and handshake signature verification.
-    ///
-    /// This is called by [`ConfigBuilder::with_root_certificates()`],
-    /// [`server::WebPkiClientVerifier::builder()`] and
-    /// [`client::WebPkiServerVerifier::builder()`].
-    pub signature_verification_algorithms: WebPkiSupportedAlgorithms,
-
     /// Source of cryptographically secure random numbers.
     pub secure_random: &'static dyn SecureRandom,
 
@@ -258,17 +249,15 @@ impl CryptoProvider {
             tls12_cipher_suites,
             tls13_cipher_suites,
             kx_groups,
-            signature_verification_algorithms,
             secure_random,
             key_provider,
             ticketer_factory,
         } = self;
 
         let mut status = Ord::min(
-            signature_verification_algorithms.fips(),
             secure_random.fips(),
+            key_provider.fips(),
         );
-        status = Ord::min(status, key_provider.fips());
         status = Ord::min(status, ticketer_factory.fips());
         for cs in tls12_cipher_suites.iter() {
             status = Ord::min(status, cs.fips());

--- a/rustls/src/crypto/test_provider.rs
+++ b/rustls/src/crypto/test_provider.rs
@@ -31,7 +31,6 @@ pub const TEST_PROVIDER: crypto::CryptoProvider = crypto::CryptoProvider {
     tls12_cipher_suites: Cow::Borrowed(&[TLS_TEST_SUITE]),
     tls13_cipher_suites: Cow::Borrowed(&[TLS13_TEST_SUITE]),
     kx_groups: Cow::Borrowed(&[KEY_EXCHANGE_GROUP]),
-    signature_verification_algorithms: VERIFY_ALGORITHMS,
     secure_random: &Provider,
     key_provider: &Provider,
     ticketer_factory: &Provider,
@@ -504,7 +503,7 @@ const AEAD_MASK: &[u8] = b"AeadMaskPattern";
 const AEAD_TAG: &[u8] = b"AeadTagA";
 const AEAD_OVERHEAD: usize = 16;
 
-static VERIFY_ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+pub(crate) static VERIFY_ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[VERIFY_ALGORITHM],
     mapping: &[(SIGNATURE_SCHEME, &[VERIFY_ALGORITHM])],
 };


### PR DESCRIPTION
What do we think of doing something like this?

It feels like projects depending on, say, the platform verifier shouldn't have to drag around the provider's signature verification algorithms, even if that means a small ergonomic hit.