### PR TITLE
Backport client: allow skipping selected ALPN validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3332,7 +3332,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 dependencies = [
  "log",
  "once_cell",

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -1727,6 +1727,32 @@ pub mod encoding {
         handshake_framing(HandshakeType::ClientHello, out)
     }
 
+    pub fn server_hello(
+        legacy_version: ProtocolVersion,
+        random: &[u8; 32],
+        session_id: &[u8],
+        cipher_suite: CipherSuite,
+        extensions: Vec<Extension>,
+    ) -> Vec<u8> {
+        let mut out = vec![];
+
+        out.extend_from_slice(&legacy_version.to_array());
+        out.extend_from_slice(random);
+        out.extend_from_slice(session_id);
+        out.extend_from_slice(&cipher_suite.to_array());
+        out.extend_from_slice(&[0x00]); // null compression
+
+        let mut exts = vec![];
+        for e in extensions {
+            exts.extend_from_slice(&e.typ.to_array());
+            exts.extend_from_slice(&(e.body.len() as u16).to_be_bytes());
+            exts.extend_from_slice(&e.body);
+        }
+
+        out.extend(len_u16(exts));
+        handshake_framing(HandshakeType::ServerHello, out)
+    }
+
     /// Apply handshake framing to `body`.
     ///
     /// This does not do fragmentation.
@@ -1792,6 +1818,13 @@ pub mod encoding {
             Self {
                 typ: ExtensionType::KeyShare,
                 body: len_u16(share),
+            }
+        }
+
+        pub fn new_alpn(body: &[u8]) -> Self {
+            Self {
+                typ: ExtensionType::ALProtocolNegotiation,
+                body: len_u16(body.to_vec()),
             }
         }
     }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -165,6 +165,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
         ClientConfig {
             provider: self.provider,
             alpn_protocols: Vec::new(),
+            check_selected_alpn: true,
             resumption: Resumption::default(),
             max_fragment_size: None,
             client_auth_cert_resolver,

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -166,6 +166,11 @@ pub struct ClientConfig {
     /// If empty, no ALPN extension is sent.
     pub alpn_protocols: Vec<Vec<u8>>,
 
+    /// Whether to check the selected ALPN was offered.
+    ///
+    /// The default is true.
+    pub check_selected_alpn: bool,
+
     /// How and when the client can resume a previous session.
     ///
     /// # Sharing `resumption` between `ClientConfig`s

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -590,11 +590,12 @@ pub(super) fn process_alpn_protocol(
     common: &mut CommonState,
     offered_protocols: &[ProtocolName],
     selected: Option<&ProtocolName>,
+    check_selected_offered: bool,
 ) -> Result<(), Error> {
     common.alpn_protocol = selected.map(ToOwned::to_owned);
 
     if let Some(alpn_protocol) = &common.alpn_protocol {
-        if !offered_protocols.contains(alpn_protocol) {
+        if check_selected_offered && !offered_protocols.contains(alpn_protocol) {
             return Err(common.send_fatal_alert(
                 AlertDescription::IllegalParameter,
                 PeerMisbehaved::SelectedUnofferedApplicationProtocol,
@@ -743,6 +744,7 @@ impl State<ClientConnectionData> for ExpectServerHello {
                     .selected_protocol
                     .as_ref()
                     .map(|s| s.as_ref()),
+                self.input.config.check_selected_alpn,
             )?;
         }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -506,6 +506,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
             exts.selected_protocol
                 .as_ref()
                 .map(|protocol| protocol.as_ref()),
+            self.config.check_selected_alpn,
         )?;
         hs::process_client_cert_type_extension(
             cx.common,

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -258,6 +258,55 @@ fn connection_level_alpn_protocols() {
     assert_eq!(client.alpn_protocol(), Some(&b"http/1.1"[..]));
 }
 
+#[test]
+fn server_selects_unoffered_alpn_checked() {
+    let result = unoffered_alpn_test(true);
+    assert_eq!(
+        result.err(),
+        Some(PeerMisbehaved::SelectedUnofferedApplicationProtocol.into())
+    );
+}
+
+#[test]
+fn server_selects_unoffered_alpn_unchecked() {
+    let result = unoffered_alpn_test(false);
+    assert_ne!(
+        result.err(),
+        Some(PeerMisbehaved::SelectedUnofferedApplicationProtocol.into())
+    );
+}
+
+fn unoffered_alpn_test(check_selected_alpn: bool) -> Result<rustls::IoState, Error> {
+    let mut config = make_client_config(KeyType::Rsa2048, &provider::default_provider());
+    config.check_selected_alpn = check_selected_alpn;
+    let mut client = ClientConnection::new_with_alpn(
+        Arc::new(config),
+        server_name("localhost"),
+        vec![b"http/1.1".to_vec()],
+    )
+    .unwrap();
+    client
+        .write_tls(&mut Vec::new())
+        .unwrap();
+    client
+        .read_tls(
+            &mut encoding::message_framing(
+                ContentType::Handshake,
+                ProtocolVersion::TLSv1_2,
+                encoding::server_hello(
+                    ProtocolVersion::TLSv1_2,
+                    &[b'a'; 32],
+                    &[0],
+                    CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                    vec![encoding::Extension::new_alpn(b"\x05blorp")],
+                ),
+            )
+            .as_slice(),
+        )
+        .unwrap();
+    client.process_new_packets()
+}
+
 fn version_test(
     client_versions: &[&'static rustls::SupportedProtocolVersion],
     server_versions: &[&'static rustls::SupportedProtocolVersion],


### PR DESCRIPTION
This backports #3009 to 0.23