### PR TITLE
Default require_ems based on CryptoProvider FIPS status

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -162,6 +162,9 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
         self,
         client_auth_cert_resolver: Arc<dyn ResolvesClientCert>,
     ) -> ClientConfig {
+        #[cfg(feature = "tls12")]
+        let require_ems = self.provider.fips();
+
         ClientConfig {
             provider: self.provider,
             alpn_protocols: Vec::new(),
@@ -176,7 +179,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             enable_secret_extraction: false,
             enable_early_data: false,
             #[cfg(feature = "tls12")]
-            require_ems: cfg!(feature = "fips"),
+            require_ems,
             time_provider: self.time_provider,
             cert_compressors: compress::default_cert_compressors().to_vec(),
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -229,7 +229,8 @@ pub struct ClientConfig {
     /// If set to `true`, requires the server to support the extended
     /// master secret extraction method defined in [RFC 7627].
     ///
-    /// The default is `true` if the `fips` crate feature is enabled,
+    /// The default is `true` if the configured [`CryptoProvider`] is
+    /// FIPS-compliant (i.e., [`CryptoProvider::fips()`] returns `true`),
     /// `false` otherwise.
     ///
     /// It must be set to `true` to meet FIPS requirement mentioned in section

--- a/rustls/src/manual/fips.rs
+++ b/rustls/src/manual/fips.rs
@@ -1,7 +1,8 @@
 /*! # Using rustls with FIPS-approved cryptography
 
-To use FIPS-approved cryptography with rustls, you should take
-these actions:
+To use FIPS-approved cryptography with rustls, you should
+utilize a FIPS-approved `CryptoProvider`.
+rustls ships with one using `aws-lc-rs`, take these actions to make use of it:
 
 ## 1. Enable the `fips` crate feature for rustls.
 

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -100,6 +100,9 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
 
     /// Sets a custom [`ResolvesServerCert`].
     pub fn with_cert_resolver(self, cert_resolver: Arc<dyn ResolvesServerCert>) -> ServerConfig {
+        #[cfg(feature = "tls12")]
+        let require_ems = self.provider.fips();
+
         ServerConfig {
             provider: self.provider,
             verifier: self.state.verifier,
@@ -119,7 +122,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             send_half_rtt_data: false,
             send_tls13_tickets: 2,
             #[cfg(feature = "tls12")]
-            require_ems: cfg!(feature = "fips"),
+            require_ems,
             time_provider: self.time_provider,
             cert_compressors: compress::default_cert_compressors().to_vec(),
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -401,7 +401,8 @@ pub struct ServerConfig {
     /// If set to `true`, requires the client to support the extended
     /// master secret extraction method defined in [RFC 7627].
     ///
-    /// The default is `true` if the "fips" crate feature is enabled,
+    /// The default is `true` if the configured [`CryptoProvider`] is
+    /// FIPS-compliant (i.e., [`CryptoProvider::fips()`] returns `true`),
     /// `false` otherwise.
     ///
     /// It must be set to `true` to meet FIPS requirement mentioned in section


### PR DESCRIPTION
Previously, require_ems was defaulted solely based on cfg!(feature = "fips"), which is a compile-time check tied to the fips cargo feature. The fips feature unconditionally pulls in aws-lc-rs as the cryptographic provider, making it impossible for third-party FIPS-compliant CryptoProvider implementations (e.g., those backed by BoringSSL) to get correct FIPS policy defaults without also pulling in aws-lc-rs — which may conflict with their own crypto backend.

This change also considers the runtime CryptoProvider::fips() status when defaulting require_ems in both ClientConfig and ServerConfig builders. If the configured provider reports itself as FIPS-compliant, require_ems is now automatically set to true, ensuring that ClientConfig::fips() and ServerConfig::fips() return the correct result without requiring the fips cargo feature.

This is backward-compatible: existing users of the fips feature see no behavior change, while third-party providers now work correctly out of the box.