### PR TITLE
Customizable cipher suite selection

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -43,7 +43,8 @@ use rustls::pki_types::{
 };
 use rustls::server::danger::{ClientIdentity, ClientVerifier, SignatureVerificationInput};
 use rustls::server::{
-    self, ClientHello, ServerConfig, ServerConnection, ServerSessionKey, WebPkiClientVerifier,
+    self, ClientHello, PreferClientOrder, PreferServerOrder, ServerConfig, ServerConnection,
+    ServerSessionKey, WebPkiClientVerifier,
 };
 use rustls::{Connection, DistinguishedName, HandshakeKind, RootCertStore, compress};
 use rustls_aws_lc_rs::hpke;
@@ -1647,7 +1648,11 @@ fn make_server_cfg(opts: &Options, key_log: &Arc<KeyLogMemo>) -> Arc<ServerConfi
     cfg.max_fragment_size = opts.max_fragment;
     cfg.send_tls13_tickets = 1;
     cfg.require_ems = opts.require_ems;
-    cfg.ignore_client_order = opts.server_preference;
+    cfg.cipher_suite_selector = match opts.server_preference {
+        true => &PreferServerOrder,
+        false => &PreferClientOrder,
+    };
+
     if opts.export_traffic_secrets {
         cfg.key_log = key_log.clone();
     }

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -18,7 +18,9 @@ use rustls::crypto::{
 };
 use rustls::enums::{ApplicationProtocol, ContentType, HandshakeType, ProtocolVersion};
 use rustls::error::{AlertDescription, ApiMisuse, CertificateError, Error, PeerMisbehaved};
