### PR TITLE
Introduce new state-based API, and move buffered APIs to use it

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Check simple 0rtt client
         run: cargo run --locked -p rustls-examples --bin simple_0rtt_client
 
+      - name: Check async state-based tokio client
+        run: cargo run --locked -p rustls-examples --bin async-client
+
       # Test the server_acceptor binary builds - we invoke with --help since it
       # will run a server process that doesn't exit when invoked with no args
       - name: Check server acceptor

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ We recommend new users start by looking at `simpleclient.rs` and `simpleserver.r
 
 ## Client examples
 
+* `async-client.rs` - demonstrates using the lower-level state-based API to make a client using `tokio` for asynchronous I/O.
 * `simpleclient.rs` - shows a simple client configuration that uses sensible defaults. It demonstrates using the `Stream` helper to treat a Rustls connection as you would a bi-directional TCP stream.
 * `tlsclient-mio.rs` - shows a more complete client example that handles command line flags for customizing TLS options, and uses MIO to handle asynchronous I/O.
 * `limitedclient.rs` - shows how to configure Rustls so that unused cryptography is discarded by the linker. This client only supports TLS 1.3 and a single cipher suite.

--- a/examples/src/bin/async-client.rs
+++ b/examples/src/bin/async-client.rs
@@ -1,0 +1,164 @@
+//! This is a simple client using rustls' state-based API, in conjunction with asynchronous I/O via
+//! tokio.  The application manages its own receive buffer.
+
+use core::error::Error;
+use std::sync::Arc;
+
+use rustls::client::{ClientHandshake, ClientTraffic};
+use rustls::crypto::cipher::OutboundPlain;
+use rustls::state::{ReceiveTrafficState, SliceInput, TlsInputBuffer};
+use rustls::{ClientConfig, RootCertStore};
+use rustls_aws_lc_rs::DEFAULT_PROVIDER;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    };
+
+    let config = ClientConfig::builder(Arc::new(DEFAULT_PROVIDER))
+        .with_root_certificates(root_store)
+        .with_no_client_auth()?;
+
+    let config = Arc::new(config);
+
+    let mut incoming_tls = vec![0; INCOMING_TLS_BUFSIZE];
+
+    let mut state = config
+        .connect(SERVER_NAME.try_into()?)
+        .start_handshake()?;
+    let mut sock = TcpStream::connect(format!("{SERVER_NAME}:{PORT}")).await?;
+
+    let mut incoming_used = 0;
+
+    // complete handshake
+    let traffic = loop {
+        state = match state {
+            ClientHandshake::SendClientFlight(mut send) => {
+                while let Some(data) = send.take_data() {
+                    sock.write_all(&data).await?;
+                }
+                send.into_next()
+            }
+
+            ClientHandshake::AwaitServerFlight(recv) => {
+                recv_tls(&mut sock, &mut incoming_tls, &mut incoming_used).await?;
+                let mut buffer = SliceInput::new(&mut incoming_tls[..incoming_used]);
+                let next = match recv.input_data(&mut buffer) {
+                    Ok(next) => next,
+                    Err((mut err_alert, _outputs)) => {
+                        while let Some(data) = err_alert.take_tls_data() {
+                            sock.write_all(&data).await?;
+                        }
+                        return Err(err_alert.error.into());
+                    }
+                };
+
+                let used = buffer.into_used();
+                // note, this is a very inefficient buffer representation.
+                incoming_tls.copy_within(used..incoming_used, 0);
+                incoming_used -= used;
+                next
+            }
+
+            ClientHandshake::Complete(traffic) => break traffic,
+
+            _ => todo!(),
+        };
+    };
+
+    let ClientTraffic {
+        mut send,
+        mut receive,
+        outputs,
+    } = *traffic;
+
+    println!(
+        "connected to server with version={:?} cipher suite={:?}",
+        outputs.protocol_version(),
+        outputs.negotiated_cipher_suite()
+    );
+
+    let request = [
+        b"GET / HTTP/1.1\r\n\
+        Host: ",
+        SERVER_NAME.as_bytes(),
+        b"\r\n\
+        Connection: close\r\n\
+        Accept-Encoding: identity\r\n\
+        \r\n",
+    ];
+    let mut tls_data = send.write(OutboundPlain::new(&request))?;
+    tls_data.push(send.close());
+    for chunk in tls_data {
+        sock.write_all(&chunk).await?;
+    }
+
+    loop {
+        let mut buffer = SliceInput::new(&mut incoming_tls[..incoming_used]);
+        let received = match receive.read(&mut buffer) {
+            Ok(received) => received,
+            Err(mut err_alert) => {
+                while let Some(data) = err_alert.take_tls_data() {
+                    sock.write_all(&data).await?;
+                }
+                return Err(err_alert.error.into());
+            }
+        };
+
+        receive = match received {
+            ReceiveTrafficState::Await(receive) => {
+                if recv_tls(&mut sock, &mut incoming_tls, &mut incoming_used).await? == 0 {
+                    println!("server uncleanly closed connection");
+                    break;
+                }
+                receive
+            }
+
+            ReceiveTrafficState::WakeSender(wake) => {
+                // sender already closed; nothing to do
+                wake.into_next()
+            }
+
+            ReceiveTrafficState::Available(data) => {
+                println!(
+                    "received response: {:?}",
+                    String::from_utf8_lossy(data.data)
+                );
+                let (used, next_state) = data.into_next();
+                buffer.discard(used);
+                let used = buffer.into_used();
+                incoming_tls.copy_within(used..incoming_used, 0);
+                incoming_used -= used;
+                next_state
+            }
+
+            ReceiveTrafficState::CloseNotify => {
+                println!("server cleanly closed connection");
+                break;
+            }
+        };
+    }
+
+    Ok(())
+}
+
+async fn recv_tls(
+    sock: &mut TcpStream,
+    incoming_tls: &mut [u8],
+    incoming_used: &mut usize,
+) -> Result<usize, Box<dyn Error>> {
+    let read = sock
+        .read(&mut incoming_tls[*incoming_used..])
+        .await?;
+    println!("received {read}B of data");
+    *incoming_used += read;
+    Ok(read)
+}
+
+const SERVER_NAME: &str = "jbp.io";
+const PORT: u16 = 443;
+
+const INCOMING_TLS_BUFSIZE: usize = 16 * 1024;

--- a/rustls-test/tests/api.rs
+++ b/rustls-test/tests/api.rs
@@ -31,6 +31,8 @@ mod tests_with_ring {
     mod resume;
     #[path = "api/server_cert_verifier.rs"]
     mod server_cert_verifier;
+    #[path = "api/state.rs"]
+    mod state;
     #[path = "api/api.rs"]
     mod tests;
 }
@@ -64,6 +66,8 @@ mod tests_with_aws_lc_rs {
     mod resume;
     #[path = "api/server_cert_verifier.rs"]
     mod server_cert_verifier;
+    #[path = "api/state.rs"]
+    mod state;
     #[path = "api/api.rs"]
     mod tests;
 }

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -2056,7 +2056,7 @@ fn test_junk_after_close_notify_received() {
 }
 
 #[test]
-fn test_data_after_close_notify_is_ignored() {
+fn test_data_after_close_notify_is_refused() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     do_handshake(&mut client, &mut server);
 
@@ -2065,10 +2065,7 @@ fn test_data_after_close_notify_is_ignored() {
         .write_all(b"before")
         .unwrap();
     client.send_close_notify();
-    client
-        .writer()
-        .write_all(b"after")
-        .unwrap();
+    assert_eq!(client.writer().write(b"after").unwrap(), 0);
     transfer(&mut client, &mut server);
     server.process_new_packets().unwrap();
 

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1,6 +1,7 @@
 //! Tests around IO, buffering, and data management.
 
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
+#![allow(clippy::std_instead_of_core)] // awaits core::io::IoSlice in stable (1.98)
 
 use core::fmt::Debug;
 use std::borrow::Cow;

--- a/rustls-test/tests/api/state.rs
+++ b/rustls-test/tests/api/state.rs
@@ -1,0 +1,248 @@
+//! Tests for mid-level state-based API
+
+#![allow(clippy::disallowed_types, clippy::duplicate_mod)]
+
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+use rustls::client::{ClientHandshake, ClientTraffic};
+use rustls::server::{ServerHandshake, ServerTraffic};
+use rustls::state::{ReceiveTrafficState, SliceInput, TlsInputBuffer};
+use rustls::{Connection, ServerConnection};
+use rustls_test::{KeyType, make_client_config, make_server_config};
+
+use super::provider;
+
+#[test]
+fn test_client_smoke() {
+    let server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut server = ServerConnection::new(server_config.into()).unwrap();
+
+    server
+        .writer()
+        .write_all(b"hello from server")
+        .unwrap();
+
+    let mut client_config = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    client_config.max_fragment_size = Some(64);
+    let mut client = Arc::new(client_config)
+        .connect("localhost".try_into().unwrap())
+        .start_handshake()
+        .unwrap();
+    let mut server_to_client = vec![];
+    for _ in 0..5 {
+        visit_client(&client);
+        client = match client {
+            ClientHandshake::AwaitServerFlight(asf) => {
+                let mut slice_input = SliceInput::new(&mut server_to_client);
+                let next = asf
+                    .input_data(&mut slice_input)
+                    .unwrap();
+                let used = slice_input.into_used();
+                server_to_client.drain(0..used);
+                next
+            }
+            ClientHandshake::SendClientFlight(mut scf) => {
+                while let Some(data) = scf.take_data() {
+                    server
+                        .read_tls(&mut data.as_slice())
+                        .unwrap();
+                    server.process_new_packets().unwrap();
+                    server
+                        .write_tls(&mut &mut server_to_client)
+                        .unwrap();
+                    println!("data send: {data:x?}");
+                }
+                scf.into_next()
+            }
+            ClientHandshake::Complete(traffic) => {
+                let ClientTraffic {
+                    mut send,
+                    receive,
+                    outputs,
+                } = *traffic;
+                println!("traffic kind: {:?}", outputs.handshake_kind());
+
+                if !server_to_client.is_empty() {
+                    let mut slice_input = SliceInput::new(&mut server_to_client);
+
+                    let ReceiveTrafficState::Available(avail) =
+                        receive.read(&mut slice_input).unwrap()
+                    else {
+                        panic!("receive failed");
+                    };
+
+                    println!("received data: {:?}", avail.data);
+
+                    let (discard, _recv) = avail.into_next();
+                    println!("received used: {:?}", discard);
+                    slice_input.discard(discard);
+                    let used = slice_input.into_used();
+                    server_to_client.drain(0..used);
+                    assert!(server_to_client.is_empty());
+
+                    let buffers = send
+                        .write(b"client says hi".as_slice().into())
+                        .unwrap();
+
+                    for b in buffers {
+                        server
+                            .read_tls(&mut b.as_slice())
+                            .unwrap();
+                    }
+                    let closure = send.close();
+                    server
+                        .read_tls(&mut closure.as_slice())
+                        .unwrap();
+                    let io_state = server.process_new_packets().unwrap();
+                    assert_eq!(0, io_state.tls_bytes_to_write());
+                    assert_eq!(14, io_state.plaintext_bytes_to_read());
+                    assert!(io_state.peer_has_closed());
+
+                    let mut received = vec![];
+                    server
+                        .reader()
+                        .read_to_end(&mut received)
+                        .unwrap();
+                    println!("server received {:x?}", received);
+                }
+
+                break;
+            }
+            _ => todo!(),
+        };
+    }
+}
+
+fn visit_client(st: &ClientHandshake) {
+    println!(
+        "client state: {st:?} ech={:?} alpn={:?} hs_kind={:?}",
+        st.ech_status(),
+        st.alpn_protocol(),
+        st.handshake_kind()
+    );
+}
+
+#[test]
+fn test_server_smoke() {
+    let client_config = Arc::new(make_client_config(
+        KeyType::Rsa2048,
+        &provider::DEFAULT_PROVIDER,
+    ));
+    let mut client = client_config
+        .connect("localhost".try_into().unwrap())
+        .build()
+        .unwrap();
+
+    client
+        .writer()
+        .write_all(b"hello from client")
+        .unwrap();
+
+    let mut server = ServerHandshake::new();
+    let mut client_to_server = vec![];
+
+    client
+        .write_tls(&mut &mut client_to_server)
+        .unwrap();
+
+    for _ in 0..5 {
+        visit_server(&server);
+        server = match dbg!(server) {
+            ServerHandshake::AwaitClientFlight(asf) => {
+                let mut slice_input = SliceInput::new(&mut client_to_server);
+                let next = asf
+                    .input_data(&mut slice_input)
+                    .unwrap();
+                let used = slice_input.into_used();
+                client_to_server.drain(0..used);
+                next
+            }
+            ServerHandshake::ChooseConfig(cc) => {
+                println!("client hello {:?}", cc.client_hello());
+                cc.with_config(Arc::new(make_server_config(
+                    KeyType::Rsa2048,
+                    &provider::DEFAULT_PROVIDER,
+                )))
+                .unwrap()
+            }
+            ServerHandshake::SendServerFlight(mut scf) => {
+                while let Some(data) = scf.take_data() {
+                    client
+                        .read_tls(&mut data.as_slice())
+                        .unwrap();
+                    client.process_new_packets().unwrap();
+                    client
+                        .write_tls(&mut &mut client_to_server)
+                        .unwrap();
+                    println!("data send: {data:x?}");
+                }
+                scf.into_next()
+            }
+            ServerHandshake::Complete(traffic) => {
+                let ServerTraffic {
+                    mut send,
+                    receive,
+                    outputs,
+                } = *traffic;
+                println!("traffic kind: {:?}", outputs.handshake_kind());
+
+                if !client_to_server.is_empty() {
+                    let mut slice_input = SliceInput::new(&mut client_to_server);
+
+                    let ReceiveTrafficState::Available(avail) =
+                        receive.read(&mut slice_input).unwrap()
+                    else {
+                        panic!("receive failed");
+                    };
+
+                    println!("received data: {:?}", avail.data);
+
+                    let (discard, _recv) = avail.into_next();
+                    println!("received used: {:?}", discard);
+                    slice_input.discard(discard);
+                    let used = slice_input.into_used();
+                    client_to_server.drain(0..used);
+                    assert!(client_to_server.is_empty());
+
+                    let buffers = send
+                        .write(b"client says hi".as_slice().into())
+                        .unwrap();
+                    for b in buffers {
+                        client
+                            .read_tls(&mut b.as_slice())
+                            .unwrap();
+                    }
+                    let closure = send.close();
+                    client
+                        .read_tls(&mut closure.as_slice())
+                        .unwrap();
+                    let io_state = client.process_new_packets().unwrap();
+                    assert_eq!(0, io_state.tls_bytes_to_write());
+                    assert_eq!(14, io_state.plaintext_bytes_to_read());
+                    assert!(io_state.peer_has_closed());
+
+                    let mut received = vec![];
+                    client
+                        .reader()
+                        .read_to_end(&mut received)
+                        .unwrap();
+                    println!("client received {:x?}", received);
+                }
+
+                break;
+            }
+            _ => todo!(),
+        };
+    }
+}
+
+fn visit_server(st: &ServerHandshake) {
+    println!(
+        "server state: {st:?} server_name={:?}, resumption_data={:?} alpn={:?} hs_kind={:?}",
+        st.server_name(),
+        st.received_resumption_data(),
+        st.alpn_protocol(),
+        st.handshake_kind()
+    );
+}

--- a/rustls-util/src/stream.rs
+++ b/rustls-util/src/stream.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::std_instead_of_core)] // awaits core::io::IoSlice in stable (1.98)
 use std::io::{BufRead, IoSlice, Read, Result, Write};
 
 use rustls::Connection;

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -75,12 +75,6 @@ impl ClientConnection {
         self.core.side.early_data.is_accepted()
     }
 
-    /// Extract secrets, so they can be used when configuring kTLS, for example.
-    /// Should be used with care as it exposes secret key material.
-    pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.core.dangerous_extract_secrets()
-    }
-
     /// Return the connection's Encrypted Client Hello (ECH) status.
     pub fn ech_status(&self) -> EchStatus {
         self.core.side.ech_status

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -11,22 +11,25 @@ use crate::client::EchStatus;
 use crate::common_state::{CommonState, ConnectionOutputs, EarlyDataEvent, Event, Protocol, Side};
 use crate::conn::private::SideOutput;
 use crate::conn::{
-    Connection, ConnectionCommon, ConnectionCore, IoState, KeyingMaterialExporter, Reader,
+    Buffers, Connection, ConnectionCore, IoState, KeyingMaterialExporter, PlaintextSink, Reader,
     SideCommonOutput, Writer,
 };
 #[cfg(doc)]
 use crate::crypto;
+use crate::crypto::cipher::OutboundPlain;
 use crate::enums::ApplicationProtocol;
 use crate::error::Error;
 use crate::log::trace;
-use crate::msgs::ClientExtensionsInput;
+use crate::msgs::{ClientExtensionsInput, Delocator, TlsInputBuffer};
 use crate::quic::QuicOutput;
 use crate::suites::ExtractedSecrets;
 use crate::sync::Arc;
 
 /// This represents a single TLS client connection.
 pub struct ClientConnection {
-    inner: ConnectionCommon<ClientSide>,
+    core: ConnectionCore<ClientSide>,
+    fips: FipsStatus,
+    buffers: Buffers,
 }
 
 impl fmt::Debug for ClientConnection {
@@ -56,13 +59,7 @@ impl ClientConnection {
     /// in this case the data is lost but the connection continues.  You
     /// can tell this happened using `is_early_data_accepted`.
     pub fn early_data(&mut self) -> Option<WriteEarlyData<'_>> {
-        if self
-            .inner
-            .core
-            .side
-            .early_data
-            .is_enabled()
-        {
+        if self.core.side.early_data.is_enabled() {
             Some(WriteEarlyData::new(self))
         } else {
             None
@@ -75,28 +72,28 @@ impl ClientConnection {
     /// handshake then the server will not process the data.  This
     /// is not an error, but you may wish to resend the data.
     pub fn is_early_data_accepted(&self) -> bool {
-        self.inner.core.is_early_data_accepted()
+        self.core.side.early_data.is_accepted()
     }
 
     /// Extract secrets, so they can be used when configuring kTLS, for example.
     /// Should be used with care as it exposes secret key material.
     pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.inner.dangerous_extract_secrets()
+        self.core.dangerous_extract_secrets()
     }
 
     /// Return the connection's Encrypted Client Hello (ECH) status.
     pub fn ech_status(&self) -> EchStatus {
-        self.inner.core.side.ech_status
+        self.core.side.ech_status
     }
 
     fn write_early_data(&mut self, data: &[u8]) -> io::Result<usize> {
-        self.inner
-            .core
+        self.core
             .side
             .early_data
             .check_write(data.len())
             .map(|sz| {
-                self.inner
+                self.core
+                    .common
                     .send
                     .send_early_plaintext(&data[..sz])
             })
@@ -104,74 +101,256 @@ impl ClientConnection {
 
     /// Returns the number of TLS1.3 tickets that have been received.
     pub fn tls13_tickets_received(&self) -> u32 {
-        self.inner
-            .core
+        self.core
             .common
             .recv
             .tls13_tickets_received
+    }
+
+    fn current_io_state(&self) -> IoState {
+        let common_state = &self.core.common;
+        IoState {
+            tls_bytes_to_write: common_state.send.sendable_tls.len(),
+            plaintext_bytes_to_read: self.buffers.received_plaintext.len(),
+            peer_has_closed: common_state
+                .recv
+                .has_received_close_notify,
+        }
     }
 }
 
 impl Connection for ClientConnection {
     fn read_tls(&mut self, rd: &mut dyn io::Read) -> Result<usize, io::Error> {
-        self.inner.read_tls(rd)
+        if self
+            .buffers
+            .received_plaintext
+            .is_full()
+        {
+            return Err(io::Error::other("received plaintext buffer full"));
+        }
+
+        if self
+            .core
+            .common
+            .recv
+            .has_received_close_notify
+        {
+            return Ok(0);
+        }
+
+        let res = self.buffers.deframer_buffer.read(rd);
+        if let Ok(0) = res {
+            self.buffers.has_seen_eof = true;
+        }
+        res
     }
 
     fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
-        self.inner.write_tls(wr)
+        self.core
+            .common
+            .send
+            .sendable_tls
+            .write_to(wr)
     }
 
     fn wants_read(&self) -> bool {
-        self.inner.wants_read()
+        // We want to read more data all the time, except when we have unprocessed plaintext.
+        // This provides back-pressure to the TCP buffers. We also don't want to read more after
+        // the peer has sent us a close notification.
+        //
+        // In the handshake case we don't have readable plaintext before the handshake has
+        // completed, but also don't want to read if we still have sendable tls.
+        self.buffers
+            .received_plaintext
+            .is_empty()
+            && !self
+                .core
+                .common
+                .recv
+                .has_received_close_notify
+            && (self
+                .core
+                .common
+                .send
+                .may_send_application_data
+                || self
+                    .core
+                    .common
+                    .send
+                    .sendable_tls
+                    .is_empty())
     }
 
     fn wants_write(&self) -> bool {
-        self.inner.wants_write()
+        !self
+            .core
+            .common
+            .send
+            .sendable_tls
+            .is_empty()
     }
 
     fn reader(&mut self) -> Reader<'_> {
-        self.inner.reader()
+        let has_received_close_notify = self
+            .core
+            .common
+            .recv
+            .has_received_close_notify;
+        Reader {
+            received_plaintext: &mut self.buffers.received_plaintext,
+            // Are we done? i.e., have we processed all received messages, and received a
+            // close_notify to indicate that no new messages will arrive?
+            has_received_close_notify,
+            has_seen_eof: self.buffers.has_seen_eof,
+        }
     }
 
     fn writer(&mut self) -> Writer<'_> {
-        self.inner.writer()
+        Writer::new(self)
     }
 
     fn process_new_packets(&mut self) -> Result<IoState, Error> {
-        self.inner.process_new_packets()
+        loop {
+            let Some(payload) = self
+                .core
+                .process_new_packets(&mut self.buffers.deframer_buffer, None)?
+            else {
+                break;
+            };
+
+            let payload =
+                payload.reborrow(&Delocator::new(self.buffers.deframer_buffer.slice_mut()));
+            self.buffers
+                .received_plaintext
+                .append(payload.into_vec());
+            self.buffers.deframer_buffer.discard(
+                self.core
+                    .common
+                    .recv
+                    .deframer
+                    .take_discard(),
+            );
+        }
+
+        // Release unsent buffered plaintext.
+        if self
+            .core
+            .common
+            .send
+            .may_send_application_data
+            && !self
+                .buffers
+                .sendable_plaintext
+                .is_empty()
+        {
+            self.core
+                .common
+                .send
+                .send_buffered_plaintext(&mut self.buffers.sendable_plaintext);
+        }
+
+        Ok(self.current_io_state())
     }
 
     fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        self.inner.exporter()
+        self.core.exporter()
     }
 
     fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.inner.dangerous_extract_secrets()
+        self.core.dangerous_extract_secrets()
     }
 
     fn set_buffer_limit(&mut self, limit: Option<usize>) {
-        self.inner.set_buffer_limit(limit)
+        self.buffers
+            .sendable_plaintext
+            .set_limit(limit);
+        self.core
+            .common
+            .send
+            .sendable_tls
+            .set_limit(limit);
     }
 
     fn set_plaintext_buffer_limit(&mut self, limit: Option<usize>) {
-        self.inner
-            .set_plaintext_buffer_limit(limit)
+        self.buffers
+            .received_plaintext
+            .set_limit(limit);
     }
 
     fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
-        self.inner.refresh_traffic_keys()
+        self.core
+            .common
+            .send
+            .refresh_traffic_keys()
     }
 
     fn send_close_notify(&mut self) {
-        self.inner.send_close_notify();
+        self.core
+            .common
+            .send
+            .send_close_notify()
     }
 
     fn is_handshaking(&self) -> bool {
-        self.inner.is_handshaking()
+        !(self
+            .core
+            .common
+            .send
+            .may_send_application_data
+            && self
+                .core
+                .common
+                .recv
+                .may_receive_application_data)
     }
 
     fn fips(&self) -> FipsStatus {
-        self.inner.fips
+        self.fips
+    }
+}
+
+impl PlaintextSink for ClientConnection {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let len = self
+            .core
+            .common
+            .send
+            .buffer_plaintext(buf.into(), &mut self.buffers.sendable_plaintext);
+        self.core
+            .common
+            .send
+            .maybe_refresh_traffic_keys();
+        Ok(len)
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        let payload_owner: Vec<&[u8]>;
+        let payload = match bufs.len() {
+            0 => return Ok(0),
+            1 => OutboundPlain::Single(bufs[0].deref()),
+            _ => {
+                payload_owner = bufs
+                    .iter()
+                    .map(|io_slice| io_slice.deref())
+                    .collect();
+
+                OutboundPlain::new(&payload_owner)
+            }
+        };
+        let len = self
+            .core
+            .common
+            .send
+            .buffer_plaintext(payload, &mut self.buffers.sendable_plaintext);
+        self.core
+            .common
+            .send
+            .maybe_refresh_traffic_keys();
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 
@@ -179,7 +358,7 @@ impl Deref for ClientConnection {
     type Target = ConnectionOutputs;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        &self.core.common.outputs
     }
 }
 
@@ -210,16 +389,15 @@ impl ClientConnectionBuilder {
         let alpn_protocols = alpn_protocols.unwrap_or_else(|| config.alpn_protocols.clone());
         let fips = config.fips();
         Ok(ClientConnection {
-            inner: ConnectionCommon::new(
-                ConnectionCore::for_client(
-                    config,
-                    name,
-                    ClientExtensionsInput::from_alpn(alpn_protocols),
-                    None,
-                    Protocol::Tcp,
-                )?,
-                fips,
-            ),
+            core: ConnectionCore::for_client(
+                config,
+                name,
+                ClientExtensionsInput::from_alpn(alpn_protocols),
+                None,
+                Protocol::Tcp,
+            )?,
+            buffers: Buffers::new(),
+            fips,
         })
     }
 }
@@ -242,7 +420,6 @@ impl<'a> WriteEarlyData<'a> {
     /// once this reaches zero.
     pub fn bytes_left(&self) -> usize {
         self.sess
-            .inner
             .core
             .side
             .early_data
@@ -269,7 +446,7 @@ impl<'a> WriteEarlyData<'a> {
     /// [RFC8446 appendix E.5.1]: https://datatracker.ietf.org/doc/html/rfc8446#appendix-E.5.1
     /// [`Connection::exporter()`]: crate::conn::Connection::exporter()
     pub fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        self.sess.inner.core.early_exporter()
+        self.sess.core.early_exporter()
     }
 }
 

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -394,6 +394,16 @@ impl ClientConnectionBuilder {
             fips,
         })
     }
+
+    /// Finalize the builder and create a [`ClientHandshake`].
+    pub fn start_handshake(self) -> Result<ClientHandshake, Error> {
+        let Self {
+            config,
+            name,
+            alpn_protocols,
+        } = self;
+        ClientHandshake::new(config, name, alpn_protocols)
+    }
 }
 
 /// Allows writing of early data in resumed TLS 1.3 connections.
@@ -505,7 +515,7 @@ impl EarlyData {
         )
     }
 
-    fn is_accepted(&self) -> bool {
+    pub(super) fn is_accepted(&self) -> bool {
         matches!(
             self.state,
             EarlyDataState::Accepted | EarlyDataState::AcceptedFinished
@@ -542,7 +552,7 @@ impl EarlyData {
         }
     }
 
-    fn check_write(&mut self, sz: usize) -> io::Result<usize> {
+    pub(super) fn check_write(&mut self, sz: usize) -> io::Result<usize> {
         self.check_write_opt(sz)
             .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))
     }
@@ -564,7 +574,7 @@ impl EarlyData {
         }
     }
 
-    fn bytes_left(&self) -> usize {
+    pub(super) fn bytes_left(&self) -> usize {
         self.left
     }
 }
@@ -580,7 +590,7 @@ enum EarlyDataState {
 }
 
 pub(crate) struct ClientConnectionData {
-    early_data: EarlyData,
+    pub(super) early_data: EarlyData,
     ech_status: EchStatus,
 }
 
@@ -590,6 +600,14 @@ impl ClientConnectionData {
             early_data: EarlyData::new(),
             ech_status: EchStatus::default(),
         }
+    }
+
+    pub(crate) fn early_data_is_enabled(&self) -> bool {
+        self.early_data.is_enabled()
+    }
+
+    pub(crate) fn ech_status(&self) -> EchStatus {
+        self.ech_status
     }
 }
 

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::ops::Deref;
 use core::{fmt, mem};
@@ -6,8 +7,8 @@ use std::io;
 use pki_types::{FipsStatus, ServerName};
 
 use super::config::ClientConfig;
-use super::hs::ClientHelloInput;
-use crate::client::EchStatus;
+use super::hs::{ClientHelloInput, ClientState};
+use super::{ClientHandshake, ClientOutputs, ClientTraffic, EchStatus, SendEarlyData};
 use crate::common_state::{CommonState, ConnectionOutputs, EarlyDataEvent, Event, Protocol, Side};
 use crate::conn::private::SideOutput;
 use crate::conn::{
@@ -18,18 +19,29 @@ use crate::conn::{
 use crate::crypto;
 use crate::crypto::cipher::OutboundPlain;
 use crate::enums::ApplicationProtocol;
-use crate::error::Error;
+use crate::error::{ApiMisuse, Error};
 use crate::log::trace;
-use crate::msgs::{ClientExtensionsInput, Delocator, TlsInputBuffer};
+use crate::msgs::ClientExtensionsInput;
 use crate::quic::QuicOutput;
+use crate::state::{ReceiveTraffic, ReceiveTrafficState, SendTraffic};
 use crate::suites::ExtractedSecrets;
 use crate::sync::Arc;
 
 /// This represents a single TLS client connection.
 pub struct ClientConnection {
-    core: ConnectionCore<ClientSide>,
-    fips: FipsStatus,
+    state: Result<InnerState, Error>,
+    err_outputs: Option<Box<ClientOutputs>>,
     buffers: Buffers,
+    fips: FipsStatus,
+}
+
+enum InnerState {
+    Handshake(ClientHandshake),
+    Traffic {
+        send: Option<SendTraffic>,
+        receive: Option<ReceiveTraffic<ClientSide>>,
+        outputs: Box<ClientOutputs>,
+    },
 }
 
 impl fmt::Debug for ClientConnection {
@@ -40,6 +52,26 @@ impl fmt::Debug for ClientConnection {
 }
 
 impl ClientConnection {
+    fn new(state: ClientHandshake, fips: FipsStatus) -> Self {
+        // pump clienthello into outgoing buffers
+        let ClientHandshake::SendClientFlight(mut send) = state else {
+            unreachable!();
+        };
+
+        let mut buffers = Buffers::new();
+        while let Some(chunk) = send.take_data() {
+            buffers.sendable_tls.append(chunk);
+        }
+        let state = Ok(InnerState::Handshake(send.into_next()));
+
+        Self {
+            state,
+            err_outputs: None,
+            buffers,
+            fips,
+        }
+    }
+
     /// Returns an `io::Write` implementer you can write bytes to
     /// to send TLS1.3 early data (a.k.a. "0-RTT data") to the server.
     ///
@@ -59,10 +91,13 @@ impl ClientConnection {
     /// in this case the data is lost but the connection continues.  You
     /// can tell this happened using `is_early_data_accepted`.
     pub fn early_data(&mut self) -> Option<WriteEarlyData<'_>> {
-        if self.core.side.early_data.is_enabled() {
-            Some(WriteEarlyData::new(self))
-        } else {
-            None
+        let Ok(InnerState::Handshake(ClientHandshake::AwaitServerFlight(st))) = &mut self.state
+        else {
+            return None;
+        };
+        match st.try_send_early_data() {
+            Some(send) => Some(WriteEarlyData::new(send, &mut self.buffers)),
+            None => None,
         }
     }
 
@@ -72,43 +107,106 @@ impl ClientConnection {
     /// handshake then the server will not process the data.  This
     /// is not an error, but you may wish to resend the data.
     pub fn is_early_data_accepted(&self) -> bool {
-        self.core.side.early_data.is_accepted()
+        match &self.state {
+            Ok(InnerState::Traffic { outputs, .. }) => outputs.early_data_was_accepted,
+            _ => false,
+        }
     }
 
     /// Return the connection's Encrypted Client Hello (ECH) status.
     pub fn ech_status(&self) -> EchStatus {
-        self.core.side.ech_status
-    }
-
-    fn write_early_data(&mut self, data: &[u8]) -> io::Result<usize> {
-        self.core
-            .side
-            .early_data
-            .check_write(data.len())
-            .map(|sz| {
-                self.core
-                    .common
-                    .send
-                    .send_early_plaintext(&data[..sz])
-            })
+        match &self.state {
+            Ok(InnerState::Handshake(st)) => st.ech_status(),
+            Ok(InnerState::Traffic { outputs, .. }) => outputs.ech_status,
+            Err(_) => match &self.err_outputs {
+                Some(o) => o.ech_status,
+                None => EchStatus::Rejected,
+            },
+        }
     }
 
     /// Returns the number of TLS1.3 tickets that have been received.
     pub fn tls13_tickets_received(&self) -> u32 {
-        self.core
-            .common
-            .recv
-            .tls13_tickets_received
+        match &self.state {
+            Ok(InnerState::Traffic { receive, .. }) => receive
+                .as_ref()
+                .map(|r| r.tls13_tickets_received())
+                .unwrap_or_default(),
+            _ => 0,
+        }
     }
 
-    fn current_io_state(&self) -> IoState {
-        let common_state = &self.core.common;
+    pub(crate) fn current_io_state(&self) -> IoState {
         IoState {
-            tls_bytes_to_write: common_state.send.sendable_tls.len(),
+            tls_bytes_to_write: self.buffers.sendable_tls.len(),
             plaintext_bytes_to_read: self.buffers.received_plaintext.len(),
-            peer_has_closed: common_state
-                .recv
-                .has_received_close_notify,
+            peer_has_closed: self.has_received_close_notify(),
+        }
+    }
+
+    fn has_received_close_notify(&self) -> bool {
+        matches!(&self.state, Ok(InnerState::Traffic { receive: None, .. }))
+    }
+
+    fn write_or_buffer_appdata(&mut self, data: OutboundPlain<'_>) -> io::Result<usize> {
+        let Ok(InnerState::Traffic { send, .. }) = &mut self.state else {
+            return Ok(self
+                .buffers
+                .sendable_plaintext
+                .append_limited_copy(data));
+        };
+
+        let Some(s) = send else {
+            return Ok(0);
+        };
+        let len = data.len();
+
+        let len = self
+            .buffers
+            .sendable_tls
+            .apply_limit(len);
+        if len == 0 {
+            // Don't send empty fragments.
+            return Ok(0);
+        }
+
+        if let Ok(chunks) = s.write(data.split_at(len).0) {
+            for c in chunks {
+                self.buffers.sendable_tls.append(c);
+            }
+        }
+        while let Some(chunk) = s.take_data() {
+            self.buffers.sendable_tls.append(chunk);
+        }
+        Ok(len)
+    }
+
+    /// Act on a potential state transition from a handshake-related state to `new`.
+    fn post_handshake_state(&mut self, new: ClientHandshake) -> InnerState {
+        let ClientHandshake::Complete(traffic) = new else {
+            return InnerState::Handshake(new);
+        };
+
+        let ClientTraffic {
+            mut send,
+            receive,
+            outputs,
+        } = *traffic;
+
+        // Release unsent buffered plaintext.
+        while let Some(chunk) = self.buffers.sendable_plaintext.pop() {
+            let Ok(chunks) = send.write(chunk.as_slice().into()) else {
+                continue;
+            };
+            for c in chunks {
+                self.buffers.sendable_tls.append(c);
+            }
+        }
+
+        InnerState::Traffic {
+            send: Some(send),
+            receive: Some(receive),
+            outputs: Box::new(outputs),
         }
     }
 }
@@ -123,12 +221,7 @@ impl Connection for ClientConnection {
             return Err(io::Error::other("received plaintext buffer full"));
         }
 
-        if self
-            .core
-            .common
-            .recv
-            .has_received_close_notify
-        {
+        if self.has_received_close_notify() {
             return Ok(0);
         }
 
@@ -136,15 +229,12 @@ impl Connection for ClientConnection {
         if let Ok(0) = res {
             self.buffers.has_seen_eof = true;
         }
+
         res
     }
 
     fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
-        self.core
-            .common
-            .send
-            .sendable_tls
-            .write_to(wr)
+        self.buffers.sendable_tls.write_to(wr)
     }
 
     fn wants_read(&self) -> bool {
@@ -158,38 +248,17 @@ impl Connection for ClientConnection {
             .received_plaintext
             .is_empty()
             && !self
-                .core
-                .common
-                .recv
-                .has_received_close_notify
-            && (self
-                .core
-                .common
-                .send
-                .may_send_application_data
-                || self
-                    .core
-                    .common
-                    .send
-                    .sendable_tls
-                    .is_empty())
+                .current_io_state()
+                .peer_has_closed()
+            && (!self.is_handshaking() || self.buffers.sendable_tls.is_empty())
     }
 
     fn wants_write(&self) -> bool {
-        !self
-            .core
-            .common
-            .send
-            .sendable_tls
-            .is_empty()
+        !self.buffers.sendable_tls.is_empty()
     }
 
     fn reader(&mut self) -> Reader<'_> {
-        let has_received_close_notify = self
-            .core
-            .common
-            .recv
-            .has_received_close_notify;
+        let has_received_close_notify = self.has_received_close_notify();
         Reader {
             received_plaintext: &mut self.buffers.received_plaintext,
             // Are we done? i.e., have we processed all received messages, and received a
@@ -205,62 +274,146 @@ impl Connection for ClientConnection {
 
     fn process_new_packets(&mut self) -> Result<IoState, Error> {
         loop {
-            let Some(payload) = self
-                .core
-                .process_new_packets(&mut self.buffers.deframer_buffer, None)?
-            else {
-                break;
+            let state = match mem::replace(
+                &mut self.state,
+                Err(ApiMisuse::PreviousConnectionError.into()),
+            ) {
+                Ok(state) => state,
+                Err(e) => {
+                    self.state = Err(e.clone());
+                    return Err(e);
+                }
             };
 
-            let payload =
-                payload.reborrow(&Delocator::new(self.buffers.deframer_buffer.slice_mut()));
-            self.buffers
-                .received_plaintext
-                .append(payload.into_vec());
-            self.buffers.deframer_buffer.discard(
-                self.core
-                    .common
-                    .recv
-                    .deframer
-                    .take_discard(),
-            );
-        }
+            match state {
+                InnerState::Handshake(ClientHandshake::SendClientFlight(mut scf)) => {
+                    while let Some(chunk) = scf.take_data() {
+                        self.buffers.sendable_tls.append(chunk);
+                    }
+                    self.state = Ok(self.post_handshake_state(scf.into_next()));
+                }
+                InnerState::Handshake(ClientHandshake::AwaitServerFlight(asf)) => {
+                    if self.buffers.deframer_buffer.is_empty() {
+                        self.state = Ok(InnerState::Handshake(ClientHandshake::AwaitServerFlight(
+                            asf,
+                        )));
+                        break;
+                    }
+                    match asf.input_data(&mut self.buffers.deframer_buffer) {
+                        Ok(state) => {
+                            self.state = Ok(self.post_handshake_state(state));
+                            if matches!(
+                                self.state,
+                                Ok(InnerState::Handshake(ClientHandshake::AwaitServerFlight(_)))
+                            ) {
+                                break;
+                            }
+                        }
+                        Err((mut err, outputs)) => {
+                            while let Some(chunk) = err.take_tls_data() {
+                                self.buffers.sendable_tls.append(chunk);
+                            }
 
-        // Release unsent buffered plaintext.
-        if self
-            .core
-            .common
-            .send
-            .may_send_application_data
-            && !self
-                .buffers
-                .sendable_plaintext
-                .is_empty()
-        {
-            self.core
-                .common
-                .send
-                .send_buffered_plaintext(&mut self.buffers.sendable_plaintext);
+                            self.state = Err(err.error.clone());
+                            self.err_outputs = Some(outputs);
+                            return Err(err.error);
+                        }
+                    };
+                }
+                InnerState::Handshake(st @ ClientHandshake::Complete(_)) => {
+                    self.state = Ok(self.post_handshake_state(st));
+                }
+                InnerState::Traffic {
+                    mut send,
+                    mut receive,
+                    outputs,
+                } => {
+                    let mut progress = true;
+
+                    while progress {
+                        progress = false;
+
+                        // Processed received data.
+                        if !self.buffers.deframer_buffer.is_empty() {
+                            let Some(recv) = receive.take() else {
+                                break;
+                            };
+                            match recv.read(&mut self.buffers.deframer_buffer) {
+                                Ok(ReceiveTrafficState::Available(received)) => {
+                                    progress = true;
+                                    self.buffers
+                                        .received_plaintext
+                                        .append(received.data.to_vec());
+                                    let (used, next) = received.into_next();
+                                    self.buffers
+                                        .deframer_buffer
+                                        .discard(used);
+                                    receive = Some(next);
+                                }
+                                Ok(ReceiveTrafficState::WakeSender(state)) => {
+                                    if let Some(send) = &mut send {
+                                        while let Some(chunk) = send.take_data() {
+                                            self.buffers.sendable_tls.append(chunk);
+                                        }
+                                    }
+                                    receive = Some(state.into_next());
+                                }
+                                Ok(ReceiveTrafficState::Await(state)) => receive = Some(state),
+                                Ok(ReceiveTrafficState::CloseNotify) => receive = None,
+                                Err(mut e) => {
+                                    while let Some(chunk) = e.take_tls_data() {
+                                        self.buffers.sendable_tls.append(chunk);
+                                    }
+                                    self.state = Err(e.error.clone());
+                                    return Err(e.error);
+                                }
+                            }
+                        }
+                    }
+
+                    self.state = Ok(InnerState::Traffic {
+                        send,
+                        receive,
+                        outputs,
+                    });
+                    break;
+                }
+            }
         }
 
         Ok(self.current_io_state())
     }
 
     fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        self.core.exporter()
+        match &mut self.state {
+            Ok(InnerState::Traffic { outputs, .. }) => outputs.take_exporter(),
+            _ => Err(Error::HandshakeNotComplete),
+        }
     }
 
     fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.core.dangerous_extract_secrets()
+        let Ok(InnerState::Traffic {
+            send: Some(send),
+            receive: Some(receive),
+            outputs,
+        }) = self.state
+        else {
+            return Err(Error::HandshakeNotComplete);
+        };
+        Ok(ClientTraffic {
+            send,
+            receive,
+            outputs: *outputs,
+        }
+        .dangerous_into_kernel_connection()?
+        .0)
     }
 
     fn set_buffer_limit(&mut self, limit: Option<usize>) {
         self.buffers
             .sendable_plaintext
             .set_limit(limit);
-        self.core
-            .common
-            .send
+        self.buffers
             .sendable_tls
             .set_limit(limit);
     }
@@ -272,30 +425,31 @@ impl Connection for ClientConnection {
     }
 
     fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
-        self.core
-            .common
-            .send
-            .refresh_traffic_keys()
+        match &mut self.state {
+            Ok(InnerState::Traffic { send, .. }) => match send {
+                Some(s) => s.refresh_traffic_keys(),
+                None => Err(ApiMisuse::SendSideAlreadyClosed.into()),
+            },
+            _ => Err(Error::HandshakeNotComplete),
+        }
     }
 
     fn send_close_notify(&mut self) {
-        self.core
-            .common
-            .send
-            .send_close_notify()
+        let Ok(InnerState::Traffic { send, .. }) = &mut self.state else {
+            return;
+        };
+
+        let Some(send) = send.take() else {
+            return;
+        };
+
+        self.buffers
+            .sendable_tls
+            .append(send.close());
     }
 
     fn is_handshaking(&self) -> bool {
-        !(self
-            .core
-            .common
-            .send
-            .may_send_application_data
-            && self
-                .core
-                .common
-                .recv
-                .may_receive_application_data)
+        !matches!(self.state, Ok(InnerState::Traffic { .. }))
     }
 
     fn fips(&self) -> FipsStatus {
@@ -305,16 +459,7 @@ impl Connection for ClientConnection {
 
 impl PlaintextSink for ClientConnection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let len = self
-            .core
-            .common
-            .send
-            .buffer_plaintext(buf.into(), &mut self.buffers.sendable_plaintext);
-        self.core
-            .common
-            .send
-            .maybe_refresh_traffic_keys();
-        Ok(len)
+        self.write_or_buffer_appdata(buf.into())
     }
 
     fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
@@ -331,16 +476,7 @@ impl PlaintextSink for ClientConnection {
                 OutboundPlain::new(&payload_owner)
             }
         };
-        let len = self
-            .core
-            .common
-            .send
-            .buffer_plaintext(payload, &mut self.buffers.sendable_plaintext);
-        self.core
-            .common
-            .send
-            .maybe_refresh_traffic_keys();
-        Ok(len)
+        self.write_or_buffer_appdata(payload)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -352,7 +488,11 @@ impl Deref for ClientConnection {
     type Target = ConnectionOutputs;
 
     fn deref(&self) -> &Self::Target {
-        &self.core.common.outputs
+        match &self.state {
+            Ok(InnerState::Handshake(hs)) => hs.deref(),
+            Ok(InnerState::Traffic { outputs, .. }) => outputs,
+            Err(_) => self.err_outputs.as_ref().unwrap(),
+        }
     }
 }
 
@@ -374,25 +514,8 @@ impl ClientConnectionBuilder {
 
     /// Finalize the builder and create the `ClientConnection`.
     pub fn build(self) -> Result<ClientConnection, Error> {
-        let Self {
-            config,
-            name,
-            alpn_protocols,
-        } = self;
-
-        let alpn_protocols = alpn_protocols.unwrap_or_else(|| config.alpn_protocols.clone());
-        let fips = config.fips();
-        Ok(ClientConnection {
-            core: ConnectionCore::for_client(
-                config,
-                name,
-                ClientExtensionsInput::from_alpn(alpn_protocols),
-                None,
-                Protocol::Tcp,
-            )?,
-            buffers: Buffers::new(),
-            fips,
-        })
+        let fips = self.config.fips();
+        Ok(ClientConnection::new(self.start_handshake()?, fips))
     }
 
     /// Finalize the builder and create a [`ClientHandshake`].
@@ -412,22 +535,19 @@ impl ClientConnectionBuilder {
 ///
 /// This type implements [`io::Write`].
 pub struct WriteEarlyData<'a> {
-    sess: &'a mut ClientConnection,
+    send: SendEarlyData<'a>,
+    buffers: &'a mut Buffers,
 }
 
 impl<'a> WriteEarlyData<'a> {
-    fn new(sess: &'a mut ClientConnection) -> Self {
-        WriteEarlyData { sess }
+    fn new(send: SendEarlyData<'a>, buffers: &'a mut Buffers) -> Self {
+        WriteEarlyData { send, buffers }
     }
 
     /// How many bytes you may send.  Writes will become short
     /// once this reaches zero.
     pub fn bytes_left(&self) -> usize {
-        self.sess
-            .core
-            .side
-            .early_data
-            .bytes_left()
+        self.send.bytes_left()
     }
 
     /// Returns the "early" exporter that can derive key material for use in early data
@@ -448,15 +568,20 @@ impl<'a> WriteEarlyData<'a> {
     /// [RFC5705]: https://datatracker.ietf.org/doc/html/rfc5705
     /// [RFC8446 S7.5]: https://datatracker.ietf.org/doc/html/rfc8446#section-7.5
     /// [RFC8446 appendix E.5.1]: https://datatracker.ietf.org/doc/html/rfc8446#appendix-E.5.1
-    /// [`Connection::exporter()`]: crate::conn::Connection::exporter()
     pub fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        self.sess.core.early_exporter()
+        self.send.early_exporter()
     }
 }
 
 impl io::Write for WriteEarlyData<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.sess.write_early_data(buf)
+        let Some((used, chunks)) = self.send.write(buf) else {
+            return Ok(0);
+        };
+        for c in chunks {
+            self.buffers.sendable_tls.append(c);
+        }
+        Ok(used)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -620,7 +745,7 @@ impl crate::conn::SideData for ClientSide {}
 
 impl crate::conn::private::Side for ClientSide {
     type Data = ClientConnectionData;
-    type State = super::hs::ClientState;
+    type State = ClientState;
 }
 
 impl SideOutput for ClientConnectionData {

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -29,7 +29,8 @@ use crate::sync::Arc;
 
 /// This represents a single TLS client connection.
 pub struct ClientConnection {
-    state: Result<InnerState, Error>,
+    state: Option<InnerState>,
+    err: Option<Error>,
     err_outputs: Option<Box<ClientOutputs>>,
     buffers: Buffers,
     fips: FipsStatus,
@@ -62,10 +63,11 @@ impl ClientConnection {
         while let Some(chunk) = send.take_data() {
             buffers.sendable_tls.append(chunk);
         }
-        let state = Ok(InnerState::Handshake(send.into_next()));
+        let state = Some(InnerState::Handshake(send.into_next()));
 
         Self {
             state,
+            err: None,
             err_outputs: None,
             buffers,
             fips,
@@ -91,7 +93,7 @@ impl ClientConnection {
     /// in this case the data is lost but the connection continues.  You
     /// can tell this happened using `is_early_data_accepted`.
     pub fn early_data(&mut self) -> Option<WriteEarlyData<'_>> {
-        let Ok(InnerState::Handshake(ClientHandshake::AwaitServerFlight(st))) = &mut self.state
+        let Some(InnerState::Handshake(ClientHandshake::AwaitServerFlight(st))) = &mut self.state
         else {
             return None;
         };
@@ -108,7 +110,7 @@ impl ClientConnection {
     /// is not an error, but you may wish to resend the data.
     pub fn is_early_data_accepted(&self) -> bool {
         match &self.state {
-            Ok(InnerState::Traffic { outputs, .. }) => outputs.early_data_was_accepted,
+            Some(InnerState::Traffic { outputs, .. }) => outputs.early_data_was_accepted,
             _ => false,
         }
     }
@@ -116,9 +118,9 @@ impl ClientConnection {
     /// Return the connection's Encrypted Client Hello (ECH) status.
     pub fn ech_status(&self) -> EchStatus {
         match &self.state {
-            Ok(InnerState::Handshake(st)) => st.ech_status(),
-            Ok(InnerState::Traffic { outputs, .. }) => outputs.ech_status,
-            Err(_) => match &self.err_outputs {
+            Some(InnerState::Handshake(st)) => st.ech_status(),
+            Some(InnerState::Traffic { outputs, .. }) => outputs.ech_status,
+            None => match &self.err_outputs {
                 Some(o) => o.ech_status,
                 None => EchStatus::Rejected,
             },
@@ -128,7 +130,7 @@ impl ClientConnection {
     /// Returns the number of TLS1.3 tickets that have been received.
     pub fn tls13_tickets_received(&self) -> u32 {
         match &self.state {
-            Ok(InnerState::Traffic { receive, .. }) => receive
+            Some(InnerState::Traffic { receive, .. }) => receive
                 .as_ref()
                 .map(|r| r.tls13_tickets_received())
                 .unwrap_or_default(),
@@ -145,11 +147,11 @@ impl ClientConnection {
     }
 
     fn has_received_close_notify(&self) -> bool {
-        matches!(&self.state, Ok(InnerState::Traffic { receive: None, .. }))
+        matches!(&self.state, Some(InnerState::Traffic { receive: None, .. }))
     }
 
     fn write_or_buffer_appdata(&mut self, data: OutboundPlain<'_>) -> io::Result<usize> {
-        let Ok(InnerState::Traffic { send, .. }) = &mut self.state else {
+        let Some(InnerState::Traffic { send, .. }) = &mut self.state else {
             return Ok(self
                 .buffers
                 .sendable_plaintext
@@ -274,15 +276,8 @@ impl Connection for ClientConnection {
 
     fn process_new_packets(&mut self) -> Result<IoState, Error> {
         loop {
-            let state = match mem::replace(
-                &mut self.state,
-                Err(ApiMisuse::PreviousConnectionError.into()),
-            ) {
-                Ok(state) => state,
-                Err(e) => {
-                    self.state = Err(e.clone());
-                    return Err(e);
-                }
+            let Some(state) = mem::take(&mut self.state) else {
+                return Err(self.err.clone().unwrap());
             };
 
             match state {
@@ -290,21 +285,21 @@ impl Connection for ClientConnection {
                     while let Some(chunk) = scf.take_data() {
                         self.buffers.sendable_tls.append(chunk);
                     }
-                    self.state = Ok(self.post_handshake_state(scf.into_next()));
+                    self.state = Some(self.post_handshake_state(scf.into_next()));
                 }
                 InnerState::Handshake(ClientHandshake::AwaitServerFlight(asf)) => {
                     if self.buffers.deframer_buffer.is_empty() {
-                        self.state = Ok(InnerState::Handshake(ClientHandshake::AwaitServerFlight(
-                            asf,
-                        )));
+                        self.state = Some(InnerState::Handshake(
+                            ClientHandshake::AwaitServerFlight(asf),
+                        ));
                         break;
                     }
                     match asf.input_data(&mut self.buffers.deframer_buffer) {
                         Ok(state) => {
-                            self.state = Ok(self.post_handshake_state(state));
+                            self.state = Some(self.post_handshake_state(state));
                             if matches!(
                                 self.state,
-                                Ok(InnerState::Handshake(ClientHandshake::AwaitServerFlight(_)))
+                                Some(InnerState::Handshake(ClientHandshake::AwaitServerFlight(_)))
                             ) {
                                 break;
                             }
@@ -314,14 +309,14 @@ impl Connection for ClientConnection {
                                 self.buffers.sendable_tls.append(chunk);
                             }
 
-                            self.state = Err(err.error.clone());
+                            self.err = Some(err.error.clone());
                             self.err_outputs = Some(outputs);
                             return Err(err.error);
                         }
                     };
                 }
                 InnerState::Handshake(st @ ClientHandshake::Complete(_)) => {
-                    self.state = Ok(self.post_handshake_state(st));
+                    self.state = Some(self.post_handshake_state(st));
                 }
                 InnerState::Traffic {
                     mut send,
@@ -364,14 +359,14 @@ impl Connection for ClientConnection {
                                     while let Some(chunk) = e.take_tls_data() {
                                         self.buffers.sendable_tls.append(chunk);
                                     }
-                                    self.state = Err(e.error.clone());
+                                    self.err = Some(e.error.clone());
                                     return Err(e.error);
                                 }
                             }
                         }
                     }
 
-                    self.state = Ok(InnerState::Traffic {
+                    self.state = Some(InnerState::Traffic {
                         send,
                         receive,
                         outputs,
@@ -386,13 +381,13 @@ impl Connection for ClientConnection {
 
     fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
         match &mut self.state {
-            Ok(InnerState::Traffic { outputs, .. }) => outputs.take_exporter(),
+            Some(InnerState::Traffic { outputs, .. }) => outputs.take_exporter(),
             _ => Err(Error::HandshakeNotComplete),
         }
     }
 
     fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        let Ok(InnerState::Traffic {
+        let Some(InnerState::Traffic {
             send: Some(send),
             receive: Some(receive),
             outputs,
@@ -426,7 +421,7 @@ impl Connection for ClientConnection {
 
     fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
         match &mut self.state {
-            Ok(InnerState::Traffic { send, .. }) => match send {
+            Some(InnerState::Traffic { send, .. }) => match send {
                 Some(s) => s.refresh_traffic_keys(),
                 None => Err(ApiMisuse::SendSideAlreadyClosed.into()),
             },
@@ -435,7 +430,7 @@ impl Connection for ClientConnection {
     }
 
     fn send_close_notify(&mut self) {
-        let Ok(InnerState::Traffic { send, .. }) = &mut self.state else {
+        let Some(InnerState::Traffic { send, .. }) = &mut self.state else {
             return;
         };
 
@@ -449,7 +444,7 @@ impl Connection for ClientConnection {
     }
 
     fn is_handshaking(&self) -> bool {
-        !matches!(self.state, Ok(InnerState::Traffic { .. }))
+        !matches!(self.state, Some(InnerState::Traffic { .. }))
     }
 
     fn fips(&self) -> FipsStatus {
@@ -489,9 +484,9 @@ impl Deref for ClientConnection {
 
     fn deref(&self) -> &Self::Target {
         match &self.state {
-            Ok(InnerState::Handshake(hs)) => hs.deref(),
-            Ok(InnerState::Traffic { outputs, .. }) => outputs,
-            Err(_) => self.err_outputs.as_ref().unwrap(),
+            Some(InnerState::Handshake(hs)) => hs.deref(),
+            Some(InnerState::Traffic { outputs, .. }) => outputs,
+            None => self.err_outputs.as_ref().unwrap(),
         }
     }
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -62,6 +62,14 @@ impl StateMachine for ClientState {
         true
     }
 
+    fn traffic(&self) -> bool {
+        matches!(
+            self,
+            Self::Tls12(tls12::Tls12State::Traffic(..))
+                | Self::Tls13(tls13::Tls13State::Traffic(..) | tls13::Tls13State::QuicTraffic(..))
+        )
+    }
+
     fn handle_decrypt_error(&mut self) {
         if let Self::Tls12(tls12::Tls12State::Finished(e)) = self {
             e.handle_decrypt_error();

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -47,6 +47,12 @@ pub(crate) use tls12::TLS12_HANDLER;
 mod tls13;
 pub(crate) use tls13::TLS13_HANDLER;
 
+mod state;
+pub use state::{
+    AwaitServerFlight, ClientHandshake, ClientOutputs, ClientTraffic, SendClientFlight,
+    SendEarlyData,
+};
+
 /// Dangerous configuration that should be audited and used with extreme care.
 pub mod danger {
     pub use super::config::danger::{DangerousClientConfig, DangerousClientConfigBuilder};

--- a/rustls/src/client/state.rs
+++ b/rustls/src/client/state.rs
@@ -1,0 +1,377 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+
+use pki_types::ServerName;
+
+use crate::client::{ClientSide, EchStatus, hs, tls12, tls13};
+use crate::common_state::Protocol;
+use crate::conn::ConnectionCore;
+use crate::crypto::cipher::OutboundPlain;
+use crate::enums::ApplicationProtocol;
+use crate::error::{ApiMisuse, ErrorWithAlert};
+use crate::kernel::KernelConnection;
+use crate::lock::Mutex;
+use crate::msgs::{ClientExtensionsInput, TlsInputBuffer};
+use crate::state::{ReceiveTraffic, SendTraffic};
+use crate::sync::Arc;
+use crate::{
+    ClientConfig, CommonState, ConnectionOutputs, Error, ExtractedSecrets, KeyingMaterialExporter,
+};
+
+/// State-based Client TLS API.
+#[non_exhaustive]
+pub enum ClientHandshake {
+    /// Handshake data should be transmitted to the peer.
+    SendClientFlight(SendClientFlight),
+
+    /// We are awaiting handshake data from the peer.
+    AwaitServerFlight(AwaitServerFlight),
+
+    /// The handshake has completed and application data may now flow.
+    Complete(Box<ClientTraffic>),
+}
+
+impl ClientHandshake {
+    /// Create a new client handshake.
+    ///
+    /// If `alpn_protocols` is [`None`], then the ALPN settings are obtained
+    /// from [`ClientConfig::alpn_protocols`].
+    pub(crate) fn new(
+        config: Arc<ClientConfig>,
+        name: ServerName<'static>,
+        alpn_protocols: Option<Vec<ApplicationProtocol<'static>>>,
+    ) -> Result<Self, Error> {
+        let input = ClientExtensionsInput::from_alpn(
+            alpn_protocols.unwrap_or_else(|| config.alpn_protocols.clone()),
+        );
+        let inner = Box::new(ConnectionCore::for_client(
+            config,
+            name,
+            input,
+            None,
+            Protocol::Tcp,
+        )?);
+
+        Ok(Self::SendClientFlight(SendClientFlight { inner }))
+    }
+
+    /// Return the connection's Encrypted Client Hello (ECH) status.
+    pub fn ech_status(&self) -> EchStatus {
+        match self {
+            Self::SendClientFlight(st) => st.inner.side.ech_status(),
+            Self::AwaitServerFlight(st) => st.inner.side.ech_status(),
+            Self::Complete(traffic) => traffic.outputs.ech_status,
+        }
+    }
+}
+
+impl Deref for ClientHandshake {
+    type Target = ConnectionOutputs;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::SendClientFlight(st) => &st.inner.common.outputs,
+            Self::AwaitServerFlight(st) => &st.inner.common.outputs,
+            Self::Complete(traffic) => &traffic.outputs,
+        }
+    }
+}
+
+impl DerefMut for ClientHandshake {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::SendClientFlight(st) => &mut st.inner.common.outputs,
+            Self::AwaitServerFlight(st) => &mut st.inner.common.outputs,
+            Self::Complete(traffic) => &mut traffic.outputs,
+        }
+    }
+}
+
+impl fmt::Debug for ClientHandshake {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SendClientFlight(_) => f
+                .debug_tuple("SendClientFlight")
+                .finish_non_exhaustive(),
+            Self::AwaitServerFlight(_) => f
+                .debug_tuple("AwaitServerFlight")
+                .finish_non_exhaustive(),
+            Self::Complete(_) => f
+                .debug_tuple("Traffic")
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+/// A handshake state where we are required to send data to the peer.
+pub struct SendClientFlight {
+    inner: Box<ConnectionCore<ClientSide>>,
+}
+
+impl SendClientFlight {
+    /// Obtain one TLS message that should be sent to the peer.
+    ///
+    /// If you wish to use vectored IO, call this function repeatedly
+    /// to collect all messages before doing the IO.
+    pub fn take_data(&mut self) -> Option<Vec<u8>> {
+        self.inner
+            .common
+            .send
+            .sendable_tls
+            .pop()
+    }
+
+    /// Move to the next state, if possible.
+    ///
+    /// This returns the current state if there is remaining data to write.
+    pub fn into_next(self) -> ClientHandshake {
+        next_state(self.inner)
+    }
+}
+
+/// A handshake state where we are awaiting handshake data from the peer.
+pub struct AwaitServerFlight {
+    inner: Box<ConnectionCore<ClientSide>>,
+}
+
+impl AwaitServerFlight {
+    /// Receive some data.
+    ///
+    /// Return the next state or an error if things are permanently broken.  If an error occurs
+    /// here it is fatal to the connection.  The error is returned as a [`ErrorWithAlert`], and
+    /// the contained alert should be communicated to the peer if possible.  A [`ClientOutputs`]
+    /// object is also returned on error, allowing presumptive (but unauthenticated) data
+    /// learned about the peer to be inspected later.
+    ///
+    /// The number of bytes consumed from `input` is communicated to the object via `discard()`.
+    pub fn input_data(
+        mut self,
+        input: &mut dyn TlsInputBuffer,
+    ) -> Result<ClientHandshake, (ErrorWithAlert, Box<ClientOutputs>)> {
+        if let Err(err) = self
+            .inner
+            .process_handshake(input, None)
+        {
+            return Err((
+                ErrorWithAlert::new(err, &mut self.inner.common.send),
+                Box::new(self.inner.into()),
+            ));
+        }
+
+        Ok(next_state(self.inner))
+    }
+
+    /// If it is currently possible to send early data, swap this object for that ability.
+    ///
+    /// If sending early data is not possible, `None` is returned.
+    pub fn try_send_early_data(&mut self) -> Option<SendEarlyData<'_>> {
+        match self.inner.side.early_data_is_enabled() {
+            true => Some(SendEarlyData {
+                inner: &mut self.inner,
+            }),
+            false => None,
+        }
+    }
+}
+
+/// An opportunity exists to send early data.
+pub struct SendEarlyData<'a> {
+    inner: &'a mut ConnectionCore<ClientSide>,
+}
+
+impl SendEarlyData<'_> {
+    /// Write early data to the peer.
+    ///
+    /// The return value is the number of plaintext bytes written, and the TLS
+    /// data. This data should then be communicated to the peer.
+    ///
+    /// This will refuse to write excess bytes, by writing a prefix of `data`.
+    ///
+    /// For example: if [`Self::bytes_left()`] returns 2, then `write(b"hello`)` will
+    /// actually write `b"he"` and return `Some((2, ..))`.  After this,
+    /// [`Self::bytes_left()`] will return 0, and then a further `write(b"llo")` will
+    /// return `None`.
+    pub fn write(&mut self, data: &[u8]) -> Option<(usize, Vec<Vec<u8>>)> {
+        let early_data = &mut self.inner.side.early_data;
+        let Ok(plain_len @ 1..) = early_data.check_write(data.len()) else {
+            return None;
+        };
+        let send = &mut self.inner.common.send;
+        let application_data = OutboundPlain::from(&data[..plain_len]);
+        let buffers = send
+            .write_plaintext(application_data.clone())
+            .ok()?;
+        Some((plain_len, buffers))
+    }
+
+    /// How many bytes may be sent as early data.
+    pub fn bytes_left(&self) -> usize {
+        self.inner.side.early_data.bytes_left()
+    }
+
+    /// Returns the "early" exporter that can derive key material for use in early data
+    ///
+    /// See [RFC5705][] for general details on what exporters are, and [RFC8446 S7.5][] for
+    /// specific details on the "early" exporter.
+    ///
+    /// **Beware** that the early exporter requires care, as it is subject to the same
+    /// potential for replay as early data itself.  See [RFC8446 appendix E.5.1][] for
+    /// more detail.
+    ///
+    /// This function can be called at most once per connection. This function will error
+    /// if called more than once per connection.
+    ///
+    /// If you are looking for the normal exporter, this is available from
+    /// [`Connection::exporter()`].
+    ///
+    /// [RFC5705]: https://datatracker.ietf.org/doc/html/rfc5705
+    /// [RFC8446 S7.5]: https://datatracker.ietf.org/doc/html/rfc8446#section-7.5
+    /// [RFC8446 appendix E.5.1]: https://datatracker.ietf.org/doc/html/rfc8446#appendix-E.5.1
+    /// [`Connection::exporter()`]: crate::Connection::exporter()
+    pub fn early_exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
+        match self
+            .inner
+            .common
+            .outputs
+            .early_exporter
+            .take()
+        {
+            Some(inner) => Ok(KeyingMaterialExporter { inner }),
+            None => Err(ApiMisuse::ExporterAlreadyUsed.into()),
+        }
+    }
+}
+
+/// The handshake is complete and data may flow in both directions.
+///
+/// When you reach this state, you should destructure it into its parts
+/// and then progress them separately.
+///
+/// For example:
+///
+/// - if you do not require any information from `outputs`, you can drop it
+///   now to save memory.
+/// - if you are only receiving data, you can drop `send` now.  That is best done
+///   by calling [`SendTraffic::close()`].
+///
+/// Note that for good behavior, it is usually necessary to service `receive`.  This
+/// covers receipt of TLS1.3 tickets and key-update requests.
+#[expect(clippy::exhaustive_structs)]
+pub struct ClientTraffic {
+    /// The send side of the connection.
+    pub send: SendTraffic,
+
+    /// The receive side of the connection.
+    pub receive: ReceiveTraffic<ClientSide>,
+
+    /// Facts about the connection established during the handshake.
+    pub outputs: ClientOutputs,
+}
+
+impl ClientTraffic {
+    /// Converts the connection into a [`KernelConnection`] for use with KTLS.
+    pub fn dangerous_into_kernel_connection(
+        self,
+    ) -> Result<(ExtractedSecrets, KernelConnection<ClientSide>), Error> {
+        ConnectionCore::from_parts_into_kernel_connection(
+            &mut self.send.0.lock().unwrap(),
+            self.receive.recv,
+            self.outputs.outputs,
+            self.receive.state,
+        )
+    }
+}
+
+impl From<Box<ConnectionCore<ClientSide>>> for Box<ClientTraffic> {
+    fn from(inner: Box<ConnectionCore<ClientSide>>) -> Self {
+        let CommonState {
+            recv,
+            send,
+            outputs,
+            ..
+        } = inner.common;
+        let early_data_was_accepted = inner.side.early_data.is_accepted();
+        let ech_status = inner.side.ech_status();
+        let send_mutex = Arc::new(Mutex::new(send));
+
+        Self::new(ClientTraffic {
+            send: SendTraffic(send_mutex.clone()),
+            receive: ReceiveTraffic {
+                state: inner.state.unwrap(), // TODO
+                recv,
+                send: send_mutex,
+                pending_wake_sender: false,
+            },
+            outputs: ClientOutputs {
+                outputs,
+                early_data_was_accepted,
+                ech_status,
+            },
+        })
+    }
+}
+
+/// Facts about the connection established during the handshake.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct ClientOutputs {
+    /// Facts about the connection established during the handshake.
+    pub outputs: ConnectionOutputs,
+
+    /// Whether the server accepted our early data (if any).
+    pub early_data_was_accepted: bool,
+
+    /// The connection's Encrypted Client Hello (ECH) status
+    pub ech_status: EchStatus,
+}
+
+impl From<Box<ConnectionCore<ClientSide>>> for ClientOutputs {
+    fn from(inner: Box<ConnectionCore<ClientSide>>) -> Self {
+        let early_data_was_accepted = inner.side.early_data.is_accepted();
+        let ech_status = inner.side.ech_status();
+
+        Self {
+            outputs: inner.common.outputs,
+            early_data_was_accepted,
+            ech_status,
+        }
+    }
+}
+
+impl Deref for ClientOutputs {
+    type Target = ConnectionOutputs;
+
+    fn deref(&self) -> &Self::Target {
+        &self.outputs
+    }
+}
+
+impl DerefMut for ClientOutputs {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.outputs
+    }
+}
+
+fn next_state(inner: Box<ConnectionCore<ClientSide>>) -> ClientHandshake {
+    if !inner
+        .common
+        .send
+        .sendable_tls
+        .is_empty()
+    {
+        return ClientHandshake::SendClientFlight(SendClientFlight { inner });
+    }
+
+    match inner.state.as_ref() {
+        Ok(
+            hs::ClientState::Tls12(tls12::Tls12State::Traffic(_))
+            | hs::ClientState::Tls13(tls13::Tls13State::Traffic(_)),
+        ) => ClientHandshake::Complete(inner.into()),
+
+        Ok(_) => ClientHandshake::AwaitServerFlight(AwaitServerFlight { inner }),
+
+        Err(_) => panic!("TODO: withdraw error fusing in core.state"),
+    }
+}

