### PR TITLE
Avoid inlining tag zeroization

### DIFF
--- a/rustls-aws-lc-rs/src/hpke.rs
+++ b/rustls-aws-lc-rs/src/hpke.rs
@@ -916,6 +916,7 @@ impl LabeledSuiteId {
 struct AeadKey<const KEY_LEN: usize>([u8; KEY_LEN]);
 
 impl<const KEY_LEN: usize> Drop for AeadKey<KEY_LEN> {
+    #[inline(never)]
     fn drop(&mut self) {
         self.0.zeroize()
     }
@@ -925,6 +926,7 @@ impl<const KEY_LEN: usize> Drop for AeadKey<KEY_LEN> {
 struct KemSharedSecret<const KDF_LEN: usize>([u8; KDF_LEN]);
 
 impl<const KDF_LEN: usize> Drop for KemSharedSecret<KDF_LEN> {
+    #[inline(never)]
     fn drop(&mut self) {
         self.0.zeroize();
     }

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -375,6 +375,7 @@ impl AeadKey {
 }
 
 impl Drop for AeadKey {
+    #[inline(never)]
     fn drop(&mut self) {
         self.buf.zeroize();
     }

--- a/rustls/src/crypto/hmac.rs
+++ b/rustls/src/crypto/hmac.rs
@@ -53,6 +53,7 @@ impl Tag {
 }
 
 impl Drop for Tag {
+    #[inline(never)]
     fn drop(&mut self) {
         self.0.buf.zeroize();
     }

--- a/rustls/src/crypto/hpke.rs
+++ b/rustls/src/crypto/hpke.rs
@@ -130,6 +130,7 @@ impl From<Vec<u8>> for HpkePrivateKey {
 }
 
 impl Drop for HpkePrivateKey {
+    #[inline(never)]
     fn drop(&mut self) {
         self.0.zeroize();
     }

--- a/rustls/src/crypto/kx/mod.rs
+++ b/rustls/src/crypto/kx/mod.rs
@@ -624,6 +624,7 @@ impl SharedSecret {
 }
 
 impl Drop for SharedSecret {
+    #[inline(never)]
     fn drop(&mut self) {
         self.buf.zeroize();
     }

--- a/rustls/src/crypto/tls13.rs
+++ b/rustls/src/crypto/tls13.rs
@@ -249,6 +249,7 @@ impl OkmBlock {
 }
 
 impl Drop for OkmBlock {
+    #[inline(never)]
     fn drop(&mut self) {
         self.buf.zeroize();
     }

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -81,6 +81,7 @@ impl<'a, L: PayloadSize<'a>, C: Cardinality> Codec<'a> for SizedPayload<'a, L, C
 }
 
 impl<C: Cardinality> Zeroize for SizedPayload<'_, u8, C> {
+    #[inline(never)]
     fn zeroize(&mut self) {
         if let Payload::Owned(buf) = &mut self.inner {
             buf.zeroize();

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -846,6 +846,7 @@ impl<const N: usize> AsRef<[u8; N]> for ZeroizingCow<'_, N> {
 }
 
 impl<const N: usize> Drop for ZeroizingCow<'_, N> {
+    #[inline(never)]
     fn drop(&mut self) {
         if let ZeroizingCow::Owned(o) = self {
             o.zeroize();


### PR DESCRIPTION
Suggested by Claude for

- #2974 

> The benchmark regression is not caused by the buffer discard logic change itself. It's caused by LLVM inlining noise: the code size changes in `ReceivePath::process_new_packets()` cause LLVM to change its inlining decisions, resulting in `Tag::drop()` (which zeroizes a 64-byte `[u8; 64]` array) being inlined into every drop site within `tls12::prf()`. Since `prf()` creates/drops multiple `Tag` values per loop iteration and is called several times during a TLS 1.2 handshake, duplicating the zeroize code at each site adds ~24,000 instructions — virtually the entire regression.
>
> The fix is in hmac.rs: adding `#[inline(never)]` to `Tag::drop()`. This is appropriate because:
>
> 1. The zeroize call on a 64-byte buffer is substantial work relative to function call overhead — inlining it provides no benefit
> 2. `Tag::drop()` is called from many sites (every `Tag` value that goes out of scope), so deduplication saves code
> 3. It stabilizes instruction counts against unrelated code layout changes elsewhere

This sounds plausible enough to me, so let's see what the benchmarks say.