### PR TITLE
Address new `std_instead_of_core` in nightly

### DIFF
--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1,6 +1,7 @@
 //! Tests around IO, buffering, and data management.
 
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
+#![allow(clippy::std_instead_of_core)] // awaits core::io::IoSlice in stable (1.98)
 
 use core::fmt::Debug;
 use std::borrow::Cow;

--- a/rustls-util/src/stream.rs
+++ b/rustls-util/src/stream.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::std_instead_of_core)] // awaits core::io::IoSlice in stable (1.98)
 use std::io::{BufRead, IoSlice, Read, Result, Write};
 
 use rustls::Connection;


### PR DESCRIPTION
previously #3053 #3036 https://github.com/rust-lang/rust-clippy/issues/13158