### PR TITLE
Address new `std_instead_of_core` in nightly

### DIFF
--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -348,6 +348,7 @@ pub(crate) mod async_io {
     }
 }
 
+#[allow(clippy::std_instead_of_core)] // awaits core::io::Cursor in stable (1.97)
 pub(crate) mod transport {
     //! Custom functions to interact between rustls clients and a servers.
     //!

--- a/rustls/src/compress.rs
+++ b/rustls/src/compress.rs
@@ -187,6 +187,7 @@ mod feat_zlib_rs {
 #[cfg(feature = "zlib")]
 pub use feat_zlib_rs::{ZLIB_COMPRESSOR, ZLIB_DECOMPRESSOR};
 
+#[allow(clippy::std_instead_of_core)] // awaits core::io::Cursor (1.97) in crate MSRV
 #[cfg(feature = "brotli")]
 mod feat_brotli {
     use std::io::{Cursor, Write};


### PR DESCRIPTION
See also #3036

Addressing https://github.com/rustls/rustls/actions/runs/25818797140/job/75854281313