--- a/rustls/src/client/state.rs
+++ b/rustls/src/client/state.rs
@@ -365,13 +365,14 @@ fn next_state(inner: Box<ConnectionCore<ClientSide>>) -> ClientHandshake {
     }
 
     match inner.state.as_ref() {
-        Ok(
+        Some(
             hs::ClientState::Tls12(tls12::Tls12State::Traffic(_))
             | hs::ClientState::Tls13(tls13::Tls13State::Traffic(_)),
         ) => ClientHandshake::Complete(inner.into()),
 
-        Ok(_) => ClientHandshake::AwaitServerFlight(AwaitServerFlight { inner }),
+        Some(_) => ClientHandshake::AwaitServerFlight(AwaitServerFlight { inner }),
 
-        Err(_) => panic!("TODO: withdraw error fusing in core.state"),
+        // indicates caller has swallowed an error
+        None => unreachable!(),
     }
 }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -11,13 +11,14 @@ use crate::crypto::Identity;
 use crate::crypto::cipher::Payload;
 use crate::crypto::kx::SupportedKxGroup;
 use crate::enums::{ApplicationProtocol, ProtocolVersion};
-use crate::error::{AlertDescription, Error};
+use crate::error::{AlertDescription, ApiMisuse, Error};
 use crate::hash_hs::HandshakeHash;
 use crate::msgs::{
     AlertLevel, Codec, Delocator, HandshakeMessagePayload, Locator, Message, MessagePayload,
 };