-use rustls::server::{Acceptor, ClientHello, ParsedCertificate, ServerCredentialResolver};
+use rustls::server::{
+    Acceptor, ClientHello, ParsedCertificate, PreferServerOrder, ServerCredentialResolver,
+};
 use rustls::{
     ClientConfig, ClientConnection, Connection as _, HandshakeKind, KeyingMaterialExporter,
     ServerConfig, ServerConnection, SupportedCipherSuite,
@@ -1016,7 +1018,7 @@ fn negotiated_ciphersuite_server_ignoring_client_preference() {
             provider_with_suites(&provider::DEFAULT_PROVIDER, &[scs, scs_other]).into(),
         )
         .finish(kt);
-        server_config.ignore_client_order = true;
+        server_config.cipher_suite_selector = &PreferServerOrder;
 
         let client_config = ClientConfig::builder(
             provider_with_suites(&provider::DEFAULT_PROVIDER, &[scs_other, scs]).into(),

--- a/rustls/src/server/config.rs
+++ b/rustls/src/server/config.rs
@@ -21,10 +21,11 @@ use crate::crypto::{Credentials, Identity, SingleCredential};
 use crate::enums::{ApplicationProtocol, CertificateType, ProtocolVersion};
 use crate::error::{Error, PeerMisbehaved};
 use crate::msgs::ServerNamePayload;
+use crate::suites::Suite;
 use crate::sync::Arc;
 use crate::time_provider::{DefaultTimeProvider, TimeProvider};
 use crate::verify::{ClientVerifier, DistinguishedName, NoClientAuth};
-use crate::{KeyLog, NoKeyLog, compress};
+use crate::{KeyLog, NoKeyLog, Tls12CipherSuite, Tls13CipherSuite, compress};
 
 /// Common configuration for a set of server sessions.
 ///
@@ -82,10 +83,8 @@ pub struct ServerConfig {
     /// Source of randomness and other crypto.
     pub(crate) provider: Arc<CryptoProvider>,
 
-    /// Ignore the client's ciphersuite order. Instead,
-    /// choose the top ciphersuite in the server list
-    /// which is supported by the client.
-    pub ignore_client_order: bool,
+    /// How to select a cipher suite to use for a TLS session.
+    pub cipher_suite_selector: &'static dyn CipherSuiteSelector,
 
     /// The maximum size of plaintext input to be emitted in a single TLS record.
     /// A value of None is equivalent to the [TLS maximum] of 16 kB.
@@ -674,7 +673,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
         let require_ems = !matches!(self.provider.fips(), FipsStatus::Unvalidated);
         Ok(ServerConfig {
             provider: self.provider,
-            ignore_client_order: false,
+            cipher_suite_selector: &PreferClientOrder,
             max_fragment_size: None,
             session_storage: handy::ServerSessionMemoryCache::new(256),
             ticketer: None,
@@ -694,4 +693,135 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             invalid_sni_policy: InvalidSniPolicy::default(),
         })
     }
+}
+
+/// A [`CipherSuiteSelector`] implementation that prioritizes client order.
+#[expect(clippy::exhaustive_structs)]
+#[derive(Debug)]
+pub struct PreferClientOrder;
+
+impl CipherSuiteSelector for PreferClientOrder {
+    fn select_tls12_cipher_suite(
+        &self,
+        client: &mut dyn Iterator<Item = &'static Tls12CipherSuite>,
+        server: &[&'static Tls12CipherSuite],
+    ) -> Option<&'static Tls12CipherSuite> {
+        self.select(client, server)
+    }
+
+    fn select_tls13_cipher_suite(
+        &self,
+        client: &mut dyn Iterator<Item = &'static Tls13CipherSuite>,
+        server: &[&'static Tls13CipherSuite],
+    ) -> Option<&'static Tls13CipherSuite> {
+        self.select(client, server)
+    }
+}
+
+impl PreferClientOrder {
+    fn select<T: Suite>(
+        &self,
+        client: &mut dyn Iterator<Item = &'static T>,
+        _server: &[&'static T],
+    ) -> Option<&'static T> {
+        client.next()
+    }
+}
+
+/// A [`CipherSuiteSelector`] implementation that prioritizes server order.
+#[expect(clippy::exhaustive_structs)]
+#[derive(Debug)]
+pub struct PreferServerOrder;
+
+impl CipherSuiteSelector for PreferServerOrder {
+    fn select_tls12_cipher_suite(
+        &self,
+        client: &mut dyn Iterator<Item = &'static Tls12CipherSuite>,
+        server: &[&'static Tls12CipherSuite],
+    ) -> Option<&'static Tls12CipherSuite> {
+        client
+            .filter_map(|cs| {
+                server
+                    .iter()
+                    .position(|&ss| ss == cs)
+                    .map(|pos| (pos, cs))
+            })
+            .min_by_key(|&(pos, _)| pos)
+            .map(|(_, cs)| cs)
+    }
+
+    fn select_tls13_cipher_suite(
+        &self,
+        client: &mut dyn Iterator<Item = &'static Tls13CipherSuite>,
+        server: &[&'static Tls13CipherSuite],
+    ) -> Option<&'static Tls13CipherSuite> {
+        client
+            .filter_map(|cs| {
+                server
+                    .iter()
+                    .position(|&ss| ss == cs)
+                    .map(|pos| (pos, cs))
+            })
+            .min_by_key(|&(pos, _)| pos)
+            .map(|(_, cs)| cs)
+    }
+}
+
+impl<T: CipherSuiteSelector + ?Sized> VersionSuiteSelector<Tls12CipherSuite> for T {
+    fn select(
+        &self,
+        client: &mut dyn Iterator<Item = &'static Tls12CipherSuite>,
+        server: &[&'static Tls12CipherSuite],
+    ) -> Option<&'static Tls12CipherSuite> {
+        self.select_tls12_cipher_suite(client, server)
+    }
+}
+
+impl<T: CipherSuiteSelector + ?Sized> VersionSuiteSelector<Tls13CipherSuite> for T {
+    fn select(
+        &self,
+        client: &mut dyn Iterator<Item = &'static Tls13CipherSuite>,
+        server: &[&'static Tls13CipherSuite],
+    ) -> Option<&'static Tls13CipherSuite> {
+        self.select_tls13_cipher_suite(client, server)
+    }
+}
+
+pub(super) trait VersionSuiteSelector<T> {
+    fn select(
+        &self,
+        client: &mut dyn Iterator<Item = &'static T>,
+        server: &[&'static T],
+    ) -> Option<&'static T>;
+}
+
+/// A filter that chooses the cipher suite to use for a TLS session.
+pub trait CipherSuiteSelector: Debug + Send + Sync {
+    /// Choose a cipher suite, given the client's and server's options, in preference order.
+    ///
+    /// The `client` list is generated in order from the [`CipherSuite`] values received in the
+    /// `ClientHello`, filtered to only contain suites that the server supports. The `server`
+    /// list comes from the [`ServerConfig`]'s [`CryptoProvider`].
+    ///
+    /// Yields the chosen cipher suite supported by both sides, or `None` to indicate that no
+    /// mutually supported cipher suite could be agreed on.
+    fn select_tls12_cipher_suite(
+        &self,
+        client: &mut dyn Iterator<Item = &'static Tls12CipherSuite>,
+        server: &[&'static Tls12CipherSuite],
+    ) -> Option<&'static Tls12CipherSuite>;
+
+    /// Choose a cipher suite, given the client's and server's options, in preference order.
+    ///
+    /// The `client` list is generated in order from the [`CipherSuite`] values received in the
+    /// `ClientHello`, filtered to only contain suites that the server supports. The `server`
+    /// list comes from the [`ServerConfig`]'s [`CryptoProvider`].
+    ///
+    /// Yields the chosen cipher suite supported by both sides, or `None` to indicate that no
+    /// mutually supported cipher suite could be agreed on.
+    fn select_tls13_cipher_suite(
+        &self,
+        server: &mut dyn Iterator<Item = &'static Tls13CipherSuite>,
+        server: &[&'static Tls13CipherSuite],
+    ) -> Option<&'static Tls13CipherSuite>;
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -6,6 +6,7 @@ use core::fmt;
 
 use pki_types::DnsName;
 
+use super::config::{CipherSuiteSelector, VersionSuiteSelector};
 use super::{ClientHello, CommonServerSessionValue, ServerConfig, tls12, tls13};
 use crate::SupportedCipherSuite;
 use crate::common_state::{Event, Output, OutputEvent, Protocol};
@@ -511,6 +512,7 @@ impl ExpectClientHello {
     where
         CryptoProvider: Borrow<[&'static T]>,
         SupportedCipherSuite: From<&'static T>,
+        dyn CipherSuiteSelector: VersionSuiteSelector<T>,
     {
         output.output(OutputEvent::ProtocolVersion(T::VERSION));
 
@@ -595,7 +597,11 @@ impl ExpectClientHello {
         sig_scheme: SignatureScheme,
         client_groups: &[NamedGroup],
         client_suites: &[CipherSuite],
-    ) -> Result<(&'static T, &'static dyn SupportedKxGroup), PeerIncompatible> {
+    ) -> Result<(&'static T, &'static dyn SupportedKxGroup), PeerIncompatible>
+    where
+        SupportedCipherSuite: From<&'static T>,
+        dyn CipherSuiteSelector: VersionSuiteSelector<T>,
+    {
         // Determine which `KeyExchangeAlgorithm`s are theoretically possible, based
         // on the offered and supported groups.
         let mut ecdhe_possible = false;
@@ -644,34 +650,32 @@ impl ExpectClientHello {
             return Err(PeerIncompatible::NoKxGroupsInCommon);
         }
 
-        let mut suitable_suites_iter = suites.iter().filter(|suite| {
-            // Reduce our supported ciphersuites by the certified key's algorithm.
-            suite.usable_for_signature_scheme(sig_scheme)
-                // And support for one of the key exchange groups
-                && (ecdhe_possible && suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::ECDHE)
-                || ffdhe_possible && suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::DHE))
-        });
-
         // RFC 7919 (https://datatracker.ietf.org/doc/html/rfc7919#section-4) requires us to send
         // the InsufficientSecurity alert in case we don't recognize client's FFDHE groups (i.e.,
         // `suitable_suites` becomes empty). But that does not make a lot of sense (e.g., client
         // proposes FFDHE4096 and we only support FFDHE2048), so we ignore that requirement here,
         // and continue to send HandshakeFailure.
 
-        let suite = if self.config.ignore_client_order {
-            suitable_suites_iter.find(|suite| client_suites.contains(&suite.suite()))
-        } else {
-            let suitable_suites = suitable_suites_iter.collect::<Vec<_>>();
-            client_suites
-                .iter()
-                .find_map(|client_suite| {
-                    suitable_suites
-                        .iter()
-                        .find(|x| *client_suite == x.suite())
-                })
-                .copied()
-        }
-        .ok_or(PeerIncompatible::NoCipherSuitesInCommon)?;
+        let mut client_suites = client_suites
+            .iter()
+            .filter_map(|&suite| {
+                let &suite = suites
+                    .iter()
+                    .find(|ss| ss.suite() == suite)?;
+
+                // Reduce our supported ciphersuites by the certified key's algorithm.
+                (suite.usable_for_signature_scheme(sig_scheme)
+                // And support for one of the key exchange groups
+                && (ecdhe_possible && suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::ECDHE)
+                || ffdhe_possible && suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::DHE)))
+                .then_some(suite)
+            });
+
+        let suite = self
+            .config
+            .cipher_suite_selector
+            .select(&mut client_suites, suites)
+            .ok_or(PeerIncompatible::NoCipherSuitesInCommon)?;
 
         // Finally, choose a key exchange group that is compatible with the selected cipher
         // suite.

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -15,8 +15,8 @@ pub use crate::webpki::{
 
 pub(crate) mod config;
 pub use config::{
-    ClientHello, InvalidSniPolicy, ServerConfig, ServerCredentialResolver, StoresServerSessions,
-    WantsServerCert,
+    CipherSuiteSelector, ClientHello, InvalidSniPolicy, PreferClientOrder, PreferServerOrder,
+    ServerConfig, ServerCredentialResolver, StoresServerSessions, WantsServerCert,
 };
 
 mod connection;

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -1,6 +1,6 @@
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
-use std::vec;
+use std::{error, vec};
 
 use pki_types::UnixTime;
 
@@ -33,6 +33,7 @@ use crate::pki_types::{CertificateDer, FipsStatus, PrivateKeyDer};
 use crate::suites::CipherSuiteCommon;
 use crate::sync::Arc;
 use crate::tls12::Tls12CipherSuite;
+use crate::tls13::Tls13CipherSuite;
 use crate::version::TLS12_VERSION;
 
 #[test]
@@ -121,6 +122,64 @@ fn test_process_client_hello(hello: ClientHelloPayload) -> Result<(), Error> {
         aligned_handshake: None,
     })
     .map(|_| ())
+}
+
+#[test]
+fn test_server_preference_cipher_suite_selection() {
+    // Configure a server to use the default CipherSuiteSelector.
+    let mut provider = ffdhe_provider(TEST_PROVIDER);
+    static SERVER_CIPHERS_TLS13: &[&Tls13CipherSuite] = &[];
+    static SERVER_CIPHERS_TLS12: &[&Tls12CipherSuite] = &[
+        &TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+        &TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+    ];
+    provider.tls13_cipher_suites = Cow::Borrowed(SERVER_CIPHERS_TLS13);
+    provider.tls12_cipher_suites = Cow::Borrowed(SERVER_CIPHERS_TLS12);
+    let config = ServerConfig::builder(provider.into())
+        .with_no_client_auth()
+        .with_single_cert(server_identity(), server_key())
+        .unwrap();
+
+    // The server should choose the first cipher suite in its supported list that is
+    // also supported by the client.
+    let mut ch = minimal_client_hello();
+    ch.cipher_suites.clear();
+    ch.cipher_suites.extend([
+        CipherSuite::TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+        CipherSuite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+    ]);
+    let selected_suite = select_cipher_suite(ServerConnection::new(config.into()).unwrap(), ch);
+    assert_eq!(
+        selected_suite.unwrap(),
+        CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+    );
+}
+
+// Process the `ClientHelloPayload` and return the `CipherSuite` from the resulting ServerHello.
+fn select_cipher_suite(
+    mut conn: ServerConnection,
+    client_hello: ClientHelloPayload,
+) -> Result<CipherSuite, Box<dyn error::Error>> {
+    let ch = Message {
+        version: ProtocolVersion::TLSv1_3,
+        payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::ClientHello(
+            client_hello,
+        ))),
+    };
+    conn.read_tls(&mut ch.into_wire_bytes().as_slice())?;
+    conn.process_new_packets()?;
+
+    let mut flight = vec![];
+    conn.write_tls(&mut &mut flight)
+        .unwrap();
+    let mut r = Reader::new(&flight[HEADER_SIZE..]);
+    let HandshakeMessagePayload(HandshakePayload::ServerHello(server_hello)) =
+        HandshakeMessagePayload::read(&mut r).unwrap()
+    else {
+        panic!("expected ServerHello");
+    };
+    Ok(server_hello.cipher_suite)
 }
 
 #[test]
@@ -407,6 +466,19 @@ static TLS_DHE_RSA_WITH_AES_128_GCM_SHA256: Tls12CipherSuite = Tls12CipherSuite 
         suite: CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
         hash_provider: FAKE_HASH,
         confidentiality_limit: 1,
+    },
+    kx: KeyExchangeAlgorithm::DHE,
+    protocol_version: TLS12_VERSION,
+    prf_provider: &tls12::PrfUsingHmac(FAKE_HMAC),
+    sign: &[SignatureScheme::ECDSA_NISTP256_SHA256],
+    aead_alg: &FakeAead,
+};
+
+static TLS_DHE_RSA_WITH_AES_256_GCM_SHA384: Tls12CipherSuite = Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+        hash_provider: FAKE_HASH,
+        confidentiality_limit: 0,
     },
     kx: KeyExchangeAlgorithm::DHE,
     protocol_version: TLS12_VERSION,


### PR DESCRIPTION
@brian-pane I ended up significantly reworking your PR, please have a look.

I dropped the ChaCha20-specific implementation for now, since I retained preference for the client order as the default (in which case we automatically pick ChaCha20 if the client has it first). I guess we could customize `PreferServerOrder` to prefer ChaCha20 if the client lists it first?

Fixes #2252; obsoletes #2987.