### PR TITLE
Account for encryption overhead in MessageFragmenter

### DIFF
--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1363,8 +1363,6 @@ fn test_server_mtu_reduction() {
         .write_all(&big_data)
         .unwrap();
 
-    let encryption_overhead = 20; // FIXME: see issue #991
-
     transfer(&mut client, &mut server);
     server.process_new_packets().unwrap();
     {
@@ -1374,7 +1372,7 @@ fn test_server_mtu_reduction() {
         assert!(
             pipe.message_lengths()
                 .iter()
-                .all(|x| *x <= 64 + encryption_overhead)
+                .all(|x| *x <= 64)
         );
     }
 
@@ -1388,7 +1386,7 @@ fn test_server_mtu_reduction() {
         assert!(
             pipe.message_lengths()
                 .iter()
-                .all(|x| *x <= 64 + encryption_overhead)
+                .all(|x| *x <= 64)
         );
     }
 

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -87,8 +87,11 @@ impl SendPath {
     pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
         debug_assert!(self.encrypt_state.is_encrypting());
 
-        // Limit on `sendable_tls` should apply to encrypted data but is enforced
-        // for plaintext data instead which does not include cipher+record overhead.
+        // This limit is applied to plaintext length, but the sendable_tls buffer
+        // receives ciphertext. The slight mismatch is acceptable because the
+        // buffer limit is a coarse backpressure mechanism, not a wire-size
+        // guarantee. The per-record wire-size guarantee comes from the
+        // MessageFragmenter, which accounts for encryption overhead.
         let len = self
             .sendable_tls
             .apply_limit(data.len());
@@ -188,8 +191,11 @@ impl SendPath {
             return sendable_plaintext.append_limited_copy(payload);
         }
 
-        // Limit on `sendable_tls` should apply to encrypted data but is enforced
-        // for plaintext data instead which does not include cipher+record overhead.
+        // This limit is applied to plaintext length, but the sendable_tls buffer
+        // receives ciphertext. The slight mismatch is acceptable because the
+        // buffer limit is a coarse backpressure mechanism, not a wire-size
+        // guarantee. The per-record wire-size guarantee comes from the
+        // MessageFragmenter, which accounts for encryption overhead.
         let len = self
             .sendable_tls
             .apply_limit(payload.len());
@@ -330,8 +336,11 @@ impl SendOutput for SendPath {
     }
 
     fn set_encrypter(&mut self, encrypter: Box<dyn MessageEncrypter>, max_messages: u64) {
+        let overhead = encrypter.encrypted_payload_len(0);
         self.encrypt_state
             .set_message_encrypter(encrypter, max_messages);
+        self.message_fragmenter
+            .set_encryption_overhead(overhead);
     }
 
     fn update_key_schedule(&mut self, schedule: Box<KeyScheduleTrafficSend>) {

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -7,13 +7,22 @@ pub(crate) const PACKET_OVERHEAD: usize = 1 + 2 + 2;
 pub(crate) const MAX_FRAGMENT_SIZE: usize = MAX_FRAGMENT_LEN + PACKET_OVERHEAD;
 
 pub(crate) struct MessageFragmenter {
+    /// Maximum plaintext bytes per fragment, after subtracting all overhead
+    /// from the user's wire-size budget.
     max_frag: usize,
+    /// The user-configured wire-size budget (record header + plaintext + encryption overhead).
+    /// `None` means "use the maximum allowable size".
+    configured_max_fragment_size: Option<usize>,
+    /// Bytes added by encryption (AEAD tag, TLS 1.3 content type byte, etc.).
+    encryption_overhead: usize,
 }
 
 impl Default for MessageFragmenter {
     fn default() -> Self {
         Self {
             max_frag: MAX_FRAGMENT_LEN,
+            configured_max_fragment_size: None,
+            encryption_overhead: 0,
         }
     }
 }
@@ -55,8 +64,9 @@ impl MessageFragmenter {
 
     /// Set the maximum fragment size that will be produced.
     ///
-    /// This includes overhead. A `max_fragment_size` of 10 will produce TLS fragments
-    /// up to 10 bytes long.
+    /// This includes all overhead: the TLS record header and encryption overhead
+    /// are subtracted to determine the maximum plaintext per fragment. Once
+    /// encryption begins, the resulting TLS records will not exceed this size.
     ///
     /// A `max_fragment_size` of `None` sets the highest allowable fragment size.
     ///
@@ -65,12 +75,34 @@ impl MessageFragmenter {
         &mut self,
         max_fragment_size: Option<usize>,
     ) -> Result<(), Error> {
-        self.max_frag = match max_fragment_size {
-            Some(sz @ 32..=MAX_FRAGMENT_SIZE) => sz - PACKET_OVERHEAD,
-            None => MAX_FRAGMENT_LEN,
+        match max_fragment_size {
+            Some(sz @ 32..=MAX_FRAGMENT_SIZE) => {
+                self.configured_max_fragment_size = Some(sz);
+            }
+            None => {
+                self.configured_max_fragment_size = None;
+            }
             _ => return Err(Error::BadMaxFragmentSize),
         };
+        self.recalculate_max_frag();
         Ok(())
+    }
+
+    /// Update the encryption overhead and recalculate the effective fragment size.
+    ///
+    /// Called when the cipher suite is negotiated or rekeyed.
+    pub(crate) fn set_encryption_overhead(&mut self, overhead: usize) {
+        self.encryption_overhead = overhead;
+        self.recalculate_max_frag();
+    }
+
+    fn recalculate_max_frag(&mut self) {
+        self.max_frag = match self.configured_max_fragment_size {
+            Some(sz) => sz.saturating_sub(PACKET_OVERHEAD + self.encryption_overhead),
+            None => MAX_FRAGMENT_LEN,
+        };
+        // Ensure we never produce zero-length fragments.
+        self.max_frag = self.max_frag.max(1);
     }
 }
 


### PR DESCRIPTION
When max_fragment_size is configured, the fragmenter now subtracts both the TLS record header and the encryption overhead (AEAD tag, TLS 1.3 content type byte) from the wire-size budget before fragmenting plaintext.  This ensures encrypted TLS records never exceed the configured limit.

The encryption overhead is communicated to the fragmenter when the cipher suite is negotiated or rekeyed, using the existing encrypted_payload_len method on MessageEncrypter.

Fixes #991.