### PR TITLE
docs: fix duplicated "the" in fips manual page

### DIFF
--- a/rustls/src/manual/fips.rs
+++ b/rustls/src/manual/fips.rs
@@ -1,7 +1,7 @@
 /*! # Using rustls with FIPS-approved cryptography
 
 To use FIPS-approved cryptography with rustls, you should use a FIPS-approved `CryptoProvider`.
-The easiest way to do this is to use the the `rustls-aws-lc-rs` crate with the `fips` feature enabled.
+The easiest way to do this is to use the `rustls-aws-lc-rs` crate with the `fips` feature enabled.
 
 ## 1. Enable the `fips` crate feature for rustls-aws-lc-rs:
 


### PR DESCRIPTION
One-line typo fix in `rustls/src/manual/fips.rs`: "The easiest way to do this is to use the the `rustls-aws-lc-rs` crate" → "The easiest way to do this is to use the `rustls-aws-lc-rs` crate". No code/behavior change.