-use crate::quic::{self, QuicOutput};
+use crate::quic::QuicOutput;
 use crate::suites::SupportedCipherSuite;
+use crate::{KeyingMaterialExporter, quic};
 
 /// Connection state common to both client and server connections.
 pub struct CommonState {
@@ -156,6 +157,13 @@ impl ConnectionOutputs {
     /// handshake occurred.
     pub fn handshake_kind(&self) -> Option<HandshakeKind> {
         self.handshake_kind
+    }
+
+    pub(crate) fn take_exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
+        match self.exporter.take() {
+            Some(inner) => Ok(KeyingMaterialExporter { inner }),
+            None => Err(ApiMisuse::ExporterAlreadyUsed.into()),
+        }
     }
 
     pub(super) fn into_kernel_parts(self) -> Option<(ProtocolVersion, SupportedCipherSuite)> {

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -197,6 +197,29 @@ impl ConnectionOutput for ConnectionOutputs {
     }
 }
 
+impl fmt::Debug for ConnectionOutputs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            negotiated_version,
+            handshake_kind,
+            suite,
+            negotiated_kx_group,
+            alpn_protocol,
+            peer_identity,
+            exporter: _,
+            early_exporter: _,
+        } = self;
+        f.debug_struct("ConnectionOutputs")
+            .field("negotiated_version", negotiated_version)
+            .field("handshake_kind", handshake_kind)
+            .field("suite", suite)
+            .field("negotiated_kx_group", negotiated_kx_group)
+            .field("alpn_protocol", alpn_protocol)
+            .field("peer_identity", peer_identity)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Send an alert via `output` if `error` specifies one.
 pub(crate) fn maybe_send_fatal_alert(send: &mut dyn SendOutput, error: &Error) {
     let Ok(alert) = AlertDescription::try_from(error) else {

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -1,7 +1,6 @@
 use alloc::boxed::Box;
-use alloc::vec::Vec;
 use core::fmt::{self, Debug};
-use core::ops::{Deref, DerefMut};
+use core::ops::Deref;
 use std::io::{self, BufRead, Read};
 
 use kernel::KernelConnection;
@@ -12,7 +11,7 @@ use crate::common_state::{
 };
 use crate::error::{ApiMisuse, Error};
 use crate::kernel::KernelState;
-use crate::msgs::{Delocator, Message, Random, TlsInputBuffer, VecInput};
+use crate::msgs::{Message, Random, TlsInputBuffer, VecInput};
 use crate::quic::QuicOutput;
 use crate::suites::{ExtractedSecrets, PartiallyExtractedSecrets};
 use crate::tls13::key_schedule::KeyScheduleTrafficSend;
@@ -28,8 +27,6 @@ pub(crate) use receive::{Input, ReceivePath, TrafficTemperCounters};
 mod send;
 use send::DEFAULT_BUFFER_LIMIT;
 pub(crate) use send::{SendOutput, SendPath};
-
-use crate::crypto::cipher::OutboundPlain;
 
 /// A trait generalizing over buffered client or server connections.
 pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
@@ -237,9 +234,9 @@ pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
 
 /// A structure that implements [`std::io::Read`] for reading plaintext.
 pub struct Reader<'a> {
-    pub(super) received_plaintext: &'a mut ChunkVecBuffer,
-    pub(super) has_received_close_notify: bool,
-    pub(super) has_seen_eof: bool,
+    pub(crate) received_plaintext: &'a mut ChunkVecBuffer,
+    pub(crate) has_received_close_notify: bool,
+    pub(crate) has_seen_eof: bool,
 }
 
 impl<'a> Reader<'a> {
@@ -382,45 +379,6 @@ pub(crate) trait PlaintextSink {
     fn flush(&mut self) -> io::Result<()>;
 }
 
-impl<Side: SideData> PlaintextSink for ConnectionCommon<Side> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let len = self
-            .core
-            .common
-            .send
-            .buffer_plaintext(buf.into(), &mut self.buffers.sendable_plaintext);
-        self.send.maybe_refresh_traffic_keys();
-        Ok(len)
-    }
-
-    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
-        let payload_owner: Vec<&[u8]>;
-        let payload = match bufs.len() {
-            0 => return Ok(0),
-            1 => OutboundPlain::Single(bufs[0].deref()),
-            _ => {
-                payload_owner = bufs
-                    .iter()
-                    .map(|io_slice| io_slice.deref())
-                    .collect();
-
-                OutboundPlain::new(&payload_owner)
-            }
-        };
-        let len = self
-            .core
-            .common
-            .send
-            .buffer_plaintext(payload, &mut self.buffers.sendable_plaintext);
-        self.send.maybe_refresh_traffic_keys();
-        Ok(len)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
 /// An object of this type can export keying material.
 pub struct KeyingMaterialExporter {
     pub(crate) inner: Box<dyn Exporter>,
@@ -501,195 +459,16 @@ impl ConnectionRandoms {
     }
 }
 
-/// TLS connection state with side-specific data (`Side`).
-///
-/// This is one of the core abstractions of the rustls API. It represents a single connection
-/// to a peer, and holds all the state associated with that connection. Note that it does
-/// not hold any IO objects: the application is responsible for reading and writing TLS records.
-/// If you want an object that does hold IO objects, see `rustls_util::Stream` and
-/// `rustls_util::StreamOwned`.
-///
-/// This object is generic over the `Side` type parameter, which must implement the marker trait
-/// [`SideData`]. This is used to store side-specific data.
-pub(crate) struct ConnectionCommon<Side: SideData> {
-    pub(crate) core: ConnectionCore<Side>,
-    pub(crate) fips: FipsStatus,
-    buffers: Buffers,
-}
-
-impl<Side: SideData> ConnectionCommon<Side> {
-    pub(crate) fn new(core: ConnectionCore<Side>, fips: FipsStatus) -> Self {
-        Self {
-            core,
-            fips,
-            buffers: Buffers::new(),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn process_new_packets(&mut self) -> Result<IoState, Error> {
-        loop {
-            let Some(payload) = self
-                .core
-                .process_new_packets(&mut self.buffers.deframer_buffer, None)?
-            else {
-                break;
-            };
-
-            let payload =
-                payload.reborrow(&Delocator::new(self.buffers.deframer_buffer.slice_mut()));
-            self.buffers
-                .received_plaintext
-                .append(payload.into_vec());
-            self.buffers.deframer_buffer.discard(
-                self.core
-                    .common
-                    .recv
-                    .deframer
-                    .take_discard(),
-            );
-        }
-
-        // Release unsent buffered plaintext.
-        if self.send.may_send_application_data
-            && !self
-                .buffers
-                .sendable_plaintext
-                .is_empty()
-        {
-            self.core
-                .common
-                .send
-                .send_buffered_plaintext(&mut self.buffers.sendable_plaintext);
-        }
-
-        Ok(self.current_io_state())
-    }
-
-    pub(crate) fn wants_read(&self) -> bool {
-        // We want to read more data all the time, except when we have unprocessed plaintext.
-        // This provides back-pressure to the TCP buffers. We also don't want to read more after
-        // the peer has sent us a close notification.
-        //
-        // In the handshake case we don't have readable plaintext before the handshake has
-        // completed, but also don't want to read if we still have sendable tls.
-        self.buffers
-            .received_plaintext
-            .is_empty()
-            && !self.recv.has_received_close_notify
-            && (self.send.may_send_application_data || self.send.sendable_tls.is_empty())
-    }
-
-    pub(crate) fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        self.core.exporter()
-    }
-
-    /// Extract secrets, so they can be used when configuring kTLS, for example.
-    /// Should be used with care as it exposes secret key material.
-    pub(crate) fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.core.dangerous_extract_secrets()
-    }
-
-    pub(crate) fn set_buffer_limit(&mut self, limit: Option<usize>) {
-        self.buffers
-            .sendable_plaintext
-            .set_limit(limit);
-        self.send.sendable_tls.set_limit(limit);
-    }
-
-    pub(crate) fn set_plaintext_buffer_limit(&mut self, limit: Option<usize>) {
-        self.buffers
-            .received_plaintext
-            .set_limit(limit);
-    }
-
-    pub(crate) fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
-        self.core
-            .common
-            .send
-            .refresh_traffic_keys()
-    }
-
-    pub(crate) fn current_io_state(&self) -> IoState {
-        let common_state = &self.core.common;
-        IoState {
-            tls_bytes_to_write: common_state.send.sendable_tls.len(),
-            plaintext_bytes_to_read: self.buffers.received_plaintext.len(),
-            peer_has_closed: common_state
-                .recv
-                .has_received_close_notify,
-        }
-    }
-}
-
-impl<Side: SideData> ConnectionCommon<Side> {
-    /// Returns an object that allows reading plaintext.
-    pub(crate) fn reader(&mut self) -> Reader<'_> {
-        let common = &mut self.core.common;
-        let has_received_close_notify = common.recv.has_received_close_notify;
-        Reader {
-            received_plaintext: &mut self.buffers.received_plaintext,
-            // Are we done? i.e., have we processed all received messages, and received a
-            // close_notify to indicate that no new messages will arrive?
-            has_received_close_notify,
-            has_seen_eof: self.buffers.has_seen_eof,
-        }
-    }
-
-    /// Returns an object that allows writing plaintext.
-    pub(crate) fn writer(&mut self) -> Writer<'_> {
-        Writer::new(self)
-    }
-
-    pub(crate) fn read_tls(&mut self, rd: &mut dyn Read) -> Result<usize, io::Error> {
-        if self
-            .buffers
-            .received_plaintext
-            .is_full()
-        {
-            return Err(io::Error::other("received plaintext buffer full"));
-        }
-
-        if self.recv.has_received_close_notify {
-            return Ok(0);
-        }
-
-        let res = self.buffers.deframer_buffer.read(rd);
-        if let Ok(0) = res {
-            self.buffers.has_seen_eof = true;
-        }
-        res
-    }
-
-    pub(crate) fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
-        self.send.sendable_tls.write_to(wr)
-    }
-}
-
-impl<Side: SideData> Deref for ConnectionCommon<Side> {
-    type Target = CommonState;
-
-    fn deref(&self) -> &Self::Target {
-        &self.core.common
-    }
-}
-
-impl<Side: SideData> DerefMut for ConnectionCommon<Side> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.core.common
-    }
-}
-
 /// Common items for buffered, std::io-using connections.
 pub(crate) struct Buffers {
-    deframer_buffer: VecInput,
+    pub(crate) deframer_buffer: VecInput,
     pub(crate) received_plaintext: ChunkVecBuffer,
     pub(crate) sendable_plaintext: ChunkVecBuffer,
     pub(crate) has_seen_eof: bool,
 }
 
 impl Buffers {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             deframer_buffer: VecInput::default(),
             received_plaintext: ChunkVecBuffer::new(Some(DEFAULT_RECEIVED_PLAINTEXT_LIMIT)),
@@ -705,9 +484,9 @@ impl Buffers {
 /// [`Connection::process_new_packets`]: crate::Connection::process_new_packets
 #[derive(Debug, Eq, PartialEq)]
 pub struct IoState {
-    tls_bytes_to_write: usize,
-    plaintext_bytes_to_read: usize,
-    peer_has_closed: bool,
+    pub(crate) tls_bytes_to_write: usize,
+    pub(crate) plaintext_bytes_to_read: usize,
+    pub(crate) peer_has_closed: bool,
 }
 
 impl IoState {

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -21,8 +21,8 @@ use crate::vecbuf::ChunkVecBuffer;
 pub mod kernel;
 
 mod receive;
-use receive::{FinishHandshake, FinishOnAppData, JoinOutput};
-pub(crate) use receive::{Input, ReceivePath, TrafficTemperCounters};
+pub(crate) use receive::{CaptureAppData, Input, JoinOutput, ReceivePath, TrafficTemperCounters};
+use receive::{FinishHandshake, FinishOnAppData};
 
 mod send;
 use send::DEFAULT_BUFFER_LIMIT;
@@ -550,7 +550,6 @@ impl<Side: SideData> ConnectionCore<Side> {
             .process_new_packets::<Side, FinishOnAppData>(buffer, &mut self.state, &mut output)
     }
 
-    #[expect(dead_code)]
     #[inline]
     pub(crate) fn process_handshake<'a>(
         &'a mut self,

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -459,7 +459,7 @@ impl ConnectionRandoms {
     }
 }
 
-/// Common items for buffered, std::io-using connections.
+/// Buffer management for connection types with internal buffering.
 pub(crate) struct Buffers {
     pub(crate) deframer_buffer: VecInput,
     pub(crate) received_plaintext: ChunkVecBuffer,
@@ -570,26 +570,6 @@ impl<Side: SideData> ConnectionCore<Side> {
             .process_new_packets::<Side, FinishHandshake>(buffer, &mut self.state, &mut output)
     }
 
-    pub(crate) fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        Ok(self
-            .dangerous_into_kernel_connection()?
-            .0)
-    }
-
-    pub(crate) fn dangerous_into_kernel_connection(
-        mut self,
-    ) -> Result<(ExtractedSecrets, KernelConnection<Side>), Error> {
-        if self.common.is_handshaking() {
-            return Err(Error::HandshakeNotComplete);
-        }
-        Self::from_parts_into_kernel_connection(
-            &mut self.common.send,
-            self.common.recv,
-            self.common.outputs,
-            self.state?,
-        )
-    }
-
     pub(crate) fn from_parts_into_kernel_connection(
         send: &mut SendPath,
         recv: ReceivePath,
@@ -619,13 +599,6 @@ impl<Side: SideData> ConnectionCore<Side> {
         match self.common.exporter.take() {
             Some(inner) => Ok(KeyingMaterialExporter { inner }),
             None if self.common.is_handshaking() => Err(Error::HandshakeNotComplete),
-            None => Err(ApiMisuse::ExporterAlreadyUsed.into()),
-        }
-    }
-
-    pub(crate) fn early_exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        match self.common.early_exporter.take() {
-            Some(inner) => Ok(KeyingMaterialExporter { inner }),
             None => Err(ApiMisuse::ExporterAlreadyUsed.into()),
         }
     }

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -22,7 +22,7 @@ use crate::vecbuf::ChunkVecBuffer;
 pub mod kernel;
 
 mod receive;
-use receive::JoinOutput;
+use receive::{FinishOnAppData, JoinOutput};
 pub(crate) use receive::{Input, ReceivePath, TrafficTemperCounters};
 
 mod send;
@@ -768,7 +768,7 @@ impl<Side: SideData> ConnectionCore<Side> {
 
         self.common
             .recv
-            .process_new_packets::<Side>(buffer, &mut self.state, &mut output)
+            .process_new_packets::<Side, FinishOnAppData>(buffer, &mut self.state, &mut output)
     }
 
     pub(crate) fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -520,7 +520,7 @@ impl IoState {
 }
 
 pub(crate) struct ConnectionCore<Side: SideData> {
-    pub(crate) state: Result<Side::State, Error>,
+    pub(crate) state: Option<Side::State>,
     pub(crate) side: Side::Data,
     pub(crate) common: CommonState,
 }
@@ -528,7 +528,7 @@ pub(crate) struct ConnectionCore<Side: SideData> {
 impl<Side: SideData> ConnectionCore<Side> {
     pub(crate) fn new(state: Side::State, side: Side::Data, common: CommonState) -> Self {
         Self {
-            state: Ok(state),
+            state: Some(state),
             side,
             common,
         }

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -22,7 +22,7 @@ use crate::vecbuf::ChunkVecBuffer;
 pub mod kernel;
 
 mod receive;
-use receive::{FinishOnAppData, JoinOutput};
+use receive::{FinishHandshake, FinishOnAppData, JoinOutput};
 pub(crate) use receive::{Input, ReceivePath, TrafficTemperCounters};
 
 mod send;
@@ -771,6 +771,25 @@ impl<Side: SideData> ConnectionCore<Side> {
             .process_new_packets::<Side, FinishOnAppData>(buffer, &mut self.state, &mut output)
     }
 
+    #[expect(dead_code)]
+    #[inline]
+    pub(crate) fn process_handshake<'a>(
+        &'a mut self,
+        buffer: &mut dyn TlsInputBuffer,
+        quic: Option<&'a mut dyn QuicOutput>,
+    ) -> Result<Option<UnborrowedPayload>, Error> {
+        let mut output = JoinOutput {
+            outputs: &mut self.common.outputs,
+            quic,
+            send: &mut self.common.send,
+            side: &mut self.side,
+        };
+
+        self.common
+            .recv
+            .process_new_packets::<Side, FinishHandshake>(buffer, &mut self.state, &mut output)
+    }
+
     pub(crate) fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
         Ok(self
             .dangerous_into_kernel_connection()?
@@ -910,6 +929,7 @@ use private::SideOutput;
 pub(crate) trait StateMachine: Sized {
     fn handle<'m>(self, input: Input<'m>, output: &mut dyn Output<'m>) -> Result<Self, Error>;
     fn wants_input(&self) -> bool;
+    fn traffic(&self) -> bool;
     fn handle_decrypt_error(&mut self);
     fn into_external_state(
         self,

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -464,6 +464,7 @@ pub(crate) struct Buffers {
     pub(crate) deframer_buffer: VecInput,
     pub(crate) received_plaintext: ChunkVecBuffer,
     pub(crate) sendable_plaintext: ChunkVecBuffer,
+    pub(crate) sendable_tls: ChunkVecBuffer,
     pub(crate) has_seen_eof: bool,
 }
 
@@ -473,6 +474,7 @@ impl Buffers {
             deframer_buffer: VecInput::default(),
             received_plaintext: ChunkVecBuffer::new(Some(DEFAULT_RECEIVED_PLAINTEXT_LIMIT)),
             sendable_plaintext: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
+            sendable_tls: ChunkVecBuffer::new(None),
             has_seen_eof: false,
         }
     }
@@ -715,4 +717,4 @@ pub(crate) trait StateMachine: Sized {
     ) -> Result<(PartiallyExtractedSecrets, Box<dyn KernelState + 'static>), Error>;
 }
 
-const DEFAULT_RECEIVED_PLAINTEXT_LIMIT: usize = 16 * 1024;
+pub(crate) const DEFAULT_RECEIVED_PLAINTEXT_LIMIT: usize = 16 * 1024;

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -5,8 +5,7 @@ use core::ops::Range;
 use super::SendOutput;
 use crate::SideData;
 use crate::common_state::{
-    ConnectionOutput, ConnectionOutputs, Event, Output, OutputEvent, Side, UnborrowedPayload,
-    maybe_send_fatal_alert,
+    ConnectionOutput, Event, Output, OutputEvent, Side, UnborrowedPayload, maybe_send_fatal_alert,
 };
 use crate::conn::StateMachine;
 use crate::conn::private::SideOutput;
@@ -50,6 +49,24 @@ impl ReceivePath {
             seen_consecutive_empty_fragments: 0,
             tls13_tickets_received: 0,
         }
+    }
+
+    pub(crate) fn process_recv_traffic<Side: SideData>(
+        &mut self,
+        input: &mut dyn TlsInputBuffer,
+        state: &mut Result<Side::State, Error>,
+        send: &mut dyn SendOutput,
+    ) -> Result<Option<UnborrowedPayload>, Error> {
+        self.process_new_packets::<Side, FinishOnAppData>(
+            input,
+            state,
+            &mut JoinOutput {
+                outputs: &mut Discard,
+                quic: None,
+                send,
+                side: &mut Discard,
+            },
+        )
     }
 
     pub(super) fn process_new_packets<'a, 'm, Side: SideData, Finish: FinishCondition>(
@@ -435,22 +452,22 @@ impl FinishCondition for FinishHandshake {
     }
 }
 
-struct CaptureAppData<'a, 'j, 'm> {
-    recv: &'a mut ReceivePath,
-    other: &'a mut JoinOutput<'j>,
+pub(crate) struct CaptureAppData<'a, 'j, 'm> {
+    pub(crate) recv: &'a mut ReceivePath,
+    pub(crate) other: &'a mut JoinOutput<'j>,
     /// Store a [`Locator`] initialized from the current receive buffer
     ///
     /// Allows received plaintext data to be unborrowed and stored in
     /// `received_plaintext` for in-place decryption.
-    plaintext_locator: &'a Locator,
+    pub(crate) plaintext_locator: &'a Locator,
     /// Unborrowed received plaintext data
     ///
     /// Set if plaintext data was received.
     ///
     /// Plaintext data may be reborrowed using a [`Delocator`] which was
     /// initialized from the same slice as `plaintext_locator`.
-    received_plaintext: &'a mut Option<UnborrowedPayload>,
-    _message_lifetime: PhantomData<&'m ()>,
+    pub(crate) received_plaintext: &'a mut Option<UnborrowedPayload>,
+    pub(crate) _message_lifetime: PhantomData<&'m ()>,
 }
 
 impl<'m> Output<'m> for CaptureAppData<'_, '_, 'm> {
@@ -510,11 +527,21 @@ impl<'m> Output<'m> for CaptureAppData<'_, '_, 'm> {
     }
 }
 
-pub(super) struct JoinOutput<'a> {
-    pub(super) outputs: &'a mut ConnectionOutputs,
-    pub(super) quic: Option<&'a mut dyn QuicOutput>,
-    pub(super) send: &'a mut dyn SendOutput,
-    pub(super) side: &'a mut dyn SideOutput,
+pub(crate) struct JoinOutput<'a> {
+    pub(crate) outputs: &'a mut dyn ConnectionOutput,
+    pub(crate) quic: Option<&'a mut dyn QuicOutput>,
+    pub(crate) send: &'a mut dyn SendOutput,
+    pub(crate) side: &'a mut dyn SideOutput,
+}
+
+struct Discard;
+
+impl ConnectionOutput for Discard {
+    fn handle(&mut self, _ev: OutputEvent<'_>) {}
+}
+
+impl SideOutput for Discard {
+    fn emit(&mut self, _ev: Event<'_>) {}
 }
 
 /// Tracking technically-allowed protocol actions

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -11,7 +11,7 @@ use crate::conn::StateMachine;
 use crate::conn::private::SideOutput;
 use crate::crypto::cipher::{Decrypted, DecryptionState, EncodedMessage, Payload};
 use crate::enums::{ContentType, HandshakeType, ProtocolVersion};
-use crate::error::{AlertDescription, Error, PeerMisbehaved};
+use crate::error::{AlertDescription, ApiMisuse, Error, PeerMisbehaved};
 use crate::log::{trace, warn};
 use crate::msgs::{
     AlertLevel, AlertLevelName, AlertMessagePayload, Deframed, Deframer, Delocator,
@@ -54,7 +54,7 @@ impl ReceivePath {
     pub(crate) fn process_recv_traffic<Side: SideData>(
         &mut self,
         input: &mut dyn TlsInputBuffer,
-        state: &mut Result<Side::State, Error>,
+        state: &mut Option<Side::State>,
         send: &mut dyn SendOutput,
     ) -> Result<Option<UnborrowedPayload>, Error> {
         self.process_new_packets::<Side, FinishOnAppData>(
@@ -72,15 +72,11 @@ impl ReceivePath {
     pub(super) fn process_new_packets<'a, 'm, Side: SideData, Finish: FinishCondition>(
         &mut self,
         input: &'m mut dyn TlsInputBuffer,
-        state: &mut Result<Side::State, Error>,
+        state: &mut Option<Side::State>,
         output: &mut JoinOutput<'a>,
     ) -> Result<Option<UnborrowedPayload>, Error> {
-        let mut st = match mem::replace(state, Err(Error::HandshakeNotComplete)) {
-            Ok(state) => state,
-            Err(e) => {
-                *state = Err(e.clone());
-                return Err(e);
-            }
+        let Some(mut st) = mem::take(state) else {
+            return Err(ApiMisuse::PreviousConnectionError.into());
         };
 
         let mut plaintext = None;
@@ -105,7 +101,6 @@ impl ReceivePath {
                     if let Error::DecryptError = e {
                         st.handle_decrypt_error();
                     }
-                    *state = Err(e.clone());
                     input.discard(self.deframer.take_discard());
                     return Err(e);
                 }
@@ -141,7 +136,6 @@ impl ReceivePath {
                 Ok(new) => st = new,
                 Err(e) => {
                     maybe_send_fatal_alert(output.other.send, &e);
-                    *state = Err(e.clone());
                     input.discard(self.deframer.take_discard());
                     return Err(e);
                 }
@@ -157,7 +151,7 @@ impl ReceivePath {
             }
 
             if let Some(payload) = plaintext.take() {
-                *state = Ok(st);
+                *state = Some(st);
                 return Ok(Some(payload));
             }
 
@@ -165,7 +159,7 @@ impl ReceivePath {
         }
 
         input.discard(self.deframer.take_discard());
-        *state = Ok(st);
+        *state = Some(st);
         Ok(None)
     }
 

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -427,6 +427,14 @@ impl FinishCondition for FinishOnAppData {
     }
 }
 
+pub(super) struct FinishHandshake;
+
+impl FinishCondition for FinishHandshake {
+    fn is_done<S: StateMachine>(state: &S) -> bool {
+        state.traffic()
+    }
+}
+
 struct CaptureAppData<'a, 'j, 'm> {
     recv: &'a mut ReceivePath,
     other: &'a mut JoinOutput<'j>,

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -52,7 +52,7 @@ impl ReceivePath {
         }
     }
 
-    pub(super) fn process_new_packets<'a, 'm, Side: SideData>(
+    pub(super) fn process_new_packets<'a, 'm, Side: SideData, Finish: FinishCondition>(
         &mut self,
         input: &'m mut dyn TlsInputBuffer,
         state: &mut Result<Side::State, Error>,
@@ -67,7 +67,8 @@ impl ReceivePath {
         };
 
         let mut plaintext = None;
-        while st.wants_input() {
+
+        while st.wants_input() && !Finish::is_done(&st) {
             let buffer = input.slice_mut();
             let locator = Locator::new(buffer);
             let res = self.deframe(buffer);
@@ -411,6 +412,18 @@ impl ReceivePath {
         }
 
         Err(err)
+    }
+}
+
+pub(super) trait FinishCondition {
+    fn is_done<S: StateMachine>(state: &S) -> bool;
+}
+
+pub(super) struct FinishOnAppData;
+
+impl FinishCondition for FinishOnAppData {
+    fn is_done<S: StateMachine>(_state: &S) -> bool {
+        false
     }
 }
 

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -28,7 +28,6 @@ pub(crate) struct SendPath {
 }
 
 impl SendPath {
-    #[expect(dead_code)]
     pub(crate) fn write_plaintext(
         &mut self,
         payload: OutboundPlain<'_>,

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -56,22 +56,6 @@ impl SendPath {
         Ok(self.sendable_tls.take())
     }
 
-    pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
-        debug_assert!(self.encrypt_state.is_encrypting());
-
-        // Limit on `sendable_tls` should apply to encrypted data but is enforced
-        // for plaintext data instead which does not include cipher+record overhead.
-        let len = self
-            .sendable_tls
-            .apply_limit(data.len());
-        if len == 0 {
-            // Don't send empty fragments.
-            return 0;
-        }
-
-        self.send_appdata_encrypt(data[..len].into())
-    }
-
     pub(crate) fn send_close_notify(&mut self) {
         if self.has_sent_close_notify {
             return;

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -77,20 +77,6 @@ impl SendPath {
         );
     }
 
-    /// Like send_msg_encrypt, but operate on an appdata directly.
-    fn send_appdata_encrypt(&mut self, payload: OutboundPlain<'_>) -> usize {
-        let len = payload.len();
-        self.send_messages(
-            self.message_fragmenter
-                .fragment_payload(
-                    ContentType::ApplicationData,
-                    ProtocolVersion::TLSv1_2,
-                    payload,
-                ),
-        );
-        len
-    }
-
     /// Encrypt and queue a single fragment.
     fn send_messages<'a>(
         &mut self,
@@ -138,43 +124,6 @@ impl SendPath {
 
             // Refuse to wrap counter at all costs. This is basically untestable unfortunately.
             Some(PreEncryptAction::Refuse) => Err(Error::EncryptError),
-        }
-    }
-
-    /// Send plaintext application data, fragmenting and
-    /// encrypting it as it goes out.
-    ///
-    /// If internal buffers are too small, this function will not accept
-    /// all the data.
-    pub(crate) fn buffer_plaintext(
-        &mut self,
-        payload: OutboundPlain<'_>,
-        sendable_plaintext: &mut ChunkVecBuffer,
-    ) -> usize {
-        self.perhaps_write_key_update();
-        if !self.may_send_application_data {
-            // If we haven't completed handshaking, buffer
-            // plaintext to send once we do.
-            return sendable_plaintext.append_limited_copy(payload);
-        }
-
-        // Limit on `sendable_tls` should apply to encrypted data but is enforced
-        // for plaintext data instead which does not include cipher+record overhead.
-        let len = self
-            .sendable_tls
-            .apply_limit(payload.len());
-        if len == 0 {
-            // Don't send empty fragments.
-            return 0;
-        }
-
-        debug_assert!(self.encrypt_state.is_encrypting());
-        self.send_appdata_encrypt(payload.split_at(len).0)
-    }
-
-    pub(crate) fn send_buffered_plaintext(&mut self, plaintext: &mut ChunkVecBuffer) {
-        while let Some(buf) = plaintext.pop() {
-            self.send_appdata_encrypt(buf.as_slice().into());
         }
     }
 

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -2,7 +2,6 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::ops::{Deref, DerefMut, Range};
 
-use crate::crypto::cipher::EncryptionState;
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::msgs::{Codec, HEADER_SIZE, MAX_FRAGMENT_LEN, Reader, hex, read_opaque_message_header};
@@ -152,11 +151,6 @@ impl EncodedMessage<OutboundPlain<'_>> {
             version: self.version,
             payload,
         }
-    }
-
-    #[expect(dead_code)]
-    pub(crate) fn encoded_len(&self, record_layer: &EncryptionState) -> usize {
-        HEADER_SIZE + record_layer.encrypted_len(self.payload.len())
     }
 }
 

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -70,13 +70,6 @@ impl EncryptionState {
         }
     }
 
-    pub(crate) fn encrypted_len(&self, payload_len: usize) -> usize {
-        self.message_encrypter
-            .as_ref()
-            .map(|enc| enc.encrypted_payload_len(payload_len))
-            .unwrap_or_default()
-    }
-
     pub(crate) fn is_encrypting(&self) -> bool {
         self.message_encrypter.is_some()
     }

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1512,6 +1512,9 @@ pub enum ApiMisuse {
 
     /// The send side of a connection was already closed.
     SendSideAlreadyClosed,
+
+    /// An unrecoverable error previously happened on this connection.
+    PreviousConnectionError,
 }
 
 impl fmt::Display for ApiMisuse {

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1506,6 +1506,12 @@ pub enum ApiMisuse {
     ///
     /// [`KernelConnection::update_tx_secret()`]: crate::conn::kernel::KernelConnection::update_tx_secret()
     KeyUpdateNotAvailableForTls12,
+
+    /// The receive side of a connection was already closed.
+    ReceiveSideAlreadyClosed,
+
+    /// The send side of a connection was already closed.
+    SendSideAlreadyClosed,
 }
 
 impl fmt::Display for ApiMisuse {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -400,6 +400,9 @@ pub use crate::versions::{ALL_VERSIONS, DEFAULT_VERSIONS, SupportedProtocolVersi
 #[cfg(feature = "webpki")]
 pub use crate::webpki::RootCertStore;
 
+/// Types supporting the state-based API.
+pub mod state;
+
 /// Items for use in a client.
 pub mod client;
 pub use client::{ClientConfig, ClientConnection};

--- a/rustls/src/msgs/deframer/buffers.rs
+++ b/rustls/src/msgs/deframer/buffers.rs
@@ -109,6 +109,10 @@ impl VecInput {
     pub(crate) fn filled(&self) -> &[u8] {
         &self.buf[..self.used]
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.used == 0
+    }
 }
 
 impl TlsInputBuffer for VecInput {

--- a/rustls/src/msgs/deframer/buffers.rs
+++ b/rustls/src/msgs/deframer/buffers.rs
@@ -3,7 +3,6 @@ use core::ops::Range;
 use std::io;
 
 #[derive(Default, Debug)]
-#[expect(unreachable_pub)]
 pub struct VecInput {
     /// Buffer of data read from the socket, in the process of being parsed into messages.
     ///
@@ -124,7 +123,6 @@ impl TlsInputBuffer for VecInput {
 
 /// A borrowed version of [`VecInput`] that tracks discard operations
 #[derive(Debug)]
-#[expect(unreachable_pub)]
 pub struct SliceInput<'a> {
     // a fully initialized buffer that will be deframed
     buf: &'a mut [u8],
@@ -132,7 +130,6 @@ pub struct SliceInput<'a> {
     discard: usize,
 }
 
-#[expect(dead_code, unreachable_pub)]
 impl<'a> SliceInput<'a> {
     pub fn new(buf: &'a mut [u8]) -> Self {
         Self { buf, discard: 0 }
@@ -155,7 +152,6 @@ impl TlsInputBuffer for SliceInput<'_> {
 }
 
 /// An abstraction over received data buffers (either owned or borrowed)
-#[expect(unreachable_pub)]
 pub trait TlsInputBuffer {
     /// Return the buffer which contains the received data.
     ///

--- a/rustls/src/msgs/deframer/mod.rs
+++ b/rustls/src/msgs/deframer/mod.rs
@@ -9,8 +9,8 @@ use crate::msgs::codec::{Codec, Reader, U24};
 use crate::msgs::{HEADER_SIZE, read_opaque_message_header};
 
 mod buffers;
-use buffers::Coalescer;
-pub(crate) use buffers::{Delocator, Locator, TlsInputBuffer, VecInput};
+pub(crate) use buffers::{Coalescer, Delocator, Locator};
+pub use buffers::{SliceInput, TlsInputBuffer, VecInput};
 
 pub fn fuzz_deframer(data: &[u8]) {
     let mut buf = data.to_vec();

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -57,9 +57,8 @@ pub(crate) use codec::{
 use codec::{LengthPrefixedBuffer, U24};
 
 mod deframer;
-pub(crate) use deframer::{
-    Deframed, Deframer, Delocator, HandshakeAlignedProof, Locator, TlsInputBuffer, VecInput,
-};
+pub(crate) use deframer::{Deframed, Deframer, Delocator, HandshakeAlignedProof, Locator};
+pub use deframer::{SliceInput, TlsInputBuffer, VecInput};
 
 mod enums;
 #[cfg(test)]

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -276,8 +276,8 @@ impl ServerConnection {
     pub fn set_resumption_data(&mut self, resumption_data: &[u8]) -> Result<(), Error> {
         assert!(resumption_data.len() < 2usize.pow(15));
         match &mut self.inner.core.state {
-            Ok(st) => st.set_resumption_data(resumption_data),
-            Err(e) => Err(e.clone()),
+            Some(st) => st.set_resumption_data(resumption_data),
+            None => Err(ApiMisuse::PreviousConnectionError.into()),
         }
     }
 

--- a/rustls/src/server/config.rs
+++ b/rustls/src/server/config.rs
@@ -20,7 +20,7 @@ use crate::crypto::{
 use crate::crypto::{Credentials, Identity, SingleCredential};
 use crate::enums::{ApplicationProtocol, CertificateType, ProtocolVersion};
 use crate::error::{Error, PeerMisbehaved};
-use crate::msgs::ServerNamePayload;
+use crate::msgs::{ClientHelloPayload, ServerNamePayload};
 use crate::suites::Suite;
 use crate::sync::Arc;
 use crate::time_provider::{DefaultTimeProvider, TimeProvider};
@@ -433,6 +433,33 @@ impl<'a> ClientHello<'a> {
                 .client_hello
                 .named_groups
                 .as_deref(),
+        }
+    }
+
+    pub(super) fn new_from_payload(hello: &'a ClientHelloPayload) -> Self {
+        let server_name = hello
+            .server_name
+            .as_ref()
+            .and_then(ServerNamePayload::to_dns_name_normalized)
+            .map(Cow::Owned);
+        Self {
+            server_name,
+            signature_schemes: hello
+                .signature_schemes
+                .as_deref()
+                .unwrap_or_default(),
+            alpn: hello.protocols.as_ref(),
+            server_cert_types: hello
+                .server_certificate_types
+                .as_deref(),
+            client_cert_types: hello
+                .client_certificate_types
+                .as_deref(),
+            cipher_suites: &hello.cipher_suites,
+            certificate_authorities: hello
+                .certificate_authority_names
+                .as_deref(),
+            named_groups: hello.named_groups.as_deref(),
         }
     }
 

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -9,18 +9,19 @@ use std::io;
 use pki_types::{DnsName, FipsStatus};
 
 use super::config::{ClientHello, ServerConfig};
+use crate::IoState;
 use crate::common_state::{CommonState, ConnectionOutputs, EarlyDataEvent, Event, Protocol, Side};
 use crate::conn::private::SideOutput;
 use crate::conn::{
-    Connection, ConnectionCommon, ConnectionCore, KeyingMaterialExporter, Reader, SendPath,
+    Buffers, Connection, ConnectionCore, KeyingMaterialExporter, PlaintextSink, Reader, SendPath,
     SideCommonOutput, Writer,
 };
 #[cfg(doc)]
 use crate::crypto;
-use crate::crypto::cipher::Payload;
+use crate::crypto::cipher::{OutboundPlain, Payload};
 use crate::error::{ApiMisuse, Error, ErrorWithAlert};
 use crate::log::trace;
-use crate::msgs::{ServerExtensionsInput, ServerNamePayload};
+use crate::msgs::{Delocator, ServerExtensionsInput, ServerNamePayload, TlsInputBuffer};
 use crate::server::hs::{ChooseConfig, ExpectClientHello, ReadClientHello, ServerState};
 use crate::suites::ExtractedSecrets;
 use crate::sync::Arc;
@@ -31,7 +32,9 @@ use crate::vecbuf::ChunkVecBuffer;
 /// Send TLS-protected data to the peer using the `io::Write` trait implementation.
 /// Read data from the peer using the `io::Read` trait implementation.
 pub struct ServerConnection {
-    pub(super) inner: ConnectionCommon<ServerSide>,
+    core: ConnectionCore<ServerSide>,
+    fips: FipsStatus,
+    buffers: Buffers,
 }
 
 impl ServerConnection {
@@ -40,14 +43,13 @@ impl ServerConnection {
     pub fn new(config: Arc<ServerConfig>) -> Result<Self, Error> {
         let fips = config.fips();
         Ok(Self {
-            inner: ConnectionCommon::new(
-                ConnectionCore::for_server(
-                    config,
-                    ServerExtensionsInput::default(),
-                    Protocol::Tcp,
-                )?,
-                fips,
-            ),
+            core: ConnectionCore::for_server(
+                config,
+                ServerExtensionsInput::default(),
+                Protocol::Tcp,
+            )?,
+            fips,
+            buffers: Buffers::new(),
         })
     }
 
@@ -67,7 +69,7 @@ impl ServerConnection {
     ///
     /// The server name is also used to match sessions during session resumption.
     pub fn server_name(&self) -> Option<&DnsName<'_>> {
-        self.inner.core.side.server_name()
+        self.core.side.server_name()
     }
 
     /// Application-controlled portion of the resumption ticket supplied by the client, if any.
@@ -76,8 +78,7 @@ impl ServerConnection {
     ///
     /// Returns `Some` if and only if a valid resumption ticket has been received from the client.
     pub fn received_resumption_data(&self) -> Option<&[u8]> {
-        self.inner
-            .core
+        self.core
             .side
             .received_resumption_data()
     }
@@ -92,7 +93,7 @@ impl ServerConnection {
     /// from the client is desired, encrypt the data separately.
     pub fn set_resumption_data(&mut self, data: &[u8]) -> Result<(), Error> {
         assert!(data.len() < 2usize.pow(15));
-        match &mut self.inner.core.state {
+        match &mut self.core.state {
             Ok(st) => st.set_resumption_data(data),
             Err(e) => Err(e.clone()),
         }
@@ -109,14 +110,8 @@ impl ServerConnection {
     /// - The connection doesn't resume an existing session.
     /// - The client hasn't sent a full ClientHello yet.
     pub fn early_data(&mut self) -> Option<ReadEarlyData<'_>> {
-        if self
-            .inner
-            .core
-            .side
-            .early_data
-            .was_accepted()
-        {
-            Some(ReadEarlyData::new(&mut self.inner))
+        if self.core.side.early_data.was_accepted() {
+            Some(ReadEarlyData::new(&mut self.core))
         } else {
             None
         }
@@ -125,70 +120,250 @@ impl ServerConnection {
     /// Extract secrets, so they can be used when configuring kTLS, for example.
     /// Should be used with care as it exposes secret key material.
     pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.inner.dangerous_extract_secrets()
+        self.core.dangerous_extract_secrets()
+    }
+
+    fn current_io_state(&self) -> IoState {
+        let common_state = &self.core.common;
+        IoState {
+            tls_bytes_to_write: common_state.send.sendable_tls.len(),
+            plaintext_bytes_to_read: self.buffers.received_plaintext.len(),
+            peer_has_closed: common_state
+                .recv
+                .has_received_close_notify,
+        }
     }
 }
 
 impl Connection for ServerConnection {
     fn read_tls(&mut self, rd: &mut dyn io::Read) -> Result<usize, io::Error> {
-        self.inner.read_tls(rd)
+        if self
+            .buffers
+            .received_plaintext
+            .is_full()
+        {
+            return Err(io::Error::other("received plaintext buffer full"));
+        }
+
+        if self
+            .core
+            .common
+            .recv
+            .has_received_close_notify
+        {
+            return Ok(0);
+        }
+
+        let res = self.buffers.deframer_buffer.read(rd);
+        if let Ok(0) = res {
+            self.buffers.has_seen_eof = true;
+        }
+        res
     }
 
     fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
-        self.inner.write_tls(wr)
+        self.core
+            .common
+            .send
+            .sendable_tls
+            .write_to(wr)
     }
 
     fn wants_read(&self) -> bool {
-        self.inner.wants_read()
+        // We want to read more data all the time, except when we have unprocessed plaintext.
+        // This provides back-pressure to the TCP buffers. We also don't want to read more after
+        // the peer has sent us a close notification.
+        //
+        // In the handshake case we don't have readable plaintext before the handshake has
+        // completed, but also don't want to read if we still have sendable tls.
+        self.buffers
+            .received_plaintext
+            .is_empty()
+            && !self
+                .core
+                .common
+                .recv
+                .has_received_close_notify
+            && (self
+                .core
+                .common
+                .send
+                .may_send_application_data
+                || self
+                    .core
+                    .common
+                    .send
+                    .sendable_tls
+                    .is_empty())
     }
 
     fn wants_write(&self) -> bool {
-        self.inner.wants_write()
+        !self
+            .core
+            .common
+            .send
+            .sendable_tls
+            .is_empty()
     }
 
     fn reader(&mut self) -> Reader<'_> {
-        self.inner.reader()
+        let common = &mut self.core.common;
+        let has_received_close_notify = common.recv.has_received_close_notify;
+        Reader {
+            received_plaintext: &mut self.buffers.received_plaintext,
+            // Are we done? i.e., have we processed all received messages, and received a
+            // close_notify to indicate that no new messages will arrive?
+            has_received_close_notify,
+            has_seen_eof: self.buffers.has_seen_eof,
+        }
     }
 
     fn writer(&mut self) -> Writer<'_> {
-        self.inner.writer()
+        Writer::new(self)
     }
 
-    fn process_new_packets(&mut self) -> Result<crate::IoState, Error> {
-        self.inner.process_new_packets()
+    fn process_new_packets(&mut self) -> Result<IoState, Error> {
+        loop {
+            let Some(payload) = self
+                .core
+                .process_new_packets(&mut self.buffers.deframer_buffer, None)?
+            else {
+                break;
+            };
+
+            let payload =
+                payload.reborrow(&Delocator::new(self.buffers.deframer_buffer.slice_mut()));
+            self.buffers
+                .received_plaintext
+                .append(payload.into_vec());
+            self.buffers.deframer_buffer.discard(
+                self.core
+                    .common
+                    .recv
+                    .deframer
+                    .take_discard(),
+            );
+        }
+
+        // Release unsent buffered plaintext.
+        if self
+            .core
+            .common
+            .send
+            .may_send_application_data
+            && !self
+                .buffers
+                .sendable_plaintext
+                .is_empty()
+        {
+            self.core
+                .common
+                .send
+                .send_buffered_plaintext(&mut self.buffers.sendable_plaintext);
+        }
+
+        Ok(self.current_io_state())
     }
 
     fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        self.inner.exporter()
+        self.core.exporter()
     }
 
     fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.inner.dangerous_extract_secrets()
+        self.core.dangerous_extract_secrets()
     }
 
     fn set_buffer_limit(&mut self, limit: Option<usize>) {
-        self.inner.set_buffer_limit(limit)
+        self.buffers
+            .sendable_plaintext
+            .set_limit(limit);
+        self.core
+            .common
+            .send
+            .sendable_tls
+            .set_limit(limit);
     }
 
     fn set_plaintext_buffer_limit(&mut self, limit: Option<usize>) {
-        self.inner
-            .set_plaintext_buffer_limit(limit)
+        self.buffers
+            .received_plaintext
+            .set_limit(limit);
     }
 
     fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
-        self.inner.refresh_traffic_keys()
+        self.core
+            .common
+            .send
+            .refresh_traffic_keys()
     }
 
     fn send_close_notify(&mut self) {
-        self.inner.send_close_notify();
+        self.core
+            .common
+            .send
+            .send_close_notify()
     }
 
     fn is_handshaking(&self) -> bool {
-        self.inner.is_handshaking()
+        !(self
+            .core
+            .common
+            .send
+            .may_send_application_data
+            && self
+                .core
+                .common
+                .recv
+                .may_receive_application_data)
     }
 
     fn fips(&self) -> FipsStatus {
-        self.inner.fips
+        self.fips
+    }
+}
+
+impl PlaintextSink for ServerConnection {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let len = self
+            .core
+            .common
+            .send
+            .buffer_plaintext(buf.into(), &mut self.buffers.sendable_plaintext);
+        self.core
+            .common
+            .send
+            .maybe_refresh_traffic_keys();
+        Ok(len)
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        let payload_owner: Vec<&[u8]>;
+        let payload = match bufs.len() {
+            0 => return Ok(0),
+            1 => OutboundPlain::Single(bufs[0].deref()),
+            _ => {
+                payload_owner = bufs
+                    .iter()
+                    .map(|io_slice| io_slice.deref())
+                    .collect();
+
+                OutboundPlain::new(&payload_owner)
+            }
+        };
+        let len = self
+            .core
+            .common
+            .send
+            .buffer_plaintext(payload, &mut self.buffers.sendable_plaintext);
+        self.core
+            .common
+            .send
+            .maybe_refresh_traffic_keys();
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 
@@ -196,7 +371,7 @@ impl Deref for ServerConnection {
     type Target = ConnectionOutputs;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        &self.core.common.outputs
     }
 }
 
@@ -254,17 +429,18 @@ impl Debug for ServerConnection {
 /// # }
 /// ```
 pub struct Acceptor {
-    inner: Option<ConnectionCommon<ServerSide>>,
+    inner: Option<ServerConnection>,
 }
 
 impl Default for Acceptor {
     /// Return an empty Acceptor, ready to receive bytes from a new client connection.
     fn default() -> Self {
         Self {
-            inner: Some(ConnectionCommon::new(
-                ConnectionCore::for_acceptor(Protocol::Tcp),
-                FipsStatus::Unvalidated,
-            )),
+            inner: Some(ServerConnection {
+                core: ConnectionCore::for_acceptor(Protocol::Tcp),
+                fips: FipsStatus::Unvalidated,
+                buffers: Buffers::new(),
+            }),
         }
     }
 }
@@ -375,12 +551,12 @@ impl Debug for AcceptedAlert {
 ///
 /// This type implements [`io::Read`].
 pub struct ReadEarlyData<'a> {
-    common: &'a mut ConnectionCommon<ServerSide>,
+    core: &'a mut ConnectionCore<ServerSide>,
 }
 
 impl<'a> ReadEarlyData<'a> {
-    fn new(common: &'a mut ConnectionCommon<ServerSide>) -> Self {
-        ReadEarlyData { common }
+    fn new(core: &'a mut ConnectionCore<ServerSide>) -> Self {
+        ReadEarlyData { core }
     }
 
     /// Returns the "early" exporter that can derive key material for use in early data
@@ -403,17 +579,13 @@ impl<'a> ReadEarlyData<'a> {
     /// [RFC8446 appendix E.5.1]: https://datatracker.ietf.org/doc/html/rfc8446#appendix-E.5.1
     /// [`Connection::exporter()`]: crate::conn::Connection::exporter()
     pub fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        self.common.core.early_exporter()
+        self.core.early_exporter()
     }
 }
 
 impl io::Read for ReadEarlyData<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.common
-            .core
-            .side
-            .early_data
-            .read(buf)
+        self.core.side.early_data.read(buf)
     }
 }
 
@@ -422,7 +594,7 @@ impl io::Read for ReadEarlyData<'_> {
 /// Contains the state required to resume the connection through [`Accepted::into_connection()`].
 pub struct Accepted {
     // invariant: `connection.core.state` is `Err(_)` and requires restoring
-    connection: ConnectionCommon<ServerSide>,
+    connection: ServerConnection,
     choose_config: Box<ChooseConfig>,
 }
 
@@ -470,6 +642,8 @@ impl Accepted {
     ) -> Result<ServerConnection, (Error, AcceptedAlert)> {
         if let Err(err) = self
             .connection
+            .core
+            .common
             .send
             .set_max_fragment_size(config.max_fragment_size)
         {
@@ -500,9 +674,7 @@ impl Accepted {
         };
         self.connection.core.state = Ok(state);
 
-        Ok(ServerConnection {
-            inner: self.connection,
-        })
+        Ok(self.connection)
     }
 }
 

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -117,12 +117,6 @@ impl ServerConnection {
         }
     }
 
-    /// Extract secrets, so they can be used when configuring kTLS, for example.
-    /// Should be used with care as it exposes secret key material.
-    pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.core.dangerous_extract_secrets()
-    }
-
     fn current_io_state(&self) -> IoState {
         let common_state = &self.core.common;
         IoState {

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -1,28 +1,27 @@
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::fmt;
 use core::fmt::{Debug, Formatter};
 use core::ops::Deref;
+use core::{fmt, mem};
 use std::io;
 
 use pki_types::{DnsName, FipsStatus};
 
 use super::config::{ClientHello, ServerConfig};
+use super::hs::{ExpectClientHello, ReadClientHello, ServerState};
+use super::{ChooseConfig, ServerHandshake, ServerOutputs, ServerTraffic};
 use crate::IoState;
 use crate::common_state::{CommonState, ConnectionOutputs, EarlyDataEvent, Event, Protocol, Side};
 use crate::conn::private::SideOutput;
 use crate::conn::{
-    Buffers, Connection, ConnectionCore, KeyingMaterialExporter, PlaintextSink, Reader, SendPath,
-    SideCommonOutput, Writer,
+    Buffers, Connection, ConnectionCore, KeyingMaterialExporter, PlaintextSink, Reader, Writer,
 };
 #[cfg(doc)]
 use crate::crypto;
 use crate::crypto::cipher::{OutboundPlain, Payload};
-use crate::error::{ApiMisuse, Error, ErrorWithAlert};
-use crate::log::trace;
-use crate::msgs::{Delocator, ServerExtensionsInput, ServerNamePayload, TlsInputBuffer};
-use crate::server::hs::{ChooseConfig, ExpectClientHello, ReadClientHello, ServerState};
+use crate::error::{ApiMisuse, Error};
+use crate::msgs::ServerExtensionsInput;
+use crate::state::{ReceiveTraffic, ReceiveTrafficState, SendTraffic};
 use crate::suites::ExtractedSecrets;
 use crate::sync::Arc;
 use crate::vecbuf::ChunkVecBuffer;
@@ -32,9 +31,15 @@ use crate::vecbuf::ChunkVecBuffer;
 /// Send TLS-protected data to the peer using the `io::Write` trait implementation.
 /// Read data from the peer using the `io::Read` trait implementation.
 pub struct ServerConnection {
-    core: ConnectionCore<ServerSide>,
-    fips: FipsStatus,
+    state: Result<InnerState, Error>,
     buffers: Buffers,
+    config: Option<Arc<ServerConfig>>, // pending ServerState::ChooseConfig
+
+    fips: FipsStatus,
+    err_outputs: Option<Box<ServerOutputs>>,
+    early_data_received: bool,
+    received_early_data: ChunkVecBuffer,
+    early_exporter: Option<KeyingMaterialExporter>,
 }
 
 impl ServerConnection {
@@ -43,13 +48,14 @@ impl ServerConnection {
     pub fn new(config: Arc<ServerConfig>) -> Result<Self, Error> {
         let fips = config.fips();
         Ok(Self {
-            core: ConnectionCore::for_server(
-                config,
-                ServerExtensionsInput::default(),
-                Protocol::Tcp,
-            )?,
-            fips,
+            state: Ok(InnerState::Handshake(ServerHandshake::new())),
             buffers: Buffers::new(),
+            config: Some(config),
+            err_outputs: None,
+            early_data_received: false,
+            received_early_data: ChunkVecBuffer::new(None),
+            early_exporter: None,
+            fips,
         })
     }
 
@@ -69,7 +75,14 @@ impl ServerConnection {
     ///
     /// The server name is also used to match sessions during session resumption.
     pub fn server_name(&self) -> Option<&DnsName<'_>> {
-        self.core.side.server_name()
+        match &self.state {
+            Ok(InnerState::Handshake(st)) => st.server_name(),
+            Ok(InnerState::Traffic { outputs, .. }) => outputs.server_name(),
+            Err(_) => match &self.err_outputs {
+                Some(o) => o.server_name(),
+                None => None,
+            },
+        }
     }
 
     /// Application-controlled portion of the resumption ticket supplied by the client, if any.
@@ -78,9 +91,14 @@ impl ServerConnection {
     ///
     /// Returns `Some` if and only if a valid resumption ticket has been received from the client.
     pub fn received_resumption_data(&self) -> Option<&[u8]> {
-        self.core
-            .side
-            .received_resumption_data()
+        match &self.state {
+            Ok(InnerState::Handshake(st)) => st.received_resumption_data(),
+            Ok(InnerState::Traffic { outputs, .. }) => outputs.received_resumption_data(),
+            Err(_) => match &self.err_outputs {
+                Some(o) => o.received_resumption_data(),
+                None => None,
+            },
+        }
     }
 
     /// Set the resumption data to embed in future resumption tickets supplied to the client.
@@ -93,8 +111,9 @@ impl ServerConnection {
     /// from the client is desired, encrypt the data separately.
     pub fn set_resumption_data(&mut self, data: &[u8]) -> Result<(), Error> {
         assert!(data.len() < 2usize.pow(15));
-        match &mut self.core.state {
-            Ok(st) => st.set_resumption_data(data),
+        match &mut self.state {
+            Ok(InnerState::Handshake(st)) => st.set_resumption_data(data),
+            Ok(InnerState::Traffic { .. }) => Err(ApiMisuse::ResumptionDataProvidedTooLate.into()),
             Err(e) => Err(e.clone()),
         }
     }
@@ -110,21 +129,99 @@ impl ServerConnection {
     /// - The connection doesn't resume an existing session.
     /// - The client hasn't sent a full ClientHello yet.
     pub fn early_data(&mut self) -> Option<ReadEarlyData<'_>> {
-        if self.core.side.early_data.was_accepted() {
-            Some(ReadEarlyData::new(&mut self.core))
+        if self.early_data_received {
+            Some(ReadEarlyData::new(self))
         } else {
             None
         }
     }
 
-    fn current_io_state(&self) -> IoState {
-        let common_state = &self.core.common;
+    pub(crate) fn current_io_state(&self) -> IoState {
         IoState {
-            tls_bytes_to_write: common_state.send.sendable_tls.len(),
+            tls_bytes_to_write: self.buffers.sendable_tls.len(),
             plaintext_bytes_to_read: self.buffers.received_plaintext.len(),
-            peer_has_closed: common_state
-                .recv
-                .has_received_close_notify,
+            peer_has_closed: self.has_received_close_notify(),
+        }
+    }
+
+    fn has_received_close_notify(&self) -> bool {
+        matches!(&self.state, Ok(InnerState::Traffic { receive: None, .. }))
+    }
+
+    fn write_or_buffer_appdata(&mut self, data: OutboundPlain<'_>) -> io::Result<usize> {
+        Ok(match &mut self.state {
+            Ok(InnerState::Traffic { send: None, .. }) => return Ok(0),
+            Ok(InnerState::Traffic {
+                send: Some(send), ..
+            }) => {
+                let len = data.len();
+
+                let len = self
+                    .buffers
+                    .sendable_tls
+                    .apply_limit(len);
+                if len == 0 {
+                    // Don't send empty fragments.
+                    return Ok(0);
+                }
+
+                if let Ok(chunks) = send.write(data.split_at(len).0) {
+                    for c in chunks {
+                        self.buffers.sendable_tls.append(c);
+                    }
+                }
+                while let Some(chunk) = send.take_data() {
+                    self.buffers.sendable_tls.append(chunk);
+                }
+                len
+            }
+            Ok(InnerState::Handshake(ServerHandshake::AwaitClientFlight(acf))) => {
+                if let Some(mut half) = acf.try_send_half_rtt() {
+                    let len = data.len();
+                    if let Ok(chunks) = half.write(data) {
+                        for c in chunks {
+                            self.buffers.sendable_tls.append(c);
+                        }
+                    }
+                    len
+                } else {
+                    self.buffers
+                        .sendable_plaintext
+                        .append_limited_copy(data)
+                }
+            }
+            _ => self
+                .buffers
+                .sendable_plaintext
+                .append_limited_copy(data),
+        })
+    }
+
+    /// Act on a potential state transition from a handshake-related state to `new`.
+    fn post_handshake_state(&mut self, new: ServerHandshake) -> InnerState {
+        let ServerHandshake::Complete(traffic) = new else {
+            return InnerState::Handshake(new);
+        };
+
+        let ServerTraffic {
+            mut send,
+            receive,
+            outputs,
+        } = *traffic;
+
+        // Release unsent buffered plaintext.
+        while let Some(chunk) = self.buffers.sendable_plaintext.pop() {
+            let Ok(chunks) = send.write(chunk.as_slice().into()) else {
+                continue;
+            };
+            for c in chunks {
+                self.buffers.sendable_tls.append(c);
+            }
+        }
+        InnerState::Traffic {
+            send: Some(send),
+            receive: Some(receive),
+            outputs: Box::new(outputs),
         }
     }
 }
@@ -139,12 +236,7 @@ impl Connection for ServerConnection {
             return Err(io::Error::other("received plaintext buffer full"));
         }
 
-        if self
-            .core
-            .common
-            .recv
-            .has_received_close_notify
-        {
+        if self.has_received_close_notify() {
             return Ok(0);
         }
 
@@ -152,15 +244,12 @@ impl Connection for ServerConnection {
         if let Ok(0) = res {
             self.buffers.has_seen_eof = true;
         }
+
         res
     }
 
     fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
-        self.core
-            .common
-            .send
-            .sendable_tls
-            .write_to(wr)
+        self.buffers.sendable_tls.write_to(wr)
     }
 
     fn wants_read(&self) -> bool {
@@ -174,35 +263,17 @@ impl Connection for ServerConnection {
             .received_plaintext
             .is_empty()
             && !self
-                .core
-                .common
-                .recv
-                .has_received_close_notify
-            && (self
-                .core
-                .common
-                .send
-                .may_send_application_data
-                || self
-                    .core
-                    .common
-                    .send
-                    .sendable_tls
-                    .is_empty())
+                .current_io_state()
+                .peer_has_closed()
+            && (!self.is_handshaking() || self.buffers.sendable_tls.is_empty())
     }
 
     fn wants_write(&self) -> bool {
-        !self
-            .core
-            .common
-            .send
-            .sendable_tls
-            .is_empty()
+        !self.buffers.sendable_tls.is_empty()
     }
 
     fn reader(&mut self) -> Reader<'_> {
-        let common = &mut self.core.common;
-        let has_received_close_notify = common.recv.has_received_close_notify;
+        let has_received_close_notify = self.has_received_close_notify();
         Reader {
             received_plaintext: &mut self.buffers.received_plaintext,
             // Are we done? i.e., have we processed all received messages, and received a
@@ -218,62 +289,191 @@ impl Connection for ServerConnection {
 
     fn process_new_packets(&mut self) -> Result<IoState, Error> {
         loop {
-            let Some(payload) = self
-                .core
-                .process_new_packets(&mut self.buffers.deframer_buffer, None)?
-            else {
-                break;
+            let state = match mem::replace(
+                &mut self.state,
+                Err(ApiMisuse::PreviousConnectionError.into()),
+            ) {
+                Ok(state) => state,
+                Err(e) => {
+                    self.state = Err(e.clone());
+                    return Err(e);
+                }
             };
 
-            let payload =
-                payload.reborrow(&Delocator::new(self.buffers.deframer_buffer.slice_mut()));
-            self.buffers
-                .received_plaintext
-                .append(payload.into_vec());
-            self.buffers.deframer_buffer.discard(
-                self.core
-                    .common
-                    .recv
-                    .deframer
-                    .take_discard(),
-            );
-        }
+            match state {
+                InnerState::Handshake(ServerHandshake::SendServerFlight(mut scf)) => {
+                    while let Some(chunk) = scf.take_data() {
+                        self.buffers.sendable_tls.append(chunk);
+                    }
+                    self.state = Ok(self.post_handshake_state(scf.into_next()));
+                }
+                InnerState::Handshake(ServerHandshake::ChooseConfig(cc))
+                    if self.config.is_some() =>
+                {
+                    match cc.with_config(self.config.take().unwrap()) {
+                        Ok(state) => self.state = Ok(self.post_handshake_state(state)),
+                        Err((mut err, outputs)) => {
+                            while let Some(chunk) = err.take_tls_data() {
+                                self.buffers.sendable_tls.append(chunk);
+                            }
 
-        // Release unsent buffered plaintext.
-        if self
-            .core
-            .common
-            .send
-            .may_send_application_data
-            && !self
-                .buffers
-                .sendable_plaintext
-                .is_empty()
-        {
-            self.core
-                .common
-                .send
-                .send_buffered_plaintext(&mut self.buffers.sendable_plaintext);
+                            self.err_outputs = Some(outputs);
+                            self.state = Err(err.error.clone());
+                            return Err(err.error);
+                        }
+                    }
+                }
+                InnerState::Handshake(ServerHandshake::ChooseConfig(ch)) => {
+                    self.state = Ok(InnerState::Handshake(ServerHandshake::ChooseConfig(ch)));
+                    break;
+                }
+                InnerState::Handshake(ServerHandshake::ReceiveEarlyData(mut sed)) => {
+                    self.early_data_received = true;
+                    while let Some(chunk) = sed.take_data() {
+                        self.received_early_data.append(chunk);
+                    }
+                    self.early_exporter = sed.early_exporter().ok();
+                    self.state = Ok(InnerState::Handshake(sed.into_next()));
+                }
+                InnerState::Handshake(ServerHandshake::AwaitClientFlight(mut asf)) => {
+                    // try half-rtt if required
+                    if !self
+                        .buffers
+                        .sendable_plaintext
+                        .is_empty()
+                    {
+                        if let Some(mut send) = asf.try_send_half_rtt() {
+                            // Release unsent buffered plaintext.
+                            while let Some(chunk) = self.buffers.sendable_plaintext.pop() {
+                                let Ok(chunks) = send.write(chunk.as_slice().into()) else {
+                                    continue;
+                                };
+                                for c in chunks {
+                                    self.buffers.sendable_tls.append(c);
+                                }
+                            }
+                        }
+                    }
+
+                    if self.buffers.deframer_buffer.is_empty() {
+                        self.state = Ok(InnerState::Handshake(ServerHandshake::AwaitClientFlight(
+                            asf,
+                        )));
+                        break;
+                    }
+                    match asf.input_data(&mut self.buffers.deframer_buffer) {
+                        Ok(state) => {
+                            self.state = Ok(self.post_handshake_state(state));
+                            if matches!(
+                                self.state,
+                                Ok(InnerState::Handshake(ServerHandshake::AwaitClientFlight(_)))
+                            ) {
+                                break;
+                            }
+                        }
+                        Err((mut err, outputs)) => {
+                            while let Some(chunk) = err.take_tls_data() {
+                                self.buffers.sendable_tls.append(chunk);
+                            }
+
+                            self.err_outputs = Some(outputs);
+                            self.state = Err(err.error.clone());
+                            return Err(err.error);
+                        }
+                    };
+                }
+                InnerState::Handshake(st) => self.state = Ok(self.post_handshake_state(st)),
+                InnerState::Traffic {
+                    mut send,
+                    mut receive,
+                    outputs,
+                } => {
+                    let mut progress = true;
+
+                    while progress {
+                        progress = false;
+
+                        // Processed received data.
+                        if !self.buffers.deframer_buffer.is_empty() {
+                            let Some(recv) = receive.take() else {
+                                break;
+                            };
+                            match recv.read(&mut self.buffers.deframer_buffer) {
+                                Ok(ReceiveTrafficState::Available(received)) => {
+                                    progress = true;
+                                    self.buffers
+                                        .received_plaintext
+                                        .append(received.data.to_vec());
+                                    let (used, next) = received.into_next();
+                                    self.buffers
+                                        .deframer_buffer
+                                        .discard(used);
+                                    receive = Some(next);
+                                }
+                                Ok(ReceiveTrafficState::WakeSender(state)) => {
+                                    if let Some(send) = &mut send {
+                                        while let Some(chunk) = send.take_data() {
+                                            self.buffers.sendable_tls.append(chunk);
+                                        }
+                                    }
+                                    receive = Some(state.into_next());
+                                }
+                                Ok(ReceiveTrafficState::Await(state)) => receive = Some(state),
+                                Ok(ReceiveTrafficState::CloseNotify) => receive = None,
+                                Err(mut e) => {
+                                    while let Some(chunk) = e.take_tls_data() {
+                                        self.buffers.sendable_tls.append(chunk);
+                                    }
+                                    self.state = Err(e.error.clone());
+                                    return Err(e.error);
+                                }
+                            }
+                        }
+                    }
+
+                    self.state = Ok(InnerState::Traffic {
+                        send,
+                        receive,
+                        outputs,
+                    });
+                    break;
+                }
+            }
         }
 
         Ok(self.current_io_state())
     }
 
     fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        self.core.exporter()
+        let Ok(InnerState::Traffic { outputs, .. }) = &mut self.state else {
+            return Err(Error::HandshakeNotComplete);
+        };
+        outputs.take_exporter()
     }
 
     fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.core.dangerous_extract_secrets()
+        let Ok(InnerState::Traffic {
+            send: Some(send),
+            receive: Some(receive),
+            outputs,
+        }) = self.state
+        else {
+            return Err(Error::HandshakeNotComplete);
+        };
+        Ok(ServerTraffic {
+            send,
+            receive,
+            outputs: *outputs,
+        }
+        .dangerous_into_kernel_connection()?
+        .0)
     }
 
     fn set_buffer_limit(&mut self, limit: Option<usize>) {
         self.buffers
             .sendable_plaintext
             .set_limit(limit);
-        self.core
-            .common
-            .send
+        self.buffers
             .sendable_tls
             .set_limit(limit);
     }
@@ -285,30 +485,33 @@ impl Connection for ServerConnection {
     }
 
     fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
-        self.core
-            .common
-            .send
-            .refresh_traffic_keys()
+        match &mut self.state {
+            Ok(InnerState::Traffic {
+                send: Some(send), ..
+            }) => send.refresh_traffic_keys(),
+            Ok(InnerState::Traffic { send: None, .. }) => {
+                Err(ApiMisuse::SendSideAlreadyClosed.into())
+            }
+            _ => Err(Error::HandshakeNotComplete),
+        }
     }
 
     fn send_close_notify(&mut self) {
-        self.core
-            .common
-            .send
-            .send_close_notify()
+        let Ok(InnerState::Traffic { send, .. }) = &mut self.state else {
+            return;
+        };
+
+        let Some(send) = send.take() else {
+            return;
+        };
+
+        self.buffers
+            .sendable_tls
+            .append(send.close());
     }
 
     fn is_handshaking(&self) -> bool {
-        !(self
-            .core
-            .common
-            .send
-            .may_send_application_data
-            && self
-                .core
-                .common
-                .recv
-                .may_receive_application_data)
+        !matches!(self.state, Ok(InnerState::Traffic { .. }))
     }
 
     fn fips(&self) -> FipsStatus {
@@ -318,16 +521,7 @@ impl Connection for ServerConnection {
 
 impl PlaintextSink for ServerConnection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let len = self
-            .core
-            .common
-            .send
-            .buffer_plaintext(buf.into(), &mut self.buffers.sendable_plaintext);
-        self.core
-            .common
-            .send
-            .maybe_refresh_traffic_keys();
-        Ok(len)
+        self.write_or_buffer_appdata(buf.into())
     }
 
     fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
@@ -344,16 +538,7 @@ impl PlaintextSink for ServerConnection {
                 OutboundPlain::new(&payload_owner)
             }
         };
-        let len = self
-            .core
-            .common
-            .send
-            .buffer_plaintext(payload, &mut self.buffers.sendable_plaintext);
-        self.core
-            .common
-            .send
-            .maybe_refresh_traffic_keys();
-        Ok(len)
+        self.write_or_buffer_appdata(payload)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -365,7 +550,11 @@ impl Deref for ServerConnection {
     type Target = ConnectionOutputs;
 
     fn deref(&self) -> &Self::Target {
-        &self.core.common.outputs
+        match &self.state {
+            Ok(InnerState::Handshake(st)) => st,
+            Ok(InnerState::Traffic { outputs, .. }) => outputs,
+            Err(_) => self.err_outputs.as_ref().unwrap(),
+        }
     }
 }
 
@@ -374,6 +563,15 @@ impl Debug for ServerConnection {
         f.debug_struct("ServerConnection")
             .finish_non_exhaustive()
     }
+}
+
+enum InnerState {
+    Handshake(ServerHandshake),
+    Traffic {
+        send: Option<SendTraffic>,
+        receive: Option<ReceiveTraffic<ServerSide>>,
+        outputs: Box<ServerOutputs>,
+    },
 }
 
 /// Handle a server-side connection before configuration is available.
@@ -431,9 +629,14 @@ impl Default for Acceptor {
     fn default() -> Self {
         Self {
             inner: Some(ServerConnection {
-                core: ConnectionCore::for_acceptor(Protocol::Tcp),
-                fips: FipsStatus::Unvalidated,
+                state: Ok(InnerState::Handshake(ServerHandshake::new())),
                 buffers: Buffers::new(),
+                config: None,
+                err_outputs: None,
+                early_data_received: false,
+                received_early_data: ChunkVecBuffer::new(None),
+                early_exporter: None,
+                fips: FipsStatus::Unvalidated,
             }),
         }
     }
@@ -475,16 +678,16 @@ impl Acceptor {
         };
 
         if let Err(e) = connection.process_new_packets() {
-            return Err(AcceptedAlert::from_error(e, connection.core.common.send));
+            return Err((e, AcceptedAlert(connection.buffers.sendable_tls)));
         }
 
-        let Ok(ServerState::ChooseConfig(_)) = connection.core.state else {
+        let Ok(InnerState::Handshake(ServerHandshake::ChooseConfig(_))) = connection.state else {
             self.inner = Some(connection);
             return Ok(None);
         };
 
-        let Ok(ServerState::ChooseConfig(choose_config)) = core::mem::replace(
-            &mut connection.core.state,
+        let Ok(InnerState::Handshake(ServerHandshake::ChooseConfig(choose_config))) = mem::replace(
+            &mut connection.state,
             Err(Error::Unreachable("Accepted misused state")),
         ) else {
             unreachable!(); // checked in previous block
@@ -504,13 +707,6 @@ impl Acceptor {
 pub struct AcceptedAlert(ChunkVecBuffer);
 
 impl AcceptedAlert {
-    pub(super) fn from_error(error: Error, mut send: SendPath) -> (Error, Self) {
-        let ErrorWithAlert { error, data } = ErrorWithAlert::new(error, &mut send);
-        let mut output = ChunkVecBuffer::new(None);
-        output.append(data);
-        (error, Self(output))
-    }
-
     pub(super) fn empty() -> Self {
         Self(ChunkVecBuffer::new(None))
     }
@@ -545,12 +741,12 @@ impl Debug for AcceptedAlert {
 ///
 /// This type implements [`io::Read`].
 pub struct ReadEarlyData<'a> {
-    core: &'a mut ConnectionCore<ServerSide>,
+    conn: &'a mut ServerConnection,
 }
 
 impl<'a> ReadEarlyData<'a> {
-    fn new(core: &'a mut ConnectionCore<ServerSide>) -> Self {
-        ReadEarlyData { core }
+    fn new(conn: &'a mut ServerConnection) -> Self {
+        ReadEarlyData { conn }
     }
 
     /// Returns the "early" exporter that can derive key material for use in early data
@@ -573,13 +769,16 @@ impl<'a> ReadEarlyData<'a> {
     /// [RFC8446 appendix E.5.1]: https://datatracker.ietf.org/doc/html/rfc8446#appendix-E.5.1
     /// [`Connection::exporter()`]: crate::conn::Connection::exporter()
     pub fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
-        self.core.early_exporter()
+        match self.conn.early_exporter.take() {
+            Some(exporter) => Ok(exporter),
+            None => Err(ApiMisuse::ExporterAlreadyUsed.into()),
+        }
     }
 }
 
 impl io::Read for ReadEarlyData<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.core.side.early_data.read(buf)
+        self.conn.received_early_data.read(buf)
     }
 }
 
@@ -587,42 +786,15 @@ impl io::Read for ReadEarlyData<'_> {
 ///
 /// Contains the state required to resume the connection through [`Accepted::into_connection()`].
 pub struct Accepted {
-    // invariant: `connection.core.state` is `Err(_)` and requires restoring
+    // invariant: `connection.state` is `Err(_)` and requires restoring
     connection: ServerConnection,
-    choose_config: Box<ChooseConfig>,
+    choose_config: ChooseConfig,
 }
 
 impl Accepted {
     /// Get the [`ClientHello`] for this connection.
     pub fn client_hello(&self) -> ClientHello<'_> {
-        let client_hello = self.choose_config.client_hello();
-        let server_name = client_hello
-            .server_name
-            .as_ref()
-            .and_then(ServerNamePayload::to_dns_name_normalized)
-            .map(Cow::Owned);
-        let ch = ClientHello {
-            server_name,
-            signature_schemes: client_hello
-                .signature_schemes
-                .as_deref()
-                .unwrap_or_default(),
-            alpn: client_hello.protocols.as_ref(),
-            server_cert_types: client_hello
-                .server_certificate_types
-                .as_deref(),
-            client_cert_types: client_hello
-                .client_certificate_types
-                .as_deref(),
-            cipher_suites: &client_hello.cipher_suites,
-            certificate_authorities: client_hello
-                .certificate_authority_names
-                .as_deref(),
-            named_groups: client_hello.named_groups.as_deref(),
-        };
-
-        trace!("Accepted::client_hello(): {ch:#?}");
-        ch
+        self.choose_config.client_hello()
     }
 
     /// Convert the [`Accepted`] into a [`ServerConnection`].
@@ -634,41 +806,15 @@ impl Accepted {
         mut self,
         config: Arc<ServerConfig>,
     ) -> Result<ServerConnection, (Error, AcceptedAlert)> {
-        if let Err(err) = self
-            .connection
-            .core
-            .common
-            .send
-            .set_max_fragment_size(config.max_fragment_size)
-        {
-            // We have a connection here, but it won't contain an alert since the error
-            // is with the fragment size configured in the `ServerConfig`.
-            return Err((err, AcceptedAlert::empty()));
-        }
         self.connection.fips = config.fips();
-
-        let mut output = SideCommonOutput {
-            side: &mut self.connection.core.side,
-            quic: None,
-            common: &mut self.connection.core.common,
-        };
-
-        let state = match self.choose_config.use_config(
-            config,
-            ServerExtensionsInput::default(),
-            &mut output,
-        ) {
-            Ok(state) => state,
-            Err(err) => {
-                return Err(AcceptedAlert::from_error(
-                    err,
-                    self.connection.core.common.send,
-                ));
-            }
-        };
-        self.connection.core.state = Ok(state);
-
-        Ok(self.connection)
+        self.connection.config = Some(config);
+        self.connection.state = Ok(InnerState::Handshake(ServerHandshake::ChooseConfig(
+            self.choose_config,
+        )));
+        match self.connection.process_new_packets() {
+            Ok(_) => Ok(self.connection),
+            Err(err) => Err((err, AcceptedAlert(self.connection.buffers.sendable_tls))),
+        }
     }
 }
 
@@ -696,10 +842,6 @@ impl EarlyDataState {
         };
     }
 
-    fn was_accepted(&self) -> bool {
-        matches!(self, Self::Accepted { .. })
-    }
-
     pub(super) fn peek(&self) -> Option<&[u8]> {
         match self {
             Self::Accepted { received, .. } => received.peek(),
@@ -716,13 +858,6 @@ impl EarlyDataState {
 
     pub(super) fn retire(&mut self) {
         *self = Self::Retired;
-    }
-
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match self {
-            Self::Accepted { received, .. } => received.read(buf),
-            _ => Err(io::Error::from(io::ErrorKind::BrokenPipe)),
-        }
     }
 
     fn take_received_plaintext(&mut self, bytes: Payload<'_>) {
@@ -812,20 +947,4 @@ impl crate::conn::SideData for ServerSide {}
 impl crate::conn::private::Side for ServerSide {
     type Data = ServerConnectionData;
     type State = ServerState;
-}
-
-#[cfg(test)]
-mod tests {
-    use std::format;
-
-    use super::*;
-
-    // these branches not reachable externally, unless something else goes wrong.
-    #[test]
-    fn test_read_in_new_state() {
-        assert_eq!(
-            format!("{:?}", EarlyDataState::default().read(&mut [0u8; 5])),
-            "Err(Kind(BrokenPipe))"
-        );
-    }
 }

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -686,6 +686,7 @@ pub(super) enum EarlyDataState {
     Accepted {
         received: ChunkVecBuffer,
     },
+    Retired,
 }
 
 impl EarlyDataState {
@@ -699,20 +700,22 @@ impl EarlyDataState {
         matches!(self, Self::Accepted { .. })
     }
 
-    #[expect(dead_code)]
-    fn peek(&self) -> Option<&[u8]> {
+    pub(super) fn peek(&self) -> Option<&[u8]> {
         match self {
             Self::Accepted { received, .. } => received.peek(),
             _ => None,
         }
     }
 
-    #[expect(dead_code)]
-    fn pop(&mut self) -> Option<Vec<u8>> {
+    pub(super) fn pop(&mut self) -> Option<Vec<u8>> {
         match self {
             Self::Accepted { received, .. } => received.pop(),
             _ => None,
         }
+    }
+
+    pub(super) fn retire(&mut self) {
+        *self = Self::Retired;
     }
 
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -768,7 +771,7 @@ impl ConnectionCore<ServerSide> {
 pub(crate) struct ServerConnectionData {
     sni: Option<DnsName<'static>>,
     received_resumption_data: Option<Vec<u8>>,
-    early_data: EarlyDataState,
+    pub(super) early_data: EarlyDataState,
 }
 
 impl ServerConnectionData {
@@ -778,6 +781,10 @@ impl ServerConnectionData {
 
     pub(crate) fn server_name(&self) -> Option<&DnsName<'static>> {
         self.sni.as_ref()
+    }
+
+    pub(crate) fn into_parts(self) -> (Option<DnsName<'static>>, Option<Vec<u8>>) {
+        (self.sni, self.received_resumption_data)
     }
 }
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -75,6 +75,14 @@ impl crate::conn::StateMachine for ServerState {
         !matches!(self, Self::ChooseConfig(_))
     }
 
+    fn traffic(&self) -> bool {
+        matches!(
+            self,
+            Self::Tls12(tls12::Tls12State::Traffic(..))
+                | Self::Tls13(tls13::Tls13State::Traffic(..) | tls13::Tls13State::QuicTraffic(..))
+        )
+    }
+
     fn handle_decrypt_error(&mut self) {}
 
     fn into_external_state(

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -32,6 +32,12 @@ pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
 mod hs;
 pub(crate) use hs::ServerHandler;
 
+mod state;
+pub use state::{
+    AwaitClientFlight, ChooseConfig, ReceiveEarlyData, SendHalfRttTraffic, SendServerFlight,
+    ServerHandshake, ServerOutputs, ServerTraffic,
+};
+
 mod tls12;
 pub(crate) use tls12::TLS12_HANDLER;
 use tls12::Tls12ServerSessionValue;

--- a/rustls/src/server/state.rs
+++ b/rustls/src/server/state.rs
@@ -1,0 +1,568 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+
+use pki_types::DnsName;
+
+use crate::common_state::Protocol;
+use crate::conn::{CaptureAppData, ConnectionCore, JoinOutput, SendPath};
+use crate::crypto::cipher::OutboundPlain;
+use crate::error::{ApiMisuse, ErrorWithAlert};
+use crate::kernel::KernelConnection;
+use crate::lock::Mutex;
+use crate::log::trace;
+use crate::msgs::{Locator, ServerExtensionsInput, TlsInputBuffer};
+use crate::server::{ClientHello, ServerSide, hs, tls12, tls13};
+use crate::state::{ReceiveTraffic, SendTraffic};
+use crate::sync::Arc;
+use crate::{
+    CommonState, ConnectionOutputs, Error, ExtractedSecrets, KeyingMaterialExporter, ServerConfig,
+};
+
+/// State-based TLS server API.
+#[non_exhaustive]
+pub enum ServerHandshake {
+    /// We are awaiting handshake data from the peer.
+    AwaitClientFlight(AwaitClientFlight),
+
+    /// We have received a `ClientHello` and it is time to choose a `ServerConfig` for this connection.
+    ChooseConfig(ChooseConfig),
+
+    /// Handshake data should be transmitted to the peer.
+    SendServerFlight(SendServerFlight),
+
+    /// Early data is available to be read or rejected.
+    ReceiveEarlyData(ReceiveEarlyData),
+
+    /// The handshake has completed and application data may now flow.
+    Complete(Box<ServerTraffic>),
+}
+
+impl ServerHandshake {
+    /// Create a new server connection.
+    ///
+    /// This starts out by reading a `ClientHello` using the [`ServerHandshake::AwaitClientFlight`] state.
+    pub fn new() -> Self {
+        let inner = Box::new(ConnectionCore::for_acceptor(Protocol::Tcp));
+        Self::AwaitClientFlight(AwaitClientFlight { inner })
+    }
+
+    /// Retrieves the server name, if any, used to select the certificate and
+    /// private key.
+    ///
+    /// This returns `None` until some time after the client's server name indication
+    /// (SNI) extension value is processed during the handshake. It will never be
+    /// `None` when the connection is ready to send or process application data,
+    /// unless the client does not support SNI.
+    ///
+    /// This is useful for application protocols that need to enforce that the
+    /// server name matches an application layer protocol hostname. For
+    /// example, HTTP/1.1 servers commonly expect the `Host:` header field of
+    /// every request on a connection to match the hostname in the SNI extension
+    /// when the client provides the SNI extension.
+    ///
+    /// The server name is also used to match sessions during session resumption.
+    pub fn server_name(&self) -> Option<&DnsName<'_>> {
+        match self {
+            Self::AwaitClientFlight(st) => st.inner.side.server_name(),
+            Self::ChooseConfig(st) => st.inner.side.server_name(),
+            Self::SendServerFlight(st) => st.inner.side.server_name(),
+            Self::ReceiveEarlyData(st) => st.inner.side.server_name(),
+            Self::Complete(st) => st.outputs.server_name.as_ref(),
+        }
+    }
+
+    /// Application-controlled portion of the resumption ticket supplied by the client, if any.
+    ///
+    /// Recovered from the prior session's `set_resumption_data`. Integrity is guaranteed by rustls.
+    ///
+    /// Returns `Some` if and only if a valid resumption ticket has been received from the client.
+    pub fn received_resumption_data(&self) -> Option<&[u8]> {
+        match self {
+            Self::AwaitClientFlight(st) => st.inner.side.received_resumption_data(),
+            Self::ChooseConfig(st) => st.inner.side.received_resumption_data(),
+            Self::SendServerFlight(st) => st.inner.side.received_resumption_data(),
+            Self::ReceiveEarlyData(st) => st.inner.side.received_resumption_data(),
+            Self::Complete(st) => st
+                .outputs
+                .received_resumption_data
+                .as_deref(),
+        }
+    }
+
+    /// Set the resumption data to embed in future resumption tickets supplied to the client.
+    ///
+    /// Defaults to the empty byte string. Must be less than 2^15 bytes to allow room for other
+    /// data. Should be called while `is_handshaking` returns true to ensure all transmitted
+    /// resumption tickets are affected.
+    ///
+    /// Integrity will be assured by rustls, but the data will be visible to the client. If secrecy
+    /// from the client is desired, encrypt the data separately.
+    pub fn set_resumption_data(&mut self, data: &[u8]) -> Result<(), Error> {
+        let state = match self {
+            Self::AwaitClientFlight(st) => st.inner.state.as_mut(),
+            Self::ChooseConfig(st) => st.inner.state.as_mut(),
+            Self::SendServerFlight(st) => st.inner.state.as_mut(),
+            Self::ReceiveEarlyData(st) => st.inner.state.as_mut(),
+            Self::Complete(_) => return Err(ApiMisuse::ResumptionDataProvidedTooLate.into()),
+        };
+
+        match state {
+            Ok(st) => st.set_resumption_data(data),
+            Err(err) => Err(err.clone()),
+        }
+    }
+}
+
+impl Deref for ServerHandshake {
+    type Target = ConnectionOutputs;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::AwaitClientFlight(st) => &st.inner.common.outputs,
+            Self::ChooseConfig(st) => &st.inner.common.outputs,
+            Self::SendServerFlight(st) => &st.inner.common.outputs,
+            Self::ReceiveEarlyData(st) => &st.inner.common.outputs,
+            Self::Complete(traffic) => &traffic.outputs.outputs,
+        }
+    }
+}
+
+impl DerefMut for ServerHandshake {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::AwaitClientFlight(st) => &mut st.inner.common.outputs,
+            Self::ChooseConfig(st) => &mut st.inner.common.outputs,
+            Self::SendServerFlight(st) => &mut st.inner.common.outputs,
+            Self::ReceiveEarlyData(st) => &mut st.inner.common.outputs,
+            Self::Complete(traffic) => &mut traffic.outputs.outputs,
+        }
+    }
+}
+
+impl fmt::Debug for ServerHandshake {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AwaitClientFlight(_) => f
+                .debug_tuple("AwaitClientFlight")
+                .finish_non_exhaustive(),
+            Self::ChooseConfig(_) => f
+                .debug_tuple("ChooseConfig")
+                .finish_non_exhaustive(),
+            Self::SendServerFlight(_) => f
+                .debug_tuple("SendServerFlight")
+                .finish_non_exhaustive(),
+            Self::ReceiveEarlyData(_) => f
+                .debug_tuple("ReceiveEarlyData")
+                .finish_non_exhaustive(),
+            Self::Complete(_) => f
+                .debug_tuple("Traffic")
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+/// A handshake state where we are awaiting handshake data from the peer.
+pub struct AwaitClientFlight {
+    inner: Box<ConnectionCore<ServerSide>>,
+}
+
+impl AwaitClientFlight {
+    /// Receive some data.
+    ///
+    /// Return the next state or an error if things are permanently broken.  If an error occurs
+    /// here it is fatal to the connection.  The error is returned as a [`ErrorWithAlert`], and
+    /// the contained alert should be communicated to the peer if possible.  A [`ServerOutputs`]
+    /// object is also returned on error, allowing presumptive (but unauthenticated) data
+    /// learned about the peer to be inspected later.
+    ///
+    /// The number of bytes consumed from `input` is communicated to the object via `discard()`.
+    pub fn input_data(
+        mut self,
+        input: &mut dyn TlsInputBuffer,
+    ) -> Result<ServerHandshake, (ErrorWithAlert, Box<ServerOutputs>)> {
+        if let Err(err) = self
+            .inner
+            .process_handshake(input, None)
+        {
+            return Err((
+                ErrorWithAlert::new(err, &mut self.inner.common.send),
+                Box::new(self.inner.into()),
+            ));
+        }
+
+        Ok(next_state(self.inner))
+    }
+
+    /// If it is currently possible to send half-RTT data, obtain an object for that ability.
+    ///
+    /// This requires that [`ServerConfig::send_half_rtt_data`] is enabled and the constraints
+    /// documented there are met.
+    pub fn try_send_half_rtt(&mut self) -> Option<SendHalfRttTraffic<'_>> {
+        match self
+            .inner
+            .common
+            .send
+            .may_send_half_rtt_data
+        {
+            true => Some(SendHalfRttTraffic {
+                send: &mut self.inner.common.send,
+            }),
+            false => None,
+        }
+    }
+}
+
+/// We have received a `ClientHello` and it is time to choose a `ServerConfig` for this connection.
+pub struct ChooseConfig {
+    // invariant: `inner.state` is `Err(_)` with a meaningless error,
+    // it should be reinserted before further use.
+    inner: Box<ConnectionCore<ServerSide>>,
+    choose_config: Box<hs::ChooseConfig>,
+}
+
+impl ChooseConfig {
+    /// Expose the received `ClientHello`
+    ///
+    /// You can use this function to view a parsed and user-friendly subset of the
+    /// information in the ClientHello, allowing you to make a decision on which
+    /// `ServerConfig` to continue the connection with via [`ChooseConfig::with_config()`].
+    pub fn client_hello(&self) -> ClientHello<'_> {
+        let ch = ClientHello::new_from_payload(self.choose_config.client_hello());
+        trace!("ChooseConfig::client_hello(): {ch:#?}");
+        ch
+    }
+
+    /// Continue the connection with a selected [`ServerConfig`].
+    ///
+    /// This continues and concludes handling of the `ClientHello`.  If this fails, it is
+    /// fatal and the error has the TLS alert (if any) attached.  This should be communicated
+    /// to the peer.
+    pub fn with_config(
+        mut self,
+        config: Arc<ServerConfig>,
+    ) -> Result<ServerHandshake, (ErrorWithAlert, Box<ServerOutputs>)> {
+        if let Err(err) = self
+            .inner
+            .common
+            .send
+            .set_max_fragment_size(config.max_fragment_size)
+        {
+            // We have a connection here, but it won't contain an alert since the error
+            // is with the fragment size configured in the `ServerConfig`.
+            return Err((
+                ErrorWithAlert::new(err, &mut self.inner.common.send),
+                Box::new(self.inner.into()),
+            ));
+        }
+
+        let mut absent = None;
+        let state = match self.choose_config.use_config(
+            config,
+            ServerExtensionsInput::default(),
+            &mut CaptureAppData {
+                recv: &mut self.inner.common.recv,
+                other: &mut JoinOutput {
+                    outputs: &mut self.inner.common.outputs,
+                    quic: None,
+                    send: &mut self.inner.common.send,
+                    side: &mut self.inner.side,
+                },
+                plaintext_locator: &Locator::new(&[]),
+                received_plaintext: &mut absent,
+                _message_lifetime: PhantomData,
+            },
+        ) {
+            Ok(state) => state,
+            Err(err) => {
+                return Err((
+                    ErrorWithAlert::new(err, &mut self.inner.common.send),
+                    Box::new(self.inner.into()),
+                ));
+            }
+        };
+        self.inner.state = Ok(state);
+
+        Ok(ServerHandshake::SendServerFlight(SendServerFlight {
+            inner: self.inner,
+        }))
+    }
+}
+
+/// A handshake state where we are required to send data to the peer.
+pub struct SendServerFlight {
+    inner: Box<ConnectionCore<ServerSide>>,
+}
+
+impl SendServerFlight {
+    /// Obtain one TLS message that should be sent to the peer.
+    ///
+    /// If you wish to use vectored IO, call this function repeatedly
+    /// to collect all messages before doing the IO.
+    pub fn take_data(&mut self) -> Option<Vec<u8>> {
+        self.inner
+            .common
+            .send
+            .sendable_tls
+            .pop()
+    }
+
+    /// Move to the next state, if possible.
+    ///
+    /// This returns the current state if there is remaining data to write.
+    pub fn into_next(self) -> ServerHandshake {
+        next_state(self.inner)
+    }
+}
+
+/// An opportunity exists to receive early data.
+pub struct ReceiveEarlyData {
+    inner: Box<ConnectionCore<ServerSide>>,
+}
+
+impl ReceiveEarlyData {
+    /// Obtain one chunk of early data received from the peer.
+    ///
+    /// Like TLS generally, early data is stream-based rather than message-based.
+    /// So you should avoid depending on the record separation implied in this
+    /// API.
+    ///
+    /// To obtain all the data, call this function repeatedly until it
+    /// returns `None`.
+    pub fn take_data(&mut self) -> Option<Vec<u8>> {
+        self.inner.side.early_data.pop()
+    }
+
+    /// Returns the "early" exporter that can derive key material for use in early data
+    ///
+    /// See [RFC5705][] for general details on what exporters are, and [RFC8446 S7.5][] for
+    /// specific details on the "early" exporter.
+    ///
+    /// **Beware** that the early exporter requires care, as it is subject to the same
+    /// potential for replay as early data itself.  See [RFC8446 appendix E.5.1][] for
+    /// more detail.
+    ///
+    /// This function can be called at most once per connection. This function will error
+    /// if called more than once per connection.
+    ///
+    /// If you are looking for the normal exporter, this is available from
+    /// [`Connection::exporter()`].
+    ///
+    /// [RFC5705]: https://datatracker.ietf.org/doc/html/rfc5705
+    /// [RFC8446 S7.5]: https://datatracker.ietf.org/doc/html/rfc8446#section-7.5
+    /// [RFC8446 appendix E.5.1]: https://datatracker.ietf.org/doc/html/rfc8446#appendix-E.5.1
+    /// [`Connection::exporter()`]: crate::Connection::exporter()
+    pub fn early_exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
+        match self
+            .inner
+            .common
+            .outputs
+            .early_exporter
+            .take()
+        {
+            Some(inner) => Ok(KeyingMaterialExporter { inner }),
+            None => Err(ApiMisuse::ExporterAlreadyUsed.into()),
+        }
+    }
+
+    /// Move to the next state, concluding reading of Early Data.
+    ///
+    /// Unread early data is discarded.
+    pub fn into_next(mut self) -> ServerHandshake {
+        self.inner.side.early_data.retire();
+        ServerHandshake::AwaitClientFlight(AwaitClientFlight { inner: self.inner })
+    }
+}
+
+/// An opportunity to send half-RTT data.
+pub struct SendHalfRttTraffic<'a> {
+    send: &'a mut SendPath,
+}
+
+impl SendHalfRttTraffic<'_> {
+    /// Write half-RTT application data to the peer, after the server's handshake has completed.
+    ///
+    /// The TLS data to send to the peer is returned.  This data should then
+    /// be communicated to the peer, in order.
+    pub fn write(&mut self, application_data: OutboundPlain<'_>) -> Result<Vec<Vec<u8>>, Error> {
+        self.send
+            .write_plaintext(application_data)
+    }
+}
+
+/// The handshake is complete and data may flow in both directions.
+///
+/// When you reach this state, you should destructure it into its parts
+/// and then progress them separately.
+///
+/// For example:
+///
+/// - if you do not require any information from `outputs`, you can drop it
+///   now to save memory.
+/// - if you are only receiving data, you can drop `send` now.  That is best done
+///   by calling [`SendTraffic::close()`].
+///
+/// Note that for good behavior, it is usually necessary to service `receive`.  This
+/// covers receipt of TLS1.3 tickets and key-update requests.
+#[expect(clippy::exhaustive_structs)]
+pub struct ServerTraffic {
+    /// The send side of the connection.
+    pub send: SendTraffic,
+
+    /// The receive side of the connection.
+    pub receive: ReceiveTraffic<ServerSide>,
+
+    /// Facts about the connection established during the handshake.
+    pub outputs: ServerOutputs,
+}
+
+impl ServerTraffic {
+    // precondition: `inner.state` is Ok(x) where x is a traffic state
+    fn new(inner: Box<ConnectionCore<ServerSide>>) -> Box<Self> {
+        let CommonState {
+            recv,
+            send,
+            outputs,
+            ..
+        } = inner.common;
+        let send_mutex = Arc::new(Mutex::new(send));
+        let (server_name, received_resumption_data) = inner.side.into_parts();
+        // SAFETY: by precondition
+        let state = inner.state.unwrap();
+
+        Box::new(Self {
+            send: SendTraffic(send_mutex.clone()),
+            receive: ReceiveTraffic {
+                state,
+                recv,
+                send: send_mutex,
+                pending_wake_sender: false,
+            },
+            outputs: ServerOutputs {
+                outputs,
+                server_name,
+                received_resumption_data,
+            },
+        })
+    }
+
+    /// Converts the connection into a [`KernelConnection`] for use with KTLS.
+    pub fn dangerous_into_kernel_connection(
+        self,
+    ) -> Result<(ExtractedSecrets, KernelConnection<ServerSide>), Error> {
+        let c = ConnectionCore::from_parts_into_kernel_connection(
+            &mut self.send.0.lock().unwrap(),
+            self.receive.recv,
+            self.outputs.outputs,
+            self.receive.state,
+        );
+        c
+    }
+}
+
+/// Facts about the connection established during the handshake.
+#[derive(Debug)]
+pub struct ServerOutputs {
+    /// Facts about the connection established during the handshake.
+    pub outputs: ConnectionOutputs,
+
+    server_name: Option<DnsName<'static>>,
+    received_resumption_data: Option<Vec<u8>>,
+}
+
+impl ServerOutputs {
+    /// Retrieves the server name, if any, used to select the certificate and
+    /// private key.
+    ///
+    /// This returns `None` until some time after the client's server name indication
+    /// (SNI) extension value is processed during the handshake. It will never be
+    /// `None` when the connection is ready to send or process application data,
+    /// unless the client does not support SNI.
+    ///
+    /// This is useful for application protocols that need to enforce that the
+    /// server name matches an application layer protocol hostname. For
+    /// example, HTTP/1.1 servers commonly expect the `Host:` header field of
+    /// every request on a connection to match the hostname in the SNI extension
+    /// when the client provides the SNI extension.
+    ///
+    /// The server name is also used to match sessions during session resumption.
+    pub fn server_name(&self) -> Option<&DnsName<'_>> {
+        self.server_name.as_ref()
+    }
+
+    /// Application-controlled portion of the resumption ticket supplied by the client, if any.
+    ///
+    /// Recovered from the prior session's `set_resumption_data`. Integrity is guaranteed by rustls.
+    ///
+    /// Returns `Some` if and only if a valid resumption ticket has been received from the client.
+    pub fn received_resumption_data(&self) -> Option<&[u8]> {
+        self.received_resumption_data.as_deref()
+    }
+}
+
+impl From<Box<ConnectionCore<ServerSide>>> for ServerOutputs {
+    fn from(inner: Box<ConnectionCore<ServerSide>>) -> Self {
+        let (server_name, received_resumption_data) = inner.side.into_parts();
+
+        Self {
+            outputs: inner.common.outputs,
+            server_name,
+            received_resumption_data,
+        }
+    }
+}
+
+impl Deref for ServerOutputs {
+    type Target = ConnectionOutputs;
+
+    fn deref(&self) -> &Self::Target {
+        &self.outputs
+    }
+}
+
+impl DerefMut for ServerOutputs {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.outputs
+    }
+}
+
+fn next_state(mut inner: Box<ConnectionCore<ServerSide>>) -> ServerHandshake {
+    if inner.side.early_data.peek().is_some() {
+        return ServerHandshake::ReceiveEarlyData(ReceiveEarlyData { inner });
+    }
+
+    if !inner
+        .common
+        .send
+        .sendable_tls
+        .is_empty()
+    {
+        return ServerHandshake::SendServerFlight(SendServerFlight { inner });
+    }
+
+    match &inner.state {
+        Ok(
+            hs::ServerState::Tls12(tls12::Tls12State::Traffic(_))
+            | hs::ServerState::Tls13(tls13::Tls13State::Traffic(_)),
+        ) => ServerHandshake::Complete(ServerTraffic::new(inner)),
+
+        Ok(hs::ServerState::ChooseConfig(_)) => {
+            let Ok(hs::ServerState::ChooseConfig(choose_config)) = core::mem::replace(
+                &mut inner.state,
+                Err(Error::Unreachable("restore state after ChooseConfig")),
+            ) else {
+                unreachable!();
+            };
+            ServerHandshake::ChooseConfig(ChooseConfig {
+                inner,
+                choose_config,
+            })
+        }
+
+        Ok(_) => ServerHandshake::AwaitClientFlight(AwaitClientFlight { inner }),
+
+        Err(_) => panic!("TODO: withdraw error fusing in core.state"),
+    }
+}

--- a/rustls/src/server/state.rs
+++ b/rustls/src/server/state.rs
@@ -110,8 +110,8 @@ impl ServerHandshake {
         };
 
         match state {
-            Ok(st) => st.set_resumption_data(data),
-            Err(err) => Err(err.clone()),
+            Some(st) => st.set_resumption_data(data),
+            None => Err(ApiMisuse::PreviousConnectionError.into()),
         }
     }
 }
@@ -217,8 +217,7 @@ impl AwaitClientFlight {
 
 /// We have received a `ClientHello` and it is time to choose a `ServerConfig` for this connection.
 pub struct ChooseConfig {
-    // invariant: `inner.state` is `Err(_)` with a meaningless error,
-    // it should be reinserted before further use.
+    // invariant: `inner.state` is `None` it should be reinserted before further use.
     inner: Box<ConnectionCore<ServerSide>>,
     choose_config: Box<hs::ChooseConfig>,
 }
@@ -283,7 +282,7 @@ impl ChooseConfig {
                 ));
             }
         };
-        self.inner.state = Ok(state);
+        self.inner.state = Some(state);
 
         Ok(ServerHandshake::SendServerFlight(SendServerFlight {
             inner: self.inner,
@@ -543,16 +542,15 @@ fn next_state(mut inner: Box<ConnectionCore<ServerSide>>) -> ServerHandshake {
     }
 
     match &inner.state {
-        Ok(
+        Some(
             hs::ServerState::Tls12(tls12::Tls12State::Traffic(_))
             | hs::ServerState::Tls13(tls13::Tls13State::Traffic(_)),
         ) => ServerHandshake::Complete(ServerTraffic::new(inner)),
 
-        Ok(hs::ServerState::ChooseConfig(_)) => {
-            let Ok(hs::ServerState::ChooseConfig(choose_config)) = core::mem::replace(
-                &mut inner.state,
-                Err(Error::Unreachable("restore state after ChooseConfig")),
-            ) else {
+        Some(hs::ServerState::ChooseConfig(_)) => {
+            let Some(hs::ServerState::ChooseConfig(choose_config)) =
+                core::mem::take(&mut inner.state)
+            else {
                 unreachable!();
             };
             ServerHandshake::ChooseConfig(ChooseConfig {
@@ -561,8 +559,9 @@ fn next_state(mut inner: Box<ConnectionCore<ServerSide>>) -> ServerHandshake {
             })
         }
 
-        Ok(_) => ServerHandshake::AwaitClientFlight(AwaitClientFlight { inner }),
+        Some(_) => ServerHandshake::AwaitClientFlight(AwaitClientFlight { inner }),
 
-        Err(_) => panic!("TODO: withdraw error fusing in core.state"),
+        // indicates caller has swallowed an error.
+        None => unreachable!(),
     }
 }

--- a/rustls/src/state.rs
+++ b/rustls/src/state.rs
@@ -1,0 +1,318 @@
+use alloc::vec::Vec;
+use core::ops::DerefMut;
+use std::prelude::v1::Box;
+use std::sync::MutexGuard;
+
+use crate::client::ClientSide;
+use crate::conn::{ReceivePath, SendOutput, SendPath};
+use crate::crypto::cipher::{MessageEncrypter, OutboundPlain, Payload};
+use crate::error::ErrorWithAlert;
+use crate::lock::Mutex;
+use crate::msgs::Delocator;
+pub use crate::msgs::{SliceInput, TlsInputBuffer, VecInput};
+use crate::sync::Arc;
+use crate::tls13::key_schedule::KeyScheduleTrafficSend;
+use crate::{Error, SideData};
+
+/// The send-side of a connection.
+///
+/// You can use this object to send data to the peer.
+pub struct SendTraffic(pub(crate) Arc<Mutex<SendPath>>);
+
+impl SendTraffic {
+    /// Write application data to the peer.
+    ///
+    /// The TLS data to send to the peer is returned.  This data should then
+    /// be communicated to the peer, in order.
+    pub fn write(&mut self, application_data: OutboundPlain<'_>) -> Result<Vec<Vec<u8>>, Error> {
+        let mut inner = self.0.lock().unwrap();
+        inner.maybe_refresh_traffic_keys();
+        inner.write_plaintext(application_data)
+    }
+
+    /// Obtain any pending data to write to the peer.
+    ///
+    /// Any such pending data will be output with any call to [`SendTraffic::write()`]
+    /// so there  is no need to call this function if you have recently written data
+    /// using this.
+    ///
+    /// The TLS data to send to the peer is returned.  This data should then
+    /// be communicated to the peer.
+    ///
+    /// This is useful to handle a [`ReceiveTrafficState::WakeSender`] event, but
+    /// where you don't have any plaintext to send.
+    pub fn take_data(&mut self) -> Option<Vec<u8>> {
+        let mut inner = self.0.lock().unwrap();
+        inner.maybe_refresh_traffic_keys();
+        inner.sendable_tls.pop()
+    }
+
+    /// Conclude sending traffic by sending a `close_notify` alert.
+    ///
+    /// The alert is written into a Vec which is returned.
+    ///
+    /// This is the final possible operation with a [`SendTraffic`].
+    pub fn close(mut self) -> Vec<u8> {
+        let mut inner = self.0.lock().unwrap();
+        inner.send_close_notify();
+        drop(inner);
+        self.take_data().unwrap_or_default()
+    }
+
+    /// Sends a TLS1.3 `key_update` message to refresh a connection's keys.
+    ///
+    /// This call refreshes our encryption keys. Once the peer receives the message,
+    /// it refreshes _its_ encryption and decryption keys and sends a response.
+    /// Once we receive that response, we refresh our decryption keys to match.
+    /// At the end of this process, keys in both directions have been refreshed.
+    ///
+    /// Note that this process does not happen synchronously: this call just
+    /// arranges that the `key_update` message will be included in the next
+    /// `write()` output.
+    ///
+    /// This returns an error if a version prior to TLS1.3 is negotiated.
+    ///
+    /// # Usage advice
+    /// Note that other implementations (including rustls) may enforce limits on
+    /// the number of `key_update` messages allowed on a given connection to prevent
+    /// denial of service.  Therefore, this should be called sparingly.
+    ///
+    /// rustls implicitly and automatically refreshes traffic keys when needed
+    /// according to the selected cipher suite's cryptographic constraints.  There
+    /// is therefore no need to call this manually to avoid cryptographic keys
+    /// "wearing out".
+    ///
+    /// The main reason to call this manually is to roll keys when it is known
+    /// a connection will be idle for a long period.
+    pub fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
+        self.0
+            .lock()
+            .unwrap()
+            .refresh_traffic_keys()
+    }
+}
+
+/// The receive-side of a connection, after a successful handshake.
+///
+/// You can use this object to receive data from the peer.
+pub struct ReceiveTraffic<Side: SideData> {
+    pub(crate) state: Side::State,
+    pub(crate) recv: ReceivePath,
+    pub(crate) send: Arc<Mutex<SendPath>>,
+    pub(crate) pending_wake_sender: bool,
+}
+
+impl<Side: SideData> ReceiveTraffic<Side> {
+    /// Receive application data from the peer.
+    ///
+    /// `received_tls` is an instance of the receive buffer abstraction containing
+    /// TLS-protected data received from the peer.
+    ///
+    /// A [`ReceiveTrafficState`] is returned on success:
+    ///
+    /// - [`ReceiveTrafficState::Available`] if an application data message
+    ///   has been received.
+    /// - [`ReceiveTrafficState::WakeSender`] if the previous operation may have
+    ///   caused some data to become sendable.  The application should service
+    ///   the send-side of the connection.
+    /// - [`ReceiveTrafficState::Await`] if more IO is required.
+    /// - [`ReceiveTrafficState::CloseNotify`] if the peer has cleanly
+    ///   closed the receive direction of the connection.
+    ///
+    /// An error from this function permanently breaks the ability to receive
+    /// data from the peer.  The error may be accompanied by a TLS alert,
+    /// which can be obtained from the returned [`ErrorWithAlert`] and sent
+    /// to the peer.  Following this, the underlying IO medium should be
+    /// closed by the application.
+    pub fn read<'a>(
+        mut self,
+        received_tls: &'a mut impl TlsInputBuffer,
+    ) -> Result<ReceiveTrafficState<'a, Side>, ErrorWithAlert> {
+        let mut send = SendAdapter::Unlocked(&self.send);
+        let mut state = Ok(self.state);
+        let received_plain =
+            match self
+                .recv
+                .process_recv_traffic::<Side>(received_tls, &mut state, &mut send)
+            {
+                Ok(received_plain) => received_plain,
+                Err(err) => {
+                    return Err(ErrorWithAlert::new(err, send.as_locked().deref_mut()));
+                }
+            };
+        self.state = state?;
+
+        if let Some(unborrowed) = received_plain {
+            let pending_discard = self.recv.deframer.take_discard();
+            let Payload::Borrowed(data) =
+                unborrowed.reborrow(&Delocator::new(received_tls.slice_mut()))
+            else {
+                return Err(Error::Unreachable("decrypted data should be borrowed").into());
+            };
+            drop(send);
+            return Ok(ReceiveTrafficState::Available(ReceivedApplicationData {
+                data,
+                pending_discard,
+                rt: self,
+            }));
+        }
+
+        // If we locked the sender during that, it is still locked and we can provide
+        // a hint to the caller they should pump the send side.
+        if let SendAdapter::Locked(_) = send {
+            self.pending_wake_sender = true;
+        }
+
+        drop(send);
+        Ok(self.into_next_state())
+    }
+
+    fn into_next_state(mut self) -> ReceiveTrafficState<'static, Side> {
+        if core::mem::take(&mut self.pending_wake_sender) {
+            return ReceiveTrafficState::WakeSender(WakeSender { rt: self });
+        }
+
+        match self.recv.has_received_close_notify {
+            true => ReceiveTrafficState::CloseNotify,
+            false => ReceiveTrafficState::Await(self),
+        }
+    }
+}
+
+impl ReceiveTraffic<ClientSide> {
+    /// Returns the number of TLS1.3 tickets that have been received.
+    pub fn tls13_tickets_received(&self) -> u32 {
+        self.recv.tls13_tickets_received
+    }
+}
+
+/// Allows the receive-side of the connection to manipulate the send-side.
+///
+/// It is important for performance and concurrency that the receive-side
+/// does not regularly lock the send-side, so this is delayed until this
+/// proves to be actually required (via [`SendOutput`] methods).
+///
+/// It is important for analysis that the lock, once taken, remains taken
+/// for the remainder of the processing.  This means that, for example,
+/// a sequence of sent messages is not interleaved with others from another
+/// thread.
+enum SendAdapter<'a> {
+    Unlocked(&'a Mutex<SendPath>),
+    Locked(MutexGuard<'a, SendPath>),
+}
+
+impl<'a> SendAdapter<'a> {
+    fn ensure_locked(&mut self) {
+        if let Self::Unlocked(m) = self {
+            *self = Self::Locked(m.lock().unwrap());
+        }
+    }
+
+    fn as_locked<'b>(&'b mut self) -> &'b mut MutexGuard<'a, SendPath> {
+        self.ensure_locked();
+        let Self::Locked(guard) = self else {
+            unreachable!();
+        };
+        guard
+    }
+}
+
+impl SendOutput for SendAdapter<'_> {
+    fn negotiated_version(&mut self, version: crate::enums::ProtocolVersion) {
+        self.as_locked()
+            .negotiated_version(version);
+    }
+
+    fn ensure_key_update_queued(&mut self) {
+        self.as_locked()
+            .ensure_key_update_queued();
+    }
+
+    fn set_encrypter(&mut self, cipher: Box<dyn MessageEncrypter>, max_messages: u64) {
+        self.as_locked()
+            .set_encrypter(cipher, max_messages);
+    }
+
+    fn update_key_schedule(&mut self, schedule: Box<KeyScheduleTrafficSend>) {
+        self.as_locked()
+            .update_key_schedule(schedule);
+    }
+
+    fn send_alert(&mut self, level: crate::msgs::AlertLevel, desc: crate::error::AlertDescription) {
+        self.as_locked().send_alert(level, desc)
+    }
+
+    fn start_traffic(&mut self) {
+        self.as_locked().start_traffic();
+    }
+
+    fn send_msg(&mut self, m: crate::msgs::Message<'_>, must_encrypt: bool) {
+        self.as_locked()
+            .send_msg(m, must_encrypt)
+    }
+}
+
+/// A state machine as a cycle between requiring further received TLS data,
+/// and discharging received application data.
+#[expect(clippy::exhaustive_enums)]
+pub enum ReceiveTrafficState<'a, Side: SideData> {
+    /// More input is required.
+    ///
+    /// Collect it into your input buffer, and then call [`ReceiveTraffic::read()`] again.
+    Await(ReceiveTraffic<Side>),
+
+    /// The sender may have new data to send.
+    WakeSender(WakeSender<Side>),
+
+    /// Some application data has been received.
+    Available(ReceivedApplicationData<'a, Side>),
+
+    /// We received a `close_notify` alert from the peer.
+    ///
+    /// This means the receive path is closed cleanly.
+    CloseNotify,
+}
+
+/// Received application data.
+pub struct ReceivedApplicationData<'a, Side: SideData> {
+    /// The application data bytes.
+    pub data: &'a [u8],
+
+    /// How many bytes on the front of the original input buffer are associated
+    /// with this data.
+    ///
+    /// This value should be added to the discard count of the original input
+    /// buffer via [`TlsInputBuffer::discard()`].
+    ///
+    /// Use [`ReceivedApplicationData::into_next()`] to obtain it while releasing
+    /// the borrow on `data` (from the original input buffer).
+    pending_discard: usize,
+
+    rt: ReceiveTraffic<Side>,
+}
+
+impl<Side: SideData> ReceivedApplicationData<'_, Side> {
+    /// Finish processing this received data.
+    ///
+    /// This yields the discard value that should now be applied to the originating
+    /// buffer, and the next `ReceiveTraffic` state.
+    pub fn into_next(self) -> (usize, ReceiveTraffic<Side>) {
+        (self.pending_discard, self.rt)
+    }
+}
+
+/// Notification that receiving data may have changed the state of the associated [`SendTraffic`]
+///
+/// The caller may wish to check whether there is any IO necessary on the send side.  If it does
+/// not, and ignores this state, any pending new data to send will be included in the next
+/// attempt to send data.
+pub struct WakeSender<Side: SideData> {
+    rt: ReceiveTraffic<Side>,
+}
+
+impl<Side: SideData> WakeSender<Side> {
+    /// Continue receiving more data.
+    pub fn into_next(self) -> ReceiveTraffic<Side> {
+        self.rt
+    }
+}

--- a/rustls/src/state.rs
+++ b/rustls/src/state.rs
@@ -129,7 +129,7 @@ impl<Side: SideData> ReceiveTraffic<Side> {
         received_tls: &'a mut impl TlsInputBuffer,
     ) -> Result<ReceiveTrafficState<'a, Side>, ErrorWithAlert> {
         let mut send = SendAdapter::Unlocked(&self.send);
-        let mut state = Ok(self.state);
+        let mut state = Some(self.state);
         let received_plain =
             match self
                 .recv
@@ -140,7 +140,8 @@ impl<Side: SideData> ReceiveTraffic<Side> {
                     return Err(ErrorWithAlert::new(err, send.as_locked().deref_mut()));
                 }
             };
-        self.state = state?;
+        // safety: state consumed only on error.
+        self.state = state.unwrap();
 
         if let Some(unborrowed) = received_plain {
             let pending_discard = self.recv.deframer.take_discard();


### PR DESCRIPTION
This is still quite messy, and hence draft. Things to do:

- [x] extract more run-up commits from the "introduce new state-based API" commit
- [x] ensure the overally shape of the new API is uniform between client and server (currently not, around the `ServerOutputs` type

fixes #2397 fixes #1723 fixes #959 fixes #2795 fixes #2698 fixes #2761 fixes #3047
