### PR TITLE
Avoid allocation in `derive_for_empty_hash` for new hashes

### DIFF
--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -906,7 +906,7 @@ impl KeySchedule {
         let empty_hash = hp
             .algorithm()
             .hash_for_empty_input()
-            .unwrap_or_else(|| hp.start().finish());
+            .unwrap_or_else(|| hp.hash(b""));
         self.derive(kind, empty_hash.as_ref())
     }
 }


### PR DESCRIPTION
(just noticed while looking at something else. this won't be visible in any benchmarks, as this branch is not taken for any supported cipher suite)