### PR TITLE
allow RUSTSEC-2026-0173, sync cargo-check-external-types nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -482,7 +482,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-10-18
+          toolchain: nightly-2026-03-20
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - name: Install cargo-check-external-types
         uses: taiki-e/cache-cargo-install-action@v3

--- a/deny.toml
+++ b/deny.toml
@@ -15,4 +15,5 @@ private = { ignore = true }
 [advisories]
 ignore = [
   "RUSTSEC-2024-0436", # Unmaintained paste via macro_rules_attributes; dev-dependency only
+  "RUSTSEC-2026-0173", # Unmaintained proc-macro-error2 via graviola -> libcrux; dev-dependency only
 ]


### PR DESCRIPTION
Ignores an audit CI finding, and updates the `cargo-check-external-types` toolchain. Both are causing failures in CI on `main` presently.

<details>
<summary>Audit finding:</summary>

```

error[unmaintained]: proc-macro-error2 is unmaintained
    ┌─ /github/workspace/Cargo.lock:178:1
    │
178 │ proc-macro-error2 2.0.1 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2026-0173
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0173
    ├ The author of `proc-macro-error2` has [confirmed](https://github.com/GnomedDev/proc-macro-error-2/issues/17#issuecomment-4643215473) that the crate is no longer maintained and recommends that users migrate away from it.
      
      `proc-macro-error2` was originally created as a maintained fork of [`proc-macro-error`](https://crates.io/crates/proc-macro-error) (see [RUSTSEC-2024-0370](https://rustsec.org/advisories/RUSTSEC-2024-0370)). Both the original crate and this fork are now unmaintained.
      
      ## Possible Alternative(s)
      
      - [manyhow](https://crates.io/crates/manyhow)
      - [proc-macro2-diagnostics](https://github.com/SergioBenitez/proc-macro2-diagnostics)
    ├ Announcement: https://github.com/GnomedDev/proc-macro-error-2/issues/17
    ├ Solution: No safe upgrade is available!
    ├ proc-macro-error2 v2.0.1
      └── hax-lib-macros v0.3.6
          └── hax-lib v0.3.6
              ├── core-models v0.0.5
              │   └── libcrux-intrinsics v0.0.6
              │       ├── libcrux-ml-kem v0.0.8
              │       │   └── rustls-graviola v0.3.4
              │       │       └── rustls-bench v0.1.0
              │       └── libcrux-sha3 v0.0.8
              │           └── libcrux-ml-kem v0.0.8 (*)
              ├── libcrux-intrinsics v0.0.6 (*)
              ├── libcrux-ml-kem v0.0.8 (*)
              ├── libcrux-secrets v0.0.5
              │   ├── libcrux-ml-kem v0.0.8 (*)
              │   └── libcrux-traits v0.0.6
              │       ├── libcrux-ml-kem v0.0.8 (*)
              │       └── libcrux-sha3 v0.0.8 (*)
              └── libcrux-sha3 v0.0.8 (*)

```
</details>

The libcrux crates have [fixed this upstream](https://github.com/cryspen/hax/pull/2039) but a release may not be available for [some time](https://github.com/cryspen/hax/issues/2037#issuecomment-4659039288). Ignore the unmaintained transitive dep warning for now.