### PR TITLE
Remove redundant clones

### DIFF
--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -132,7 +132,7 @@ impl EchConfig {
     ) -> Result<EchState, Error> {
         EchState::new(
             self,
-            server_name.clone(),
+            server_name,
             protocol,
             !config
                 .resolver()

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -723,7 +723,7 @@ impl<'a> CertificatePayloadTls13<'a> {
                         .chain(iter::repeat(None)),
                 )
                 .map(|(cert, ocsp)| {
-                    let mut e = CertificateEntry::new(cert.clone());
+                    let mut e = CertificateEntry::new(cert);
                     if let Some(ocsp) = ocsp {
                         e.extensions.status = Some(CertificateStatus::new(ocsp));
                     }


### PR DESCRIPTION
If I am not overlooking anything, these clones can be safely removed since they aren't used anywhere else later.

CC @nunoplopes