### PR TITLE
Avoid API misfeature in `test_close_notify_sent_prior_to_handshake_complete`

### DIFF
--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -2152,6 +2152,15 @@ pub mod encoding {
         message_framing(ContentType::Alert, ProtocolVersion::TLSv1_2, body)
     }
 
+    /// Return a full TLS message containing a warning alert.
+    pub fn warning_alert(desc: AlertDescription) -> Vec<u8> {
+        message_framing(
+            ContentType::Alert,
+            ProtocolVersion::TLSv1_2,
+            vec![ALERT_LEVEL_WARNING, desc.into()],
+        )
+    }
+
     /// Prefix with u8 length
     pub fn len_u8(mut body: Vec<u8>) -> Vec<u8> {
         body.splice(0..0, [body.len() as u8]);
@@ -2178,5 +2187,6 @@ pub mod encoding {
         items.into_iter().flatten().collect()
     }
 
+    const ALERT_LEVEL_WARNING: u8 = 1;
     const ALERT_LEVEL_FATAL: u8 = 2;
 }


### PR DESCRIPTION
In this test we were relying on a misfeature of the rustls API, which is that `send_close_notify()` can send the alert at an illegal time.

In some coming changes, this is impossible to express in the low-level API and therefore impossible to achieve in the high-level API (though the API remains, it does nothing if called at the wrong time). Replace this with the `encoding::` test API.