### PR TITLE
0.23.40: backport ECH padding fixes to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 dependencies = [
  "aws-lc-rs",
  "base64",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 dependencies = [
  "log",
  "once_cell",

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 edition = "2021"
 rust-version = "1.71"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -689,11 +689,9 @@ impl EchState {
                 // max(0, L - D)
                 core::cmp::max(0, max_name_len.saturating_sub(name.as_ref().len()))
             }
-            _ => {
-                // L + 9
-                // "This is the length of a "server_name" extension with an L-byte name."
-                max_name_len + 9
-            }
+            // L + 9
+            // "This is the length of a "server_name" extension with an L-byte name."
+            _ => max_name_len + 9,
         };
 
         // Let L be the length of the EncodedClientHelloInner with all the padding computed so far

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -1,6 +1,7 @@
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
+use core::iter;
 
 use pki_types::{DnsName, EchConfigListBytes, ServerName};
 use subtle::ConstantTimeEq;
@@ -697,7 +698,7 @@ impl EchState {
         // Let L be the length of the EncodedClientHelloInner with all the padding computed so far
         // Let N = 31 - ((L - 1) % 32) and add N bytes of padding.
         let padding_len = 31 - ((encoded_hello.len() + padding_len - 1) % 32);
-        encoded_hello.extend(vec![0; padding_len]);
+        encoded_hello.extend(iter::repeat(0).take(padding_len));
 
         // Construct the inner hello message that will be used for the transcript.
         let inner_hello_msg = Message {

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -688,7 +688,7 @@ impl EchState {
             Some(ServerNamePayload::SingleDnsName(name)) => {
                 // name.len() = D
                 // max(0, L - D)
-                core::cmp::max(0, max_name_len.saturating_sub(name.as_ref().len()))
+                Ord::max(0, max_name_len.saturating_sub(name.as_ref().len()))
             }
             // L + 9
             // "This is the length of a "server_name" extension with an L-byte name."

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -834,8 +834,11 @@ pub(crate) fn fatal_alert_required(
 
 #[cfg(test)]
 mod tests {
+    use std::string::String;
+
     use super::*;
     use crate::enums::CipherSuite;
+    use crate::msgs::enums::{Compression, HpkeAead, HpkeKdf};
     use crate::msgs::handshake::{Random, ServerExtensions, SessionId};
 
     #[test]
@@ -845,7 +848,7 @@ mod tests {
             random: Random([0xffu8; 32]),
             session_id: SessionId::empty(),
             cipher_suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
-            compression_method: crate::msgs::enums::Compression::Null,
+            compression_method: Compression::Null,
             extensions: Box::new(ServerExtensions::default()),
         };
         let message = Message {
@@ -890,5 +893,170 @@ mod tests {
             "020000280303ffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000001302000000",
             "                          afterwards those bytes are zeroed ^^^^^^^^^^^^^^^^            "
         );
+    }
+
+    #[test]
+    fn inner_client_hello_length_conceals_inner_name_length() {
+        let base_inner_len = inner_hello_encoding_for_name(dns_name_of_len(1), true).len();
+        assert!(
+            base_inner_len % 32 == 0,
+            "inner hello length must be 32-byte padded"
+        );
+        assert!(
+            base_inner_len >= 256,
+            "inner hello must include inner name and its padding"
+        );
+
+        for inner_name_len in 1..251 {
+            assert_eq!(
+                inner_hello_encoding_for_name(dns_name_of_len(inner_name_len), true).len(),
+                base_inner_len,
+                "all inner hello lengths must be invariant wrt inner name length"
+            );
+        }
+    }
+
+    fn inner_hello_encoding_for_name(name: DnsName<'static>, enable_sni: bool) -> Vec<u8> {
+        let config = EchConfig {
+            config: EchConfigPayload::V18(EchConfigContents {
+                key_config: HpkeKeyConfig {
+                    config_id: 0,
+                    kem_id: MockHpke::SUITE.kem,
+                    public_key: PayloadU16::new(vec![0; 32]),
+                    symmetric_cipher_suites: vec![],
+                },
+                maximum_name_length: 255,
+                public_name: DnsName::try_from("public").unwrap(),
+                extensions: vec![],
+            }),
+            suite: &MockHpke,
+        };
+
+        EchState::new(
+            &config,
+            ServerName::from(name.clone()),
+            false,
+            &FixedRandom,
+            enable_sni,
+        )
+        .unwrap()
+        .encode_inner_hello(
+            &ClientHelloPayload {
+                client_version: ProtocolVersion::TLSv1_3,
+                random: Random([0u8; 32]),
+                session_id: SessionId::empty(),
+                cipher_suites: vec![],
+                compression_methods: vec![Compression::Null],
+                extensions: Box::new(ClientExtensions {
+                    server_name: Some(ServerNamePayload::from(&name)),
+                    ..Default::default()
+                }),
+            },
+            None,
+            &None,
+        )
+    }
+
+    fn dns_name_of_len(mut len: usize) -> DnsName<'static> {
+        let mut s = String::new();
+        let labels = len.div_ceil(63);
+        for _ in 0..labels {
+            let chars = Ord::min(len, 63);
+            len -= chars;
+            for _ in 0..chars {
+                s.push('a');
+            }
+            if len != 0 {
+                s.push('.');
+            }
+        }
+        DnsName::try_from(s).unwrap()
+    }
+
+    #[derive(Debug)]
+    struct MockHpke;
+
+    impl MockHpke {
+        const SUITE: HpkeSuite = HpkeSuite {
+            kem: HpkeKem::DHKEM_P256_HKDF_SHA256,
+            sym: HpkeSymmetricCipherSuite {
+                kdf_id: HpkeKdf::HKDF_SHA256,
+                aead_id: HpkeAead::AES_128_GCM,
+            },
+        };
+    }
+
+    impl Hpke for MockHpke {
+        #[cfg_attr(coverage_nightly, coverage(off))]
+        fn seal(
+            &self,
+            _info: &[u8],
+            _aad: &[u8],
+            _plaintext: &[u8],
+            _pub_key: &HpkePublicKey,
+        ) -> Result<(EncapsulatedSecret, Vec<u8>), Error> {
+            todo!()
+        }
+
+        fn setup_sealer(
+            &self,
+            _info: &[u8],
+            _pub_key: &HpkePublicKey,
+        ) -> Result<(EncapsulatedSecret, Box<dyn HpkeSealer + 'static>), Error> {
+            Ok((EncapsulatedSecret(vec![]), Box::new(MockHpkeSealer)))
+        }
+
+        #[cfg_attr(coverage_nightly, coverage(off))]
+        fn open(
+            &self,
+            _enc: &EncapsulatedSecret,
+            _info: &[u8],
+            _aad: &[u8],
+            _ciphertext: &[u8],
+            _secret_key: &crate::crypto::hpke::HpkePrivateKey,
+        ) -> Result<Vec<u8>, Error> {
+            todo!()
+        }
+
+        #[cfg_attr(coverage_nightly, coverage(off))]
+        fn setup_opener(
+            &self,
+            _enc: &EncapsulatedSecret,
+            _info: &[u8],
+            _secret_key: &crate::crypto::hpke::HpkePrivateKey,
+        ) -> Result<Box<dyn crate::crypto::hpke::HpkeOpener + 'static>, Error> {
+            todo!()
+        }
+
+        #[cfg_attr(coverage_nightly, coverage(off))]
+        fn generate_key_pair(
+            &self,
+        ) -> Result<(HpkePublicKey, crate::crypto::hpke::HpkePrivateKey), Error> {
+            todo!()
+        }
+
+        fn suite(&self) -> HpkeSuite {
+            Self::SUITE
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockHpkeSealer;
+
+    impl HpkeSealer for MockHpkeSealer {
+        #[cfg_attr(coverage_nightly, coverage(off))]
+        fn seal(&mut self, _aad: &[u8], _plaintext: &[u8]) -> Result<Vec<u8>, Error> {
+            todo!()
+        }
+    }
+
+    #[derive(Debug)]
+    struct FixedRandom;
+
+    impl SecureRandom for FixedRandom {
+        fn fill(&self, buf: &mut [u8]) -> Result<(), crate::rand::GetRandomFailed> {
+            buf.fill(0x55);
+            Ok(())
+        }
     }
 }

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -684,7 +684,7 @@ impl EchState {
         let max_name_len = usize::from(self.maximum_name_length);
         let max_name_len = if max_name_len > 0 { max_name_len } else { 255 };
 
-        let padding_len = match &self.inner_name {
+        let name_padding_len = match &self.inner_name {
             ServerName::DnsName(name) => {
                 // name.len() = D
                 // max(0, L - D)
@@ -694,10 +694,11 @@ impl EchState {
             // "This is the length of a "server_name" extension with an L-byte name."
             _ => max_name_len + 9,
         };
+        encoded_hello.extend(iter::repeat(0).take(name_padding_len));
 
         // Let L be the length of the EncodedClientHelloInner with all the padding computed so far
         // Let N = 31 - ((L - 1) % 32) and add N bytes of padding.
-        let padding_len = 31 - ((encoded_hello.len() + padding_len - 1) % 32);
+        let padding_len = 31 - ((encoded_hello.len() - 1) % 32);
         encoded_hello.extend(iter::repeat(0).take(padding_len));
 
         // Construct the inner hello message that will be used for the transcript.

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -684,8 +684,8 @@ impl EchState {
         let max_name_len = usize::from(self.maximum_name_length);
         let max_name_len = if max_name_len > 0 { max_name_len } else { 255 };
 
-        let name_padding_len = match &self.inner_name {
-            ServerName::DnsName(name) => {
+        let name_padding_len = match &inner_hello.server_name {
+            Some(ServerNamePayload::SingleDnsName(name)) => {
                 // name.len() = D
                 // max(0, L - D)
                 core::cmp::max(0, max_name_len.saturating_sub(name.as_ref().len()))
@@ -910,6 +910,27 @@ mod tests {
         for inner_name_len in 1..251 {
             assert_eq!(
                 inner_hello_encoding_for_name(dns_name_of_len(inner_name_len), true).len(),
+                base_inner_len,
+                "all inner hello lengths must be invariant wrt inner name length"
+            );
+        }
+    }
+
+    #[test]
+    fn inner_client_hello_length_does_not_leak_length_of_omitted_inner_name() {
+        let base_inner_len = inner_hello_encoding_for_name(dns_name_of_len(1), false).len();
+        assert!(
+            base_inner_len % 32 == 0,
+            "inner hello length must be 32-byte padded"
+        );
+        assert!(
+            base_inner_len >= 256,
+            "inner hello must include maximum_name_length bytes of padding"
+        );
+
+        for inner_name_len in 1..251 {
+            assert_eq!(
+                inner_hello_encoding_for_name(dns_name_of_len(inner_name_len), false).len(),
                 base_inner_len,
                 "all inner hello lengths must be invariant wrt inner name length"
             );

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -680,23 +680,19 @@ impl EchState {
 
         // Calculate padding
         // max_name_len = L
-        let max_name_len = self.maximum_name_length;
+        let max_name_len = usize::from(self.maximum_name_length);
         let max_name_len = if max_name_len > 0 { max_name_len } else { 255 };
 
         let padding_len = match &self.inner_name {
             ServerName::DnsName(name) => {
                 // name.len() = D
                 // max(0, L - D)
-                core::cmp::max(
-                    0,
-                    max_name_len.saturating_sub(name.as_ref().len() as u8) as usize,
-                )
+                core::cmp::max(0, max_name_len.saturating_sub(name.as_ref().len()))
             }
             _ => {
                 // L + 9
                 // "This is the length of a "server_name" extension with an L-byte name."
-                // We widen to usize here to avoid overflowing u8 + u8.
-                max_name_len as usize + 9
+                max_name_len + 9
             }
         };
 


### PR DESCRIPTION
Proposed release notes:

* ECH: correct implementation of RFC-recommended padding scheme for SNI names in the inner client hello.
* ECH: correct padding of inner client hello when SNI is disabled.
* Alter default of `ServerConfig::require_ems` based on provider's FIPS status. Prior to this change, the default followed the `fips` crate feature, which was less helpful for users of external FIPS-approved providers.