### PR TITLE
Externalize input buffers

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -46,7 +46,7 @@ use rustls::server::{
     self, ClientHello, PreferClientOrder, PreferServerOrder, ServerConfig, ServerConnection,
     ServerSessionKey, WebPkiClientVerifier,
 };
-use rustls::{Connection, DistinguishedName, HandshakeKind, RootCertStore, compress};
+use rustls::{Connection, DistinguishedName, HandshakeKind, RootCertStore, VecInput, compress};
 use rustls_aws_lc_rs::hpke;
 
 pub fn main() {
@@ -154,6 +154,7 @@ fn exec(opts: &Options, mut sess: impl Connection + 'static, key_log: &KeyLogMem
     conn.write_all(&opts.shim_id.to_le_bytes())
         .unwrap();
 
+    let mut input = VecInput::default();
     loop {
         if !sent_message && (opts.queue_data || (opts.queue_data_on_resume && count > 0)) {
             if !opts
@@ -162,7 +163,13 @@ fn exec(opts: &Options, mut sess: impl Connection + 'static, key_log: &KeyLogMem
             {
                 flush(&mut sess, &mut conn);
                 for message_size_estimate in &opts.queue_early_data_after_received_messages {
-                    read_n_bytes(opts, &mut sess, &mut conn, *message_size_estimate);
+                    read_n_bytes(
+                        opts,
+                        &mut input,
+                        &mut sess,
+                        &mut conn,
+                        *message_size_estimate,
+                    );
                 }
                 println!("now ready for early data");
             }
@@ -188,7 +195,7 @@ fn exec(opts: &Options, mut sess: impl Connection + 'static, key_log: &KeyLogMem
         }
 
         if sess.wants_read() {
-            read_all_bytes(opts, &mut sess, &mut conn);
+            read_all_bytes(opts, &mut input, &mut sess, &mut conn);
         }
 
         if opts.side == Side::Server && opts.enable_early_data {
@@ -414,37 +421,69 @@ fn server(conn: &mut dyn Any) -> &mut ServerConnection {
         .unwrap()
 }
 
-fn read_n_bytes(opts: &Options, sess: &mut impl Connection, conn: &mut net::TcpStream, n: usize) {
+fn read_n_bytes(
+    opts: &Options,
+    input: &mut VecInput,
+    sess: &mut impl Connection,
+    conn: &mut net::TcpStream,
+    n: usize,
+) {
     let mut bytes = [0u8; MAX_MESSAGE_SIZE];
     match conn.read(&mut bytes[..n]) {
         Ok(count) => {
             println!("read {count:?} bytes");
-            sess.read_tls(&mut io::Cursor::new(&mut bytes[..count]))
+            input
+                .read(&mut io::Cursor::new(&mut bytes[..count]))
                 .expect("read_tls not expected to fail reading from buffer");
         }
         Err(err) if err.kind() == io::ErrorKind::ConnectionReset => {}
         Err(err) => panic!("invalid read: {err}"),
     };
 
-    after_read(opts, sess, conn);
+    after_read(opts, input, sess, conn);
 }
 
-fn read_all_bytes(opts: &Options, sess: &mut impl Connection, conn: &mut net::TcpStream) {
-    match sess.read_tls(conn) {
+fn read_all_bytes(
+    opts: &Options,
+    input: &mut VecInput,
+    sess: &mut impl Connection,
+    conn: &mut net::TcpStream,
+) {
+    match input.read(conn) {
         Ok(_) => {}
         Err(err) if err.kind() == io::ErrorKind::ConnectionReset => {}
         Err(err) => panic!("invalid read: {err}"),
     };
 
-    after_read(opts, sess, conn);
+    after_read(opts, input, sess, conn);
 }
 
-fn after_read(opts: &Options, sess: &mut impl Connection, conn: &mut net::TcpStream) {
-    if let Err(err) = sess.process_new_packets() {
+fn after_read(
+    opts: &Options,
+    input: &mut VecInput,
+    sess: &mut impl Connection,
+    conn: &mut net::TcpStream,
+) {
+    //dbg!("process new packets", input.slice_mut().len());
+    if let Err(err) = sess.process_new_packets(input) {
+        //dbg!(&err);
         flush(sess, conn); /* send any alerts before exiting */
         orderly_close(conn);
         handle_err(opts, err);
     }
+    /*
+    let mut plaintext = [0u8; MAX_MESSAGE_SIZE];
+    let mut reader = sess.reader();
+    loop {
+        match reader.read(&mut plaintext) {
+            Ok(0) => break,
+            Ok(read) => {
+                dbg!(read);
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
+            Err(err) => panic!("invalid plaintext read: {err:?}"),
+        }
+    }*/
 }
 
 fn flush(sess: &mut impl Connection, conn: &mut net::TcpStream) {

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -21,7 +21,7 @@ use rustls::enums::ProtocolVersion;
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::{
     ClientConfig, ClientConnection, Connection, HandshakeKind, RootCertStore, ServerConfig,
-    ServerConnection,
+    ServerConnection, VecInput,
 };
 use rustls_test::KeyType;
 
@@ -237,6 +237,7 @@ fn main() -> anyhow::Result<()> {
                                     &bench.params,
                                     resumption_kind,
                                 ),
+                                input: VecInput::default(),
                             },
                             bench.kind,
                             resumed_reps,
@@ -252,6 +253,7 @@ fn main() -> anyhow::Result<()> {
                                     &bench.params,
                                     resumption_kind,
                                 ),
+                                input: VecInput::default(),
                             },
                             bench.kind,
                             resumed_reps,
@@ -296,6 +298,7 @@ fn main() -> anyhow::Result<()> {
                                     handshake_buf,
                                 },
                                 config: ServerSideStepper::make_config(params, resumption_kind),
+                                input: VecInput::default(),
                             },
                             bench.kind,
                             RESUMED_HANDSHAKE_RUNS,
@@ -314,6 +317,7 @@ fn main() -> anyhow::Result<()> {
                                 },
                                 resumption_kind,
                                 config: ClientSideStepper::make_config(params, resumption_kind),
+                                input: VecInput::default(),
                             },
                             bench.kind,
                             RESUMED_HANDSHAKE_RUNS,
@@ -686,6 +690,7 @@ struct ClientSideStepper<'a> {
     io: StepperIo<'a>,
     resumption_kind: ResumptionKind,
     config: Arc<ClientConfig>,
+    input: VecInput,
 }
 
 impl ClientSideStepper<'_> {
@@ -739,7 +744,13 @@ impl BenchStepper for ClientSideStepper<'_> {
             if !client.is_handshaking() && !client.wants_write() {
                 break;
             }
-            read_handshake_message(&mut client, self.io.reader, self.io.handshake_buf).await?;
+            read_handshake_message(
+                &mut self.input,
+                &mut client,
+                self.io.reader,
+                self.io.handshake_buf,
+            )
+            .await?;
         }
 
         // Session ids and tickets are no longer part of the handshake in TLS 1.3, so we need to
@@ -747,7 +758,13 @@ impl BenchStepper for ClientSideStepper<'_> {
         if self.resumption_kind != ResumptionKind::No
             && client.protocol_version().unwrap() == ProtocolVersion::TLSv1_3
         {
-            read_handshake_message(&mut client, self.io.reader, self.io.handshake_buf).await?;
+            read_handshake_message(
+                &mut self.input,
+                &mut client,
+                self.io.reader,
+                self.io.handshake_buf,
+            )
+            .await?;
         }
 
         Ok(client)
@@ -763,7 +780,8 @@ impl BenchStepper for ClientSideStepper<'_> {
     }
 
     async fn transmit_data(&mut self, endpoint: &mut Self::Endpoint) -> anyhow::Result<()> {
-        let total_plaintext_read = read_plaintext_to_end_bounded(endpoint, self.io.reader).await?;
+        let total_plaintext_read =
+            read_plaintext_to_end_bounded(&mut self.input, endpoint, self.io.reader).await?;
         assert_eq!(total_plaintext_read, TRANSFER_PLAINTEXT_SIZE);
         Ok(())
     }
@@ -777,6 +795,7 @@ impl BenchStepper for ClientSideStepper<'_> {
 struct ServerSideStepper<'a> {
     io: StepperIo<'a>,
     config: Arc<ServerConfig>,
+    input: VecInput,
 }
 
 impl ServerSideStepper<'_> {
@@ -816,7 +835,13 @@ impl BenchStepper for ServerSideStepper<'_> {
         server.set_buffer_limit(None);
 
         while server.is_handshaking() {
-            read_handshake_message(&mut server, self.io.reader, self.io.handshake_buf).await?;
+            read_handshake_message(
+                &mut self.input,
+                &mut server,
+                self.io.reader,
+                self.io.handshake_buf,
+            )
+            .await?;
             send_handshake_message(&mut server, self.io.writer, self.io.handshake_buf).await?;
         }
 

--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -366,7 +366,7 @@ pub(crate) mod transport {
     use std::io::{Cursor, Read, Write};
 
     use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-    use rustls::{ClientConnection, Connection, ServerConnection};
+    use rustls::{ClientConnection, Connection, ServerConnection, VecInput};
 
     use super::async_io::{AsyncRead, AsyncWrite};
 
@@ -416,6 +416,7 @@ pub(crate) mod transport {
     /// Used in combination with [`send_handshake_message`] (see that function's documentation for
     /// more details).
     pub(crate) async fn read_handshake_message(
+        input: &mut VecInput,
         conn: &mut impl Connection,
         reader: &mut dyn AsyncRead,
         buf: &mut [u8],
@@ -441,8 +442,8 @@ pub(crate) mod transport {
 
         // Feed the data to rustls
         let in_memory_reader = &mut &buf[..length];
-        while conn.read_tls(in_memory_reader)? != 0 {
-            conn.process_new_packets()?;
+        while input.read(in_memory_reader)? != 0 {
+            conn.process_new_packets(input)?;
         }
 
         Ok(length)
@@ -452,6 +453,7 @@ pub(crate) mod transport {
     ///
     /// Returns the amount of plaintext bytes received.
     pub(crate) async fn read_plaintext_to_end_bounded(
+        input: &mut VecInput,
         client: &mut ClientConnection,
         reader: &mut dyn AsyncRead,
     ) -> anyhow::Result<usize> {
@@ -482,11 +484,11 @@ pub(crate) mod transport {
             // Load the buffer's bytes into rustls
             let mut chunk_buf_offset = 0;
             while chunk_buf_offset < chunk_buf_end {
-                let read = client.read_tls(&mut &chunk_buf[chunk_buf_offset..chunk_buf_end])?;
+                let read = input.read(&mut &chunk_buf[chunk_buf_offset..chunk_buf_end])?;
                 chunk_buf_offset += read;
 
                 // Process packets to free space in the message buffer
-                let state = client.process_new_packets()?;
+                let state = client.process_new_packets(input)?;
                 let available_plaintext_bytes = state.plaintext_bytes_to_read();
                 let mut plaintext_bytes_read = 0;
                 while plaintext_bytes_read < available_plaintext_bytes {

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -46,7 +46,7 @@ use rustls::client::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
 use rustls::crypto::hpke::Hpke;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, EchConfigListBytes, ServerName};
-use rustls::{ClientConfig, Connection, RootCertStore};
+use rustls::{ClientConfig, Connection, RootCertStore, VecInput};
 use rustls_aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
 use rustls_util::{KeyLogFile, Stream};
 
@@ -135,7 +135,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .next()
             .ok_or("cannot resolve hostname")?;
         let mut sock = TcpStream::connect(sock_addr)?;
-        let mut tls = Stream::new(&mut conn, &mut sock);
+        let mut input = VecInput::default();
+        let mut tls = Stream::new(&mut input, &mut conn, &mut sock);
 
         // Trim a leading '/' from the user-supplied path so we never emit a request line
         // like `GET //foo HTTP/1.1`.

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -8,7 +8,7 @@ use std::net::TcpStream;
 use std::sync::Arc;
 
 use rustls::crypto::CryptoProvider;
-use rustls::{ClientConfig, RootCertStore};
+use rustls::{ClientConfig, RootCertStore, VecInput};
 use rustls_aws_lc_rs as provider;
 use rustls_util::Stream;
 
@@ -32,7 +32,8 @@ fn main() {
         .build()
         .unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
-    let mut tls = Stream::new(&mut conn, &mut sock);
+    let mut input = VecInput::default();
+    let mut tls = Stream::new(&mut input, &mut conn, &mut sock);
     tls.write_all(
         concat!(
             "GET / HTTP/1.1\r\n",

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -14,10 +14,10 @@ use std::{fs, thread};
 
 use clap::Parser;
 use rcgen::{Issuer, KeyPair, SerialNumber};
-use rustls::RootCertStore;
 use rustls::crypto::{CryptoProvider, Identity};
 use rustls::pki_types::{CertificateRevocationListDer, PrivatePkcs8KeyDer};
 use rustls::server::{Acceptor, ClientHello, ServerConfig, WebPkiClientVerifier};
+use rustls::{RootCertStore, VecInput};
 use rustls_aws_lc_rs::DEFAULT_PROVIDER;
 use rustls_util::{KeyLogFile, complete_io};
 
@@ -78,13 +78,13 @@ fn main() {
     for stream in listener.incoming() {
         let mut stream = stream.unwrap();
         let mut acceptor = Acceptor::default();
+        let mut input = VecInput::default();
 
         // Read TLS packets until we've consumed a full client hello and are ready to accept a
         // connection.
         let accepted = loop {
-            acceptor.read_tls(&mut stream).unwrap();
-
-            match acceptor.accept() {
+            input.read(&mut stream).unwrap();
+            match acceptor.accept(&mut input) {
                 Ok(Some(accepted)) => break accepted,
                 Ok(None) => continue,
                 Err((e, mut alert)) => {
@@ -107,7 +107,7 @@ fn main() {
 
         // Proceed with handling the ServerConnection
         // Important: We do no error handling here, but you should!
-        _ = complete_io(&mut stream, &mut conn);
+        _ = complete_io(&mut stream, &mut input, &mut conn);
     }
 }
 

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, ServerName};
-use rustls::{ClientConfig, RootCertStore};
+use rustls::{ClientConfig, RootCertStore, VecInput};
 use rustls_aws_lc_rs::DEFAULT_PROVIDER;
 use rustls_util::{KeyLogFile, Stream};
 
@@ -53,7 +53,8 @@ fn start_connection(config: &Arc<ClientConfig>, domain_name: &str, port: u16) {
         println!("  * 0-RTT request sent");
     }
 
-    let mut stream = Stream::new(&mut conn, &mut sock);
+    let mut input = VecInput::default();
+    let mut stream = Stream::new(&mut input, &mut conn, &mut sock);
 
     // Complete handshake.
     stream.flush().unwrap();

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -21,7 +21,7 @@ use std::{env, io};
 use rustls::crypto::Identity;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::{Connection, ServerConfig, ServerConnection};
+use rustls::{Connection, ServerConfig, ServerConnection, VecInput};
 use rustls_aws_lc_rs::DEFAULT_PROVIDER;
 use rustls_util::complete_io;
 
@@ -56,6 +56,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
 
         let mut conn = ServerConnection::new(Arc::new(config.clone()))?;
 
+        let mut input = VecInput::default();
         let mut buf = Vec::new();
         let mut did_early_data = false;
         'handshake: while conn.is_handshaking() {
@@ -69,7 +70,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
             stream.flush()?;
 
             while conn.wants_read() {
-                match conn.read_tls(&mut stream) {
+                match input.read(&mut stream) {
                     Ok(0) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into()),
                     Ok(_) => break,
                     Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
@@ -77,7 +78,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
                 };
             }
 
-            if let Err(e) = conn.process_new_packets() {
+            if let Err(e) = conn.process_new_packets(&mut input) {
                 let _ignored = conn.write_tls(&mut stream);
                 stream.flush()?;
 
@@ -109,6 +110,6 @@ fn main() -> Result<(), Box<dyn StdError>> {
         conn.writer()
             .write_all(b"Hello from the server")?;
         conn.send_close_notify();
-        complete_io(&mut stream, &mut conn)?;
+        complete_io(&mut stream, &mut input, &mut conn)?;
     }
 }

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -12,7 +12,7 @@ use std::io::{Read, Write, stdout};
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use rustls::{ClientConfig, RootCertStore};
+use rustls::{ClientConfig, RootCertStore, VecInput};
 use rustls_util::{KeyLogFile, Stream};
 
 fn main() {
@@ -34,7 +34,8 @@ fn main() {
         .build()
         .unwrap();
     let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
-    let mut tls = Stream::new(&mut conn, &mut sock);
+    let mut input = VecInput::default();
+    let mut tls = Stream::new(&mut input, &mut conn, &mut sock);
     tls.write_all(
         concat!(
             "GET / HTTP/1.1\r\n",

--- a/examples/src/bin/simpleserver.rs
+++ b/examples/src/bin/simpleserver.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use rustls::crypto::Identity;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::{ServerConfig, ServerConnection};
+use rustls::{ServerConfig, ServerConnection, VecInput};
 use rustls_aws_lc_rs::DEFAULT_PROVIDER;
 use rustls_util::Stream;
 
@@ -42,7 +42,8 @@ fn main() -> Result<(), Box<dyn StdError>> {
     let listener = TcpListener::bind(format!("[::]:{}", 4443)).unwrap();
     let (mut tcp_stream, _) = listener.accept()?;
     let mut conn = ServerConnection::new(Arc::new(config))?;
-    let mut tls_stream = Stream::new(&mut conn, &mut tcp_stream);
+    let mut input = VecInput::default();
+    let mut tls_stream = Stream::new(&mut input, &mut conn, &mut tcp_stream);
 
     tls_stream.write_all(b"Hello from the server")?;
     tls_stream.flush()?;

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -33,7 +33,7 @@ use rustls::crypto::{CryptoProvider, Identity};
 use rustls::enums::{ApplicationProtocol, ProtocolVersion};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
-use rustls::{ClientConfig, ClientConnection, Connection, RootCertStore};
+use rustls::{ClientConfig, ClientConnection, Connection, RootCertStore, VecInput};
 use rustls_aws_lc_rs as provider;
 use rustls_util::KeyLogFile;
 
@@ -46,6 +46,7 @@ struct TlsClient {
     closing: bool,
     clean_closure: bool,
     tls_conn: ClientConnection,
+    input: VecInput,
 }
 
 impl TlsClient {
@@ -58,6 +59,7 @@ impl TlsClient {
                 .connect(server_name)
                 .build()
                 .unwrap(),
+            input: VecInput::default(),
         }
     }
 
@@ -93,7 +95,7 @@ impl TlsClient {
     fn do_read(&mut self) {
         // Read TLS data.  This fails if the underlying TCP connection
         // is broken.
-        match self.tls_conn.read_tls(&mut self.socket) {
+        match self.input.read(&mut self.socket) {
             Err(error) => {
                 if error.kind() == io::ErrorKind::WouldBlock {
                     return;
@@ -117,7 +119,10 @@ impl TlsClient {
         // Reading some TLS data might have yielded new TLS
         // messages to process.  Errors from this indicate
         // TLS protocol problems and are fatal.
-        let io_state = match self.tls_conn.process_new_packets() {
+        let io_state = match self
+            .tls_conn
+            .process_new_packets(&mut self.input)
+        {
             Ok(io_state) => io_state,
             Err(err) => {
                 println!("TLS error: {err}");

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -33,7 +33,7 @@ use rustls::enums::{ApplicationProtocol, ProtocolVersion};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use rustls::server::{NoServerSessionStorage, WebPkiClientVerifier};
-use rustls::{Connection, RootCertStore, ServerConfig, ServerConnection};
+use rustls::{Connection, RootCertStore, ServerConfig, ServerConnection, VecInput};
 use rustls_aws_lc_rs as provider;
 use rustls_util::KeyLogFile;
 
@@ -130,6 +130,7 @@ struct OpenConnection {
     mode: ServerMode,
     tls_conn: ServerConnection,
     back: Option<TcpStream>,
+    input: VecInput,
     sent_http_response: bool,
 }
 
@@ -176,6 +177,7 @@ impl OpenConnection {
             mode,
             tls_conn,
             back,
+            input: VecInput::default(),
             sent_http_response: false,
         }
     }
@@ -217,7 +219,7 @@ impl OpenConnection {
 
     fn do_tls_read(&mut self) {
         // Read some TLS data.
-        match self.tls_conn.read_tls(&mut self.socket) {
+        match self.input.read(&mut self.socket) {
             Err(err) => {
                 if let io::ErrorKind::WouldBlock = err.kind() {
                     return;
@@ -236,7 +238,10 @@ impl OpenConnection {
         };
 
         // Process newly-received TLS messages.
-        if let Err(err) = self.tls_conn.process_new_packets() {
+        if let Err(err) = self
+            .tls_conn
+            .process_new_packets(&mut self.input)
+        {
             error!("cannot process packet: {err:?}");
 
             // last gasp write to send any alerts
@@ -248,7 +253,10 @@ impl OpenConnection {
 
     fn try_plain_read(&mut self) {
         // Read and process all available plaintext.
-        if let Ok(io_state) = self.tls_conn.process_new_packets() {
+        if let Ok(io_state) = self
+            .tls_conn
+            .process_new_packets(&mut self.input)
+        {
             if let Some(mut early_data) = self.tls_conn.early_data() {
                 let mut buf = Vec::new();
                 early_data

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -6,7 +6,7 @@ extern crate rustls;
 use std::io;
 use std::sync::Arc;
 
-use rustls::{ClientConfig, Connection};
+use rustls::{ClientConfig, Connection, VecInput};
 
 fuzz_target!(|data: &[u8]| {
     let _ = env_logger::try_init();
@@ -24,9 +24,13 @@ fuzz_target!(|data: &[u8]| {
         .unwrap();
 
     let mut stream = io::Cursor::new(data);
+    let mut input = VecInput::default();
     loop {
-        let rd = client.read_tls(&mut stream);
-        if client.process_new_packets().is_err() {
+        let rd = input.read(&mut stream);
+        if client
+            .process_new_packets(&mut input)
+            .is_err()
+        {
             break;
         }
 

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::sync::Arc;
 
 use rustls::server::{Accepted, Acceptor};
-use rustls::{Connection, ServerConfig, ServerConnection};
+use rustls::{Connection, ServerConfig, ServerConnection, VecInput};
 
 fuzz_target!(|data: &[u8]| {
     let _ = env_logger::try_init();
@@ -28,21 +28,19 @@ fn fuzz_buffered_api(data: &[u8]) {
     let mut stream = io::Cursor::new(data);
     let mut server = ServerConnection::new(config).unwrap();
 
-    service_connection(&mut stream, &mut server);
+    service_connection(&mut stream, &mut VecInput::default(), &mut server);
 }
 
 fn fuzz_acceptor_api(data: &[u8]) {
     let mut server = Acceptor::default();
     let mut stream = io::Cursor::new(data);
+    let mut input = VecInput::default();
 
     loop {
-        let rd = server
-            .read_tls(&mut stream)
-            .unwrap_or(0);
-
-        match server.accept() {
+        let rd = input.read(&mut stream).unwrap_or(0);
+        match server.accept(&mut input) {
             Ok(Some(accepted)) => {
-                fuzz_accepted(&mut stream, accepted);
+                fuzz_accepted(&mut stream, &mut input, accepted);
                 break;
             }
             Err(_) => {
@@ -56,7 +54,7 @@ fn fuzz_acceptor_api(data: &[u8]) {
     }
 }
 
-fn fuzz_accepted(stream: &mut dyn io::Read, accepted: Accepted) {
+fn fuzz_accepted(stream: &mut dyn io::Read, input: &mut VecInput, accepted: Accepted) {
     let mut maybe_server = accepted.into_connection(Arc::new(
         ServerConfig::builder(rustls_fuzzing_provider::PROVIDER.into())
             .with_no_client_auth()
@@ -65,14 +63,21 @@ fn fuzz_accepted(stream: &mut dyn io::Read, accepted: Accepted) {
     ));
 
     if let Ok(conn) = &mut maybe_server {
-        service_connection(stream, conn);
+        service_connection(stream, input, conn);
     }
 }
 
-fn service_connection(stream: &mut dyn io::Read, server: &mut ServerConnection) {
+fn service_connection(
+    stream: &mut dyn io::Read,
+    input: &mut VecInput,
+    server: &mut ServerConnection,
+) {
     loop {
-        let rd = server.read_tls(stream);
-        if server.process_new_packets().is_err() {
+        let rd = input.read(stream);
+        if server
+            .process_new_packets(input)
+            .is_err()
+        {
             break;
         }
 

--- a/openssl-tests/src/early_exporter.rs
+++ b/openssl-tests/src/early_exporter.rs
@@ -7,7 +7,7 @@ use openssl::ssl::{SslConnector, SslMethod, SslSession, SslStream};
 use rustls::crypto::Identity;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::{Connection, ServerConfig};
+use rustls::{Connection, ServerConfig, VecInput};
 use rustls_aws_lc_rs as provider;
 use rustls_util::complete_io;
 
@@ -37,12 +37,13 @@ fn test_early_exporter() {
         for _ in 0..ITERS {
             let mut server = rustls::ServerConnection::new(config.clone()).unwrap();
             let (mut tcp_stream, _addr) = listener.accept().unwrap();
+            let mut input = VecInput::default();
 
             // read clienthello and then inspect early_data status
+            input.read(&mut tcp_stream).unwrap();
             server
-                .read_tls(&mut tcp_stream)
+                .process_new_packets(&mut input)
                 .unwrap();
-            server.process_new_packets().unwrap();
 
             let message = if let Some(mut early) = server.early_data() {
                 let secret = early
@@ -68,7 +69,7 @@ fn test_early_exporter() {
                 .write_all(&message)
                 .unwrap();
 
-            complete_io(&mut tcp_stream, &mut server).unwrap();
+            complete_io(&mut tcp_stream, &mut input, &mut server).unwrap();
 
             tcp_stream.flush().unwrap();
         }

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -8,7 +8,7 @@ use openssl::ssl::{SslAcceptor, SslConnector, SslFiletype, SslMethod};
 use rustls::crypto::{CryptoProvider, Identity};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
-use rustls::{ClientConfig, Connection, RootCertStore, ServerConfig, ServerConnection};
+use rustls::{ClientConfig, Connection, RootCertStore, ServerConfig, ServerConnection, VecInput};
 use rustls_aws_lc_rs as provider;
 use rustls_util::complete_io;
 
@@ -38,12 +38,13 @@ fn test_rustls_server_with_ffdhe_kx(provider: CryptoProvider, iters: usize) {
         for _ in 0..iters {
             let mut server = ServerConnection::new(config.clone()).unwrap();
             let (mut tcp_stream, _addr) = listener.accept().unwrap();
+            let mut input = VecInput::default();
             server
                 .writer()
                 .write_all(message.as_bytes())
                 .unwrap();
 
-            complete_io(&mut tcp_stream, &mut server).unwrap();
+            complete_io(&mut tcp_stream, &mut input, &mut server).unwrap();
             tcp_stream.flush().unwrap();
         }
     });
@@ -136,12 +137,14 @@ fn test_rustls_client_with_ffdhe_kx(iters: usize) {
             .connect(server_name.clone())
             .build()
             .unwrap();
+        let mut input = VecInput::default();
+
         client
             .writer()
             .write_all(message.as_bytes())
             .unwrap();
 
-        complete_io(&mut tcp_stream, &mut client).unwrap();
+        complete_io(&mut tcp_stream, &mut input, &mut client).unwrap();
         client.send_close_notify();
         client
             .write_tls(&mut tcp_stream)

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -22,7 +22,7 @@ mod client {
     use rustls::pki_types::pem::PemObject;
     use rustls::pki_types::{PrivateKeyDer, SubjectPublicKeyInfoDer};
     use rustls::server::danger::SignatureVerificationInput;
-    use rustls::{ClientConfig, Error};
+    use rustls::{ClientConfig, Error, VecInput};
     use rustls_aws_lc_rs as provider;
     use rustls_util::Stream;
 
@@ -68,7 +68,8 @@ mod client {
             .build()
             .unwrap();
         let mut sock = TcpStream::connect(format!("[::]:{port}")).unwrap();
-        let mut tls = Stream::new(&mut conn, &mut sock);
+        let mut input = VecInput::default();
+        let mut tls = Stream::new(&mut input, &mut conn, &mut sock);
 
         let mut buf = vec![0; 128];
         let len = tls.read(&mut buf).unwrap();
@@ -162,7 +163,7 @@ mod server {
     use rustls::server::danger::{
         ClientIdentity, ClientVerifier, PeerVerified, SignatureVerificationInput,
     };
-    use rustls::{Connection, DistinguishedName, ServerConfig, ServerConnection};
+    use rustls::{Connection, DistinguishedName, ServerConfig, ServerConnection, VecInput};
     use rustls_aws_lc_rs as provider;
     use rustls_util::complete_io;
 
@@ -209,11 +210,12 @@ mod server {
         let (mut stream, _) = listener.accept()?;
 
         let mut conn = ServerConnection::new(Arc::new(config)).unwrap();
-        complete_io(&mut stream, &mut conn)?;
+        let mut input = VecInput::default();
+        complete_io(&mut stream, &mut input, &mut conn)?;
 
         conn.writer()
             .write_all(b"Hello from the server")?;
-        complete_io(&mut stream, &mut conn)?;
+        complete_io(&mut stream, &mut input, &mut conn)?;
 
         let mut buf = [0; 128];
 
@@ -221,12 +223,13 @@ mod server {
             match conn.reader().read(&mut buf) {
                 Ok(len) => {
                     conn.send_close_notify();
-                    complete_io(&mut stream, &mut conn)?;
+                    complete_io(&mut stream, &mut input, &mut conn)?;
                     return Ok(String::from_utf8_lossy(&buf[..len]).to_string());
                 }
                 Err(err) if err.kind() == ErrorKind::WouldBlock => {
-                    conn.read_tls(&mut stream)?;
-                    conn.process_new_packets().unwrap();
+                    input.read(&mut stream)?;
+                    conn.process_new_packets(&mut input)
+                        .unwrap();
                 }
                 Err(err) => {
                     return Err(err);

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -18,7 +18,7 @@ use rustls::enums::ProtocolVersion;
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::{
     ClientConfig, ClientConnection, Connection, HandshakeKind, RootCertStore, ServerConfig,
-    ServerConnection,
+    ServerConnection, VecInput,
 };
 use rustls_test::KeyType;
 
@@ -298,21 +298,47 @@ fn bench_handshake_buffered(
                 .build()
                 .unwrap()
         });
+        let mut client_input = VecInput::default();
         let mut server = time(&mut server_time, || {
             ServerConnection::new(server_config.clone()).unwrap()
         });
+        let mut server_input = VecInput::default();
 
         time(&mut server_time, || {
-            transfer(&mut buffers, &mut client, &mut server, None);
+            transfer(
+                &mut buffers,
+                &mut client,
+                &mut server_input,
+                &mut server,
+                None,
+            );
         });
         time(&mut client_time, || {
-            transfer(&mut buffers, &mut server, &mut client, None);
+            transfer(
+                &mut buffers,
+                &mut server,
+                &mut client_input,
+                &mut client,
+                None,
+            );
         });
         time(&mut server_time, || {
-            transfer(&mut buffers, &mut client, &mut server, None);
+            transfer(
+                &mut buffers,
+                &mut client,
+                &mut server_input,
+                &mut server,
+                None,
+            );
         });
         time(&mut client_time, || {
-            transfer(&mut buffers, &mut server, &mut client, None);
+            transfer(
+                &mut buffers,
+                &mut server,
+                &mut client_input,
+                &mut client,
+                None,
+            );
         });
 
         // check we reached idle
@@ -465,12 +491,20 @@ fn bench_bulk_buffered(
         .build()
         .unwrap();
     client.set_buffer_limit(None);
+    let mut client_input = VecInput::default();
     let mut server = ServerConnection::new(server_config).unwrap();
     server.set_buffer_limit(None);
+    let mut server_input = VecInput::default();
 
     let mut timings = Timings::default();
     let mut buffers = TempBuffers::new();
-    do_handshake(&mut buffers, &mut client, &mut server);
+    do_handshake(
+        &mut buffers,
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let buf = vec![0; plaintext_size as usize];
     for _ in 0..rounds {
@@ -478,7 +512,13 @@ fn bench_bulk_buffered(
             server.writer().write_all(&buf).unwrap();
         });
 
-        timings.client += transfer(&mut buffers, &mut server, &mut client, Some(buf.len()));
+        timings.client += transfer(
+            &mut buffers,
+            &mut server,
+            &mut client_input,
+            &mut client,
+            Some(buf.len()),
+        );
     }
 
     timings
@@ -519,14 +559,18 @@ fn bench_memory(
     let mut buffers = TempBuffers::new();
 
     for _i in 0..conn_count {
-        servers.push(ServerConnection::new(server_config.clone()).unwrap());
+        servers.push((
+            VecInput::default(),
+            ServerConnection::new(server_config.clone()).unwrap(),
+        ));
         let server_name = "localhost".try_into().unwrap();
-        clients.push(
+        clients.push((
+            VecInput::default(),
             client_config
                 .connect(server_name)
                 .build()
                 .unwrap(),
-        );
+        ));
     }
 
     for _step in 0..5 {
@@ -534,12 +578,19 @@ fn bench_memory(
             .iter_mut()
             .zip(servers.iter_mut())
         {
-            do_handshake_step(&mut buffers, client, server);
+            do_handshake_step(
+                &mut buffers,
+                &mut client.0,
+                &mut client.1,
+                &mut server.0,
+                &mut server.1,
+            );
         }
     }
 
     for client in clients.iter_mut() {
         client
+            .1
             .writer()
             .write_all(&[0u8; 1024])
             .unwrap();
@@ -549,7 +600,13 @@ fn bench_memory(
         .iter_mut()
         .zip(servers.iter_mut())
     {
-        transfer(&mut buffers, client, server, Some(1024));
+        transfer(
+            &mut buffers,
+            &mut client.1,
+            &mut server.0,
+            &mut server.1,
+            Some(1024),
+        );
     }
 }
 
@@ -931,12 +988,14 @@ impl From<RequestedKeyType> for KeyType {
 
 fn do_handshake_step(
     buffers: &mut TempBuffers,
+    client_input: &mut VecInput,
     client: &mut ClientConnection,
+    server_input: &mut VecInput,
     server: &mut ServerConnection,
 ) -> bool {
     if server.is_handshaking() || client.is_handshaking() {
-        transfer(buffers, client, server, None);
-        transfer(buffers, server, client, None);
+        transfer(buffers, client, server_input, server, None);
+        transfer(buffers, server, client_input, client, None);
         true
     } else {
         false
@@ -945,10 +1004,12 @@ fn do_handshake_step(
 
 fn do_handshake(
     buffers: &mut TempBuffers,
+    client_input: &mut VecInput,
     client: &mut ClientConnection,
+    server_input: &mut VecInput,
     server: &mut ServerConnection,
 ) {
-    while do_handshake_step(buffers, client, server) {}
+    while do_handshake_step(buffers, client_input, client, server_input, server) {}
 }
 
 fn time<F, T>(time_out: &mut f64, mut f: F) -> T
@@ -965,6 +1026,7 @@ where
 fn transfer(
     buffers: &mut TempBuffers,
     left: &mut impl Connection,
+    right_input: &mut VecInput,
     right: &mut impl Connection,
     expect_data: Option<usize>,
 ) -> f64 {
@@ -992,9 +1054,11 @@ fn transfer(
         let mut offs = 0;
         loop {
             let start = Instant::now();
-            match right.read_tls(&mut buffers.tls[offs..sz].as_ref()) {
+            match right_input.read(&mut buffers.tls[offs..sz].as_ref()) {
                 Ok(read) => {
-                    right.process_new_packets().unwrap();
+                    right
+                        .process_new_packets(right_input)
+                        .unwrap();
                     offs += read;
                 }
                 Err(err) => {

--- a/rustls-fuzzing-provider/tests/smoke.rs
+++ b/rustls-fuzzing-provider/tests/smoke.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::sync::Arc;
 
 use rustls::crypto::CryptoProvider;
-use rustls::{ClientConfig, Connection, ServerConfig, ServerConnection};
+use rustls::{ClientConfig, Connection, ServerConfig, ServerConnection, VecInput};
 
 // These tests exercise rustls_fuzzing_provider and makes sure it can
 // handshake with itself without errors.
@@ -103,6 +103,7 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         .unwrap();
 
     let mut transcript = Transcript::default();
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
 
     while client.is_handshaking() || server.is_handshaking() {
         let mut buffer = vec![];
@@ -112,10 +113,12 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         transcript
             .client_wrote
             .extend_from_slice(&buffer);
-        server
-            .read_tls(&mut &buffer[..])
+        server_input
+            .read(&mut &buffer[..])
             .unwrap();
-        server.process_new_packets().unwrap();
+        server
+            .process_new_packets(&mut server_input)
+            .unwrap();
 
         let mut buffer = vec![];
         server
@@ -124,10 +127,12 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         transcript
             .server_wrote
             .extend_from_slice(&buffer);
-        client
-            .read_tls(&mut &buffer[..])
+        client_input
+            .read(&mut &buffer[..])
             .unwrap();
-        client.process_new_packets().unwrap();
+        client
+            .process_new_packets(&mut client_input)
+            .unwrap();
     }
 
     transcript

--- a/rustls-post-quantum/examples/client.rs
+++ b/rustls-post-quantum/examples/client.rs
@@ -11,6 +11,9 @@ use std::io::{Read, Write, stdout};
 use std::net::TcpStream;
 use std::sync::Arc;
 
+use rustls::VecInput;
+use rustls_util::Stream;
+
 fn main() {
     env_logger::init();
 
@@ -32,7 +35,8 @@ fn main() {
         .build()
         .unwrap();
     let mut sock = TcpStream::connect("pq.cloudflareresearch.com:443").unwrap();
-    let mut tls = rustls_util::Stream::new(&mut conn, &mut sock);
+    let mut input = VecInput::default();
+    let mut tls = Stream::new(&mut input, &mut conn, &mut sock);
     tls.write_all(
         concat!(
             "GET /cdn-cgi/trace HTTP/1.0\r\n",

--- a/rustls-post-quantum/src/lib.rs
+++ b/rustls-post-quantum/src/lib.rs
@@ -292,7 +292,7 @@ mod tests {
         CertificateParams, CertifiedIssuer, ExtendedKeyUsagePurpose, IsCa, KeyPair, KeyUsagePurpose,
     };
     use rustls::crypto::Identity;
-    use rustls::{ClientConfig, RootCertStore, ServerConfig, ServerConnection};
+    use rustls::{ClientConfig, RootCertStore, ServerConfig, ServerConnection, VecInput};
     use rustls_test::do_handshake;
 
     use super::*;
@@ -336,7 +336,14 @@ mod tests {
         .build()
         .unwrap();
 
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
     }
 }

--- a/rustls-ring/benches/benchmarks.rs
+++ b/rustls-ring/benches/benchmarks.rs
@@ -1,13 +1,10 @@
-use std::sync::Arc;
-
 use bencher::{Bencher, benchmark_group, benchmark_main};
-use rustls::{Connection, ServerConnection};
-use rustls_test::{KeyType, TestNonBlockIo, make_server_config};
+use rustls::VecInput;
+use rustls_test::TestNonBlockIo;
 
 fn bench_ewouldblock(c: &mut Bencher) {
-    let server_config = make_server_config(KeyType::Rsa2048, &rustls_ring::DEFAULT_PROVIDER);
-    let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
-    c.iter(|| server.read_tls(&mut TestNonBlockIo::default()));
+    let mut input = VecInput::default();
+    c.iter(|| input.read(&mut TestNonBlockIo::default()));
 }
 
 benchmark_group!(benches, bench_ewouldblock);

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -33,7 +33,7 @@ use rustls::server::{
 use rustls::{
     ClientConfig, ClientConnection, ConfigBuilder, Connection, ConnectionTrafficSecrets,
     DistinguishedName, RootCertStore, ServerConfig, ServerConnection, SupportedCipherSuite,
-    WantsVerifier,
+    VecInput, WantsVerifier,
 };
 
 macro_rules! embed_files {
@@ -200,7 +200,7 @@ embed_files! {
     (RSA_4096_INTER_KEY, "rsa-4096", "inter.key");
 }
 
-pub fn transfer(left: &mut impl Connection, right: &mut impl Connection) -> usize {
+pub fn transfer(left: &mut impl Connection, right_input: &mut VecInput) -> usize {
     let mut buf = [0u8; 262144];
     let mut total = 0;
 
@@ -217,7 +217,7 @@ pub fn transfer(left: &mut impl Connection, right: &mut impl Connection) -> usiz
         let mut offs = 0;
         loop {
             let from_buf: &mut dyn io::Read = &mut &buf[offs..sz];
-            offs += right.read_tls(from_buf).unwrap();
+            offs += right_input.read(from_buf).unwrap();
             if sz == offs {
                 break;
             }
@@ -227,10 +227,10 @@ pub fn transfer(left: &mut impl Connection, right: &mut impl Connection) -> usiz
     total
 }
 
-pub fn transfer_eof(conn: &mut impl Connection) {
+pub fn transfer_eof(input: &mut VecInput) {
     let empty_buf = [0u8; 0];
     let empty_cursor: &mut dyn io::Read = &mut &empty_buf[..];
-    let sz = conn.read_tls(empty_cursor).unwrap();
+    let sz = input.read(empty_cursor).unwrap();
     assert_eq!(sz, 0);
 }
 
@@ -244,7 +244,7 @@ pub enum Altered {
 pub fn transfer_altered<F>(
     left: &mut impl Connection,
     filter: F,
-    right: &mut impl Connection,
+    right_input: &mut VecInput,
 ) -> usize
 where
     F: Fn(&mut EncodedMessage<Vec<u8>>) -> Altered,
@@ -296,8 +296,8 @@ where
             };
 
             let message_enc_reader: &mut dyn io::Read = &mut &message_enc[..];
-            let len = right
-                .read_tls(message_enc_reader)
+            let len = right_input
+                .read(message_enc_reader)
                 .unwrap();
             assert_eq!(len, message_enc.len());
         }
@@ -753,13 +753,22 @@ pub fn make_disjoint_suite_configs(provider: CryptoProvider) -> (ClientConfig, S
     (client_config, server_config)
 }
 
-pub fn do_handshake(client: &mut impl Connection, server: &mut impl Connection) -> (usize, usize) {
+pub fn do_handshake(
+    client_input: &mut VecInput,
+    client: &mut impl Connection,
+    server_input: &mut VecInput,
+    server: &mut impl Connection,
+) -> (usize, usize) {
     let (mut to_client, mut to_server) = (0, 0);
     while server.is_handshaking() || client.is_handshaking() {
-        to_server += transfer(client, server);
-        server.process_new_packets().unwrap();
-        to_client += transfer(server, client);
-        client.process_new_packets().unwrap();
+        to_server += transfer(client, server_input);
+        server
+            .process_new_packets(server_input)
+            .unwrap();
+        to_client += transfer(server, client_input);
+        client
+            .process_new_packets(client_input)
+            .unwrap();
     }
     (to_server, to_client)
 }
@@ -771,17 +780,19 @@ pub enum ErrorFromPeer {
 }
 
 pub fn do_handshake_until_error(
+    client_input: &mut VecInput,
     client: &mut ClientConnection,
+    server_input: &mut VecInput,
     server: &mut ServerConnection,
 ) -> Result<(), ErrorFromPeer> {
     while server.is_handshaking() || client.is_handshaking() {
-        transfer(client, server);
+        transfer(client, server_input);
         server
-            .process_new_packets()
+            .process_new_packets(server_input)
             .map_err(ErrorFromPeer::Server)?;
-        transfer(server, client);
+        transfer(server, client_input);
         client
-            .process_new_packets()
+            .process_new_packets(client_input)
             .map_err(ErrorFromPeer::Client)?;
     }
 
@@ -794,17 +805,19 @@ pub fn do_handshake_altered(
     alter_client_message: impl Fn(&mut EncodedMessage<Vec<u8>>) -> Altered,
     mut server: ServerConnection,
 ) -> Result<(), ErrorFromPeer> {
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     while server.is_handshaking() || client.is_handshaking() {
-        transfer_altered(&mut client, &alter_client_message, &mut server);
+        transfer_altered(&mut client, &alter_client_message, &mut server_input);
 
         server
-            .process_new_packets()
+            .process_new_packets(&mut server_input)
             .map_err(ErrorFromPeer::Server)?;
 
-        transfer_altered(&mut server, &alter_server_message, &mut client);
+        transfer_altered(&mut server, &alter_server_message, &mut client_input);
 
         client
-            .process_new_packets()
+            .process_new_packets(&mut client_input)
             .map_err(ErrorFromPeer::Client)?;
     }
 
@@ -812,15 +825,17 @@ pub fn do_handshake_altered(
 }
 
 pub fn do_handshake_until_both_error(
+    client_input: &mut VecInput,
     client: &mut ClientConnection,
+    server_input: &mut VecInput,
     server: &mut ServerConnection,
 ) -> Result<(), Vec<ErrorFromPeer>> {
-    match do_handshake_until_error(client, server) {
+    match do_handshake_until_error(client_input, client, server_input, server) {
         Err(server_err @ ErrorFromPeer::Server(_)) => {
             let mut errors = vec![server_err];
-            transfer(server, client);
+            transfer(server, client_input);
             let client_err = client
-                .process_new_packets()
+                .process_new_packets(client_input)
                 .map_err(ErrorFromPeer::Client)
                 .expect_err("client didn't produce error after server error");
             errors.push(client_err);
@@ -829,9 +844,9 @@ pub fn do_handshake_until_both_error(
 
         Err(client_err @ ErrorFromPeer::Client(_)) => {
             let mut errors = vec![client_err];
-            transfer(client, server);
+            transfer(client, server_input);
             let server_err = server
-                .process_new_packets()
+                .process_new_packets(server_input)
                 .map_err(ErrorFromPeer::Server)
                 .expect_err("server didn't produce error after client error");
             errors.push(server_err);
@@ -920,6 +935,8 @@ pub fn do_suite_and_kx_test(
         expect_suite.suite()
     );
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     assert_eq!(None, client.negotiated_cipher_suite());
     assert_eq!(None, server.negotiated_cipher_suite());
@@ -938,8 +955,10 @@ pub fn do_suite_and_kx_test(
     assert!(client.is_handshaking());
     assert!(server.is_handshaking());
 
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     assert!(client.is_handshaking());
     assert!(server.is_handshaking());
@@ -968,8 +987,10 @@ pub fn do_suite_and_kx_test(
         );
     }
 
-    transfer(&mut server, &mut client);
-    client.process_new_packets().unwrap();
+    transfer(&mut server, &mut client_input);
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
 
     assert_eq!(Some(expect_suite), client.negotiated_cipher_suite());
     assert_eq!(Some(expect_suite), server.negotiated_cipher_suite());
@@ -996,10 +1017,14 @@ pub fn do_suite_and_kx_test(
         );
     }
 
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
-    transfer(&mut server, &mut client);
-    client.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
+    transfer(&mut server, &mut client_input);
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
 
     assert!(!client.is_handshaking());
     assert!(!server.is_handshaking());
@@ -1345,7 +1370,7 @@ impl RawTls {
     pub fn encrypt_and_send(
         &mut self,
         msg: &EncodedMessage<Payload<'_>>,
-        peer: &mut impl Connection,
+        peer_input: &mut VecInput,
     ) {
         let data = self
             .encrypter
@@ -1353,7 +1378,8 @@ impl RawTls {
             .unwrap()
             .encode();
         self.enc_seq += 1;
-        peer.read_tls(&mut io::Cursor::new(data))
+        peer_input
+            .read(&mut io::Cursor::new(data))
             .unwrap();
     }
 
@@ -1559,6 +1585,7 @@ impl ServerCredentialResolver for ServerCheckCertResolve {
 
 pub struct OtherSession<'a, C: Connection> {
     sess: &'a mut C,
+    input: &'a mut VecInput,
     pub reads: usize,
     /// Writevs(Chunks(Bytes))
     pub writevs: Vec<Vec<Vec<u8>>>,
@@ -1570,9 +1597,10 @@ pub struct OtherSession<'a, C: Connection> {
 }
 
 impl<'a, C: Connection> OtherSession<'a, C> {
-    pub fn new(sess: &'a mut C) -> Self {
+    pub fn new(input: &'a mut VecInput, sess: &'a mut C) -> Self {
         OtherSession {
             sess,
+            input,
             reads: 0,
             writevs: vec![],
             fail_ok: false,
@@ -1583,14 +1611,14 @@ impl<'a, C: Connection> OtherSession<'a, C> {
         }
     }
 
-    pub fn new_buffered(sess: &'a mut C) -> Self {
-        let mut os = OtherSession::new(sess);
+    pub fn new_buffered(input: &'a mut VecInput, sess: &'a mut C) -> Self {
+        let mut os = OtherSession::new(input, sess);
         os.buffered = true;
         os
     }
 
-    pub fn new_fails(sess: &'a mut C) -> Self {
-        let mut os = OtherSession::new(sess);
+    pub fn new_fails(input: &'a mut VecInput, sess: &'a mut C) -> Self {
+        let mut os = OtherSession::new(input, sess);
         os.fail_ok = true;
         os
     }
@@ -1610,8 +1638,8 @@ impl<'a, C: Connection> OtherSession<'a, C> {
             };
 
             let l = self
-                .sess
-                .read_tls(&mut io::Cursor::new(&bytes[..write_len]))?;
+                .input
+                .read(&mut io::Cursor::new(&bytes[..write_len]))?;
             chunks.push(bytes[..write_len].to_vec());
             total += l;
             if bytes.len() != l {
@@ -1619,7 +1647,9 @@ impl<'a, C: Connection> OtherSession<'a, C> {
             }
         }
 
-        let rc = self.sess.process_new_packets();
+        let rc = self
+            .sess
+            .process_new_packets(self.input);
         if !self.fail_ok {
             rc.unwrap();
         } else if rc.is_err() {

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -23,7 +23,7 @@ use rustls::server::{
 };
 use rustls::{
     ClientConfig, ClientConnection, Connection as _, HandshakeKind, KeyingMaterialExporter,
-    ServerConfig, ServerConnection, SupportedCipherSuite,
+    ServerConfig, ServerConnection, SupportedCipherSuite, VecInput,
 };
 #[cfg(feature = "aws-lc-rs")]
 use rustls::{
@@ -65,10 +65,17 @@ fn alpn_test_error(
 
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
         assert_eq!(client.alpn_protocol(), None);
         assert_eq!(server.alpn_protocol(), None);
-        let error = do_handshake_until_error(&mut client, &mut server);
+        let error = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(client.alpn_protocol(), agreed.as_ref());
         assert_eq!(server.alpn_protocol(), agreed.as_ref());
         assert_eq!(error.err(), expected_error);
@@ -136,7 +143,15 @@ fn connection_level_alpn_protocols() {
         .build()
         .unwrap();
     let mut server = ServerConnection::new(server_config.clone()).unwrap();
-    do_handshake_until_error(&mut client, &mut server).unwrap();
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake_until_error(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    )
+    .unwrap();
     assert_eq!(client.alpn_protocol(), Some(&ApplicationProtocol::Http2));
 
     // Specify `http/1.1` for the connection, server agrees
@@ -146,7 +161,15 @@ fn connection_level_alpn_protocols() {
         .build()
         .unwrap();
     let mut server = ServerConnection::new(server_config).unwrap();
-    do_handshake_until_error(&mut client, &mut server).unwrap();
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake_until_error(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    )
+    .unwrap();
     assert_eq!(client.alpn_protocol(), Some(&ApplicationProtocol::Http11));
 }
 
@@ -179,8 +202,10 @@ fn unoffered_alpn_test(check_selected_alpn: bool) -> Result<rustls::IoState, Err
     client
         .write_tls(&mut Vec::new())
         .unwrap();
-    client
-        .read_tls(
+
+    let mut input = VecInput::default();
+    input
+        .read(
             &mut encoding::message_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
@@ -195,7 +220,8 @@ fn unoffered_alpn_test(check_selected_alpn: bool) -> Result<rustls::IoState, Err
             .as_slice(),
         )
         .unwrap();
-    client.process_new_packets()
+
+    client.process_new_packets(&mut input)
 }
 
 fn version_test(
@@ -213,14 +239,26 @@ fn version_test(
     println!("version {client_versions:?} {server_versions:?} -> {result:?}");
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     assert_eq!(client.protocol_version(), None);
     assert_eq!(server.protocol_version(), None);
     if result.is_none() {
-        let err = do_handshake_until_error(&mut client, &mut server);
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert!(err.is_err());
     } else {
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(client.protocol_version(), result);
         assert_eq!(server.protocol_version(), result);
     }
@@ -385,7 +423,14 @@ fn client_can_get_server_cert() {
             let client_config = make_client_config(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_configs(client_config, make_server_config(*kt, &provider));
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(client.peer_identity().unwrap(), &*kt.identity());
         }
     }
@@ -400,14 +445,28 @@ fn client_can_get_server_cert_after_resumption() {
             let client_config = make_client_config(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_configs(client_config.clone(), server_config.clone());
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
 
             let original_certs = client.peer_identity();
 
             let (mut client, mut server) =
                 make_pair_for_configs(client_config.clone(), server_config.clone());
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
 
             let resumed_certs = client.peer_identity();
@@ -429,7 +488,14 @@ fn server_can_get_client_cert() {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(server.peer_identity().unwrap(), &*kt.client_identity());
         }
     }
@@ -448,12 +514,26 @@ fn server_can_get_client_cert_after_resumption() {
             let client_config = Arc::new(client_config);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&client_config, &server_config);
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             let original_certs = server.peer_identity();
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&client_config, &server_config);
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             let resumed_certs = server.peer_identity();
             assert_eq!(original_certs, resumed_certs);
         }
@@ -496,19 +576,22 @@ fn test_config_builders_debug() {
 #[test]
 fn test_tls13_valid_early_plaintext_alert() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut server_input = VecInput::default();
 
     // Perform the start of a TLS 1.3 handshake, sending a client hello to the server.
     // The client will not have written a CCS or any encrypted messages to the server yet.
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     // Inject a plaintext alert from the client. The server should accept this since:
     //  * It hasn't decrypted any messages from the peer yet.
     //  * The message content type is Alert.
     //  * The payload size is indicative of a plaintext alert message.
     //  * The negotiated protocol version is TLS 1.3.
-    server
-        .read_tls(&mut io::Cursor::new(&encoding::alert(
+    server_input
+        .read(&mut io::Cursor::new(&encoding::alert(
             AlertDescription::UnknownCa,
             &[],
         )))
@@ -516,7 +599,7 @@ fn test_tls13_valid_early_plaintext_alert() {
 
     // The server should process the plaintext alert without error.
     assert_eq!(
-        server.process_new_packets(),
+        server.process_new_packets(&mut server_input),
         Err(Error::AlertReceived(AlertDescription::UnknownCa)),
     );
 }
@@ -524,43 +607,59 @@ fn test_tls13_valid_early_plaintext_alert() {
 #[test]
 fn test_tls13_too_short_early_plaintext_alert() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut server_input = VecInput::default();
 
     // Perform the start of a TLS 1.3 handshake, sending a client hello to the server.
     // The client will not have written a CCS or any encrypted messages to the server yet.
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     // Inject a plaintext alert from the client. The server should attempt to decrypt this message
     // because the payload length is too large to be considered an early plaintext alert.
-    server
-        .read_tls(&mut io::Cursor::new(&encoding::alert(
+    server_input
+        .read(&mut io::Cursor::new(&encoding::alert(
             AlertDescription::UnknownCa,
             &[0xff],
         )))
         .unwrap();
 
     // The server should produce a decrypt error trying to decrypt the plaintext alert.
-    assert_eq!(server.process_new_packets(), Err(Error::DecryptError),);
+    assert_eq!(
+        server.process_new_packets(&mut server_input),
+        Err(Error::DecryptError),
+    );
 }
 
 #[test]
 fn test_tls13_late_plaintext_alert() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     // Complete a bi-directional TLS1.3 handshake. After this point no plaintext messages
     // should occur.
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     // Inject a plaintext alert from the client. The server should attempt to decrypt this message.
-    server
-        .read_tls(&mut io::Cursor::new(&encoding::alert(
+    server_input
+        .read(&mut io::Cursor::new(&encoding::alert(
             AlertDescription::UnknownCa,
             &[],
         )))
         .unwrap();
 
     // The server should produce a decrypt error, trying to decrypt a plaintext alert.
-    assert_eq!(server.process_new_packets(), Err(Error::DecryptError));
+    assert_eq!(
+        server.process_new_packets(&mut server_input),
+        Err(Error::DecryptError)
+    );
 }
 
 #[test]
@@ -571,7 +670,13 @@ fn server_rejects_empty_post_handshake_alert_fragment() {
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     // Encrypt and send an alert record whose (decrypted) fragment is empty.
     // Per RFC 8446 section 5.4, empty handshake and alert fragments must be rejected.
@@ -582,10 +687,10 @@ fn server_rejects_empty_post_handshake_alert_fragment() {
             version: ProtocolVersion::TLSv1_3,
             payload: Payload::new(vec![]),
         },
-        &mut server,
+        &mut server_input,
     );
     assert_eq!(
-        server.process_new_packets(),
+        server.process_new_packets(&mut server_input),
         Err(PeerMisbehaved::EmptyFragment.into())
     );
 
@@ -599,28 +704,30 @@ fn server_rejects_empty_post_handshake_alert_fragment() {
 #[test]
 fn client_error_is_sticky() {
     let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    client
-        .read_tls(&mut b"\x16\x03\x03\x00\x08\x0f\x00\x00\x04junk".as_ref())
+    let mut client_input = VecInput::default();
+    client_input
+        .read(&mut b"\x16\x03\x03\x00\x08\x0f\x00\x00\x04junk".as_ref())
         .unwrap();
     client
-        .process_new_packets()
+        .process_new_packets(&mut client_input)
         .unwrap_err();
     client
-        .process_new_packets()
+        .process_new_packets(&mut client_input)
         .unwrap_err();
 }
 
 #[test]
 fn server_error_is_sticky() {
     let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    server
-        .read_tls(&mut b"\x16\x03\x03\x00\x08\x0f\x00\x00\x04junk".as_ref())
+    let mut server_input = VecInput::default();
+    server_input
+        .read(&mut b"\x16\x03\x03\x00\x08\x0f\x00\x00\x04junk".as_ref())
         .unwrap();
     server
-        .process_new_packets()
+        .process_new_packets(&mut server_input)
         .unwrap_err();
     server
-        .process_new_packets()
+        .process_new_packets(&mut server_input)
         .unwrap_err();
 }
 
@@ -677,7 +784,14 @@ fn server_exposes_offered_sni() {
             ServerConnection::new(Arc::new(make_server_config(kt, &provider))).unwrap();
 
         assert_eq!(None, server.server_name());
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             Some(&DnsName::try_from("second.testserver.com").unwrap()),
             server.server_name()
@@ -701,7 +815,14 @@ fn server_exposes_offered_sni_smashed_to_lowercase() {
             ServerConnection::new(Arc::new(make_server_config(kt, &provider))).unwrap();
 
         assert_eq!(None, server.server_name());
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             Some(&DnsName::try_from("second.testserver.com").unwrap()),
             server.server_name()
@@ -771,10 +892,17 @@ fn do_exporter_test(
     let mut server_secret = [0u8; 64];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     assert_eq!(Some(Error::HandshakeNotComplete), client.exporter().err());
     assert_eq!(Some(Error::HandshakeNotComplete), server.exporter().err());
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let client_exporter = client.exporter().unwrap();
     let server_exporter = server.exporter().unwrap();
@@ -867,7 +995,14 @@ fn test_extended_master_secret_reporting() {
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     assert_eq!(client.extended_master_secret(), None);
     assert_eq!(server.extended_master_secret(), None);
-    do_handshake(&mut client, &mut server);
+
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert_eq!(client.extended_master_secret(), Some(true));
     assert_eq!(server.extended_master_secret(), Some(true));
 
@@ -877,7 +1012,13 @@ fn test_extended_master_secret_reporting() {
     let client_config = make_client_config(KeyType::Rsa2048, &provider);
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert_eq!(client.extended_master_secret(), None);
     assert_eq!(server.extended_master_secret(), None);
 }
@@ -889,7 +1030,14 @@ fn test_tls13_exporter_maximum_output_length() {
     let server_config = make_server_config(KeyType::EcdsaP256, &provider);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     assert_eq!(
         client.negotiated_cipher_suite(),
@@ -1142,12 +1290,16 @@ fn test_client_rejects_illegal_tls13_ccs() {
     }
 
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
-    transfer_altered(&mut server, corrupt_ccs, &mut client);
+    transfer_altered(&mut server, corrupt_ccs, &mut client_input);
     assert_eq!(
-        client.process_new_packets(),
+        client.process_new_packets(&mut client_input),
         Err(Error::PeerMisbehaved(
             PeerMisbehaved::IllegalMiddleboxChangeCipherSpec
         ))
@@ -1165,7 +1317,14 @@ fn test_no_warning_logging_during_successful_sessions() {
             let client_config = make_client_config(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_configs(client_config, make_server_config(*kt, &provider));
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
         }
     }
 
@@ -1200,7 +1359,14 @@ fn test_explicit_provider_selection() {
         ServerConfig::builder(rustls_aws_lc_rs::DEFAULT_PROVIDER.into()).finish(KeyType::Rsa2048);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 }
 
 #[derive(Debug)]
@@ -1337,13 +1503,28 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
 
     // successful handshake to allow resumption
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     // resumption
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
-    transfer_altered(&mut server, inject_corrupt_finished_message, &mut client);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
+    transfer_altered(
+        &mut server,
+        inject_corrupt_finished_message,
+        &mut client_input,
+    );
 
     // discard storage operations up to this point, to observe the one we want to test for.
     storage.ops_and_reset();
@@ -1352,7 +1533,9 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
     // server resumption is buggy.
     assert_eq!(
         Some(Error::DecryptError),
-        client.process_new_packets().err()
+        client
+            .process_new_packets(&mut client_input)
+            .err()
     );
 
     assert!(matches!(
@@ -1479,7 +1662,14 @@ fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
     server_config.enable_secret_extraction = true;
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let mut raw_server = RawTls::new_server(server);
 
@@ -1491,9 +1681,9 @@ fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
             vec![],
         )),
     };
-    raw_server.encrypt_and_send(&msg, &mut client);
+    raw_server.encrypt_and_send(&msg, &mut client_input);
     let err = client
-        .process_new_packets()
+        .process_new_packets(&mut client_input)
         .unwrap_err();
     assert_eq!(
         err,
@@ -1512,7 +1702,14 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
     server_config.enable_secret_extraction = true;
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let mut raw_server = RawTls::new_server(server);
 
@@ -1526,8 +1723,10 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
     };
 
     // one is allowed (and elicits a warning alert)
-    raw_server.encrypt_and_send(&msg, &mut client);
-    client.process_new_packets().unwrap();
+    raw_server.encrypt_and_send(&msg, &mut client_input);
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
     raw_server.receive_and_decrypt(&mut client, |m| {
         assert_eq!(m.version, ProtocolVersion::TLSv1_2);
         assert_eq!(m.typ, ContentType::Alert);
@@ -1535,10 +1734,10 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
     });
 
     // second is fatal
-    raw_server.encrypt_and_send(&msg, &mut client);
+    raw_server.encrypt_and_send(&msg, &mut client_input);
     assert_eq!(
         client
-            .process_new_packets()
+            .process_new_packets(&mut client_input)
             .unwrap_err(),
         Error::PeerMisbehaved(PeerMisbehaved::TooManyRenegotiationRequests)
     );
@@ -1552,7 +1751,14 @@ fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let mut raw_client = RawTls::new_client(client);
 
@@ -1561,9 +1767,9 @@ fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
         version: ProtocolVersion::TLSv1_3,
         payload: Payload::new(encoding::basic_client_hello(vec![])),
     };
-    raw_client.encrypt_and_send(&msg, &mut server);
+    raw_client.encrypt_and_send(&msg, &mut server_input);
     let err = server
-        .process_new_packets()
+        .process_new_packets(&mut server_input)
         .unwrap_err();
     assert_eq!(
         format!("{err:?}"),
@@ -1577,21 +1783,22 @@ fn test_illegal_client_renegotiation_attempt_during_tls12_handshake() {
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
     let client_config = make_client_config(KeyType::Rsa2048, &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut server_input = VecInput::default();
 
     let mut client_hello = vec![];
     client
         .write_tls(&mut io::Cursor::new(&mut client_hello))
         .unwrap();
 
-    server
-        .read_tls(&mut io::Cursor::new(&client_hello))
+    server_input
+        .read(&mut io::Cursor::new(&client_hello))
         .unwrap();
-    server
-        .read_tls(&mut io::Cursor::new(&client_hello))
+    server_input
+        .read(&mut io::Cursor::new(&client_hello))
         .unwrap();
     assert_eq!(
         server
-            .process_new_packets()
+            .process_new_packets(&mut server_input)
             .unwrap_err(),
         Error::InappropriateHandshakeMessage {
             expect_types: vec![HandshakeType::ClientKeyExchange],
@@ -1623,6 +1830,7 @@ fn tls13_packed_handshake() {
         .connect(server_name("localhost"))
         .build()
         .unwrap();
+    let mut client_input = VecInput::default();
 
     let mut hello = Vec::new();
     client
@@ -1630,18 +1838,20 @@ fn tls13_packed_handshake() {
         .unwrap();
 
     let first_flight = include_bytes!("../data/bug2040-message-1.bin");
-    client
-        .read_tls(&mut io::Cursor::new(first_flight))
+    client_input
+        .read(&mut io::Cursor::new(first_flight))
         .unwrap();
-    client.process_new_packets().unwrap();
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
 
     let second_flight = include_bytes!("../data/bug2040-message-2.bin");
-    client
-        .read_tls(&mut io::Cursor::new(second_flight))
+    client_input
+        .read(&mut io::Cursor::new(second_flight))
         .unwrap();
     assert_eq!(
         client
-            .process_new_packets()
+            .process_new_packets(&mut client_input)
             .unwrap_err(),
         Error::InvalidCertificate(CertificateError::UnknownIssuer),
     );
@@ -1650,25 +1860,29 @@ fn tls13_packed_handshake() {
 #[test]
 fn large_client_hello() {
     let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut server_input = VecInput::default();
     let hello = include_bytes!("../data/bug2227-clienthello.bin");
     let mut cursor = io::Cursor::new(hello);
     loop {
-        if server.read_tls(&mut cursor).unwrap() == 0 {
+        if server_input.read(&mut cursor).unwrap() == 0 {
             break;
         }
-        server.process_new_packets().unwrap();
+        server
+            .process_new_packets(&mut server_input)
+            .unwrap();
     }
 }
 
 #[test]
 fn large_client_hello_acceptor() {
     let mut acceptor = Acceptor::default();
+    let mut input = VecInput::default();
     let hello = include_bytes!("../data/bug2227-clienthello.bin");
     let mut cursor = io::Cursor::new(hello);
     loop {
-        acceptor.read_tls(&mut cursor).unwrap();
+        input.read(&mut cursor).unwrap();
 
-        if let Some(accepted) = acceptor.accept().unwrap() {
+        if let Some(accepted) = acceptor.accept(&mut input).unwrap() {
             println!("{accepted:?}");
             break;
         }
@@ -1681,8 +1895,9 @@ fn acceptor_with_illegal_max_fragment_size() {
     server_config.max_fragment_size = Some(31);
 
     let mut acceptor = Acceptor::default();
-    acceptor
-        .read_tls(
+    let mut input = VecInput::default();
+    input
+        .read(
             &mut encoding::message_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
@@ -1692,7 +1907,10 @@ fn acceptor_with_illegal_max_fragment_size() {
         )
         .unwrap();
 
-    let accepted = acceptor.accept().unwrap().unwrap();
+    let accepted = acceptor
+        .accept(&mut input)
+        .unwrap()
+        .unwrap();
     let (err, mut alert) = accepted
         .into_connection(Arc::new(server_config))
         .err()
@@ -1716,10 +1934,11 @@ fn excess_client_hello_acceptor() {
     let hello = encoding::message_framing(ContentType::Handshake, ProtocolVersion::TLSv1_2, hello);
 
     let mut acceptor = Acceptor::default();
-    acceptor
-        .read_tls(&mut io::Cursor::new(hello))
+    let mut input = VecInput::default();
+    input
+        .read(&mut io::Cursor::new(hello))
         .unwrap();
-    let (error, mut alert) = acceptor.accept().unwrap_err();
+    let (error, mut alert) = acceptor.accept(&mut input).unwrap_err();
     assert_eq!(error, PeerMisbehaved::KeyEpochWithPendingFragment.into());
 
     let mut alert_buf = vec![];
@@ -1797,10 +2016,11 @@ fn server_invalid_sni_policy() {
             .build()
             .unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+        let mut server_input = VecInput::default();
 
-        transfer_altered(&mut client, replace_sni(sni), &mut server);
+        transfer_altered(&mut client, replace_sni(sni), &mut server_input);
         assert_eq!(
-            &server.process_new_packets(),
+            &server.process_new_packets(&mut server_input),
             match expected_result {
                 Accept | AcceptNoSni => &accept_result,
                 Reject => &reject_result,

--- a/rustls-test/tests/api/client_cert_verifier.rs
+++ b/rustls-test/tests/api/client_cert_verifier.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use rustls::error::{AlertDescription, CertificateError, Error, InvalidMessage, PeerMisbehaved};
 use rustls::server::danger::PeerVerified;
-use rustls::{ServerConfig, ServerConnection};
+use rustls::{ServerConfig, ServerConnection, VecInput};
 use rustls_test::{
     ErrorFromPeer, KeyType, MockClientVerifier, do_handshake, do_handshake_until_both_error,
     do_handshake_until_error, make_client_config, make_client_config_with_auth,
@@ -55,7 +55,14 @@ fn client_verifier_works() {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config.clone()), &server_config);
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(err, Ok(()));
         }
     }
@@ -75,7 +82,14 @@ fn client_verifier_no_schemes() {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config.clone()), &server_config);
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 err,
                 Err(ErrorFromPeer::Client(Error::InvalidMessage(
@@ -104,7 +118,14 @@ fn client_verifier_no_auth_yes_root() {
                 .build()
                 .unwrap();
 
-            let errs = do_handshake_until_both_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let errs = do_handshake_until_both_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 errs,
                 Err(vec![
@@ -136,7 +157,14 @@ fn client_verifier_fails_properly() {
                 .connect(server_name("localhost"))
                 .build()
                 .unwrap();
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 err,
                 Err(ErrorFromPeer::Server(Error::General("test err".into())))
@@ -175,7 +203,14 @@ fn server_allow_any_anonymous_or_authenticated_client() {
             };
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(server.peer_identity(), client_cert_chain.as_deref());
         }
     }
@@ -193,7 +228,14 @@ fn client_auth_works() {
             let client_config = make_client_config_with_auth(*kt, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
         }
     }
 }
@@ -244,7 +286,14 @@ fn client_mandatory_auth_client_revocation_works() {
             let client_config = Arc::new(make_client_config_with_auth(*kt, &version_provider));
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&client_config, &revoked_server_config);
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 err,
                 Err(ErrorFromPeer::Server(Error::InvalidCertificate(
@@ -255,7 +304,14 @@ fn client_mandatory_auth_client_revocation_works() {
             // fail with the expected unknown revocation status error.
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&client_config, &missing_client_crl_server_config);
-            let res = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let res = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 res,
                 Err(ErrorFromPeer::Server(Error::InvalidCertificate(
@@ -266,7 +322,15 @@ fn client_mandatory_auth_client_revocation_works() {
             // if the server's verifier allows unknown revocation status.
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&client_config, &allow_missing_client_crl_server_config);
-            do_handshake_until_error(&mut client, &mut server).unwrap();
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            )
+            .unwrap();
         }
     }
 }
@@ -307,7 +371,14 @@ fn client_mandatory_auth_intermediate_revocation_works() {
             let client_config = Arc::new(make_client_config_with_auth(*kt, &version_provider));
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&client_config, &full_chain_server_config);
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 err,
                 Err(ErrorFromPeer::Server(Error::InvalidCertificate(
@@ -318,7 +389,15 @@ fn client_mandatory_auth_intermediate_revocation_works() {
             // revocation status should not be checked.
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&client_config, &ee_server_config);
-            do_handshake_until_error(&mut client, &mut server).unwrap();
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            )
+            .unwrap();
         }
     }
 }
@@ -339,7 +418,14 @@ fn client_optional_auth_client_revocation_works() {
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
             // Because the client certificate is revoked, the handshake should fail.
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 err,
                 Err(ErrorFromPeer::Server(Error::InvalidCertificate(

--- a/rustls-test/tests/api/compress.rs
+++ b/rustls-test/tests/api/compress.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 #[cfg(feature = "zlib")]
 use rustls::ClientConfig;
-use rustls::Connection;
 #[cfg(feature = "zlib")]
 use rustls::client::Resumption;
 #[cfg(feature = "zlib")]
@@ -16,6 +15,7 @@ use rustls::enums::CertificateCompressionAlgorithm;
 use rustls::error::{AlertDescription, Error, InvalidMessage, PeerMisbehaved};
 #[cfg(feature = "zlib")]
 use rustls::pki_types::CertificateDer;
+use rustls::{Connection, VecInput};
 #[cfg(feature = "zlib")]
 use rustls_test::{ClientConfigExt, make_pair_for_arc_configs};
 use rustls_test::{
@@ -43,7 +43,14 @@ fn test_server_uses_cached_compressed_certificates() {
     for _i in 0..10 {
         dbg!(_i);
         let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         dbg!(client.handshake_kind());
     }
 
@@ -77,7 +84,14 @@ fn test_server_uses_uncompressed_certificate_if_compression_fails() {
     client_config.cert_decompressors = vec![&NeverDecompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 }
 
 #[test]
@@ -90,7 +104,14 @@ fn test_client_uses_uncompressed_certificate_if_compression_fails() {
     client_config.cert_compressors = vec![&FailingCompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 }
 
 #[derive(Debug)]
@@ -146,7 +167,14 @@ fn test_server_can_opt_out_of_compression_cache() {
     for _i in 0..10 {
         dbg!(_i);
         let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         dbg!(client.handshake_kind());
     }
 
@@ -181,15 +209,22 @@ fn test_cert_decompression_by_client_produces_invalid_cert_payload() {
     client_config.cert_decompressors = vec![&GarbageDecompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     assert_eq!(
-        do_handshake_until_error(&mut client, &mut server),
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server
+        ),
         Err(ErrorFromPeer::Client(Error::InvalidMessage(
             InvalidMessage::CertificatePayloadTooLarge
         )))
     );
-    transfer(&mut client, &mut server);
+    transfer(&mut client, &mut server_input);
     assert_eq!(
-        server.process_new_packets(),
+        server.process_new_packets(&mut server_input),
         Err(Error::AlertReceived(AlertDescription::BadCertificate))
     );
 }
@@ -204,15 +239,22 @@ fn test_cert_decompression_by_server_produces_invalid_cert_payload() {
     client_config.cert_compressors = vec![&IdentityCompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     assert_eq!(
-        do_handshake_until_error(&mut client, &mut server),
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server
+        ),
         Err(ErrorFromPeer::Server(Error::InvalidMessage(
             InvalidMessage::CertificatePayloadTooLarge
         )))
     );
-    transfer(&mut server, &mut client);
+    transfer(&mut server, &mut client_input);
     assert_eq!(
-        client.process_new_packets(),
+        client.process_new_packets(&mut client_input),
         Err(Error::AlertReceived(AlertDescription::BadCertificate))
     );
 }
@@ -227,15 +269,22 @@ fn test_cert_decompression_by_server_fails() {
     client_config.cert_compressors = vec![&IdentityCompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     assert_eq!(
-        do_handshake_until_error(&mut client, &mut server),
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server
+        ),
         Err(ErrorFromPeer::Server(Error::PeerMisbehaved(
             PeerMisbehaved::InvalidCertCompression
         )))
     );
-    transfer(&mut server, &mut client);
+    transfer(&mut server, &mut client_input);
     assert_eq!(
-        client.process_new_packets(),
+        client.process_new_packets(&mut client_input),
         Err(Error::AlertReceived(AlertDescription::BadCertificate))
     );
 }
@@ -261,15 +310,22 @@ fn test_cert_decompression_by_server_would_result_in_excessively_large_cert() {
         .unwrap();
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     assert_eq!(
-        do_handshake_until_error(&mut client, &mut server),
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server
+        ),
         Err(ErrorFromPeer::Server(Error::InvalidMessage(
             InvalidMessage::CertificatePayloadTooLarge
         )))
     );
-    transfer(&mut server, &mut client);
+    transfer(&mut server, &mut client_input);
     assert_eq!(
-        client.process_new_packets(),
+        client.process_new_packets(&mut client_input),
         Err(Error::AlertReceived(AlertDescription::BadCertificate))
     );
 }

--- a/rustls-test/tests/api/crypto.rs
+++ b/rustls-test/tests/api/crypto.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use rustls::crypto::{Credentials, CryptoProvider};
 use rustls::{
     ClientConfig, ClientConnection, Connection, ConnectionTrafficSecrets, Error, KeyLog,
-    ServerConfig, ServerConnection, SupportedCipherSuite,
+    ServerConfig, ServerConnection, SupportedCipherSuite, VecInput,
 };
 use rustls_test::{
     ClientConfigExt, KeyType, ServerConfigExt, aes_128_gcm_with_1024_confidentiality_limit,
@@ -35,9 +35,17 @@ fn key_log_for_tls12() {
     server_config.key_log = server_key_log.clone();
     let server_config = Arc::new(server_config);
 
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+
     // full handshake
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let client_full_log = client_key_log.take();
     let server_full_log = server_key_log.take();
@@ -47,7 +55,12 @@ fn key_log_for_tls12() {
 
     // resumed
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let client_resume_log = client_key_log.take();
     let server_resume_log = server_key_log.take();
@@ -72,9 +85,17 @@ fn key_log_for_tls13() {
     server_config.key_log = server_key_log.clone();
     let server_config = Arc::new(server_config);
 
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+
     // full handshake
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let client_full_log = client_key_log.take();
     let server_full_log = server_key_log.take();
@@ -94,7 +115,12 @@ fn key_log_for_tls13() {
 
     // resumed
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let client_resume_log = client_key_log.take();
     let server_resume_log = server_key_log.take();
@@ -185,6 +211,8 @@ fn test_secret_extraction_enabled() {
     // Chacha20Poly1305), so that's 2*3 = 6 combinations to test.
     let kt = KeyType::Rsa2048;
     let provider = provider::DEFAULT_PROVIDER;
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     for suite in [
         SupportedCipherSuite::Tls13(cipher_suite::TLS13_AES_128_GCM_SHA256),
         SupportedCipherSuite::Tls13(cipher_suite::TLS13_AES_256_GCM_SHA384),
@@ -213,7 +241,12 @@ fn test_secret_extraction_enabled() {
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         // The handshake is finished, we're now able to extract traffic secrets
         let client_secrets = client
@@ -254,6 +287,8 @@ fn test_secret_extraction_enabled() {
 fn test_secret_extract_produces_correct_variant() {
     fn check(suite: SupportedCipherSuite, f: impl Fn(ConnectionTrafficSecrets) -> bool) {
         let kt = KeyType::Rsa2048;
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
         let provider: Arc<CryptoProvider> =
             provider_with_one_suite(&provider::DEFAULT_PROVIDER, suite).into();
@@ -269,7 +304,12 @@ fn test_secret_extract_produces_correct_variant() {
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         let client_secrets = client
             .dangerous_extract_secrets()
@@ -316,6 +356,8 @@ fn test_secret_extract_produces_correct_variant() {
 #[test]
 fn test_secret_extraction_disabled_or_too_early() {
     let kt = KeyType::Rsa2048;
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     let provider = Arc::new(CryptoProvider {
         tls13_cipher_suites: Cow::Owned(vec![cipher_suite::TLS13_AES_128_GCM_SHA256]),
         ..provider::DEFAULT_PROVIDER
@@ -349,7 +391,12 @@ fn test_secret_extraction_disabled_or_too_early() {
 
         let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         assert_eq!(
             server_enable,
@@ -386,9 +433,21 @@ fn test_refresh_traffic_keys_during_handshake() {
 #[test]
 fn test_refresh_traffic_keys() {
     let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
-    fn check_both_directions(client: &mut ClientConnection, server: &mut ServerConnection) {
+    fn check_both_directions(
+        client_input: &mut VecInput,
+        client: &mut ClientConnection,
+        server_input: &mut VecInput,
+        server: &mut ServerConnection,
+    ) {
         client
             .writer()
             .write_all(b"to-server-1")
@@ -397,11 +456,15 @@ fn test_refresh_traffic_keys() {
             .writer()
             .write_all(b"to-client-1")
             .unwrap();
-        transfer(client, server);
-        server.process_new_packets().unwrap();
+        transfer(client, server_input);
+        server
+            .process_new_packets(server_input)
+            .unwrap();
 
-        transfer(server, client);
-        client.process_new_packets().unwrap();
+        transfer(server, client_input);
+        client
+            .process_new_packets(client_input)
+            .unwrap();
 
         let mut buf = [0u8; 16];
         let len = server.reader().read(&mut buf).unwrap();
@@ -411,11 +474,26 @@ fn test_refresh_traffic_keys() {
         assert_eq!(&buf[..len], b"to-client-1");
     }
 
-    check_both_directions(&mut client, &mut server);
+    check_both_directions(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     client.refresh_traffic_keys().unwrap();
-    check_both_directions(&mut client, &mut server);
+    check_both_directions(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     server.refresh_traffic_keys().unwrap();
-    check_both_directions(&mut client, &mut server);
+    check_both_directions(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 }
 
 #[test]
@@ -434,7 +512,14 @@ fn test_automatic_refresh_traffic_keys() {
     let server_config = ServerConfig::builder(provider).finish(KeyType::Ed25519);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     for i in 0..(CONFIDENTIALITY_LIMIT + 16) {
         let message = format!("{i:08}");
@@ -442,12 +527,14 @@ fn test_automatic_refresh_traffic_keys() {
             .writer()
             .write_all(message.as_bytes())
             .unwrap();
-        let transferred = transfer(&mut client, &mut server);
+        let transferred = transfer(&mut client, &mut server_input);
         println!(
             "{}: {} -> {:?}",
             i,
             transferred,
-            server.process_new_packets().unwrap()
+            server
+                .process_new_packets(&mut server_input)
+                .unwrap()
         );
 
         // at CONFIDENTIALITY_LIMIT messages, we also have a key_update message sent
@@ -470,12 +557,14 @@ fn test_automatic_refresh_traffic_keys() {
         .writer()
         .write_all(message)
         .unwrap();
-    let transferred = transfer(&mut server, &mut client);
+    let transferred = transfer(&mut server, &mut client_input);
 
     println!(
         "F: {} -> {:?}",
         transferred,
-        client.process_new_packets().unwrap()
+        client
+            .process_new_packets(&mut client_input)
+            .unwrap()
     );
     assert_eq!(transferred, KEY_UPDATE_SIZE + encrypted_size(message.len()));
 }
@@ -493,7 +582,14 @@ fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
     let server_config = ServerConfig::builder(provider).finish(KeyType::Ed25519);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     for i in 0..CONFIDENTIALITY_LIMIT {
         let message = format!("{i:08}");
@@ -501,12 +597,14 @@ fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
             .writer()
             .write_all(message.as_bytes())
             .unwrap();
-        let transferred = transfer(&mut client, &mut server);
+        let transferred = transfer(&mut client, &mut server_input);
         println!(
             "{}: {} -> {:?}",
             i,
             transferred,
-            server.process_new_packets().unwrap()
+            server
+                .process_new_packets(&mut server_input)
+                .unwrap()
         );
 
         let mut buf = [0u8; 32];

--- a/rustls-test/tests/api/ffdhe.rs
+++ b/rustls-test/tests/api/ffdhe.rs
@@ -13,7 +13,7 @@ use rustls::crypto::kx::{
 };
 use rustls::crypto::{CipherSuite, CipherSuiteCommon, CryptoProvider};
 use rustls::enums::ProtocolVersion;
-use rustls::{ClientConfig, ServerConfig, SupportedCipherSuite, Tls12CipherSuite};
+use rustls::{ClientConfig, ServerConfig, SupportedCipherSuite, Tls12CipherSuite, VecInput};
 use rustls_test::{
     ClientConfigExt, KeyType, ServerConfigExt, do_handshake, do_suite_and_kx_test,
     make_pair_for_arc_configs, make_pair_for_configs, provider_with_one_suite,
@@ -108,7 +108,14 @@ fn server_avoids_dhe_cipher_suites_when_client_has_no_known_dhe_in_groups_ext() 
     .finish(KeyType::Rsa2048);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert_eq!(
         server
             .negotiated_cipher_suite()
@@ -233,7 +240,14 @@ fn server_avoids_cipher_suite_with_no_common_kx_groups() {
             .into();
 
         let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             server
                 .negotiated_cipher_suite()

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -16,7 +16,7 @@ use rustls::error::{
     AlertDescription, ApiMisuse, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved,
 };
 use rustls::server::Acceptor;
-use rustls::{ClientConfig, Connection, HandshakeKind, ServerConfig, ServerConnection};
+use rustls::{ClientConfig, Connection, HandshakeKind, ServerConfig, ServerConnection, VecInput};
 use rustls_test::{
     ClientConfigExt, KeyType, OtherSession, ServerConfigExt, TestNonBlockIo, check_fill_buf,
     check_fill_buf_err, check_read, check_read_and_close, check_read_err, do_handshake, encoding,
@@ -40,13 +40,22 @@ fn buffered_client_data_sent() {
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
         assert_eq!(0, server.writer().write(b"").unwrap());
         assert_eq!(5, client.writer().write(b"hello").unwrap());
 
-        do_handshake(&mut client, &mut server);
-        transfer(&mut client, &mut server);
-        server.process_new_packets().unwrap();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        transfer(&mut client, &mut server_input);
+        server
+            .process_new_packets(&mut server_input)
+            .unwrap();
 
         check_read(&mut server.reader(), b"hello");
     }
@@ -63,13 +72,22 @@ fn buffered_server_data_sent() {
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
         assert_eq!(0, server.writer().write(b"").unwrap());
         assert_eq!(5, server.writer().write(b"hello").unwrap());
 
-        do_handshake(&mut client, &mut server);
-        transfer(&mut server, &mut client);
-        client.process_new_packets().unwrap();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        transfer(&mut server, &mut client_input);
+        client
+            .process_new_packets(&mut client_input)
+            .unwrap();
 
         check_read(&mut client.reader(), b"hello");
     }
@@ -86,6 +104,8 @@ fn buffered_both_data_sent() {
         let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
         assert_eq!(
             12,
@@ -102,12 +122,21 @@ fn buffered_both_data_sent() {
                 .unwrap()
         );
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
-        transfer(&mut server, &mut client);
-        client.process_new_packets().unwrap();
-        transfer(&mut client, &mut server);
-        server.process_new_packets().unwrap();
+        transfer(&mut server, &mut client_input);
+        client
+            .process_new_packets(&mut client_input)
+            .unwrap();
+        transfer(&mut client, &mut server_input);
+        server
+            .process_new_packets(&mut server_input)
+            .unwrap();
 
         check_read(&mut client.reader(), b"from-server!");
         check_read(&mut server.reader(), b"from-client!");
@@ -117,6 +146,8 @@ fn buffered_both_data_sent() {
 #[test]
 fn server_respects_buffer_limit_pre_handshake() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     server.set_buffer_limit(Some(32));
 
@@ -135,9 +166,16 @@ fn server_respects_buffer_limit_pre_handshake() {
         12
     );
 
-    do_handshake(&mut client, &mut server);
-    transfer(&mut server, &mut client);
-    client.process_new_packets().unwrap();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
+    transfer(&mut server, &mut client_input);
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
 
     check_read(&mut client.reader(), b"01234567890123456789012345678901");
 }
@@ -145,6 +183,8 @@ fn server_respects_buffer_limit_pre_handshake() {
 #[test]
 fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     server.set_buffer_limit(Some(32));
 
@@ -159,9 +199,16 @@ fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
         32
     );
 
-    do_handshake(&mut client, &mut server);
-    transfer(&mut server, &mut client);
-    client.process_new_packets().unwrap();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
+    transfer(&mut server, &mut client_input);
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
 
     check_read(&mut client.reader(), b"01234567890123456789012345678901");
 }
@@ -169,9 +216,16 @@ fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
 #[test]
 fn server_respects_buffer_limit_post_handshake() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     // this test will vary in behaviour depending on the default suites
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     server.set_buffer_limit(Some(48));
 
     assert_eq!(
@@ -189,8 +243,10 @@ fn server_respects_buffer_limit_post_handshake() {
         6
     );
 
-    transfer(&mut server, &mut client);
-    client.process_new_packets().unwrap();
+    transfer(&mut server, &mut client_input);
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
 
     check_read(&mut client.reader(), b"01234567890123456789012345");
 }
@@ -198,6 +254,8 @@ fn server_respects_buffer_limit_post_handshake() {
 #[test]
 fn client_respects_buffer_limit_pre_handshake() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     client.set_buffer_limit(Some(32));
 
@@ -216,9 +274,16 @@ fn client_respects_buffer_limit_pre_handshake() {
         12
     );
 
-    do_handshake(&mut client, &mut server);
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     check_read(&mut server.reader(), b"01234567890123456789012345678901");
 }
@@ -226,6 +291,8 @@ fn client_respects_buffer_limit_pre_handshake() {
 #[test]
 fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     client.set_buffer_limit(Some(32));
 
@@ -240,9 +307,16 @@ fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
         32
     );
 
-    do_handshake(&mut client, &mut server);
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     check_read(&mut server.reader(), b"01234567890123456789012345678901");
 }
@@ -250,8 +324,15 @@ fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
 #[test]
 fn client_respects_buffer_limit_post_handshake() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     client.set_buffer_limit(Some(48));
 
     assert_eq!(
@@ -269,8 +350,10 @@ fn client_respects_buffer_limit_post_handshake() {
         6
     );
 
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     check_read(&mut server.reader(), b"01234567890123456789012345");
 }
@@ -307,17 +390,26 @@ fn client_detects_broken_write_vectored_impl() {
 #[test]
 fn buf_read() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     // Write two separate messages ensuring that empty messages are not written
     assert_eq!(client.writer().write(b"").unwrap(), 0);
     assert_eq!(client.writer().write(b"hello").unwrap(), 5);
-    transfer(&mut client, &mut server);
+    transfer(&mut client, &mut server_input);
     assert_eq!(client.writer().write(b"world").unwrap(), 5);
     assert_eq!(client.writer().write(b"").unwrap(), 0);
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     let mut reader = server.reader();
     // fill_buf() returns each record separately (this is an implementation detail)
@@ -368,7 +460,10 @@ fn client_fill_buf_returns_wouldblock_when_no_data() {
 #[test]
 fn new_server_returns_initial_io_state() {
     let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    let io_state = server.process_new_packets().unwrap();
+    let mut server_input = VecInput::default();
+    let io_state = server
+        .process_new_packets(&mut server_input)
+        .unwrap();
     println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
     assert!(!io_state.peer_has_closed());
@@ -378,7 +473,10 @@ fn new_server_returns_initial_io_state() {
 #[test]
 fn new_client_returns_initial_io_state() {
     let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    let io_state = client.process_new_packets().unwrap();
+    let mut client_input = VecInput::default();
+    let io_state = client
+        .process_new_packets(&mut client_input)
+        .unwrap();
     println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
     assert!(!io_state.peer_has_closed());
@@ -388,9 +486,16 @@ fn new_client_returns_initial_io_state() {
 #[test]
 fn client_complete_io_for_handshake() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     assert!(client.is_handshaking());
-    let (rdlen, wrlen) = complete_io(&mut OtherSession::new(&mut server), &mut client).unwrap();
+    let (rdlen, wrlen) = complete_io(
+        &mut OtherSession::new(&mut server_input, &mut server),
+        &mut client_input,
+        &mut client,
+    )
+    .unwrap();
     assert!(rdlen > 0 && wrlen > 0);
     assert!(!client.is_handshaking());
     assert!(!client.wants_write());
@@ -399,10 +504,16 @@ fn client_complete_io_for_handshake() {
 #[test]
 fn buffered_client_complete_io_for_handshake() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     assert!(client.is_handshaking());
-    let (rdlen, wrlen) =
-        complete_io(&mut OtherSession::new_buffered(&mut server), &mut client).unwrap();
+    let (rdlen, wrlen) = complete_io(
+        &mut OtherSession::new_buffered(&mut server_input, &mut server),
+        &mut client_input,
+        &mut client,
+    )
+    .unwrap();
     assert!(rdlen > 0 && wrlen > 0);
     assert!(!client.is_handshaking());
     assert!(!client.wants_write());
@@ -411,10 +522,11 @@ fn buffered_client_complete_io_for_handshake() {
 #[test]
 fn client_complete_io_for_handshake_eof() {
     let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
     let mut input = io::Cursor::new(Vec::new());
 
     assert!(client.is_handshaking());
-    let err = complete_io(&mut input, &mut client).unwrap_err();
+    let err = complete_io(&mut input, &mut client_input, &mut client).unwrap_err();
     assert_eq!(io::ErrorKind::UnexpectedEof, err.kind());
 }
 
@@ -423,8 +535,15 @@ fn client_complete_io_for_write() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         client
             .writer()
@@ -435,8 +554,8 @@ fn client_complete_io_for_write() {
             .write_all(b"01234567890123456789")
             .unwrap();
         {
-            let mut pipe = OtherSession::new(&mut server);
-            let (rdlen, wrlen) = complete_io(&mut pipe, &mut client).unwrap();
+            let mut pipe = OtherSession::new(&mut server_input, &mut server);
+            let (rdlen, wrlen) = complete_io(&mut pipe, &mut client_input, &mut client).unwrap();
             assert!(rdlen == 0 && wrlen > 0);
             println!("{:?}", pipe.writev_lengths());
             assert_eq!(pipe.writev_lengths(), vec![vec![42, 42]]);
@@ -451,23 +570,30 @@ fn client_complete_io_for_write() {
 #[test]
 fn client_complete_io_with_nonblocking_io() {
     let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
 
     // absolutely no progress writing ClientHello
     assert_eq!(
-        complete_io(&mut TestNonBlockIo::default(), &mut client)
-            .unwrap_err()
-            .kind(),
+        complete_io(
+            &mut TestNonBlockIo::default(),
+            &mut client_input,
+            &mut client
+        )
+        .unwrap_err()
+        .kind(),
         io::ErrorKind::WouldBlock
     );
 
     // a little progress writing ClientHello
     let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
     assert_eq!(
         complete_io(
             &mut TestNonBlockIo {
                 writes: vec![1],
                 reads: vec![],
             },
+            &mut client_input,
             &mut client
         )
         .unwrap(),
@@ -476,12 +602,14 @@ fn client_complete_io_with_nonblocking_io() {
 
     // complete writing ClientHello
     let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
     assert_eq!(
         complete_io(
             &mut TestNonBlockIo {
                 writes: vec![4096],
                 reads: vec![],
             },
+            &mut client_input,
             &mut client
         )
         .unwrap_err()
@@ -491,11 +619,13 @@ fn client_complete_io_with_nonblocking_io() {
 
     // complete writing ClientHello, partial read of ServerHello
     let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
     let (rd, wr) = dbg!(complete_io(
         &mut TestNonBlockIo {
             writes: vec![4096],
             reads: vec![vec![ContentType::Handshake.into()]],
         },
+        &mut client_input,
         &mut client
     ))
     .unwrap();
@@ -504,7 +634,14 @@ fn client_complete_io_with_nonblocking_io() {
 
     // data phase:
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     // read
     assert_eq!(
@@ -513,6 +650,7 @@ fn client_complete_io_with_nonblocking_io() {
                 reads: vec![vec![ContentType::ApplicationData.into()]],
                 writes: vec![],
             },
+            &mut client_input,
             &mut client
         )
         .unwrap(),
@@ -532,6 +670,7 @@ fn client_complete_io_with_nonblocking_io() {
                 reads: vec![],
                 writes: vec![],
             },
+            &mut client_input,
             &mut client
         )
         .unwrap_err()
@@ -546,6 +685,7 @@ fn client_complete_io_with_nonblocking_io() {
                 reads: vec![],
                 writes: vec![1],
             },
+            &mut client_input,
             &mut client
         )
         .unwrap(),
@@ -558,8 +698,15 @@ fn buffered_client_complete_io_for_write() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         client
             .writer()
@@ -570,8 +717,8 @@ fn buffered_client_complete_io_for_write() {
             .write_all(b"01234567890123456789")
             .unwrap();
         {
-            let mut pipe = OtherSession::new_buffered(&mut server);
-            let (rdlen, wrlen) = complete_io(&mut pipe, &mut client).unwrap();
+            let mut pipe = OtherSession::new_buffered(&mut server_input, &mut server);
+            let (rdlen, wrlen) = complete_io(&mut pipe, &mut client_input, &mut client).unwrap();
             assert!(rdlen == 0 && wrlen > 0);
             println!("{:?}", pipe.writev_lengths());
             assert_eq!(pipe.writev_lengths(), vec![vec![42, 42]]);
@@ -588,16 +735,23 @@ fn client_complete_io_for_read() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         server
             .writer()
             .write_all(b"01234567890123456789")
             .unwrap();
         {
-            let mut pipe = OtherSession::new(&mut server);
-            let (rdlen, wrlen) = complete_io(&mut pipe, &mut client).unwrap();
+            let mut pipe = OtherSession::new(&mut server_input, &mut server);
+            let (rdlen, wrlen) = complete_io(&mut pipe, &mut client_input, &mut client).unwrap();
             assert!(rdlen > 0 && wrlen == 0);
             assert_eq!(pipe.reads, 1);
         }
@@ -610,9 +764,16 @@ fn server_complete_io_for_handshake() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
         assert!(server.is_handshaking());
-        let (rdlen, wrlen) = complete_io(&mut OtherSession::new(&mut client), &mut server).unwrap();
+        let (rdlen, wrlen) = complete_io(
+            &mut OtherSession::new(&mut client_input, &mut client),
+            &mut server_input,
+            &mut server,
+        )
+        .unwrap();
         assert!(rdlen > 0 && wrlen > 0);
         assert!(!server.is_handshaking());
         assert!(!server.wants_write());
@@ -622,10 +783,11 @@ fn server_complete_io_for_handshake() {
 #[test]
 fn server_complete_io_for_handshake_eof() {
     let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut server_input = VecInput::default();
     let mut input = io::Cursor::new(Vec::new());
 
     assert!(server.is_handshaking());
-    let err = complete_io(&mut input, &mut server).unwrap_err();
+    let err = complete_io(&mut input, &mut server_input, &mut server).unwrap_err();
     assert_eq!(io::ErrorKind::UnexpectedEof, err.kind());
 }
 
@@ -634,8 +796,15 @@ fn server_complete_io_for_write() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         server
             .writer()
@@ -646,8 +815,8 @@ fn server_complete_io_for_write() {
             .write_all(b"01234567890123456789")
             .unwrap();
         {
-            let mut pipe = OtherSession::new(&mut client);
-            let (rdlen, wrlen) = complete_io(&mut pipe, &mut server).unwrap();
+            let mut pipe = OtherSession::new(&mut client_input, &mut client);
+            let (rdlen, wrlen) = complete_io(&mut pipe, &mut server_input, &mut server).unwrap();
             assert!(rdlen == 0 && wrlen > 0);
             assert_eq!(pipe.writev_lengths(), vec![vec![42, 42]]);
         }
@@ -663,8 +832,15 @@ fn server_complete_io_for_write_eof() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         // Queue 20 bytes to write.
         server
@@ -676,12 +852,14 @@ fn server_complete_io_for_write_eof() {
             let mut eof_writer = EofWriter::<BYTES_BEFORE_EOF>::default();
 
             // Only BYTES_BEFORE_EOF should be written.
-            let (rdlen, wrlen) = complete_io(&mut eof_writer, &mut server).unwrap();
+            let (rdlen, wrlen) =
+                complete_io(&mut eof_writer, &mut server_input, &mut server).unwrap();
             assert_eq!(rdlen, 0);
             assert_eq!(wrlen, BYTES_BEFORE_EOF);
 
             // Now nothing should be written.
-            let (rdlen, wrlen) = complete_io(&mut eof_writer, &mut server).unwrap();
+            let (rdlen, wrlen) =
+                complete_io(&mut eof_writer, &mut server_input, &mut server).unwrap();
             assert_eq!(rdlen, 0);
             assert_eq!(wrlen, 0);
         }
@@ -716,16 +894,23 @@ fn server_complete_io_for_read() {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         client
             .writer()
             .write_all(b"01234567890123456789")
             .unwrap();
         {
-            let mut pipe = OtherSession::new(&mut client);
-            let (rdlen, wrlen) = complete_io(&mut pipe, &mut server).unwrap();
+            let mut pipe = OtherSession::new(&mut client_input, &mut client);
+            let (rdlen, wrlen) = complete_io(&mut pipe, &mut server_input, &mut server).unwrap();
             assert!(rdlen > 0 && wrlen == 0);
             assert_eq!(pipe.reads, 1);
         }
@@ -737,11 +922,13 @@ fn server_complete_io_for_read() {
 fn server_complete_io_for_handshake_ending_with_alert() {
     let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     assert!(server.is_handshaking());
 
-    let mut pipe = OtherSession::new_fails(&mut client);
-    let rc = complete_io(&mut pipe, &mut server);
+    let mut pipe = OtherSession::new_fails(&mut client_input, &mut client);
+    let rc = complete_io(&mut pipe, &mut server_input, &mut server);
     assert!(rc.is_err(), "server io failed due to handshake failure");
     assert!(!server.wants_write(), "but server did send its alert");
     assert_eq!(
@@ -773,11 +960,13 @@ fn test_client_stream_write(stream_kind: StreamKind) {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
         let data = b"hello";
         {
-            let mut pipe = OtherSession::new(&mut server);
+            let mut pipe = OtherSession::new(&mut server_input, &mut server);
             let mut stream: Box<dyn Write> = match stream_kind {
-                StreamKind::Ref => Box::new(Stream::new(&mut client, &mut pipe)),
+                StreamKind::Ref => Box::new(Stream::new(&mut client_input, &mut client, &mut pipe)),
                 StreamKind::Owned => Box::new(StreamOwned::new(client, pipe)),
             };
             assert_eq!(stream.write(data).unwrap(), 5);
@@ -790,11 +979,13 @@ fn test_server_stream_write(stream_kind: StreamKind) {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
         let data = b"hello";
         {
-            let mut pipe = OtherSession::new(&mut client);
+            let mut pipe = OtherSession::new(&mut client_input, &mut client);
             let mut stream: Box<dyn Write> = match stream_kind {
-                StreamKind::Ref => Box::new(Stream::new(&mut server, &mut pipe)),
+                StreamKind::Ref => Box::new(Stream::new(&mut server_input, &mut server, &mut pipe)),
                 StreamKind::Owned => Box::new(StreamOwned::new(server, pipe)),
             };
             assert_eq!(stream.write(data).unwrap(), 5);
@@ -842,15 +1033,17 @@ fn test_client_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
         let data = b"world";
         server.writer().write_all(data).unwrap();
 
         {
-            let mut pipe = OtherSession::new(&mut server);
-            transfer_eof(&mut client);
+            let mut pipe = OtherSession::new(&mut server_input, &mut server);
+            transfer_eof(&mut client_input);
 
             let stream: Box<dyn BufRead> = match stream_kind {
-                StreamKind::Ref => Box::new(Stream::new(&mut client, &mut pipe)),
+                StreamKind::Ref => Box::new(Stream::new(&mut client_input, &mut client, &mut pipe)),
                 StreamKind::Owned => Box::new(StreamOwned::new(client, pipe)),
             };
 
@@ -863,15 +1056,17 @@ fn test_server_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
     let provider = provider::DEFAULT_PROVIDER;
     for kt in KeyType::all_for_provider(&provider) {
         let (mut client, mut server) = make_pair(*kt, &provider);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
         let data = b"world";
         client.writer().write_all(data).unwrap();
 
         {
-            let mut pipe = OtherSession::new(&mut client);
-            transfer_eof(&mut server);
+            let mut pipe = OtherSession::new(&mut client_input, &mut client);
+            transfer_eof(&mut server_input);
 
             let stream: Box<dyn BufRead> = match stream_kind {
-                StreamKind::Ref => Box::new(Stream::new(&mut server, &mut pipe)),
+                StreamKind::Ref => Box::new(Stream::new(&mut server_input, &mut server, &mut pipe)),
                 StreamKind::Owned => Box::new(StreamOwned::new(server, pipe)),
             };
 
@@ -883,7 +1078,14 @@ fn test_server_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
 #[test]
 fn test_client_write_and_vectored_write_equivalence() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     const N: usize = 1000;
 
@@ -892,7 +1094,7 @@ fn test_client_write_and_vectored_write_equivalence() {
         .writer()
         .write_vectored(&data_chunked)
         .unwrap();
-    let bytes_sent_chunked = transfer(&mut client, &mut server);
+    let bytes_sent_chunked = transfer(&mut client, &mut server_input);
     println!("write_vectored returned {bytes_written_chunked} and sent {bytes_sent_chunked}");
 
     let data_contiguous = &[b'A'; N];
@@ -900,7 +1102,7 @@ fn test_client_write_and_vectored_write_equivalence() {
         .writer()
         .write(data_contiguous)
         .unwrap();
-    let bytes_sent_contiguous = transfer(&mut client, &mut server);
+    let bytes_sent_contiguous = transfer(&mut client, &mut server_input);
     println!("write returned {bytes_written_contiguous} and sent {bytes_sent_contiguous}");
 
     assert_eq!(bytes_written_chunked, bytes_written_contiguous);
@@ -910,13 +1112,20 @@ fn test_client_write_and_vectored_write_equivalence() {
 #[test]
 fn test_write_vectored_degenerate_cases() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     // empty writes accepted and ignored
     assert_eq!(client.writer().write_vectored(&[]).ok(), Some(0));
     assert_eq!(server.writer().write_vectored(&[]).ok(), Some(0));
-    assert_eq!(transfer(&mut client, &mut server), 0);
-    assert_eq!(transfer(&mut server, &mut client), 0);
+    assert_eq!(transfer(&mut client, &mut server_input), 0);
+    assert_eq!(transfer(&mut server, &mut client_input), 0);
 
     // single writes equiv. normal writes
     assert_eq!(
@@ -933,10 +1142,14 @@ fn test_write_vectored_degenerate_cases() {
             .ok(),
         Some(6)
     );
-    assert!(transfer(&mut client, &mut server) > 0);
-    assert!(transfer(&mut server, &mut client) > 0);
-    server.process_new_packets().unwrap();
-    client.process_new_packets().unwrap();
+    assert!(transfer(&mut client, &mut server_input) > 0);
+    assert!(transfer(&mut server, &mut client_input) > 0);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
 
     let mut buf = [0; 6];
     assert_eq!(client.reader().read(&mut buf).unwrap(), 6);
@@ -974,7 +1187,14 @@ impl Write for FailsWrites {
 #[test]
 fn stream_write_reports_underlying_io_error_before_plaintext_processed() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let mut pipe = FailsWrites {
         errkind: io::ErrorKind::ConnectionAborted,
@@ -984,7 +1204,7 @@ fn stream_write_reports_underlying_io_error_before_plaintext_processed() {
         .writer()
         .write_all(b"hello")
         .unwrap();
-    let mut client_stream = Stream::new(&mut client, &mut pipe);
+    let mut client_stream = Stream::new(&mut client_input, &mut client, &mut pipe);
     let rc = client_stream.write(b"world");
     assert!(rc.is_err());
     let err = rc.err().unwrap();
@@ -994,7 +1214,14 @@ fn stream_write_reports_underlying_io_error_before_plaintext_processed() {
 #[test]
 fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let mut pipe = FailsWrites {
         errkind: io::ErrorKind::ConnectionAborted,
@@ -1004,7 +1231,7 @@ fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
         .writer()
         .write_all(b"hello")
         .unwrap();
-    let mut client_stream = Stream::new(&mut client, &mut pipe);
+    let mut client_stream = Stream::new(&mut client_input, &mut client, &mut pipe);
     let rc = client_stream.write(b"world");
     assert_eq!(format!("{rc:?}"), "Ok(5)");
 }
@@ -1013,10 +1240,12 @@ fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
 fn client_stream_handshake_error() {
     let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     {
-        let mut pipe = OtherSession::new_fails(&mut server);
-        let mut client_stream = Stream::new(&mut client, &mut pipe);
+        let mut pipe = OtherSession::new_fails(&mut server_input, &mut server);
+        let mut client_stream = Stream::new(&mut client_input, &mut client, &mut pipe);
         let rc = client_stream.write(b"hello");
         assert!(rc.is_err());
         assert_eq!(
@@ -1036,8 +1265,9 @@ fn client_stream_handshake_error() {
 fn client_streamowned_handshake_error() {
     let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut server_input = VecInput::default();
 
-    let pipe = OtherSession::new_fails(&mut server);
+    let pipe = OtherSession::new_fails(&mut server_input, &mut server);
     let mut client_stream = StreamOwned::new(client, pipe);
     let rc = client_stream.write(b"hello");
     assert!(rc.is_err());
@@ -1059,6 +1289,8 @@ fn client_streamowned_handshake_error() {
 fn server_stream_handshake_error() {
     let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     client
         .writer()
@@ -1066,8 +1298,8 @@ fn server_stream_handshake_error() {
         .unwrap();
 
     {
-        let mut pipe = OtherSession::new_fails(&mut client);
-        let mut server_stream = Stream::new(&mut server, &mut pipe);
+        let mut pipe = OtherSession::new_fails(&mut client_input, &mut client);
+        let mut server_stream = Stream::new(&mut server_input, &mut server, &mut pipe);
         let mut bytes = [0u8; 5];
         let rc = server_stream.read(&mut bytes);
         assert!(rc.is_err());
@@ -1082,13 +1314,14 @@ fn server_stream_handshake_error() {
 fn server_streamowned_handshake_error() {
     let (client_config, server_config) = make_disjoint_suite_configs(provider::DEFAULT_PROVIDER);
     let (mut client, server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
 
     client
         .writer()
         .write_all(b"world")
         .unwrap();
 
-    let pipe = OtherSession::new_fails(&mut client);
+    let pipe = OtherSession::new_fails(&mut client_input, &mut client);
     let mut server_stream = StreamOwned::new(server, pipe);
     let mut bytes = [0u8; 5];
     let rc = server_stream.read(&mut bytes);
@@ -1102,7 +1335,14 @@ fn server_streamowned_handshake_error() {
 #[test]
 fn vectored_write_for_server_appdata() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     server
         .writer()
@@ -1113,7 +1353,7 @@ fn vectored_write_for_server_appdata() {
         .write_all(b"01234567890123456789")
         .unwrap();
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         let wrlen = server.write_tls(&mut pipe).unwrap();
         assert_eq!(84, wrlen);
         assert_eq!(pipe.writev_lengths(), vec![vec![42, 42]]);
@@ -1127,7 +1367,14 @@ fn vectored_write_for_server_appdata() {
 #[test]
 fn vectored_write_for_client_appdata() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     client
         .writer()
@@ -1138,7 +1385,7 @@ fn vectored_write_for_client_appdata() {
         .write_all(b"01234567890123456789")
         .unwrap();
     {
-        let mut pipe = OtherSession::new(&mut server);
+        let mut pipe = OtherSession::new(&mut server_input, &mut server);
         let wrlen = client.write_tls(&mut pipe).unwrap();
         assert_eq!(84, wrlen);
         assert_eq!(pipe.writev_lengths(), vec![vec![42, 42]]);
@@ -1158,6 +1405,8 @@ fn vectored_write_for_server_handshake_with_half_rtt_data() {
         make_client_config_with_auth(KeyType::Rsa2048, &provider),
         server_config,
     );
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     server
         .writer()
@@ -1168,10 +1417,12 @@ fn vectored_write_for_server_handshake_with_half_rtt_data() {
         .write_all(b"0123456789")
         .unwrap();
 
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         let wrlen = server.write_tls(&mut pipe).unwrap();
         // don't assert exact sizes here, to avoid a brittle test
         assert!(wrlen > 2400); // its pretty big (contains cert chain)
@@ -1179,11 +1430,15 @@ fn vectored_write_for_server_handshake_with_half_rtt_data() {
         assert_eq!(pipe.writev_lengths()[0].len(), 5); // at least a server hello/ccs/cert/serverkx/0.5rtt data
     }
 
-    client.process_new_packets().unwrap();
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         let wrlen = server.write_tls(&mut pipe).unwrap();
         // 2 tickets (in one flight)
         assert_eq!(wrlen, 184);
@@ -1200,6 +1455,8 @@ fn check_half_rtt_does_not_work(server_config: ServerConfig) {
         make_client_config_with_auth(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER),
         server_config,
     );
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     server
         .writer()
@@ -1210,10 +1467,12 @@ fn check_half_rtt_does_not_work(server_config: ServerConfig) {
         .write_all(b"0123456789")
         .unwrap();
 
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         let wrlen = server.write_tls(&mut pipe).unwrap();
         // don't assert exact sizes here, to avoid a brittle test
         assert!(wrlen > 2400); // its pretty big (contains cert chain)
@@ -1222,15 +1481,19 @@ fn check_half_rtt_does_not_work(server_config: ServerConfig) {
     }
 
     // client second flight
-    client.process_new_packets().unwrap();
-    transfer(&mut client, &mut server);
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
+    transfer(&mut client, &mut server_input);
 
     // when client auth is enabled, we don't sent 0.5-rtt data, as we'd be sending
     // it to an unauthenticated peer. so it happens here, in the server's second
     // flight (42 and 32 are lengths of appdata sent above).
-    server.process_new_packets().unwrap();
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         let wrlen = server.write_tls(&mut pipe).unwrap();
         assert_eq!(wrlen, 258);
         assert_eq!(pipe.writev_lengths(), vec![vec![184, 42, 32]]);
@@ -1261,6 +1524,8 @@ fn vectored_write_for_server_handshake_no_half_rtt_by_default() {
 #[test]
 fn vectored_write_for_client_handshake() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     client
         .writer()
@@ -1271,7 +1536,7 @@ fn vectored_write_for_client_handshake() {
         .write_all(b"0123456789")
         .unwrap();
     {
-        let mut pipe = OtherSession::new(&mut server);
+        let mut pipe = OtherSession::new(&mut server_input, &mut server);
         let wrlen = client.write_tls(&mut pipe).unwrap();
         // don't assert exact sizes here, to avoid a brittle test
         assert!(wrlen > 200); // just the client hello
@@ -1279,11 +1544,13 @@ fn vectored_write_for_client_handshake() {
         assert!(pipe.writev_lengths()[0].len() == 1); // only a client hello
     }
 
-    transfer(&mut server, &mut client);
-    client.process_new_packets().unwrap();
+    transfer(&mut server, &mut client_input);
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
 
     {
-        let mut pipe = OtherSession::new(&mut server);
+        let mut pipe = OtherSession::new(&mut server_input, &mut server);
         let wrlen = client.write_tls(&mut pipe).unwrap();
         assert_eq!(wrlen, 138);
         // CCS, finished, then two application data records
@@ -1298,17 +1565,24 @@ fn vectored_write_for_client_handshake() {
 #[test]
 fn vectored_write_with_slow_client() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     client.set_buffer_limit(Some(32));
 
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     server
         .writer()
         .write_all(b"01234567890123456789")
         .unwrap();
 
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         pipe.short_writes = true;
         let wrlen = server.write_tls(&mut pipe).unwrap()
             + server.write_tls(&mut pipe).unwrap()
@@ -1337,7 +1611,8 @@ fn test_client_mtu_reduction() {
         );
 
         {
-            let mut pipe = OtherSession::new(&mut server);
+            let mut server_input = VecInput::default();
+            let mut pipe = OtherSession::new(&mut server_input, &mut server);
             client.write_tls(&mut pipe).unwrap();
 
             assert!(
@@ -1359,6 +1634,8 @@ fn test_server_mtu_reduction() {
         make_client_config(KeyType::Rsa2048, &provider),
         server_config,
     );
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     let big_data = [0u8; 2048];
     server
@@ -1368,10 +1645,12 @@ fn test_server_mtu_reduction() {
 
     let encryption_overhead = 20; // FIXME: see issue #991
 
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         server.write_tls(&mut pipe).unwrap();
 
         assert!(
@@ -1381,11 +1660,15 @@ fn test_server_mtu_reduction() {
         );
     }
 
-    client.process_new_packets().unwrap();
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         server.write_tls(&mut pipe).unwrap();
 
         assert!(
@@ -1395,7 +1678,9 @@ fn test_server_mtu_reduction() {
         );
     }
 
-    client.process_new_packets().unwrap();
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
     check_read(&mut client.reader(), &big_data);
 }
 
@@ -1445,19 +1730,30 @@ fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
                 server_config.max_fragment_size = Some(frag_size);
 
                 let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-                do_handshake(&mut client, &mut server);
+                let mut client_input = VecInput::default();
+                let mut server_input = VecInput::default();
+                do_handshake(
+                    &mut client_input,
+                    &mut client,
+                    &mut server_input,
+                    &mut server,
+                );
 
                 // check server -> client data flow
                 let pattern = (0x00..=0xffu8).collect::<Vec<u8>>();
                 assert_eq!(pattern.len(), server.writer().write(&pattern).unwrap());
-                transfer(&mut server, &mut client);
-                client.process_new_packets().unwrap();
+                transfer(&mut server, &mut client_input);
+                client
+                    .process_new_packets(&mut client_input)
+                    .unwrap();
                 check_read(&mut client.reader(), &pattern);
 
                 // and client -> server
                 assert_eq!(pattern.len(), client.writer().write(&pattern).unwrap());
-                transfer(&mut client, &mut server);
-                server.process_new_packets().unwrap();
+                transfer(&mut client, &mut server_input);
+                server
+                    .process_new_packets(&mut server_input)
+                    .unwrap();
                 check_read(&mut server.reader(), &pattern);
             }
         }
@@ -1477,10 +1773,14 @@ fn test_acceptor() {
 
     let server_config = Arc::new(make_server_config(KeyType::Ed25519, &provider));
     let mut acceptor = Acceptor::default();
-    acceptor
-        .read_tls(&mut buf.as_slice())
+    let mut acceptor_input = VecInput::default();
+    acceptor_input
+        .read(&mut buf.as_slice())
         .unwrap();
-    let accepted = acceptor.accept().unwrap().unwrap();
+    let accepted = acceptor
+        .accept(&mut acceptor_input)
+        .unwrap()
+        .unwrap();
     let ch = accepted.client_hello();
     assert_eq!(
         ch.server_name(),
@@ -1503,28 +1803,37 @@ fn test_acceptor() {
     // Reusing an acceptor is not allowed
     assert_eq!(
         acceptor
-            .read_tls(&mut [0u8].as_ref())
+            .accept(&mut acceptor_input)
             .err()
             .unwrap()
-            .kind(),
-        io::ErrorKind::Other,
-    );
-    assert_eq!(
-        acceptor.accept().err().unwrap().0,
+            .0,
         ApiMisuse::AcceptorPolledAfterCompletion.into()
     );
 
     let mut acceptor = Acceptor::default();
-    assert!(acceptor.accept().unwrap().is_none());
-    acceptor
-        .read_tls(&mut &buf[..3])
+    let mut acceptor_input = VecInput::default();
+    assert!(
+        acceptor
+            .accept(&mut acceptor_input)
+            .unwrap()
+            .is_none()
+    );
+    acceptor_input
+        .read(&mut &buf[..3])
         .unwrap(); // incomplete message
-    assert!(acceptor.accept().unwrap().is_none());
+    assert!(
+        acceptor
+            .accept(&mut acceptor_input)
+            .unwrap()
+            .is_none()
+    );
 
-    acceptor
-        .read_tls(&mut [0x80, 0x00].as_ref())
+    acceptor_input
+        .read(&mut [0x80, 0x00].as_ref())
         .unwrap(); // invalid message (len = 32k bytes)
-    let (err, mut alert) = acceptor.accept().unwrap_err();
+    let (err, mut alert) = acceptor
+        .accept(&mut acceptor_input)
+        .unwrap_err();
     assert_eq!(err, Error::InvalidMessage(InvalidMessage::MessageTooLarge));
     let mut alert_content = Vec::new();
     let _ = alert.write(&mut alert_content);
@@ -1532,9 +1841,10 @@ fn test_acceptor() {
     assert_eq!(alert_content, expected);
 
     let mut acceptor = Acceptor::default();
+    let mut acceptor_input = VecInput::default();
     // Minimal valid 1-byte application data message is not a handshake message
-    acceptor
-        .read_tls(
+    acceptor_input
+        .read(
             &mut encoding::message_framing(
                 ContentType::ApplicationData,
                 ProtocolVersion::TLSv1_2,
@@ -1543,7 +1853,9 @@ fn test_acceptor() {
             .as_slice(),
         )
         .unwrap();
-    let (err, mut alert) = acceptor.accept().unwrap_err();
+    let (err, mut alert) = acceptor
+        .accept(&mut acceptor_input)
+        .unwrap_err();
     assert!(matches!(err, Error::InappropriateMessage { .. }));
     let mut alert_content = Vec::new();
     alert
@@ -1554,9 +1866,10 @@ fn test_acceptor() {
     assert_eq!(format!("{alert:?}"), "AcceptedAlert { .. }");
 
     let mut acceptor = Acceptor::default();
+    let mut acceptor_input = VecInput::default();
     // Minimal 1-byte ClientHello message is not a legal handshake message
-    acceptor
-        .read_tls(
+    acceptor_input
+        .read(
             &mut encoding::message_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
@@ -1565,7 +1878,9 @@ fn test_acceptor() {
             .as_slice(),
         )
         .unwrap();
-    let (err, mut alert) = acceptor.accept().unwrap_err();
+    let (err, mut alert) = acceptor
+        .accept(&mut acceptor_input)
+        .unwrap_err();
     assert!(matches!(
         err,
         Error::InvalidMessage(InvalidMessage::MissingData(_))
@@ -1601,17 +1916,28 @@ fn test_acceptor_continues_tls13_hrr_with_compatibility_ccs() {
         vec![provider::kx_group::X25519],
         &provider,
     ));
-    let mut acceptor = Acceptor::default();
-    acceptor
-        .read_tls(&mut client_hello.as_slice())
+
+    let mut server_input = VecInput::default();
+    server_input
+        .read(&mut client_hello.as_slice())
         .unwrap();
 
-    let accepted = acceptor.accept().unwrap().unwrap();
+    let mut acceptor = Acceptor::default();
+    let accepted = acceptor
+        .accept(&mut server_input)
+        .unwrap()
+        .unwrap();
     let mut server = accepted
         .into_connection(server_config)
         .unwrap();
 
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     assert_eq!(
         client.handshake_kind(),
@@ -1638,10 +1964,14 @@ fn test_acceptor_rejected_handshake() {
     let server_config =
         ServerConfig::builder(provider::DEFAULT_TLS12_PROVIDER.into()).finish(KeyType::Ed25519);
     let mut acceptor = Acceptor::default();
-    acceptor
-        .read_tls(&mut buf.as_slice())
+    let mut acceptor_input = VecInput::default();
+    acceptor_input
+        .read(&mut buf.as_slice())
         .unwrap();
-    let accepted = acceptor.accept().unwrap().unwrap();
+    let accepted = acceptor
+        .accept(&mut acceptor_input)
+        .unwrap()
+        .unwrap();
     let ch = accepted.client_hello();
     assert_eq!(
         ch.server_name(),
@@ -1671,6 +2001,7 @@ fn test_received_plaintext_backpressure() {
 }
 
 fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
+    dbg!(plaintext_limit);
     let kt = KeyType::Rsa2048;
     let provider = provider::DEFAULT_PROVIDER;
 
@@ -1691,19 +2022,27 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
 
     let client_config = Arc::new(make_client_config(kt, &provider));
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+    let mut client_tls_input = VecInput::default();
+    let mut server_tls_input = VecInput::default();
 
     if let Some(limit) = limit {
         server.set_plaintext_buffer_limit(Some(limit));
         client.set_plaintext_buffer_limit(Some(limit));
     }
 
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_tls_input,
+        &mut client,
+        &mut server_tls_input,
+        &mut server,
+    );
 
     for direction in [false, true] {
-        let (left, right): (&mut dyn Connection, &mut dyn Connection) = match direction {
-            false => (&mut client, &mut server),
-            true => (&mut server, &mut client),
-        };
+        let (left, right_input, right): (&mut dyn Connection, _, &mut dyn Connection) =
+            match direction {
+                false => (&mut client, &mut server_tls_input, &mut server),
+                true => (&mut server, &mut client_tls_input, &mut client),
+            };
 
         // Fill the server's received plaintext buffer with 16k bytes
         let write_buf = vec![0; plaintext_limit];
@@ -1716,8 +2055,8 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
         let mut read = 0;
         while read < sent {
             let new = dbg!(
-                right
-                    .read_tls(&mut &network_buf[read..sent])
+                right_input
+                    .read(&mut &network_buf[read..sent])
                     .unwrap()
             );
             if new == 4096 {
@@ -1726,7 +2065,9 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
                 break;
             }
         }
-        right.process_new_packets().unwrap();
+        right
+            .process_new_packets(right_input)
+            .unwrap();
 
         // Send one more byte from client to server
         assert_eq!(left.writer().write(&[1]).unwrap(), 1);
@@ -1735,15 +2076,19 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
                 .unwrap()
         );
 
+        right_input
+            .read(&mut &network_buf[..sent])
+            .unwrap();
+
         // Get an error because the received plaintext buffer is full
         assert_eq!(
             format!(
                 "{:?}",
                 right
-                    .read_tls(&mut &network_buf[..sent])
+                    .process_new_packets(right_input)
                     .unwrap_err()
             ),
-            "Custom { kind: Other, error: \"received plaintext buffer full\" }"
+            "ApiMisuse(ReceivedPlaintextBufferFull)"
         );
 
         // Read out some of the plaintext
@@ -1754,8 +2099,8 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
 
         // Now there's room again in the plaintext buffer
         assert_eq!(
-            right
-                .read_tls(&mut &network_buf[..sent])
+            right_input
+                .read(&mut &network_buf[..sent])
                 .unwrap(),
             sent
         );
@@ -1784,7 +2129,14 @@ fn server_close_notify() {
         let client_config = make_client_config_with_auth(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         // check that alerts don't overtake appdata
         assert_eq!(
@@ -1803,13 +2155,17 @@ fn server_close_notify() {
         );
         server.send_close_notify();
 
-        transfer(&mut server, &mut client);
-        let io_state = client.process_new_packets().unwrap();
+        transfer(&mut server, &mut client_input);
+        let io_state = client
+            .process_new_packets(&mut client_input)
+            .unwrap();
         assert!(io_state.peer_has_closed());
         check_read_and_close(&mut client.reader(), b"from-server!");
 
-        transfer(&mut client, &mut server);
-        server.process_new_packets().unwrap();
+        transfer(&mut client, &mut server_input);
+        server
+            .process_new_packets(&mut server_input)
+            .unwrap();
         check_read(&mut server.reader(), b"from-client!");
     }
 }
@@ -1824,7 +2180,14 @@ fn client_close_notify() {
         let client_config = make_client_config_with_auth(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         // check that alerts don't overtake appdata
         assert_eq!(
@@ -1843,13 +2206,17 @@ fn client_close_notify() {
         );
         client.send_close_notify();
 
-        transfer(&mut client, &mut server);
-        let io_state = server.process_new_packets().unwrap();
+        transfer(&mut client, &mut server_input);
+        let io_state = server
+            .process_new_packets(&mut server_input)
+            .unwrap();
         assert!(io_state.peer_has_closed());
         check_read_and_close(&mut server.reader(), b"from-client!");
 
-        transfer(&mut server, &mut client);
-        client.process_new_packets().unwrap();
+        transfer(&mut server, &mut client_input);
+        client
+            .process_new_packets(&mut client_input)
+            .unwrap();
         check_read(&mut client.reader(), b"from-server!");
     }
 }
@@ -1864,7 +2231,14 @@ fn server_closes_uncleanly() {
         let client_config = make_client_config(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         // check that unclean EOF reporting does not overtake appdata
         assert_eq!(
@@ -1882,9 +2256,11 @@ fn server_closes_uncleanly() {
                 .unwrap()
         );
 
-        transfer(&mut server, &mut client);
-        transfer_eof(&mut client);
-        let io_state = client.process_new_packets().unwrap();
+        transfer(&mut server, &mut client_input);
+        transfer_eof(&mut client_input);
+        let io_state = client
+            .process_new_packets(&mut client_input)
+            .unwrap();
         assert!(!io_state.peer_has_closed());
         check_read(&mut client.reader(), b"from-server!");
 
@@ -1894,8 +2270,10 @@ fn server_closes_uncleanly() {
         );
 
         // may still transmit pending frames
-        transfer(&mut client, &mut server);
-        server.process_new_packets().unwrap();
+        transfer(&mut client, &mut server_input);
+        server
+            .process_new_packets(&mut server_input)
+            .unwrap();
         check_read(&mut server.reader(), b"from-client!");
     }
 }
@@ -1910,7 +2288,14 @@ fn client_closes_uncleanly() {
         let client_config = make_client_config(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         // check that unclean EOF reporting does not overtake appdata
         assert_eq!(
@@ -1928,9 +2313,11 @@ fn client_closes_uncleanly() {
                 .unwrap()
         );
 
-        transfer(&mut client, &mut server);
-        transfer_eof(&mut server);
-        let io_state = server.process_new_packets().unwrap();
+        transfer(&mut client, &mut server_input);
+        transfer_eof(&mut server_input);
+        let io_state = server
+            .process_new_packets(&mut server_input)
+            .unwrap();
         assert!(!io_state.peer_has_closed());
         check_read(&mut server.reader(), b"from-client!");
 
@@ -1940,8 +2327,10 @@ fn client_closes_uncleanly() {
         );
 
         // may still transmit pending frames
-        transfer(&mut server, &mut client);
-        client.process_new_packets().unwrap();
+        transfer(&mut server, &mut client_input);
+        client
+            .process_new_packets(&mut client_input)
+            .unwrap();
         check_read(&mut client.reader(), b"from-server!");
     }
 }
@@ -1969,9 +2358,10 @@ fn test_complete_io_errors_if_close_notify_received_too_early() {
         \x1a\x1a\x00\x1d\x00\x17\x00\x18\x1a\x1a\x00\x01\x00\
         \x15\x03\x03\x00\x02\x01\x00";
 
+    let mut server_input = VecInput::default();
     let mut stream = FakeStream(client_hello_followed_by_close_notify_alert);
     assert_eq!(
-        complete_io(&mut stream, &mut server)
+        complete_io(&mut stream, &mut server_input, &mut server)
             .unwrap_err()
             .kind(),
         io::ErrorKind::UnexpectedEof
@@ -1981,21 +2371,32 @@ fn test_complete_io_errors_if_close_notify_received_too_early() {
 #[test]
 fn test_complete_io_with_no_io_needed() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     client
         .writer()
         .write_all(b"hello")
         .unwrap();
     client.send_close_notify();
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
     server
         .writer()
         .write_all(b"hello")
         .unwrap();
     server.send_close_notify();
-    transfer(&mut server, &mut client);
-    client.process_new_packets().unwrap();
+    transfer(&mut server, &mut client_input);
+    client
+        .process_new_packets(&mut client_input)
+        .unwrap();
 
     // neither want any IO: both directions are closed.
     assert!(!client.wants_write());
@@ -2003,11 +2404,11 @@ fn test_complete_io_with_no_io_needed() {
     assert!(!server.wants_write());
     assert!(!server.wants_read());
     assert_eq!(
-        complete_io(&mut FakeStream(&[]), &mut client).unwrap(),
+        complete_io(&mut FakeStream(&[]), &mut client_input, &mut client).unwrap(),
         (0, 0)
     );
     assert_eq!(
-        complete_io(&mut FakeStream(&[]), &mut server).unwrap(),
+        complete_io(&mut FakeStream(&[]), &mut server_input, &mut server).unwrap(),
         (0, 0)
     );
 }
@@ -2015,7 +2416,14 @@ fn test_complete_io_with_no_io_needed() {
 #[test]
 fn test_junk_after_close_notify_received() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     client
         .writer()
         .write_all(b"hello")
@@ -2031,11 +2439,15 @@ fn test_junk_after_close_notify_received() {
     // after the close_notify
     client_buffer.extend_from_slice(&[0x17, 0x03, 0x03, 0x01]);
 
-    server
-        .read_tls(&mut io::Cursor::new(&client_buffer[..]))
+    server_input
+        .read(&mut io::Cursor::new(&client_buffer[..]))
         .unwrap();
-    server.process_new_packets().unwrap();
-    server.process_new_packets().unwrap(); // check for desync
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap(); // check for desync
 
     // can read data received prior to close_notify
     let mut received_data = [0u8; 128];
@@ -2058,7 +2470,14 @@ fn test_junk_after_close_notify_received() {
 #[test]
 fn test_data_after_close_notify_is_ignored() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     client
         .writer()
@@ -2069,8 +2488,10 @@ fn test_data_after_close_notify_is_ignored() {
         .writer()
         .write_all(b"after")
         .unwrap();
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     let mut received_data = [0u8; 128];
     let count = server
@@ -2095,8 +2516,9 @@ fn test_close_notify_sent_prior_to_handshake_complete() {
     )))
     .unwrap();
 
-    server
-        .read_tls(
+    let mut server_input = VecInput::default();
+    server_input
+        .read(
             &mut encoding::message_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
@@ -2105,51 +2527,73 @@ fn test_close_notify_sent_prior_to_handshake_complete() {
             .as_slice(),
         )
         .unwrap();
-    server
-        .read_tls(&mut encoding::warning_alert(AlertDescription::CloseNotify).as_slice())
+    server_input
+        .read(&mut encoding::warning_alert(AlertDescription::CloseNotify).as_slice())
         .unwrap();
+
     assert_eq!(
-        server.process_new_packets().err(),
+        server
+            .process_new_packets(&mut server_input)
+            .err(),
         Some(PeerMisbehaved::IllegalWarningAlert(AlertDescription::CloseNotify).into())
     );
 }
 
 #[test]
 fn test_subsequent_close_notify_ignored() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut server_input = VecInput::default();
     client.send_close_notify();
-    assert!(transfer(&mut client, &mut server) > 0);
+    assert!(transfer(&mut client, &mut server_input) > 0);
 
     // does nothing
     client.send_close_notify();
-    assert_eq!(transfer(&mut client, &mut server), 0);
+    assert_eq!(transfer(&mut client, &mut server_input), 0);
 }
 
 #[test]
 fn test_second_close_notify_after_handshake() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     client.send_close_notify();
-    assert!(transfer(&mut client, &mut server) > 0);
-    server.process_new_packets().unwrap();
+    assert!(transfer(&mut client, &mut server_input) > 0);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     // does nothing
     client.send_close_notify();
-    assert_eq!(transfer(&mut client, &mut server), 0);
+    assert_eq!(transfer(&mut client, &mut server_input), 0);
 }
 
 #[test]
 fn test_read_tls_artificial_eof_after_close_notify() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     client.send_close_notify();
-    assert!(transfer(&mut client, &mut server) > 0);
-    server.process_new_packets().unwrap();
+    assert!(transfer(&mut client, &mut server_input) > 0);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     let buf = [1, 2, 3, 4];
     assert_eq!(
-        server
-            .read_tls(&mut io::Cursor::new(buf))
+        server_input
+            .read(&mut io::Cursor::new(buf))
             .unwrap(),
         0
     );

--- a/rustls-test/tests/api/kx.rs
+++ b/rustls-test/tests/api/kx.rs
@@ -13,7 +13,7 @@ use rustls::crypto::kx::{
 };
 use rustls::enums::{ContentType, ProtocolVersion};
 use rustls::error::{AlertDescription, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
-use rustls::{ClientConfig, Connection, HandshakeKind, ServerConfig};
+use rustls::{ClientConfig, Connection, HandshakeKind, ServerConfig, VecInput};
 use rustls_test::{
     ClientConfigExt, ClientStorage, ClientStorageOp, ErrorFromPeer, KeyType, OtherSession,
     ServerConfigExt, do_handshake, do_handshake_until_error, encoding,
@@ -31,7 +31,15 @@ fn test_client_config_keyshare() {
         make_client_config_with_kx_groups(KeyType::Rsa2048, kx_groups.clone(), &provider);
     let server_config = make_server_config_with_kx_groups(KeyType::Rsa2048, kx_groups, &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    do_handshake_until_error(&mut client, &mut server).unwrap();
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake_until_error(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -48,8 +56,16 @@ fn test_client_config_keyshare_mismatch() {
         &provider,
     );
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     assert_eq!(
-        do_handshake_until_error(&mut client, &mut server).err(),
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server
+        )
+        .err(),
         Some(ErrorFromPeer::Server(
             PeerIncompatible::NoKxGroupsInCommon.into()
         ))
@@ -58,6 +74,8 @@ fn test_client_config_keyshare_mismatch() {
 
 #[test]
 fn exercise_all_key_exchange_methods() {
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     for (version, version_provider) in [
         (ProtocolVersion::TLSv1_3, provider::DEFAULT_TLS13_PROVIDER),
         (ProtocolVersion::TLSv1_2, provider::DEFAULT_TLS12_PROVIDER),
@@ -81,7 +99,13 @@ fn exercise_all_key_exchange_methods() {
                 &version_provider,
             );
             let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-            do_handshake_until_error(&mut client, &mut server).unwrap();
+            do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            )
+            .unwrap();
             println!("kx_group {:?} is self-consistent", kx_group.name());
         }
     }
@@ -108,13 +132,15 @@ fn test_client_sends_helloretryrequest() {
     );
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     assert_eq!(client.handshake_kind(), None);
     assert_eq!(server.handshake_kind(), None);
 
     // client sends hello
     {
-        let mut pipe = OtherSession::new(&mut server);
+        let mut pipe = OtherSession::new(&mut server_input, &mut server);
         let wrlen = client.write_tls(&mut pipe).unwrap();
         assert!(wrlen > 200);
         assert_eq!(pipe.writevs.len(), 1);
@@ -126,7 +152,7 @@ fn test_client_sends_helloretryrequest() {
 
     // server sends HRR
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         let wrlen = server.write_tls(&mut pipe).unwrap();
         assert!(wrlen < 100); // just the hello retry request
         assert_eq!(pipe.writevs.len(), 1); // only one writev
@@ -138,7 +164,7 @@ fn test_client_sends_helloretryrequest() {
 
     // client sends fixed hello
     {
-        let mut pipe = OtherSession::new(&mut server);
+        let mut pipe = OtherSession::new(&mut server_input, &mut server);
         let wrlen = client.write_tls(&mut pipe).unwrap();
         assert!(wrlen > 200); // just the client hello retry
         assert_eq!(pipe.writevs.len(), 1); // only one writev
@@ -147,7 +173,7 @@ fn test_client_sends_helloretryrequest() {
 
     // server completes handshake
     {
-        let mut pipe = OtherSession::new(&mut client);
+        let mut pipe = OtherSession::new(&mut client_input, &mut client);
         let wrlen = server.write_tls(&mut pipe).unwrap();
         assert!(wrlen > 200);
         assert_eq!(pipe.writevs.len(), 1);
@@ -163,7 +189,13 @@ fn test_client_sends_helloretryrequest() {
         Some(HandshakeKind::FullWithHelloRetryRequest)
     );
 
-    do_handshake_until_error(&mut client, &mut server).unwrap();
+    do_handshake_until_error(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    )
+    .unwrap();
 
     // client only did following storage queries:
     println!("storage {:#?}", storage.ops());
@@ -204,6 +236,8 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     // common to both client configs
     let shared_storage = Arc::new(ClientStorage::new());
     let provider = provider::DEFAULT_PROVIDER;
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     // first, client sends a secp-256 share and server agrees. secp-256 is inserted
     //   into kx group cache.
@@ -227,7 +261,13 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
 
     // first handshake
     let (mut client_1, mut server) = make_pair_for_configs(client_config_1, server_config.clone());
-    do_handshake_until_error(&mut client_1, &mut server).unwrap();
+    do_handshake_until_error(
+        &mut client_input,
+        &mut client_1,
+        &mut server_input,
+        &mut server,
+    )
+    .unwrap();
 
     let ops = shared_storage.ops();
     println!("storage {ops:#?}");
@@ -239,7 +279,13 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
 
     // second handshake
     let (mut client_2, mut server) = make_pair_for_configs(client_config_2, server_config);
-    do_handshake_until_error(&mut client_2, &mut server).unwrap();
+    do_handshake_until_error(
+        &mut client_input,
+        &mut client_2,
+        &mut server_input,
+        &mut server,
+    )
+    .unwrap();
 
     let ops = shared_storage.ops();
     println!("storage {:?} {:#?}", ops.len(), ops);
@@ -263,6 +309,8 @@ fn test_client_sends_share_for_less_preferred_group() {
     // common to both client configs
     let shared_storage = Arc::new(ClientStorage::new());
     let provider = provider::DEFAULT_PROVIDER;
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     // first, client sends a secp384r1 share and server agrees. secp384r1 is inserted
     //   into kx group cache.
@@ -290,7 +338,13 @@ fn test_client_sends_share_for_less_preferred_group() {
 
     // first handshake
     let (mut client_1, mut server) = make_pair_for_configs(client_config_1, server_config.clone());
-    do_handshake_until_error(&mut client_1, &mut server).unwrap();
+    do_handshake_until_error(
+        &mut client_input,
+        &mut client_1,
+        &mut server_input,
+        &mut server,
+    )
+    .unwrap();
     assert_eq!(
         client_1
             .negotiated_key_exchange_group()
@@ -310,7 +364,12 @@ fn test_client_sends_share_for_less_preferred_group() {
     // second handshake; HRR'd from secp384r1 to X25519
     // (but resuming is possible, since the session storage is shared)
     let (mut client_2, mut server) = make_pair_for_configs(client_config_2, server_config);
-    do_handshake(&mut client_2, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client_2,
+        &mut server_input,
+        &mut server,
+    );
     assert_eq!(
         client_2
             .negotiated_key_exchange_group()
@@ -326,8 +385,9 @@ fn test_client_sends_share_for_less_preferred_group() {
 #[test]
 fn test_server_rejects_clients_without_any_kx_groups() {
     let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    server
-        .read_tls(
+    let mut server_input = VecInput::default();
+    server_input
+        .read(
             &mut encoding::message_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
@@ -347,7 +407,7 @@ fn test_server_rejects_clients_without_any_kx_groups() {
         )
         .unwrap();
     assert_eq!(
-        server.process_new_packets(),
+        server.process_new_packets(&mut server_input),
         Err(Error::InvalidMessage(InvalidMessage::IllegalEmptyList(
             "NamedGroups"
         )))
@@ -356,6 +416,8 @@ fn test_server_rejects_clients_without_any_kx_groups() {
 
 #[test]
 fn test_server_rejects_clients_without_any_kx_group_overlap() {
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     for version_provider in ALL_VERSIONS {
         let (mut client, mut server) = make_pair_for_configs(
             make_client_config_with_kx_groups(
@@ -372,16 +434,16 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
             )
             .finish(KeyType::Rsa2048),
         );
-        transfer(&mut client, &mut server);
+        transfer(&mut client, &mut server_input);
         assert_eq!(
-            server.process_new_packets(),
+            server.process_new_packets(&mut server_input),
             Err(Error::PeerIncompatible(
                 PeerIncompatible::NoKxGroupsInCommon
             ))
         );
-        transfer(&mut server, &mut client);
+        transfer(&mut server, &mut client_input);
         assert_eq!(
-            client.process_new_packets(),
+            client.process_new_packets(&mut client_input),
             Err(Error::AlertReceived(AlertDescription::HandshakeFailure))
         );
     }
@@ -403,14 +465,18 @@ fn hybrid_kx_component_share_offered_but_server_chooses_something_else() {
 
     let (mut client_1, mut server) = make_pair_for_configs(client_config, server_config);
     let (mut client_2, _) = make_pair(kt, &provider);
+    let mut client_1_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     // client_2 supplies the ClientHello, client_1 receives the ServerHello
-    transfer(&mut client_2, &mut server);
-    server.process_new_packets().unwrap();
-    transfer(&mut server, &mut client_1);
+    transfer(&mut client_2, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
+    transfer(&mut server, &mut client_1_input);
     assert_eq!(
         client_1
-            .process_new_packets()
+            .process_new_packets(&mut client_1_input)
             .unwrap_err(),
         PeerMisbehaved::WrongGroupForKeyShare.into()
     );

--- a/rustls-test/tests/api/raw_keys.rs
+++ b/rustls-test/tests/api/raw_keys.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use rustls::VecInput;
 use rustls::crypto::Identity;
 use rustls::enums::CertificateType;
 use rustls::error::{Error, PeerIncompatible};
@@ -21,7 +22,14 @@ fn successful_raw_key_connection_and_correct_peer_certificates() {
         let server_config = make_server_config_with_raw_key_support(*kt, &provider);
 
         let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         // Test that the client peer certificate is the server's public key
         match client.peer_identity() {
@@ -67,7 +75,14 @@ fn correct_certificate_type_extensions_from_client_hello() {
         });
 
         let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-        let err = do_handshake_until_error(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             err.err(),
             Some(ErrorFromPeer::Server(Error::NoSuitableCertificate))
@@ -85,7 +100,14 @@ fn only_client_supports_raw_keys() {
         let (mut client_rpk, mut server) = make_pair_for_configs(client_config_rpk, server_config);
 
         // The client
-        match do_handshake_until_error(&mut client_rpk, &mut server) {
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        match do_handshake_until_error(
+            &mut client_input,
+            &mut client_rpk,
+            &mut server_input,
+            &mut server,
+        ) {
             Err(err) => {
                 assert_eq!(
                     err,
@@ -110,7 +132,14 @@ fn only_server_supports_raw_keys() {
 
         let (mut client, mut server_rpk) = make_pair_for_configs(client_config, server_config_rpk);
 
-        match do_handshake_until_error(&mut client, &mut server_rpk) {
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        match do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server_rpk,
+        ) {
             Err(err) => {
                 assert_eq!(
                     err,

--- a/rustls-test/tests/api/resolve.rs
+++ b/rustls-test/tests/api/resolve.rs
@@ -14,7 +14,7 @@ use rustls::error::{CertificateError, Error, PeerMisbehaved};
 use rustls::server::{ClientHello, ServerCredentialResolver, ServerNameResolver};
 use rustls::{
     ClientConfig, Connection, DistinguishedName, ServerConfig, ServerConnection,
-    SupportedCipherSuite,
+    SupportedCipherSuite, VecInput,
 };
 use rustls_test::{
     ClientConfigExt, ErrorFromPeer, KeyType, ServerCheckCertResolve,
@@ -43,8 +43,15 @@ fn server_cert_resolve_with_sni() {
             .build()
             .unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-        let err = do_handshake_until_error(&mut client, &mut server);
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             err.err(),
             Some(ErrorFromPeer::Server(Error::NoSuitableCertificate))
@@ -74,7 +81,14 @@ fn server_cert_resolve_with_alpn() {
             .unwrap();
 
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
-        let err = do_handshake_until_error(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             err.err(),
             Some(ErrorFromPeer::Server(Error::NoSuitableCertificate))
@@ -101,7 +115,14 @@ fn server_cert_resolve_with_named_groups() {
         });
 
         let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-        let err = do_handshake_until_error(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             err.err(),
             Some(ErrorFromPeer::Server(Error::NoSuitableCertificate))
@@ -126,8 +147,15 @@ fn client_trims_terminating_dot() {
             .build()
             .unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-        let err = do_handshake_until_error(&mut client, &mut server);
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             err.err(),
             Some(ErrorFromPeer::Server(Error::NoSuitableCertificate))
@@ -158,8 +186,15 @@ fn check_sigalgs_reduced_by_ciphersuite(
         .build()
         .unwrap();
     let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
-    let err = do_handshake_until_error(&mut client, &mut server);
+    let err = do_handshake_until_error(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert_eq!(
         Some(ErrorFromPeer::Server(Error::NoSuitableCertificate)),
         err.err()
@@ -240,7 +275,14 @@ fn client_with_sni_disabled_does_not_send_sni() {
                 .unwrap();
 
             let mut server = ServerConnection::new(server_config.clone()).unwrap();
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             dbg!(&err);
             assert_eq!(
                 err.err(),
@@ -340,9 +382,16 @@ fn test_client_cert_resolve(
 
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
         assert_eq!(
-            do_handshake_until_error(&mut client, &mut server),
+            do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server
+            ),
             Err(ErrorFromPeer::Server(Error::PeerMisbehaved(
                 PeerMisbehaved::NoCertificatesPresented
             )))
@@ -447,10 +496,11 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
             .build()
             .unwrap();
 
+        let mut server_input = VecInput::default();
         assert_eq!(None, server.server_name());
-        transfer(&mut client, &mut server);
+        transfer(&mut client, &mut server_input);
         assert_eq!(
-            server.process_new_packets(),
+            server.process_new_packets(&mut server_input),
             Err(Error::NoSuitableCertificate)
         );
         assert_eq!(
@@ -482,7 +532,14 @@ fn sni_resolver_works() {
         .connect(server_name("localhost"))
         .build()
         .unwrap();
-    let err = do_handshake_until_error(&mut client1, &mut server1);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    let err = do_handshake_until_error(
+        &mut client_input,
+        &mut client1,
+        &mut server_input,
+        &mut server1,
+    );
     assert_eq!(err, Ok(()));
 
     let mut server2 = ServerConnection::new(server_config).unwrap();
@@ -490,7 +547,14 @@ fn sni_resolver_works() {
         .connect(server_name("notlocalhost"))
         .build()
         .unwrap();
-    let err = do_handshake_until_error(&mut client2, &mut server2);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    let err = do_handshake_until_error(
+        &mut client_input,
+        &mut client2,
+        &mut server_input,
+        &mut server2,
+    );
     assert_eq!(
         err,
         Err(ErrorFromPeer::Server(Error::NoSuitableCertificate))
@@ -546,7 +610,14 @@ fn sni_resolver_lower_cases_configured_names() {
         .connect(server_name("localhost"))
         .build()
         .unwrap();
-    let err = do_handshake_until_error(&mut client1, &mut server1);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    let err = do_handshake_until_error(
+        &mut client_input,
+        &mut client1,
+        &mut server_input,
+        &mut server1,
+    );
     assert_eq!(err, Ok(()));
 }
 
@@ -575,7 +646,14 @@ fn sni_resolver_lower_cases_queried_names() {
         .connect(server_name("LOCALHOST"))
         .build()
         .unwrap();
-    let err = do_handshake_until_error(&mut client1, &mut server1);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    let err = do_handshake_until_error(
+        &mut client_input,
+        &mut client1,
+        &mut server_input,
+        &mut server1,
+    );
     assert_eq!(err, Ok(()));
 }
 

--- a/rustls-test/tests/api/resume.rs
+++ b/rustls-test/tests/api/resume.rs
@@ -13,7 +13,7 @@ use rustls::crypto::{CertificateIdentity, Identity};
 use rustls::enums::ProtocolVersion;
 use rustls::error::{ApiMisuse, Error, PeerMisbehaved};
 use rustls::server::ServerSessionKey;
-use rustls::{ClientConfig, Connection, HandshakeKind, ServerConfig, ServerConnection};
+use rustls::{ClientConfig, Connection, HandshakeKind, ServerConfig, ServerConnection, VecInput};
 use rustls_test::{
     ClientConfigExt, ClientStorage, ClientStorageOp, ErrorFromPeer, KeyType, ServerConfigExt,
     do_handshake, do_handshake_until_error, make_client_config, make_client_config_with_auth,
@@ -30,23 +30,40 @@ fn client_only_attempts_resumption_with_compatible_security() {
 
     let server_config = make_server_config(kt, &provider);
     for version_provider in ALL_VERSIONS {
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
         let base_client_config = make_client_config(kt, &version_provider);
         let (mut client, mut server) =
             make_pair_for_configs(base_client_config.clone(), server_config.clone());
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
 
         // base case
         let (mut client, mut server) =
             make_pair_for_configs(base_client_config.clone(), server_config.clone());
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
 
         // allowed case, using `clone`
         let client_config = ClientConfig::clone(&base_client_config);
         let (mut client, mut server) =
             make_pair_for_configs(client_config.clone(), server_config.clone());
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
 
         // disallowed case: unmatching `client_auth_cert_resolver`
@@ -61,7 +78,12 @@ fn client_only_attempts_resumption_with_compatible_security() {
 
         let (mut client, mut server) =
             make_pair_for_configs(client_config.clone(), server_config.clone());
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
 
         // disallowed case: unmatching `verifier`
@@ -79,7 +101,12 @@ fn client_only_attempts_resumption_with_compatible_security() {
 
         let (mut client, mut server) =
             make_pair_for_configs(client_config.clone(), server_config.clone());
-        do_handshake(&mut client, &mut server);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
     }
 }
@@ -93,6 +120,8 @@ fn resumption_combinations() {
             (ProtocolVersion::TLSv1_2, provider::DEFAULT_TLS12_PROVIDER),
             (ProtocolVersion::TLSv1_3, provider::DEFAULT_TLS13_PROVIDER),
         ] {
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
             let resumption_data = format!("resumption data {kt:?} {version:?}");
             let client_config = make_client_config(*kt, &version_provider);
             let (mut client, mut server) =
@@ -100,7 +129,12 @@ fn resumption_combinations() {
             server
                 .set_resumption_data(resumption_data.as_bytes())
                 .unwrap();
-            do_handshake(&mut client, &mut server);
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
 
             let expected_kx = expected_kx_for_version(version);
 
@@ -123,7 +157,12 @@ fn resumption_combinations() {
 
             let (mut client, mut server) =
                 make_pair_for_configs(client_config.clone(), server_config.clone());
-            do_handshake(&mut client, &mut server);
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
 
             assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
             assert_eq!(server.handshake_kind(), Some(HandshakeKind::Resumed));
@@ -191,13 +230,21 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
         ServerConfig::builder(provider::DEFAULT_TLS12_PROVIDER.into()).finish(KeyType::Ed25519);
     server_config_2.session_storage = Arc::new(rustls::server::NoServerSessionStorage {});
 
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+
     dbg!("handshake 1");
     let mut client_1 = client_config
         .connect("localhost".try_into().unwrap())
         .build()
         .unwrap();
     let mut server_1 = ServerConnection::new(server_config_1).unwrap();
-    do_handshake(&mut client_1, &mut server_1);
+    do_handshake(
+        &mut client_input,
+        &mut client_1,
+        &mut server_input,
+        &mut server_1,
+    );
 
     assert_eq!(client_storage.ops().len(), 7);
     println!("hs1 storage ops: {:#?}", client_storage.ops());
@@ -220,7 +267,12 @@ fn test_client_tls12_no_resume_after_server_downgrade() {
         .build()
         .unwrap();
     let mut server_2 = ServerConnection::new(Arc::new(server_config_2)).unwrap();
-    do_handshake(&mut client_2, &mut server_2);
+    do_handshake(
+        &mut client_input,
+        &mut client_2,
+        &mut server_input,
+        &mut server_2,
+    );
     println!("hs2 storage ops: {:#?}", client_storage.ops());
     assert_eq!(client_storage.ops().len(), 9);
 
@@ -247,9 +299,18 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     server_config.send_tls13_tickets = 5;
     let server_config = Arc::new(server_config);
 
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+
     // first handshake: client obtains 5 tickets from server.
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake_until_error(&mut client, &mut server).unwrap();
+    do_handshake_until_error(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    )
+    .unwrap();
 
     let ops = shared_storage.ops_and_reset();
     println!("storage {ops:#?}");
@@ -270,8 +331,10 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     // connectivity uncertainty.
     for _ in 0..5 {
         let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-        transfer(&mut client, &mut server);
-        server.process_new_packets().unwrap();
+        transfer(&mut client, &mut server_input);
+        server
+            .process_new_packets(&mut server_input)
+            .unwrap();
 
         let ops = shared_storage.ops_and_reset();
         assert!(matches!(ops[0], ClientStorageOp::TakeTls13Ticket(_, true)));
@@ -279,8 +342,10 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
 
     // 6th subsequent handshake: cannot be resumed; we ran out of tickets
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     let ops = shared_storage.ops_and_reset();
     println!("last {ops:?}");
@@ -299,9 +364,17 @@ fn tls13_stateful_resumption() {
     server_config.session_storage = storage.clone();
     let server_config = Arc::new(server_config);
 
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+
     // full handshake
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    let (full_c2s, full_s2c) = do_handshake(&mut client, &mut server);
+    let (full_c2s, full_s2c) = do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert_eq!(client.tls13_tickets_received(), 2);
     assert_eq!(storage.puts(), 2);
     assert_eq!(storage.gets(), 0);
@@ -320,7 +393,12 @@ fn tls13_stateful_resumption() {
 
     // resumed
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    let (resume_c2s, resume_s2c) = do_handshake(&mut client, &mut server);
+    let (resume_c2s, resume_s2c) = do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert!(resume_c2s > full_c2s);
     assert!(resume_s2c < full_s2c);
     assert_eq!(storage.puts(), 4);
@@ -340,7 +418,12 @@ fn tls13_stateful_resumption() {
 
     // resumed again
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    let (resume2_c2s, resume2_s2c) = do_handshake(&mut client, &mut server);
+    let (resume2_c2s, resume2_s2c) = do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert_eq!(resume_s2c, resume2_s2c);
     assert_eq!(resume_c2s, resume2_c2s);
     assert_eq!(storage.puts(), 6);
@@ -377,9 +460,17 @@ fn tls13_stateless_resumption() {
     server_config.session_storage = storage.clone();
     let server_config = Arc::new(server_config);
 
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+
     // full handshake
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    let (full_c2s, full_s2c) = do_handshake(&mut client, &mut server);
+    let (full_c2s, full_s2c) = do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert_eq!(storage.puts(), 0);
     assert_eq!(storage.gets(), 0);
     assert_eq!(storage.takes(), 0);
@@ -397,7 +488,12 @@ fn tls13_stateless_resumption() {
 
     // resumed
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    let (resume_c2s, resume_s2c) = do_handshake(&mut client, &mut server);
+    let (resume_c2s, resume_s2c) = do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert!(resume_c2s > full_c2s);
     assert!(resume_s2c < full_s2c);
     assert_eq!(storage.puts(), 0);
@@ -417,7 +513,12 @@ fn tls13_stateless_resumption() {
 
     // resumed again
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    let (resume2_c2s, resume2_s2c) = do_handshake(&mut client, &mut server);
+    let (resume2_c2s, resume2_s2c) = do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     assert_eq!(resume_s2c, resume2_s2c);
     assert_eq!(resume_c2s, resume2_c2s);
     assert_eq!(storage.puts(), 0);
@@ -457,9 +558,16 @@ fn early_data_configs() -> (Arc<ClientConfig>, Arc<ServerConfig>) {
 #[test]
 fn early_data_is_available_on_resumption() {
     let (client_config, server_config) = early_data_configs();
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
     assert!(client.early_data().is_some());
@@ -504,7 +612,12 @@ fn early_data_is_available_on_resumption() {
             .err(),
         Some(Error::ApiMisuse(ApiMisuse::ExporterAlreadyUsed)),
     );
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let mut received_early_data = [0u8; 5];
     assert_eq!(
@@ -553,10 +666,17 @@ fn early_data_not_available_on_server_before_client_hello() {
 #[test]
 fn early_data_is_limited_on_client() {
     let (client_config, server_config) = early_data_configs();
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     // warm up
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
     assert!(client.early_data().is_some());
@@ -580,7 +700,12 @@ fn early_data_is_limited_on_client() {
             .unwrap(),
         1234
     );
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let mut received_early_data = [0u8; 1234];
     assert_eq!(
@@ -606,14 +731,23 @@ fn early_data_configs_allowing_client_to_send_excess_data() -> (Arc<ClientConfig
     let client_config = Arc::new(client_config);
 
     // warm up
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
-    do_handshake(&mut client, &mut server);
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
     (client_config, server_config)
 }
 
 #[test]
 fn server_detects_excess_early_data() {
     let (client_config, server_config) = early_data_configs_allowing_client_to_send_excess_data();
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
 
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
     assert!(client.early_data().is_some());
@@ -638,7 +772,12 @@ fn server_detects_excess_early_data() {
         2024
     );
     assert_eq!(
-        do_handshake_until_error(&mut client, &mut server),
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server
+        ),
         Err(ErrorFromPeer::Server(Error::PeerMisbehaved(
             PeerMisbehaved::TooMuchEarlyDataReceived
         ))),
@@ -649,6 +788,7 @@ fn server_detects_excess_early_data() {
 #[test]
 fn server_detects_excess_streamed_early_data() {
     let (client_config, server_config) = early_data_configs_allowing_client_to_send_excess_data();
+    let mut server_input = VecInput::default();
 
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
     assert!(client.early_data().is_some());
@@ -672,8 +812,10 @@ fn server_detects_excess_streamed_early_data() {
             .unwrap(),
         1024
     );
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
+    transfer(&mut client, &mut server_input);
+    server
+        .process_new_packets(&mut server_input)
+        .unwrap();
 
     let mut received_early_data = [0u8; 1024];
     assert_eq!(
@@ -694,9 +836,9 @@ fn server_detects_excess_streamed_early_data() {
             .unwrap(),
         1000
     );
-    transfer(&mut client, &mut server);
+    transfer(&mut client, &mut server_input);
     assert_eq!(
-        server.process_new_packets(),
+        server.process_new_packets(&mut server_input),
         Err(Error::PeerMisbehaved(
             PeerMisbehaved::TooMuchEarlyDataReceived
         ))

--- a/rustls-test/tests/api/server_cert_verifier.rs
+++ b/rustls-test/tests/api/server_cert_verifier.rs
@@ -17,7 +17,9 @@ use rustls::error::{
     AlertDescription, CertificateError, Error, ExtendedKeyPurpose, InvalidMessage, PeerIncompatible,
 };
 use rustls::server::{ClientHello, ParsedCertificate, ServerCredentialResolver};
-use rustls::{ClientConfig, DistinguishedName, RootCertStore, ServerConfig, ServerConnection};
+use rustls::{
+    ClientConfig, DistinguishedName, RootCertStore, ServerConfig, ServerConnection, VecInput,
+};
 use rustls_test::{
     ErrorFromPeer, KeyType, MockServerVerifier, certificate_error_expecting_name, do_handshake,
     do_handshake_until_both_error, do_handshake_until_error, make_client_config,
@@ -46,7 +48,14 @@ fn client_can_override_certificate_verification() {
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            do_handshake(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
         }
     }
 }
@@ -69,7 +78,14 @@ fn client_can_override_certificate_verification_and_reject_certificate() {
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            let errs = do_handshake_until_both_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let errs = do_handshake_until_both_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 errs,
                 Err(vec![
@@ -98,7 +114,14 @@ fn client_can_override_certificate_verification_and_reject_tls12_signatures() {
 
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-        let errs = do_handshake_until_both_error(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let errs = do_handshake_until_both_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             errs,
             Err(vec![
@@ -126,7 +149,14 @@ fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
 
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-        let errs = do_handshake_until_both_error(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let errs = do_handshake_until_both_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
         assert_eq!(
             errs,
             Err(vec![
@@ -153,7 +183,14 @@ fn client_can_override_certificate_verification_and_offer_no_signature_schemes()
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            let errs = do_handshake_until_both_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let errs = do_handshake_until_both_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 errs,
                 Err(vec![
@@ -188,7 +225,14 @@ fn test_pinned_ocsp_response_given_to_custom_server_cert_verifier() {
             .unwrap();
 
         let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
     }
 }
 
@@ -244,7 +288,14 @@ fn client_can_request_certain_trusted_cas() {
 
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(cas_sending_client_config), &server_config);
-        do_handshake(&mut client, &mut server);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
 
         let cas_unaware_client_config = ClientConfig::builder(provider.clone().into())
             .dangerous()
@@ -254,17 +305,22 @@ fn client_can_request_certain_trusted_cas() {
 
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(cas_unaware_client_config), &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-        cas_unaware_error_count += do_handshake_until_error(&mut client, &mut server)
-            .inspect_err(|e| {
-                assert!(matches!(
-                    e,
-                    ErrorFromPeer::Client(Error::InvalidCertificate(
-                        CertificateError::UnknownIssuer
-                    ))
-                ))
-            })
-            .is_err() as usize;
+        cas_unaware_error_count += do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        )
+        .inspect_err(|e| {
+            assert!(matches!(
+                e,
+                ErrorFromPeer::Client(Error::InvalidCertificate(CertificateError::UnknownIssuer))
+            ))
+        })
+        .is_err() as usize;
 
         println!("key type {key_type:?} success!");
     }
@@ -286,7 +342,14 @@ fn client_checks_server_certificate_with_given_ip_address() {
             .build()
             .unwrap();
         let mut server = ServerConnection::new(server_config).unwrap();
-        do_handshake_until_error(&mut client, &mut server)
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        )
     }
 
     let provider = provider::DEFAULT_PROVIDER;
@@ -341,7 +404,14 @@ fn client_checks_server_certificate_with_given_name() {
                 .unwrap();
             let mut server = ServerConnection::new(server_config.clone()).unwrap();
 
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 err,
                 Err(ErrorFromPeer::Client(Error::InvalidCertificate(
@@ -374,7 +444,14 @@ fn client_check_server_certificate_ee_revoked() {
             let mut server = ServerConnection::new(server_config.clone()).unwrap();
 
             // We expect the handshake to fail since the server's EE certificate is revoked.
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 err,
                 Err(ErrorFromPeer::Client(Error::InvalidCertificate(
@@ -420,7 +497,14 @@ fn client_check_server_certificate_ee_unknown_revocation() {
 
             // We expect if we use the forbid_unknown_verifier that the handshake will fail since the
             // server's EE certificate's revocation status is unknown given the CRLs we've provided.
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 err,
                 Err(ErrorFromPeer::Client(Error::InvalidCertificate(
@@ -436,7 +520,15 @@ fn client_check_server_certificate_ee_unknown_revocation() {
                 .build()
                 .unwrap();
             let mut server = ServerConnection::new(server_config.clone()).unwrap();
-            do_handshake_until_error(&mut client, &mut server).unwrap();
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            )
+            .unwrap();
         }
     }
 }
@@ -476,7 +568,14 @@ fn client_check_server_certificate_intermediate_revoked() {
 
             // We expect the handshake to fail when using the full chain verifier since the intermediate's
             // EE certificate is revoked.
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert_eq!(
                 err,
                 Err(ErrorFromPeer::Client(Error::InvalidCertificate(
@@ -493,7 +592,15 @@ fn client_check_server_certificate_intermediate_revoked() {
             let mut server = ServerConnection::new(server_config.clone()).unwrap();
             // We expect the handshake to succeed when we use the verifier that only checks the EE certificate
             // revocation status. The revoked intermediate status should not be checked.
-            do_handshake_until_error(&mut client, &mut server).unwrap();
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            )
+            .unwrap();
         }
     }
 }
@@ -531,7 +638,14 @@ fn client_check_server_certificate_ee_crl_expired() {
             let mut server = ServerConnection::new(server_config.clone()).unwrap();
 
             // We expect the handshake to fail since the CRL is expired.
-            let err = do_handshake_until_error(&mut client, &mut server);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            let err = do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
             assert!(matches!(
                 err,
                 Err(ErrorFromPeer::Client(Error::InvalidCertificate(
@@ -550,7 +664,15 @@ fn client_check_server_certificate_ee_crl_expired() {
             let mut server = ServerConnection::new(server_config.clone()).unwrap();
 
             // We expect the handshake to succeed when CRL expiration is ignored.
-            do_handshake_until_error(&mut client, &mut server).unwrap();
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake_until_error(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            )
+            .unwrap();
         }
     }
 }

--- a/rustls-test/tests/api/split.rs
+++ b/rustls-test/tests/api/split.rs
@@ -8,14 +8,20 @@ use std::io::{Cursor, Write};
 
 use rustls::error::{AlertDescription, ApiMisuse, InvalidMessage};
 use rustls::split::{ReceiveTraffic, ReceiveTrafficState, SplitConnection};
-use rustls::{Connection, Error, SideData, SliceInput};
+use rustls::{Connection, Error, SideData, SliceInput, VecInput};
 use rustls_test::{KeyType, do_handshake, make_pair};
 
 #[test]
 fn split_pairwise() {
     let (mut client, mut server) =
         make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let client_split = client.split().unwrap();
     println!("{client_split:?}");
@@ -86,7 +92,13 @@ fn split_pairwise() {
 fn split_incremental() {
     let (mut client, mut server) =
         make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let SplitConnection {
         send: mut client_send,
@@ -122,7 +134,13 @@ fn split_incremental() {
 fn split_client_tickets_received() {
     let (mut client, mut server) =
         make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     assert_eq!(
         client
@@ -153,7 +171,14 @@ fn split_fails_with_pending_plaintext() {
         make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
     assert_eq!(client.writer().write(b"huh").unwrap(), 3);
     assert_eq!(server.writer().write(b"hmm").unwrap(), 3);
-    do_handshake(&mut client, &mut server);
+
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     assert_eq!(
         server.split().err(),
@@ -169,7 +194,13 @@ fn split_fails_with_pending_plaintext() {
 fn key_update() {
     let (mut client, mut server) =
         make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let SplitConnection {
         send: mut client_send,
@@ -219,7 +250,13 @@ fn key_update() {
 fn key_update_alongside_data() {
     let (mut client, mut server) =
         make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let SplitConnection {
         send: mut client_send,
@@ -252,7 +289,13 @@ fn key_update_alongside_data() {
 fn close_alongside_data() {
     let (mut client, mut server) =
         make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let SplitConnection {
         send: mut client_send,
@@ -285,7 +328,13 @@ fn close_alongside_data() {
 fn read_invalid_data_and_send_alert() {
     let (mut client, mut server) =
         make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
-    do_handshake(&mut client, &mut server);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
 
     let receive = client.split().unwrap().receive;
 
@@ -299,11 +348,13 @@ fn read_invalid_data_and_send_alert() {
         Error::InvalidMessage(InvalidMessage::InvalidContentType)
     );
 
-    server
-        .read_tls(&mut Cursor::new(data))
+    server_input
+        .read(&mut Cursor::new(data))
         .unwrap();
     assert_eq!(
-        server.process_new_packets().err(),
+        server
+            .process_new_packets(&mut server_input)
+            .err(),
         Some(Error::AlertReceived(AlertDescription::DecodeError))
     );
 }

--- a/rustls-test/tests/key_log_file_env/tests.rs
+++ b/rustls-test/tests/key_log_file_env/tests.rs
@@ -27,7 +27,7 @@ use std::env;
 use std::io::Write;
 use std::sync::Arc;
 
-use rustls::Connection;
+use rustls::{Connection, VecInput};
 use rustls_test::{
     KeyType, do_handshake, make_client_config, make_pair_for_arc_configs, make_server_config,
     transfer,
@@ -49,12 +49,21 @@ fn exercise_key_log_file_for_client() {
 
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
 
             assert_eq!(5, client.writer().write(b"hello").unwrap());
 
-            do_handshake(&mut client, &mut server);
-            transfer(&mut client, &mut server);
-            server.process_new_packets().unwrap();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
+            transfer(&mut client, &mut server_input);
+            server
+                .process_new_packets(&mut server_input)
+                .unwrap();
         }
     })
 }
@@ -73,12 +82,21 @@ fn exercise_key_log_file_for_server() {
             let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
 
             assert_eq!(5, client.writer().write(b"hello").unwrap());
 
-            do_handshake(&mut client, &mut server);
-            transfer(&mut client, &mut server);
-            server.process_new_packets().unwrap();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
+            transfer(&mut client, &mut server_input);
+            server
+                .process_new_packets(&mut server_input)
+                .unwrap();
         }
     })
 }

--- a/rustls-util/src/lib.rs
+++ b/rustls-util/src/lib.rs
@@ -2,7 +2,7 @@ use std::io;
 
 mod key_log_file;
 pub use key_log_file::KeyLogFile;
-use rustls::Connection;
+use rustls::{Connection, VecInput};
 
 mod stream;
 pub use crate::stream::{Stream, StreamOwned};
@@ -37,6 +37,7 @@ pub use crate::stream::{Stream, StreamOwned};
 /// [`process_new_packets()`]: rustls::ConnectionCommon::process_new_packets
 pub fn complete_io(
     io: &mut (impl io::Read + io::Write),
+    input: &mut VecInput,
     conn: &mut dyn Connection,
 ) -> Result<(usize, usize), io::Error> {
     let mut eof = false;
@@ -83,7 +84,7 @@ pub fn complete_io(
         }
 
         while !eof && conn.wants_read() {
-            let read_size = match conn.read_tls(io) {
+            let read_size = match input.read(io) {
                 Ok(0) => {
                     eof = true;
                     Some(0)
@@ -104,7 +105,7 @@ pub fn complete_io(
             }
         }
 
-        if let Err(e) = conn.process_new_packets() {
+        if let Err(e) = conn.process_new_packets(input) {
             // In case we have an alert to send describing this error, try a last-gasp
             // write -- but don't predate the primary error.
             let _ignored = conn.write_tls(io);

--- a/rustls-util/src/stream.rs
+++ b/rustls-util/src/stream.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::std_instead_of_core)] // awaits core::io::IoSlice in stable (1.98)
 use std::io::{BufRead, IoSlice, Read, Result, Write};
 
-use rustls::Connection;
+use rustls::{Connection, VecInput};
 
 use crate::complete_io;
 
@@ -21,6 +21,9 @@ pub struct Stream<'a, C: 'a + ?Sized, T: 'a + Read + Write + ?Sized> {
 
     /// The underlying transport, like a socket
     pub sock: &'a mut T,
+
+    /// The input buffer
+    pub input: &'a mut VecInput,
 }
 
 impl<'a, C, T> Stream<'a, C, T>
@@ -30,19 +33,19 @@ where
 {
     /// Make a new Stream using the Connection `conn` and socket-like object
     /// `sock`.  This does not fail and does no IO.
-    pub fn new(conn: &'a mut C, sock: &'a mut T) -> Self {
-        Self { conn, sock }
+    pub fn new(input: &'a mut VecInput, conn: &'a mut C, sock: &'a mut T) -> Self {
+        Self { conn, sock, input }
     }
 
     /// If we're handshaking, complete all the IO for that.
     /// If we have data to write, write it all.
     fn complete_prior_io(&mut self) -> Result<()> {
         if self.conn.is_handshaking() {
-            complete_io(self.sock, self.conn)?;
+            complete_io(self.sock, self.input, self.conn)?;
         }
 
         if self.conn.wants_write() {
-            complete_io(self.sock, self.conn)?;
+            complete_io(self.sock, self.input, self.conn)?;
         }
 
         Ok(())
@@ -56,7 +59,7 @@ where
         // needed to get more plaintext, which we must do if EOF has not been
         // hit.
         while self.conn.wants_read() {
-            if complete_io(self.sock, self.conn)?.0 == 0 {
+            if complete_io(self.sock, self.input, self.conn)?.0 == 0 {
                 break;
             }
         }
@@ -92,6 +95,7 @@ where
         Stream {
             conn: self.conn,
             sock: self.sock,
+            input: self.input,
         }
         .fill_buf()
     }
@@ -114,7 +118,7 @@ where
         // Try to write the underlying transport here, but don't let
         // any errors mask the fact we've consumed `len` bytes.
         // Callers will learn of permanent errors on the next call.
-        let _ = complete_io(self.sock, self.conn);
+        let _ = complete_io(self.sock, self.input, self.conn);
 
         Ok(len)
     }
@@ -130,7 +134,7 @@ where
         // Try to write the underlying transport here, but don't let
         // any errors mask the fact we've consumed `len` bytes.
         // Callers will learn of permanent errors on the next call.
-        let _ = complete_io(self.sock, self.conn);
+        let _ = complete_io(self.sock, self.input, self.conn);
 
         Ok(len)
     }
@@ -140,7 +144,7 @@ where
 
         self.conn.writer().flush()?;
         if self.conn.wants_write() {
-            complete_io(self.sock, self.conn)?;
+            complete_io(self.sock, self.input, self.conn)?;
         }
         Ok(())
     }
@@ -162,6 +166,9 @@ pub struct StreamOwned<C: Sized, T: Read + Write + Sized> {
 
     /// The underlying transport, like a socket
     pub sock: T,
+
+    /// The input buffer
+    pub input: VecInput,
 }
 
 impl<C, T> StreamOwned<C, T>
@@ -175,7 +182,11 @@ where
     /// This is the same as `Stream::new` except `conn` and `sock` are
     /// moved into the StreamOwned.
     pub fn new(conn: C, sock: T) -> Self {
-        Self { conn, sock }
+        Self {
+            conn,
+            sock,
+            input: VecInput::default(),
+        }
     }
 
     /// Get a reference to the underlying socket
@@ -203,6 +214,7 @@ where
         Stream {
             conn: &mut self.conn,
             sock: &mut self.sock,
+            input: &mut self.input,
         }
     }
 }

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -7,6 +7,7 @@ use pki_types::{FipsStatus, ServerName};
 
 use super::config::ClientConfig;
 use super::hs::ClientHelloInput;
+use crate::TlsInputBuffer;
 use crate::client::EchStatus;
 use crate::common_state::{CommonState, ConnectionOutputs, EarlyDataEvent, Event, Protocol, Side};
 use crate::conn::private::SideOutput;
@@ -127,10 +128,6 @@ impl ClientConnection {
 }
 
 impl Connection for ClientConnection {
-    fn read_tls(&mut self, rd: &mut dyn io::Read) -> Result<usize, io::Error> {
-        self.inner.read_tls(rd)
-    }
-
     fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
         self.inner.write_tls(wr)
     }
@@ -151,8 +148,8 @@ impl Connection for ClientConnection {
         self.inner.writer()
     }
 
-    fn process_new_packets(&mut self) -> Result<IoState, Error> {
-        self.inner.process_new_packets()
+    fn process_new_packets(&mut self, buf: &mut dyn TlsInputBuffer) -> Result<IoState, Error> {
+        self.inner.process_new_packets(buf)
     }
 
     fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -37,7 +37,9 @@ use crate::verify::{
     HandshakeSignatureValid, PeerVerified, ServerIdentity, ServerVerifier,
     SignatureVerificationInput,
 };
-use crate::{Connection, DigitallySignedStruct, DistinguishedName, KeyLog, RootCertStore};
+use crate::{
+    Connection, DigitallySignedStruct, DistinguishedName, KeyLog, RootCertStore, VecInput,
+};
 
 #[test]
 fn tls12_client_session_value_roundtrip() {
@@ -199,10 +201,13 @@ fn test_client_rejects_hrr_with_varied_session_id() {
         )),
     };
 
-    conn.read_tls(&mut hrr.into_wire_bytes().as_slice())
+    let mut input = VecInput::default();
+    input
+        .read(&mut hrr.into_wire_bytes().as_slice())
         .unwrap();
     assert_eq!(
-        conn.process_new_packets().unwrap_err(),
+        conn.process_new_packets(&mut input)
+            .unwrap_err(),
         PeerMisbehaved::IllegalHelloRetryRequestWithWrongSessionId.into()
     );
 }
@@ -240,11 +245,13 @@ fn test_client_rejects_no_extended_master_secret_extension_when_require_ems_or_f
             },
         ))),
     };
-    conn.read_tls(&mut sh.into_wire_bytes().as_slice())
+    let mut input = VecInput::default();
+    input
+        .read(&mut sh.into_wire_bytes().as_slice())
         .unwrap();
 
     assert_eq!(
-        conn.process_new_packets(),
+        conn.process_new_packets(&mut input),
         Err(PeerIncompatible::ExtendedMasterSecretExtensionRequired.into())
     );
 }
@@ -314,9 +321,12 @@ fn test_client_with_custom_verifier_can_accept_ecdsa_sha1_signatures() {
             },
         ))),
     };
-    conn.read_tls(&mut sh.into_wire_bytes().as_slice())
+    let mut input = VecInput::default();
+    input
+        .read(&mut sh.into_wire_bytes().as_slice())
         .unwrap();
-    conn.process_new_packets().unwrap();
+    conn.process_new_packets(&mut input)
+        .unwrap();
 
     let cert = Message {
         version: ProtocolVersion::TLSv1_2,
@@ -324,9 +334,11 @@ fn test_client_with_custom_verifier_can_accept_ecdsa_sha1_signatures() {
             CertificateChain(vec![CertificateDer::from(&b"does not matter"[..])]),
         ))),
     };
-    conn.read_tls(&mut cert.into_wire_bytes().as_slice())
+    input
+        .read(&mut cert.into_wire_bytes().as_slice())
         .unwrap();
-    conn.process_new_packets().unwrap();
+    conn.process_new_packets(&mut input)
+        .unwrap();
 
     let server_kx = Message {
         version: ProtocolVersion::TLSv1_2,
@@ -348,9 +360,11 @@ fn test_client_with_custom_verifier_can_accept_ecdsa_sha1_signatures() {
             )),
         )),
     };
-    conn.read_tls(&mut server_kx.into_wire_bytes().as_slice())
+    input
+        .read(&mut server_kx.into_wire_bytes().as_slice())
         .unwrap();
-    conn.process_new_packets().unwrap();
+    conn.process_new_packets(&mut input)
+        .unwrap();
 
     let server_done = Message {
         version: ProtocolVersion::TLSv1_2,
@@ -358,9 +372,11 @@ fn test_client_with_custom_verifier_can_accept_ecdsa_sha1_signatures() {
             HandshakePayload::ServerHelloDone,
         )),
     };
-    conn.read_tls(&mut server_done.into_wire_bytes().as_slice())
+    input
+        .read(&mut server_done.into_wire_bytes().as_slice())
         .unwrap();
-    conn.process_new_packets().unwrap();
+    conn.process_new_packets(&mut input)
+        .unwrap();
 
     assert!(
         verifier
@@ -517,9 +533,12 @@ fn client_requiring_rpk_receives_server_ee(
             },
         ))),
     };
-    conn.read_tls(&mut sh.into_wire_bytes().as_slice())
+    let mut input = VecInput::default();
+    input
+        .read(&mut sh.into_wire_bytes().as_slice())
         .unwrap();
-    conn.process_new_packets().unwrap();
+    conn.process_new_packets(&mut input)
+        .unwrap();
 
     let ee = Message {
         version: ProtocolVersion::TLSv1_3,
@@ -532,10 +551,15 @@ fn client_requiring_rpk_receives_server_ee(
     let enc_ee = encrypter
         .encrypt(EncodedMessage::<Payload<'_>>::from(ee).borrow_outbound(), 0)
         .unwrap();
-    conn.read_tls(&mut enc_ee.encode().as_slice())
+    input
+        .read(&mut enc_ee.encode().as_slice())
         .unwrap();
 
-    assert_eq!(conn.process_new_packets().map(|_| ()), expected);
+    assert_eq!(
+        conn.process_new_packets(&mut input)
+            .map(|_| ()),
+        expected
+    );
 }
 
 fn client_credentials(provider: &CryptoProvider) -> Credentials {

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -39,30 +39,6 @@ use crate::crypto::cipher::OutboundPlain;
 
 /// A trait generalizing over buffered client or server connections.
 pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
-    /// Read TLS content from `rd` into the internal buffer.
-    ///
-    /// Due to the internal buffering, `rd` can supply TLS messages in arbitrary-sized chunks (like
-    /// a socket or pipe might).
-    ///
-    /// You should call [`process_new_packets()`] each time a call to this function succeeds in order
-    /// to empty the incoming TLS data buffer.
-    ///
-    /// This function returns `Ok(0)` when the underlying `rd` does so. This typically happens when
-    /// a socket is cleanly closed, or a file is at EOF. Errors may result from the IO done through
-    /// `rd`; additionally, errors of `ErrorKind::Other` are emitted to signal backpressure:
-    ///
-    /// * In order to empty the incoming TLS data buffer, you should call [`process_new_packets()`]
-    ///   each time a call to this function succeeds.
-    /// * In order to empty the incoming plaintext data buffer, you should empty it through
-    ///   the [`reader()`] after the call to [`process_new_packets()`].
-    ///
-    /// This function also returns `Ok(0)` once a `close_notify` alert has been successfully
-    /// received.  No additional data is ever read in this state.
-    ///
-    /// [`process_new_packets()`]: Connection::process_new_packets
-    /// [`reader()`]: Connection::reader
-    fn read_tls(&mut self, rd: &mut dyn Read) -> Result<usize, io::Error>;
-
     /// Writes TLS messages to `wr`.
     ///
     /// On success, this function returns `Ok(n)` where `n` is a number of bytes written to `wr`
@@ -73,15 +49,14 @@ pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
     /// empty.
     fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error>;
 
-    /// Returns true if the caller should call [`Connection::read_tls`] as soon
+    /// Returns true if the caller should call [`Connection::process_new_packets()`] as soon
     /// as possible.
     ///
-    /// If there is pending plaintext data to read with [`Connection::reader`],
+    /// If there is pending plaintext data to read with [`Connection::reader()`],
     /// this returns false.  If your application respects this mechanism,
     /// only one full TLS message will be buffered by rustls.
     ///
     /// [`Connection::reader`]: crate::Connection::reader
-    /// [`Connection::read_tls`]: crate::Connection::read_tls
     fn wants_read(&self) -> bool;
 
     /// Returns true if the caller should call [`Connection::write_tls`] as soon as possible.
@@ -95,15 +70,13 @@ pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
     /// Returns an object that allows writing plaintext.
     fn writer(&mut self) -> Writer<'_>;
 
-    /// Processes any new packets read by a previous call to
-    /// [`Connection::read_tls`].
+    /// Processes any new packets from the buffer supplied in `buf`.
     ///
     /// Errors from this function relate to TLS protocol errors, and
     /// are fatal to the connection.  Future calls after an error will do
     /// no new work and will return the same error. After an error is
-    /// received from [`process_new_packets()`], you should not call [`read_tls()`]
-    /// any more (it will fill up buffers to no purpose). However, you
-    /// may call the other methods on the connection, including `write`,
+    /// received from [`process_new_packets()`], you should not continue to fill up the buffer.
+    /// However, you may call the other methods on the connection, including `write`,
     /// `send_close_notify`, and `write_tls`. Most likely you will want to
     /// call `write_tls` to send any alerts queued by the error and then
     /// close the underlying connection.
@@ -112,8 +85,7 @@ pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
     /// about the connection.
     ///
     /// [`process_new_packets()`]: Connection::process_new_packets
-    /// [`read_tls()`]: Connection::read_tls
-    fn process_new_packets(&mut self) -> Result<IoState, Error>;
+    fn process_new_packets(&mut self, buf: &mut dyn TlsInputBuffer) -> Result<IoState, Error>;
 
     /// Returns an object that can derive key material from the agreed connection secrets.
     ///
@@ -531,21 +503,33 @@ impl<Side: SideData> ConnectionCommon<Side> {
     }
 
     #[inline]
-    pub(crate) fn process_new_packets(&mut self) -> Result<IoState, Error> {
+    pub(crate) fn process_new_packets(
+        &mut self,
+        buf: &mut dyn TlsInputBuffer,
+    ) -> Result<IoState, Error> {
+        if buf.has_seen_eof() {
+            self.buffers.has_seen_eof = true;
+        } else if self
+            .buffers
+            .received_plaintext
+            .is_full()
+        {
+            return Err(ApiMisuse::ReceivedPlaintextBufferFull.into());
+        }
+
         loop {
             let Some(payload) = self
                 .core
-                .process_new_packets(&mut self.buffers.deframer_buffer, None)?
+                .process_new_packets(buf, None)?
             else {
                 break;
             };
 
-            let payload =
-                payload.reborrow(&Delocator::new(self.buffers.deframer_buffer.slice_mut()));
+            let payload = payload.reborrow(&Delocator::new(buf.slice_mut()));
             self.buffers
                 .received_plaintext
                 .append(payload.into_vec());
-            self.buffers.deframer_buffer.discard(
+            buf.discard(
                 self.core
                     .common
                     .recv
@@ -659,26 +643,6 @@ impl<Side: SideData> ConnectionCommon<Side> {
         Writer::new(self)
     }
 
-    pub(crate) fn read_tls(&mut self, rd: &mut dyn Read) -> Result<usize, io::Error> {
-        if self
-            .buffers
-            .received_plaintext
-            .is_full()
-        {
-            return Err(io::Error::other("received plaintext buffer full"));
-        }
-
-        if self.recv.has_received_close_notify {
-            return Ok(0);
-        }
-
-        let res = self.buffers.deframer_buffer.read(rd);
-        if let Ok(0) = res {
-            self.buffers.has_seen_eof = true;
-        }
-        res
-    }
-
     pub(crate) fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
         self.send.sendable_tls.write_to(wr)
     }
@@ -700,7 +664,6 @@ impl<Side: SideData> DerefMut for ConnectionCommon<Side> {
 
 /// Common items for buffered, std::io-using connections.
 pub(crate) struct Buffers {
-    deframer_buffer: VecInput,
     pub(crate) received_plaintext: ChunkVecBuffer,
     pub(crate) sendable_plaintext: ChunkVecBuffer,
     pub(crate) has_seen_eof: bool,
@@ -709,7 +672,6 @@ pub(crate) struct Buffers {
 impl Buffers {
     fn new() -> Self {
         Self {
-            deframer_buffer: VecInput::default(),
             received_plaintext: ChunkVecBuffer::new(Some(DEFAULT_RECEIVED_PLAINTEXT_LIMIT)),
             sendable_plaintext: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
             has_seen_eof: false,
@@ -717,9 +679,7 @@ impl Buffers {
     }
 
     fn is_empty(&self) -> bool {
-        self.received_plaintext.is_empty()
-            && self.deframer_buffer.filled().is_empty()
-            && self.sendable_plaintext.is_empty()
+        self.received_plaintext.is_empty() && self.sendable_plaintext.is_empty()
     }
 }
 

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -168,6 +168,7 @@ impl ReceivePath {
                 // Then the rest of any input data.
                 let entirety = input.slice_mut().len();
                 input.discard(entirety);
+                input.received_close_notify();
                 break;
             }
 
@@ -683,6 +684,12 @@ pub struct VecInput {
 
     /// What size prefix of `buf` is used.
     used: usize,
+
+    /// Whether we've seen a 0-byte read.
+    has_seen_eof: bool,
+
+    /// Whether a CloseNotify alert has been seen.
+    received_close_notify: bool,
 }
 
 impl VecInput {
@@ -715,8 +722,10 @@ impl VecInput {
     }
 
     /// Read some bytes from `rd`, and add them to the buffer.
-    pub(crate) fn read(&mut self, rd: &mut dyn Read) -> io::Result<usize> {
-        if let Err(err) = self.prepare_read() {
+    pub fn read(&mut self, rd: &mut dyn Read) -> io::Result<usize> {
+        if self.received_close_notify {
+            return Ok(0);
+        } else if let Err(err) = self.prepare_read() {
             return Err(io::Error::new(io::ErrorKind::InvalidData, err));
         }
 
@@ -725,6 +734,10 @@ impl VecInput {
         // we do a zero length read.  That looks like an EOF to
         // the next layer up, which is fine.
         let new_bytes = rd.read(&mut self.buf[self.used..])?;
+        if new_bytes == 0 {
+            self.has_seen_eof = true;
+        }
+
         self.used += new_bytes;
         Ok(new_bytes)
     }
@@ -791,6 +804,14 @@ impl TlsInputBuffer for VecInput {
     fn discard(&mut self, num_bytes: usize) {
         self.discard(num_bytes)
     }
+
+    fn received_close_notify(&mut self) {
+        self.received_close_notify = true;
+    }
+
+    fn has_seen_eof(&self) -> bool {
+        self.has_seen_eof
+    }
 }
 
 /// A borrowed version of [`VecInput`] that tracks discard operations
@@ -800,12 +821,21 @@ pub struct SliceInput<'a> {
     buf: &'a mut [u8],
     // number of bytes to discard from the front of `buf` at a later time
     discard: usize,
+    /// Whether we've seen a 0-byte read.
+    has_seen_eof: bool,
+    /// Whether a CloseNotify alert has been seen.
+    received_close_notify: bool,
 }
 
 impl<'a> SliceInput<'a> {
     /// Create a new [`SliceInput`] from a mutable slice of bytes.
     pub fn new(buf: &'a mut [u8]) -> Self {
-        Self { buf, discard: 0 }
+        Self {
+            buf,
+            discard: 0,
+            has_seen_eof: false,
+            received_close_notify: false,
+        }
     }
 
     /// Returns how many bytes were consumed at the start of the original buffer.
@@ -821,6 +851,14 @@ impl TlsInputBuffer for SliceInput<'_> {
 
     fn discard(&mut self, num_bytes: usize) {
         self.discard += num_bytes;
+    }
+
+    fn received_close_notify(&mut self) {
+        self.received_close_notify = true;
+    }
+
+    fn has_seen_eof(&self) -> bool {
+        self.has_seen_eof
     }
 }
 
@@ -850,6 +888,16 @@ pub trait TlsInputBuffer {
     /// Rustls guarantees it will not `discard()` more bytes than are returned
     /// from `slice_mut()`.
     fn discard(&mut self, num_bytes: usize);
+
+    /// Signal that the connection has received a TLS `close_notify` alert.
+    ///
+    /// The buffer should not accept any more data, because the peer has closed the connection.
+    fn received_close_notify(&mut self);
+
+    /// Whether the buffer has seen a TCP EOF.
+    ///
+    /// This is not a TCP-level event, but it is signalled to the TLS state via the input buffer.
+    fn has_seen_eof(&self) -> bool;
 }
 
 /// cf. BoringSSL's `kMaxEmptyRecords`

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1448,6 +1448,9 @@ pub enum ApiMisuse {
     /// ECH attempted with a configuration that also supports TLS1.2.
     EchForbidsTls12Support,
 
+    /// The received plaintext buffer is full; read out some plaintext before receiving more.
+    ReceivedPlaintextBufferFull,
+
     /// Secret extraction operation attempted without opting-in to secret extraction.
     ///
     /// This is possible from [`Connection::dangerous_extract_secrets()`][crate::Connection::dangerous_extract_secrets].

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -114,10 +114,9 @@
 //!
 //! ### Rustls provides encrypted pipes
 //! These are the [`ServerConnection`] and [`ClientConnection`] types.  You supply raw TLS traffic
-//! on the left (via the [`read_tls()`] and [`write_tls()`] methods) and then read/write the
+//! on the left (via a [`TlsInputBuffer`] and [`write_tls()`] methods) and then read/write the
 //! plaintext on the right:
 //!
-//! [`read_tls()`]: Connection::read_tls
 //! [`write_tls()`]: Connection::write_tls
 //!
 //! ```text
@@ -234,14 +233,15 @@
 //! #   panic!();
 //! # }
 //! use std::io;
-//! use rustls::Connection;
+//! use rustls::{Connection, VecInput};
 //!
 //! client.writer().write(b"GET / HTTP/1.0\r\n\r\n").unwrap();
 //! let mut socket = connect("example.com", 443);
+//! let mut input = VecInput::default();
 //! loop {
 //!   if client.wants_read() && socket.ready_for_read() {
-//!     client.read_tls(&mut socket).unwrap();
-//!     client.process_new_packets().unwrap();
+//!     input.read(&mut socket).unwrap();
+//!     client.process_new_packets(&mut input).unwrap();
 //!
 //!     let mut plaintext = Vec::new();
 //!     client.reader().read_to_end(&mut plaintext).unwrap();

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -475,7 +475,7 @@ fn check_server_config(config: &ServerConfig) -> Result<(), Error> {
 /// A shared interface for QUIC connections.
 struct ConnectionCommon<Side: SideData> {
     core: ConnectionCore<Side>,
-    deframer_buffer: VecInput,
+    input: VecInput,
     quic: Quic,
 }
 
@@ -483,7 +483,7 @@ impl<Side: SideData> ConnectionCommon<Side> {
     fn new(core: ConnectionCore<Side>, quic: Quic) -> Self {
         Self {
             core,
-            deframer_buffer: VecInput::default(),
+            input: VecInput::default(),
             quic,
         }
     }
@@ -514,7 +514,7 @@ impl<Side: SideData> ConnectionCommon<Side> {
     }
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), Error> {
-        let range = self.deframer_buffer.extend(plaintext);
+        let range = self.input.extend(plaintext);
 
         let deframer = &mut self.core.common.recv.deframer;
         deframer.add_processed(range.len());
@@ -522,7 +522,7 @@ impl<Side: SideData> ConnectionCommon<Side> {
             EncodedMessage {
                 typ: ContentType::Handshake,
                 version: ProtocolVersion::TLSv1_3,
-                payload: &self.deframer_buffer.filled()[range.start..range.end],
+                payload: &self.input.filled()[range.start..range.end],
             },
             range,
         );
@@ -531,10 +531,10 @@ impl<Side: SideData> ConnectionCommon<Side> {
             .common
             .recv
             .deframer
-            .coalesce(self.deframer_buffer.filled_mut())?;
+            .coalesce(self.input.filled_mut())?;
 
         self.core
-            .process_new_packets(&mut self.deframer_buffer, Some(&mut self.quic))?;
+            .process_new_packets(&mut self.input, Some(&mut self.quic))?;
 
         Ok(())
     }

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -13,7 +13,7 @@ use crate::conn::private::SideOutput;
 use crate::conn::split::SplitConnection;
 use crate::conn::{
     Connection, ConnectionCommon, ConnectionCore, KeyingMaterialExporter, Reader, SendPath,
-    SideData, Writer,
+    SideData, TlsInputBuffer, Writer,
 };
 #[cfg(doc)]
 use crate::crypto;
@@ -139,10 +139,6 @@ impl ServerConnection {
 }
 
 impl Connection for ServerConnection {
-    fn read_tls(&mut self, rd: &mut dyn io::Read) -> Result<usize, io::Error> {
-        self.inner.read_tls(rd)
-    }
-
     fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
         self.inner.write_tls(wr)
     }
@@ -163,8 +159,11 @@ impl Connection for ServerConnection {
         self.inner.writer()
     }
 
-    fn process_new_packets(&mut self) -> Result<crate::IoState, Error> {
-        self.inner.process_new_packets()
+    fn process_new_packets(
+        &mut self,
+        buf: &mut dyn TlsInputBuffer,
+    ) -> Result<crate::IoState, Error> {
+        self.inner.process_new_packets(buf)
     }
 
     fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
@@ -278,21 +277,6 @@ impl Default for Acceptor {
 }
 
 impl Acceptor {
-    /// Read TLS content from `rd`.
-    ///
-    /// Returns an error if this `Acceptor` has already yielded an [`Accepted`]. For more details,
-    /// refer to [`Connection::read_tls()`].
-    ///
-    /// [`Connection::read_tls()`]: crate::Connection::read_tls
-    pub fn read_tls(&mut self, rd: &mut dyn io::Read) -> Result<usize, io::Error> {
-        match &mut self.inner {
-            Some(conn) => conn.read_tls(rd),
-            None => Err(io::Error::other(
-                "acceptor cannot read after successful acceptance",
-            )),
-        }
-    }
-
     /// Check if a `ClientHello` message has been received.
     ///
     /// Returns `Ok(None)` if the complete `ClientHello` has not yet been received.
@@ -304,7 +288,10 @@ impl Acceptor {
     /// Returns `Err((err, alert))` if an error occurred. If an alert is returned, the
     /// application should call `alert.write()` to send the alert to the client. It should
     /// not call `accept()` again.
-    pub fn accept(&mut self) -> Result<Option<Accepted>, (Error, AcceptedAlert)> {
+    pub fn accept(
+        &mut self,
+        buf: &mut dyn TlsInputBuffer,
+    ) -> Result<Option<Accepted>, (Error, AcceptedAlert)> {
         let Some(mut connection) = self.inner.take() else {
             return Err((
                 ApiMisuse::AcceptorPolledAfterCompletion.into(),
@@ -312,7 +299,7 @@ impl Acceptor {
             ));
         };
 
-        if let Err(e) = connection.process_new_packets() {
+        if let Err(e) = connection.process_new_packets(buf) {
             return Err(AcceptedAlert::from_error(e, connection.core.common.send));
         }
 

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -9,7 +9,7 @@ use super::{
     CommonServerSessionValue, ServerConfig, ServerConnection, ServerSessionValue,
     Tls13ServerSessionValue,
 };
-use crate::conn::{Connection, Input};
+use crate::conn::{Connection, Input, VecInput};
 use crate::crypto::cipher::FakeAead;
 use crate::crypto::kx::ffdhe::{FFDHE2048, FfdheGroup};
 use crate::crypto::kx::{
@@ -167,8 +167,10 @@ fn select_cipher_suite(
             client_hello,
         ))),
     };
-    conn.read_tls(&mut ch.into_wire_bytes().as_slice())?;
-    conn.process_new_packets()?;
+
+    let mut input = VecInput::default();
+    input.read(&mut ch.into_wire_bytes().as_slice())?;
+    conn.process_new_packets(&mut input)?;
 
     let mut flight = vec![];
     conn.write_tls(&mut &mut flight)
@@ -196,6 +198,7 @@ fn test_server_rejects_no_extended_master_secret_extension_when_require_ems_or_f
         config.require_ems = true;
     }
     let mut conn = ServerConnection::new(config.into()).unwrap();
+    let mut input = VecInput::default();
 
     let mut ch = minimal_client_hello();
     ch.extensions
@@ -207,11 +210,12 @@ fn test_server_rejects_no_extended_master_secret_extension_when_require_ems_or_f
             ch,
         ))),
     };
-    conn.read_tls(&mut ch.into_wire_bytes().as_slice())
+    input
+        .read(&mut ch.into_wire_bytes().as_slice())
         .unwrap();
 
     assert_eq!(
-        conn.process_new_packets(),
+        conn.process_new_packets(&mut input),
         Err(Error::PeerIncompatible(
             PeerIncompatible::ExtendedMasterSecretExtensionRequired
         ))
@@ -284,15 +288,18 @@ fn server_chooses_ffdhe_group_for_client_hello(
     mut conn: ServerConnection,
     client_hello: ClientHelloPayload,
 ) {
+    let mut input = VecInput::default();
     let ch = Message {
         version: ProtocolVersion::TLSv1_3,
         payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::ClientHello(
             client_hello,
         ))),
     };
-    conn.read_tls(&mut ch.into_wire_bytes().as_slice())
+    input
+        .read(&mut ch.into_wire_bytes().as_slice())
         .unwrap();
-    conn.process_new_packets().unwrap();
+    conn.process_new_packets(&mut input)
+        .unwrap();
 
     let mut flight = vec![];
     conn.write_tls(&mut &mut flight)
@@ -334,10 +341,13 @@ fn test_server_requiring_rpk_client_rejects_x509_client() {
     };
 
     let mut conn = ServerConnection::new(Arc::new(server_config)).unwrap();
-    conn.read_tls(&mut ch.into_wire_bytes().as_slice())
+    let mut input = VecInput::default();
+    input
+        .read(&mut ch.into_wire_bytes().as_slice())
         .unwrap();
     assert_eq!(
-        conn.process_new_packets().unwrap_err(),
+        conn.process_new_packets(&mut input)
+            .unwrap_err(),
         PeerIncompatible::IncorrectCertificateTypeExtension.into(),
     );
 }
@@ -358,11 +368,14 @@ fn test_rpk_only_server_rejects_x509_only_client() {
     };
 
     let mut conn = ServerConnection::new(Arc::new(server_config)).unwrap();
-    conn.read_tls(&mut ch.into_wire_bytes().as_slice())
+    let mut input = VecInput::default();
+    input
+        .read(&mut ch.into_wire_bytes().as_slice())
         .unwrap();
 
     assert_eq!(
-        conn.process_new_packets().unwrap_err(),
+        conn.process_new_packets(&mut input)
+            .unwrap_err(),
         PeerIncompatible::IncorrectCertificateTypeExtension.into(),
     );
 }


### PR DESCRIPTION
This is an incremental step towards externalizing buffer management. After this, I think we can drop the received plaintext buffer in favor of yielding a slice iterator from `process_new_packets()`, and other simplifications.