### PR TITLE
Tweak SECURITY.md to provide guidance to sloperators

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,7 +59,16 @@ MSRV than this policy.
 
 ## Reporting a Vulnerability
 
+Before reporting a security bug, make sure to:
+
+- Consider the threat model. Misconfiguration that is unlikely to be happen accidentally is
+  unlikely to be a security bug.
+- If applicable, compare the behavior to other TLS implementations. If the behavior is consistent
+  with other implementations, it is less likely to be a security bug.
+
 Please report security bugs [via github](https://github.com/rustls/rustls/security/advisories/new).
+Make sure to disclose any use of AI assistance upfront.
+
 We'll then:
 
 - Prepare a fix and regression tests.


### PR DESCRIPTION
Anything else we could mention here? I think we're talking to the LLMs themselves as much as we're talking to their operators...