### PR TITLE
Fix new `clippy::useless-borrows-in-formatting`

### DIFF
--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -386,7 +386,7 @@ impl ExpectCertificateStatus {
 
         trace!(
             "Server stapled OCSP response is {:?}",
-            &server_cert_ocsp_response
+            server_cert_ocsp_response
         );
 
         let server_cert = ServerCertDetails::new(self.server_cert_chain, server_cert_ocsp_response);

--- a/rustls/src/webpki/anchors.rs
+++ b/rustls/src/webpki/anchors.rs
@@ -119,7 +119,7 @@ impl Extend<TrustAnchor<'static>> for RootCertStore {
 impl fmt::Debug for RootCertStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RootCertStore")
-            .field("roots", &format!("({} roots)", &self.roots.len()))
+            .field("roots", &format!("({} roots)", self.roots.len()))
             .finish()
     }
 }

--- a/rustls/src/webpki/mod.rs
+++ b/rustls/src/webpki/mod.rs
@@ -269,8 +269,8 @@ mod tests {
             ),
         ];
         for t in testcases {
-            std::println!("webpki: {:?}", &t.0);
-            std::println!("rustls: {:?}", &t.1);
+            std::println!("webpki: {:?}", t.0);
+            std::println!("rustls: {:?}", t.1);
             assert_eq!(crl_error(t.0.clone()), t.1);
         }
 


### PR DESCRIPTION
addressing https://github.com/rustls/rustls/actions/runs/25336092853/job/74281599372