### PR TITLE
Delete duplicate `dangerous_extract_secrets()`

### DIFF
--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -78,12 +78,6 @@ impl ClientConnection {
         self.inner.core.is_early_data_accepted()
     }
 
-    /// Extract secrets, so they can be used when configuring kTLS, for example.
-    /// Should be used with care as it exposes secret key material.
-    pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.inner.dangerous_extract_secrets()
-    }
-
     /// Return the connection's Encrypted Client Hello (ECH) status.
     pub fn ech_status(&self) -> EchStatus {
         self.inner.core.side.ech_status

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -121,12 +121,6 @@ impl ServerConnection {
             None
         }
     }
-
-    /// Extract secrets, so they can be used when configuring kTLS, for example.
-    /// Should be used with care as it exposes secret key material.
-    pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
-        self.inner.dangerous_extract_secrets()
-    }
 }
 
 impl Connection for ServerConnection {


### PR DESCRIPTION
This is accessed via the `Connection` trait - see https://rustls.dev/docs/trait.Connection.html#tymethod.dangerous_extract_secrets