### PR TITLE
Expose whether Extended Master Secret was negotiated

### DIFF
--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -824,6 +824,32 @@ fn test_tls13_exporter() {
 }
 
 #[test]
+fn test_extended_master_secret_reporting() {
+    // TLS 1.2: rustls always offers the Extended Master Secret extension, so a
+    // rustls<->rustls 1.2 handshake negotiates it and reports `Some(true)` on
+    // both ends.
+    let provider = provider::DEFAULT_TLS12_PROVIDER;
+    let client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    assert_eq!(client.extended_master_secret(), None);
+    assert_eq!(server.extended_master_secret(), None);
+    do_handshake(&mut client, &mut server);
+    assert_eq!(client.extended_master_secret(), Some(true));
+    assert_eq!(server.extended_master_secret(), Some(true));
+
+    // TLS 1.3 has no Extended Master Secret extension (the property is intrinsic
+    // to its key schedule), so it is reported as `None`.
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
+    let client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    do_handshake(&mut client, &mut server);
+    assert_eq!(client.extended_master_secret(), None);
+    assert_eq!(server.extended_master_secret(), None);
+}
+
+#[test]
 fn test_tls13_exporter_maximum_output_length() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let client_config = make_client_config(KeyType::EcdsaP256, &provider);

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1135,6 +1135,7 @@ impl ExpectFinished {
             .then(|| st.secrets.extract_secrets(Side::Client));
 
         output.output(OutputEvent::PeerIdentity(st.peer_identity));
+        output.output(OutputEvent::ExtendedMasterSecret(st.hs.using_ems));
         output.output(OutputEvent::Exporter(st.secrets.into_exporter()));
         output.start_traffic();
 

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -97,6 +97,7 @@ pub struct ConnectionOutputs {
     negotiated_kx_group: Option<&'static dyn SupportedKxGroup>,
     alpn_protocol: Option<ApplicationProtocol<'static>>,
     peer_identity: Option<Identity<'static>>,
+    extended_master_secret: Option<bool>,
     pub(crate) exporter: Option<Box<dyn Exporter>>,
     pub(crate) early_exporter: Option<Box<dyn Exporter>>,
 }
@@ -150,6 +151,17 @@ impl ConnectionOutputs {
         self.negotiated_version
     }
 
+    /// Whether the Extended Master Secret extension was negotiated.
+    ///
+    /// Returns:
+    /// - `None` until the handshake reaches the point where this is known.
+    /// - `None` for TLS 1.3, where the extension does not apply.
+    /// - `Some(true) for TLS 1.2 if the extension was negotiated.
+    /// - `Some(false) otherwise.
+    pub fn extended_master_secret(&self) -> Option<bool> {
+        self.extended_master_secret
+    }
+
     /// Which kind of handshake was performed.
     ///
     /// This tells you whether the handshake was a resumption or not.
@@ -183,6 +195,7 @@ impl ConnectionOutput for ConnectionOutputs {
             OutputEvent::CipherSuite(suite) => self.suite = Some(suite),
             OutputEvent::EarlyExporter(exporter) => self.early_exporter = Some(exporter),
             OutputEvent::Exporter(exporter) => self.exporter = Some(exporter),
+            OutputEvent::ExtendedMasterSecret(ems) => self.extended_master_secret = Some(ems),
             OutputEvent::HandshakeKind(hk) => {
                 assert!(self.handshake_kind.is_none());
                 self.handshake_kind = Some(hk);
@@ -278,6 +291,7 @@ pub(crate) enum OutputEvent<'a> {
     CipherSuite(SupportedCipherSuite),
     EarlyExporter(Box<dyn Exporter>),
     Exporter(Box<dyn Exporter>),
+    ExtendedMasterSecret(bool),
     HandshakeKind(HandshakeKind),
     KeyExchangeGroup(&'static dyn SupportedKxGroup),
     PeerIdentity(Identity<'static>),

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1041,6 +1041,7 @@ impl ExpectFinished {
                     .extract_secrets(Side::Server)
             });
 
+        output.output(OutputEvent::ExtendedMasterSecret(self.hs.using_ems));
         output.output(OutputEvent::Exporter(self.secrets.into_exporter()));
         output.start_traffic();
 


### PR DESCRIPTION
Adds `ConnectionOutputs::extended_master_secret() -> Option<bool>`, reporting whether the Extended Master Secret extension (RFC 7627) was negotiated.

A TLS exporter is only a sound channel binding (RFC 9266 tls-exporter) on TLS 1.3, or on TLS 1.2 with Extended Master Secret; without EMS the TLS 1.2 exporter is vulnerable to the triple-handshake attack.

Currently, rustls exposes the exporter and protocol_version(), but not EMS status, so a caller doing channel binding currently has no way to tell whether a TLS 1.2 exporter is safe to use.

See [this concrete use case in reqwest](https://github.com/seanmonstar/reqwest/pull/3048).