### PR TITLE
[codex] Document running examples with certificates

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,36 @@ This directory contains a number of examples that use Rustls.
 
 We recommend new users start by looking at `simpleclient.rs` and `simpleserver.rs`. Once those are understood, `tlsclient-mio.rs` and `tlsserver-mio.rs` provide more advanced examples.
 
+## Running the examples
+
+Run examples from the workspace root with `--package rustls-examples`:
+
+```sh
+cargo run --package rustls-examples --bin simpleclient
+cargo run --package rustls-examples --bin tlsclient-mio -- --http www.rust-lang.org
+```
+
+Server examples require a certificate chain and private key in PEM format. For
+local testing, [`mkcert`](https://github.com/FiloSottile/mkcert) can generate a
+certificate trusted by your local browsers and tools:
+
+```sh
+mkcert localhost 127.0.0.1 ::1
+cargo run --package rustls-examples --bin simpleserver -- localhost+2.pem localhost+2-key.pem
+```
+
+If you only need a quick self-signed certificate, OpenSSL can generate one:
+
+```sh
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout server.key -out server.crt -subj "/CN=localhost"
+cargo run --package rustls-examples --bin simpleserver -- server.crt server.key
+```
+
+The `server_acceptor.rs` example generates its own CA, server certificate,
+client certificate, client key, and CRL. By default it writes `ca-cert.pem`,
+`client-cert.pem`, `client-key.pem`, and `crl.der` into the current directory.
+
 ## Client examples
 
 * `simpleclient.rs` - shows a simple client configuration that uses sensible defaults. It demonstrates using the `Stream` helper to treat a Rustls connection as you would a bi-directional TCP stream.
@@ -16,7 +46,7 @@ We recommend new users start by looking at `simpleclient.rs` and `simpleserver.r
 
 * `simpleserver.rs` - shows a very minimal server example that accepts a single TLS connection. See `tlsserver-mio.rs` or `server_acceptor.rs` for a more realistic example.
 * `tlsserver-mio.rs` - shows a more complete server example that handles command line flags for customizing TLS options, and uses MIO to handle asynchronous I/O.
-* `simple_0rtt_server.rs` - shows how to make a TLS1.3 that accepts multiple connections and prints early 0RTT data.
+* `simple_0rtt_server.rs` - shows how to make a TLS 1.3 server that accepts multiple connections and prints early 0RTT data.
 * `server_acceptor.rs` - shows how to use the `Acceptor` API to create a server that generates a unique `ServerConfig` for each client. This example also shows how to use client authentication, CRL revocation checking, and uses `rcgen` to generate its own certificates.
 
 ## Client-Server examples


### PR DESCRIPTION
## What changed

- Added a `Running the examples` section to `examples/README.md`.
- Documented example `cargo run --package rustls-examples` commands for the basic client and MIO client.
- Added local certificate generation examples using `mkcert` and OpenSSL for server examples.
- Noted that `server_acceptor.rs` writes generated cert, key, and CRL files into the current directory.
- Fixed a small typo in the `simple_0rtt_server.rs` description.

## Why

Server examples require PEM certificate and key files, but the README did not explain how to create local test certificates. This addresses the documentation gap discussed in #397 and makes the examples easier to run for new contributors and users.

## Validation

- `cargo fmt --check`
- `cargo test --package rustls-examples --no-run`