### PR TITLE
examples/ech-client: trim leading slash from --path

### DIFF
--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -137,9 +137,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let mut sock = TcpStream::connect(sock_addr)?;
         let mut tls = Stream::new(&mut conn, &mut sock);
 
+        // Trim a leading '/' from the user-supplied path so we never emit a request line
+        // like `GET //foo HTTP/1.1`.
+        let path = args.path.trim_start_matches('/');
         let request = format!(
-            "GET /{} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n",
-            args.path,
+            "GET /{path} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n",
             args.host
                 .as_ref()
                 .unwrap_or(&args.inner_hostname),


### PR DESCRIPTION
The HTTP request in `examples/src/bin/ech-client.rs` is built with
`format!("GET /{} HTTP/1.1\r\n...", args.path, ...)`, so invoking the
example with a leading slash in `--path` produces a malformed-looking
request line with a double slash, e.g.:

    cargo run --locked -p rustls-examples --bin ech-client -- \
        cloudflare-ech.com research.cloudflare.com \
        --path /cdn-cgi/trace

emits:

    GET //cdn-cgi/trace HTTP/1.1

Some origins reject `//`-prefixed paths with a 5xx even though the
TLS+ECH handshake itself succeeded, which makes this look like an
ECH regression when it isn't — the handshake logs still show
`ECH accepted by server`.

This matches how users naturally write paths (`curl`, browsers, etc.
accept a leading `/`), and keeps the example working both with and
without a leading slash in `--path`.

Verified against `cloudflare-ech.com` / `research.cloudflare.com`:

* Before: `--path /cdn-cgi/trace` → `GET //cdn-cgi/trace` → HTTP 500
* After:  `--path /cdn-cgi/trace` → `GET /cdn-cgi/trace`  → HTTP 200
* After:  `--path cdn-cgi/trace`  → `GET /cdn-cgi/trace`  → HTTP 200