### PR TITLE
fix(bogo): panic macro typo

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -982,7 +982,7 @@ impl Options {
             "-wait-for-debugger" => {
                 #[cfg(windows)]
                 {
-                    panic("-wait-for-debugger not supported on Windows");
+                    panic!("-wait-for-debugger not supported on Windows");
                 }
                 #[cfg(unix)]
                 {


### PR DESCRIPTION
rust-analyzer complain it on my windows