### PR TITLE
Adjust --release profile for benchmarking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,13 +249,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Smoke-test benchmark program (ring)
-        run: cargo run -p rustls-bench --profile=bench --locked --features ring -- --multiplier 0.1
+        run: cargo run -p rustls-bench --release --locked --features ring -- --multiplier 0.1
 
       - name: Smoke-test benchmark program (aws-lc-rs)
-        run: cargo run -p rustls-bench --profile=bench --locked --features aws-lc-rs -- --multiplier 0.1
+        run: cargo run -p rustls-bench --release --locked --features aws-lc-rs -- --multiplier 0.1
 
       - name: Smoke-test benchmark program (fips)
-        run: cargo run -p rustls-bench --profile=bench --locked --features fips -- --provider aws-lc-rs-fips --multiplier 0.1
+        run: cargo run -p rustls-bench --release --locked --features fips -- --provider aws-lc-rs-fips --multiplier 0.1
 
       - name: Run micro-benchmarks
         run: cargo bench --locked --all-features

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -27,11 +27,9 @@ benchmarks](https://github.com/ctz/openssl-bench), which produce similar measure
 #### Building
 
 The benchmarks are implemented in `rustls-bench/src/main.rs`.
-Use `cargo build --profile=bench -p rustls-bench --features aws-lc-rs` to obtain the corresponding
+Use `cargo build --release -p rustls-bench --features aws-lc-rs` to obtain the corresponding
 binary (you can toggle conditionally compiled code with the `--no-default-features` and `--features`
 flags) or simply run below, which will build and run the benchmark.
-
-Note: The usage of `--release` instead of `--profile=bench` also works, but it is less performant.
 
 #### Running
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,10 +113,6 @@ zlib-rs = "0.6"
 [profile.release]
 lto = true
 
-[profile.bench]
-codegen-units = 1
-lto = true
-
 [workspace.lints.clippy]
 alloc_instead_of_core = "warn"
 cloned_instead_of_copied = "warn"

--- a/admin/bench-measure.mk
+++ b/admin/bench-measure.mk
@@ -69,6 +69,6 @@ clean:
 	cargo clean
 
 $(BENCH): .FORCE
-	cargo build --profile=bench -p rustls-bench --features $(PROVIDER)
+	cargo build --release -p rustls-bench --features $(PROVIDER)
 
 .FORCE:


### PR DESCRIPTION
Turns on LTO for `--release`, which should affect the CI benchmarks somewhat, at the expense of slower `--release` builds. That effect isn't transitive onto our dependents.