### PR TITLE
Add QUIC support for server Acceptor

### DIFF
--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -242,6 +242,248 @@ fn test_quic_handshake() {
 }
 
 #[test]
+fn test_quic_acceptor() {
+    let kt = KeyType::Rsa2048;
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
+    let mut client_config = make_client_config(kt, &provider);
+    client_config.alpn_protocols = vec![b"h3".into()];
+    let client_config = Arc::new(client_config);
+    let mut server_config = make_server_config(kt, &provider);
+    server_config.alpn_protocols = vec![b"h3".into()];
+    let server_config = Arc::new(server_config);
+    let client_fips = client_config.fips();
+    let server_fips = server_config.fips();
+    let client_params = &b"client params"[..];
+    let server_params = &b"server params"[..];
+
+    let mut client = quic::ClientConnection::new(
+        client_config,
+        quic::Version::V1,
+        server_name("localhost"),
+        client_params.into(),
+    )
+    .unwrap();
+    assert_eq!(client.fips(), client_fips);
+
+    let mut acceptor = quic::Acceptor::new(quic::Version::V1);
+    assert!(acceptor.accept().unwrap().is_none());
+
+    let mut client_initial = Vec::new();
+    assert!(
+        client
+            .write_hs(&mut client_initial)
+            .is_none()
+    );
+    assert!(client_initial.len() > 8);
+
+    acceptor
+        .read_hs(&client_initial[..8])
+        .unwrap();
+    assert!(acceptor.accept().unwrap().is_none());
+
+    acceptor
+        .read_hs(&client_initial[8..])
+        .unwrap();
+    let accepted = acceptor.accept().unwrap().unwrap();
+    assert_eq!(
+        acceptor.accept().err(),
+        Some(ApiMisuse::AcceptorPolledAfterCompletion.into())
+    );
+    assert_eq!(
+        acceptor.read_hs(&[]).err(),
+        Some(ApiMisuse::AcceptorPolledAfterCompletion.into())
+    );
+    {
+        let client_hello = accepted.client_hello();
+        assert_eq!(
+            client_hello
+                .server_name()
+                .unwrap()
+                .as_ref(),
+            "localhost"
+        );
+        assert_eq!(
+            client_hello
+                .alpn()
+                .unwrap()
+                .collect::<Vec<_>>(),
+            vec![b"h3".as_slice()]
+        );
+    }
+
+    let mut server = accepted
+        .into_connection(server_config, server_params.into())
+        .unwrap();
+    assert_eq!(server.fips(), server_fips);
+    assert_eq!(server.quic_transport_parameters(), Some(client_params));
+
+    step(&mut server, &mut client)
+        .unwrap()
+        .unwrap();
+    step(&mut client, &mut server)
+        .unwrap()
+        .unwrap();
+    step(&mut server, &mut client)
+        .unwrap()
+        .unwrap();
+    step(&mut client, &mut server)
+        .unwrap()
+        .unwrap();
+
+    assert!(!client.is_handshaking());
+    assert!(!server.is_handshaking());
+    assert_eq!(client.quic_transport_parameters(), Some(server_params));
+}
+
+#[test]
+fn test_quic_acceptor_continues_with_server_config_chosen_from_client_hello() {
+    let kt = KeyType::Rsa2048;
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
+    let mut client_config = make_client_config(kt, &provider);
+    client_config.alpn_protocols = vec![b"h3".into()];
+    let client_config = Arc::new(client_config);
+
+    let mut h3_server_config = make_server_config(kt, &provider);
+    h3_server_config.alpn_protocols = vec![b"h3".into()];
+    let h3_server_config = Arc::new(h3_server_config);
+
+    let mut incompatible_server_config = make_server_config(kt, &provider);
+    incompatible_server_config.alpn_protocols = vec![b"hq-interop".into()];
+    let incompatible_server_config = Arc::new(incompatible_server_config);
+
+    let client_params = &b"client params"[..];
+    let server_params = &b"server params"[..];
+
+    let mut client = quic::ClientConnection::new(
+        client_config,
+        quic::Version::V1,
+        server_name("localhost"),
+        client_params.into(),
+    )
+    .unwrap();
+
+    let mut acceptor = quic::Acceptor::new(quic::Version::V1);
+    let mut client_initial = Vec::new();
+    assert!(
+        client
+            .write_hs(&mut client_initial)
+            .is_none()
+    );
+
+    acceptor
+        .read_hs(&client_initial)
+        .unwrap();
+    let accepted = acceptor.accept().unwrap().unwrap();
+
+    let selected_config = {
+        let client_hello = accepted.client_hello();
+        assert_eq!(
+            client_hello
+                .server_name()
+                .map(|name| name.as_ref()),
+            Some("localhost")
+        );
+        assert_eq!(
+            client_hello
+                .alpn()
+                .unwrap()
+                .collect::<Vec<_>>(),
+            vec![b"h3".as_slice()]
+        );
+
+        match client_hello
+            .server_name()
+            .map(|name| name.as_ref())
+        {
+            Some("localhost") => h3_server_config,
+            _ => incompatible_server_config,
+        }
+    };
+
+    let mut server = accepted
+        .into_connection(selected_config, server_params.into())
+        .unwrap();
+
+    step(&mut server, &mut client)
+        .unwrap()
+        .unwrap();
+    step(&mut client, &mut server)
+        .unwrap()
+        .unwrap();
+    step(&mut server, &mut client)
+        .unwrap()
+        .unwrap();
+    step(&mut client, &mut server)
+        .unwrap()
+        .unwrap();
+
+    assert!(!client.is_handshaking());
+    assert!(!server.is_handshaking());
+    assert_eq!(client.quic_transport_parameters(), Some(server_params));
+    assert_eq!(server.quic_transport_parameters(), Some(client_params));
+}
+
+#[test]
+fn test_quic_acceptor_invalid_early_data_size() {
+    let kt = KeyType::Ed25519;
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
+    let client_config = Arc::new(make_client_config(kt, &provider));
+    let mut server_config = make_server_config(kt, &provider);
+    server_config.max_early_data_size = 5;
+    let client_params = &b"client params"[..];
+
+    let mut client = quic::ClientConnection::new(
+        client_config,
+        quic::Version::V1,
+        server_name("localhost"),
+        client_params.into(),
+    )
+    .unwrap();
+
+    let mut acceptor = quic::Acceptor::new(quic::Version::V1);
+    let mut client_initial = Vec::new();
+    assert!(
+        client
+            .write_hs(&mut client_initial)
+            .is_none()
+    );
+
+    acceptor
+        .read_hs(&client_initial)
+        .unwrap();
+    let accepted = acceptor.accept().unwrap().unwrap();
+
+    assert_eq!(
+        accepted
+            .into_connection(Arc::new(server_config), b"server params".to_vec())
+            .err(),
+        Some(ApiMisuse::QuicRestrictsMaxEarlyDataSize.into())
+    );
+}
+
+#[test]
+fn test_quic_acceptor_read_error_is_terminal() {
+    let mut acceptor = quic::Acceptor::new(quic::Version::V1);
+
+    let err = acceptor
+        .read_hs(&encoding::handshake_framing(
+            rustls::enums::HandshakeType::ClientHello,
+            vec![0x00; 32],
+        ))
+        .err()
+        .unwrap();
+    assert_eq!(err, InvalidMessage::MissingData("Random").into());
+    assert_eq!(
+        acceptor.accept().err(),
+        Some(InvalidMessage::MissingData("Random").into())
+    );
+    assert_eq!(
+        acceptor.accept().err(),
+        Some(ApiMisuse::AcceptorPolledAfterCompletion.into())
+    );
+}
+
+#[test]
 fn test_quic_rejects_missing_alpn() {
     let client_params = &b"client params"[..];
     let server_params = &b"server params"[..];

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -87,6 +87,7 @@ fn test_quic_handshake() {
         client_params.into(),
     )
     .unwrap();
+    assert_eq!(client.fips(), client_config.fips());
 
     let mut server = quic::ServerConnection::new(
         server_config.clone(),
@@ -94,6 +95,7 @@ fn test_quic_handshake() {
         server_params.into(),
     )
     .unwrap();
+    assert_eq!(server.fips(), server_config.fips());
 
     let client_initial = step(&mut client, &mut server).unwrap();
     assert!(client_initial.is_none());

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1395,9 +1395,11 @@ pub enum ApiMisuse {
     /// [`KeyingMaterialExporter::derive()`]: crate::KeyingMaterialExporter::derive()
     ExporterOutputZeroLength,
 
-    /// [`Acceptor::accept()`][] called after it yielded a connection.
+    /// A server [`Acceptor::accept()`][] or QUIC [`quic::Acceptor::accept()`][] called after it
+    /// yielded a connection.
     ///
     /// [`Acceptor::accept()`]: crate::server::Acceptor::accept()
+    /// [`quic::Acceptor::accept()`]: crate::quic::Acceptor::accept()
     AcceptorPolledAfterCompletion,
 
     /// Incorrect sample length provided to [`quic::HeaderProtectionKey::encrypt_in_place()`][]

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
+use core::mem;
 use core::ops::{Deref, DerefMut};
 
 use pki_types::{DnsName, FipsStatus, ServerName};
@@ -9,7 +10,7 @@ use pki_types::{DnsName, FipsStatus, ServerName};
 use crate::client::{ClientConfig, ClientSide};
 pub use crate::common_state::Side;
 use crate::common_state::{CommonState, ConnectionOutputs, Protocol};
-use crate::conn::{ConnectionCore, KeyingMaterialExporter, SideData};
+use crate::conn::{ConnectionCore, KeyingMaterialExporter, SideCommonOutput, SideData};
 use crate::crypto::cipher::{AeadKey, EncodedMessage, Iv, Payload};
 use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock};
 use crate::enums::{ApplicationProtocol, ContentType, ProtocolVersion};
@@ -18,7 +19,7 @@ use crate::msgs::{
     ClientExtensionsInput, Message, MessagePayload, ServerExtensionsInput, TransportParameters,
     VecInput,
 };
-use crate::server::{ServerConfig, ServerSide};
+use crate::server::{ChooseConfig, ClientHello, ServerConfig, ServerSide, ServerState};
 use crate::suites::SupportedCipherSuite;
 use crate::sync::Arc;
 use crate::tls13::Tls13CipherSuite;
@@ -341,6 +342,134 @@ impl Deref for ServerConnection {
 impl Debug for ServerConnection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("quic::ServerConnection")
+            .finish_non_exhaustive()
+    }
+}
+
+/// A QUIC server-side acceptor.
+///
+/// `Acceptor` allows callers to choose a [`ServerConfig`] after reading the
+/// [`ClientHello`] of an incoming QUIC connection.
+pub struct Acceptor {
+    inner: Option<ConnectionCommon<ServerSide>>,
+}
+
+impl Acceptor {
+    /// Make a new QUIC acceptor.
+    pub fn new(version: Version) -> Self {
+        Self {
+            inner: Some(ConnectionCommon::new(
+                ConnectionCore::for_acceptor(Protocol::Quic(version)),
+                FipsStatus::Unvalidated,
+                Quic {
+                    version,
+                    ..Quic::default()
+                },
+            )),
+        }
+    }
+
+    /// Consume unencrypted TLS handshake data.
+    ///
+    /// The plaintext should be ordered QUIC CRYPTO stream data for one encryption level.
+    ///
+    /// Handshake data obtained from separate encryption levels should be supplied in separate calls.
+    pub fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), Error> {
+        match &mut self.inner {
+            Some(conn) => conn.read_hs(plaintext),
+            None => Err(ApiMisuse::AcceptorPolledAfterCompletion.into()),
+        }
+    }
+
+    /// Check if a `ClientHello` message has been received.
+    ///
+    /// Returns `Ok(None)` if the complete `ClientHello` has not yet been received.
+    /// Supply more handshake data with [`Acceptor::read_hs()`] and call this function again.
+    ///
+    /// Returns `Ok(Some(accepted))` if the connection has been accepted. Call
+    /// [`Accepted::into_connection()`] to continue. Do not call this function again.
+    pub fn accept(&mut self) -> Result<Option<Accepted>, Error> {
+        let Some(mut connection) = self.inner.take() else {
+            return Err(ApiMisuse::AcceptorPolledAfterCompletion.into());
+        };
+
+        const MISUSED: Error = Error::Unreachable("Accepted misused state");
+        let state = mem::replace(&mut connection.core.state, Err(MISUSED))?;
+
+        Ok(match state {
+            ServerState::ChooseConfig(choose_config) => Some(Accepted {
+                connection,
+                choose_config,
+            }),
+            state => {
+                connection.core.state = Ok(state);
+                self.inner = Some(connection);
+                None
+            }
+        })
+    }
+}
+
+/// Represents a `ClientHello` message received through the [`Acceptor`].
+///
+/// Contains the state required to resume the connection through
+/// [`Accepted::into_connection()`].
+pub struct Accepted {
+    // invariant: `connection.core.state` is `Err(_)` and requires restoring
+    connection: ConnectionCommon<ServerSide>,
+    choose_config: Box<ChooseConfig>,
+}
+
+impl Accepted {
+    /// Get the [`ClientHello`] for this connection.
+    pub fn client_hello(&self) -> ClientHello<'_> {
+        self.choose_config.client_hello()
+    }
+
+    /// Convert the [`Accepted`] into a [`ServerConnection`].
+    ///
+    /// Takes the state returned from [`Acceptor::accept()`], the [`ServerConfig`]
+    /// that should be used for the session, and the TLS-encoded QUIC transport
+    /// parameters to send. Returns an error if configuration-dependent validation
+    /// of the received `ClientHello` message fails.
+    pub fn into_connection(
+        mut self,
+        config: Arc<ServerConfig>,
+        params: Vec<u8>,
+    ) -> Result<ServerConnection, Error> {
+        check_server_config(&config)?;
+        self.connection
+            .core
+            .common
+            .send
+            .set_max_fragment_size(config.max_fragment_size)?;
+        self.connection.fips = config.fips();
+
+        let exts = ServerExtensionsInput {
+            transport_parameters: Some(match self.connection.quic.version {
+                Version::V1 | Version::V2 => TransportParameters::Quic(Payload::new(params)),
+            }),
+        };
+        let mut output = SideCommonOutput {
+            side: &mut self.connection.core.side,
+            quic: Some(&mut self.connection.quic),
+            common: &mut self.connection.core.common,
+        };
+
+        self.connection.core.state =
+            Ok(self
+                .choose_config
+                .use_config(config, exts, &mut output)?);
+
+        Ok(ServerConnection {
+            inner: self.connection,
+        })
+    }
+}
+
+impl Debug for Accepted {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("quic::Accepted")
             .finish_non_exhaustive()
     }
 }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -87,6 +87,7 @@ impl ClientConnection {
         params: Vec<u8>,
         alpn_protocols: Vec<ApplicationProtocol<'static>>,
     ) -> Result<Self, Error> {
+        let fips = config.fips();
         let suites = &config.provider().tls13_cipher_suites;
         if suites.is_empty() {
             return Err(ApiMisuse::QuicRequiresTls13Support.into());
@@ -121,8 +122,13 @@ impl ClientConnection {
         )?;
 
         Ok(Self {
-            inner: ConnectionCommon::new(inner, quic),
+            inner: ConnectionCommon::new(inner, fips, quic),
         })
+    }
+
+    /// Return the FIPS validation status of the connection.
+    pub fn fips(&self) -> FipsStatus {
+        self.inner.fips
     }
 
     /// Returns True if the server signalled it will process early data.
@@ -214,6 +220,7 @@ impl ServerConnection {
         params: Vec<u8>,
     ) -> Result<Self, Error> {
         check_server_config(&config)?;
+        let fips = config.fips();
 
         let exts = ServerExtensionsInput {
             transport_parameters: Some(match version {
@@ -224,12 +231,18 @@ impl ServerConnection {
         let core = ConnectionCore::for_server(config, exts, Protocol::Quic(version))?;
         let inner = ConnectionCommon::new(
             core,
+            fips,
             Quic {
                 version,
                 ..Quic::default()
             },
         );
         Ok(Self { inner })
+    }
+
+    /// Return the FIPS validation status of the connection.
+    pub fn fips(&self) -> FipsStatus {
+        self.inner.fips
     }
 
     /// Retrieves the server name, if any, used to select the certificate and
@@ -355,14 +368,16 @@ fn check_server_config(config: &ServerConfig) -> Result<(), Error> {
 /// A shared interface for QUIC connections.
 struct ConnectionCommon<Side: SideData> {
     core: ConnectionCore<Side>,
+    fips: FipsStatus,
     deframer_buffer: VecInput,
     quic: Quic,
 }
 
 impl<Side: SideData> ConnectionCommon<Side> {
-    fn new(core: ConnectionCore<Side>, quic: Quic) -> Self {
+    fn new(core: ConnectionCore<Side>, fips: FipsStatus, quic: Quic) -> Self {
         Self {
             core,
+            fips,
             deframer_buffer: VecInput::default(),
             quic,
         }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -213,21 +213,7 @@ impl ServerConnection {
         version: Version,
         params: Vec<u8>,
     ) -> Result<Self, Error> {
-        let suites = &config.provider.tls13_cipher_suites;
-        if suites.is_empty() {
-            return Err(ApiMisuse::QuicRequiresTls13Support.into());
-        }
-
-        if !suites
-            .iter()
-            .any(|scs| scs.quic.is_some())
-        {
-            return Err(ApiMisuse::NoQuicCompatibleCipherSuites.into());
-        }
-
-        if config.max_early_data_size != 0 && config.max_early_data_size != 0xffff_ffff {
-            return Err(ApiMisuse::QuicRestrictsMaxEarlyDataSize.into());
-        }
+        check_server_config(&config)?;
 
         let exts = ServerExtensionsInput {
             transport_parameters: Some(match version {
@@ -344,6 +330,26 @@ impl Debug for ServerConnection {
         f.debug_struct("quic::ServerConnection")
             .finish_non_exhaustive()
     }
+}
+
+fn check_server_config(config: &ServerConfig) -> Result<(), Error> {
+    let suites = &config.provider.tls13_cipher_suites;
+    if suites.is_empty() {
+        return Err(ApiMisuse::QuicRequiresTls13Support.into());
+    }
+
+    if !suites
+        .iter()
+        .any(|scs| scs.quic.is_some())
+    {
+        return Err(ApiMisuse::NoQuicCompatibleCipherSuites.into());
+    }
+
+    if config.max_early_data_size != 0 && config.max_early_data_size != 0xffff_ffff {
+        return Err(ApiMisuse::QuicRestrictsMaxEarlyDataSize.into());
+    }
+
+    Ok(())
 }
 
 /// A shared interface for QUIC connections.

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -1,4 +1,3 @@
-use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt::{Debug, Formatter};
@@ -20,7 +19,7 @@ use crate::crypto;
 use crate::crypto::cipher::Payload;
 use crate::error::{ApiMisuse, Error, ErrorWithAlert};
 use crate::log::trace;
-use crate::msgs::{ServerExtensionsInput, ServerNamePayload};
+use crate::msgs::ServerExtensionsInput;
 use crate::server::hs::{ChooseConfig, ExpectClientHello, ReadClientHello, ServerState};
 use crate::suites::ExtractedSecrets;
 use crate::sync::Arc;
@@ -423,14 +422,7 @@ pub struct Accepted {
 impl Accepted {
     /// Get the [`ClientHello`] for this connection.
     pub fn client_hello(&self) -> ClientHello<'_> {
-        let client_hello = self.choose_config.client_hello();
-        let server_name = client_hello
-            .server_name
-            .as_ref()
-            .and_then(ServerNamePayload::to_dns_name_normalized)
-            .map(Cow::Owned);
-
-        let ch = ClientHello::new(client_hello, None, server_name, None);
+        let ch = self.choose_config.client_hello();
         trace!("Accepted::client_hello(): {ch:#?}");
         ch
     }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -406,14 +406,22 @@ impl ChooseConfig {
             .with_input(ClientHelloInput::from_input(&self.client_hello)?, output)
     }
 
-    pub(crate) fn client_hello(&self) -> &ClientHelloPayload {
-        match &self.client_hello.message.payload {
+    pub(crate) fn client_hello(&self) -> ClientHello<'_> {
+        let client_hello = match &self.client_hello.message.payload {
             MessagePayload::Handshake { parsed, .. } => match &parsed.0 {
                 HandshakePayload::ClientHello(ch) => ch,
                 _ => unreachable!(),
             },
             _ => unreachable!(),
-        }
+        };
+
+        let server_name = client_hello
+            .server_name
+            .as_ref()
+            .and_then(ServerNamePayload::to_dns_name_normalized)
+            .map(Cow::Owned);
+
+        ClientHello::new(client_hello, None, server_name, None)
     }
 
     fn set_resumption_data(&mut self, resumption_data: &[u8]) -> Result<(), Error> {

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -30,7 +30,7 @@ pub use handy::ServerNameResolver;
 pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
 
 mod hs;
-pub(crate) use hs::ServerHandler;
+pub(crate) use hs::{ChooseConfig, ServerHandler, ServerState};
 
 mod tls12;
 pub(crate) use tls12::TLS12_HANDLER;


### PR DESCRIPTION
This adds a QUIC-compatible server `Acceptor` path.

The goal is to let QUIC integrations feed TLS handshake bytes into rustls until
`ClientHello` is available, inspect rustls' `ClientHello`, and then continue the
QUIC TLS session with a selected `ServerConfig`.

This keeps `ClientHello` parsing inside rustls. QUIC integrations remain
responsible for packet/CID/ACK handling and only use rustls to consume and
continue the QUIC TLS stream.

This is related to rustls/rustls#1218.

One boundary note: this PR intentionally keeps QUIC packet/CID/ACK handling out
of rustls.

The reason is that rustls only sees the QUIC TLS stream bytes. It does not own
the QUIC packet number spaces, connection IDs, peer path state, ACK generation,
anti-amplification accounting, or packet retransmission timers. Those are QUIC
transport responsibilities.

This matters for multi-packet ClientHello cases. A QUIC implementation using
this acceptor still needs to keep processing Initial packets and ACKing received
Initial packet numbers while waiting for enough CRYPTO data to expose
ClientHello. Rustls can report that more TLS bytes are needed, but it cannot
drive that transport state itself.

A Quinn-side prototype using this boundary is being discussed in
quinn-rs/quinn#2024.

So the intended split is:

- rustls: consume QUIC TLS stream bytes, expose ClientHello, continue the TLS
  session with the selected ServerConfig
- QUIC implementation: own packet/CID/ACK/timer state while feeding bytes into
  rustls

Tests cover:

- exposing `ClientHello` through the QUIC acceptor path
- continuing with a `ServerConfig` selected from `ClientHello`
- terminal read errors
- QUIC early-data size validation