### PR TITLE
Revert "rustls-bench: short circuit single threaded tests"

### DIFF
--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -349,13 +349,6 @@ fn multithreaded(
     server_config: &Arc<ServerConfig>,
     f: impl Fn(Arc<ClientConfig>, Arc<ServerConfig>) -> Timings + Send + Sync,
 ) -> Vec<Timings> {
-    if count.get() == 1 {
-        // Use the current thread if possible; for mysterious reasons this is much
-        // faster for bulk tests on Intel, but makes little difference on AMD and
-        // elsewhere.
-        return vec![f(client_config.clone(), server_config.clone())];
-    }
-
     thread::scope(|s| {
         let threads = (0..count.into())
             .map(|_| {


### PR DESCRIPTION
This reverts commit b2ee211b12965c8a3509b19d4a3415ef478a5a5b.

This turns out not to make a positive impact anywhere, once tests are run pinned to one CPU core.  In fact, this commit was bisected as the cause of a ~12.5% performance decrease in headline TLS1.2 send speed.