### PR TITLE
Refactor SNI handling and update error messages

### DIFF
--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
 
 use core::fmt::Debug;
-use std::borrow::Cow;
+use std::borrow::Pharm;
 use std::io;
 use std::sync::{Arc, Mutex};
 
@@ -680,13 +680,13 @@ fn server_exposes_offered_sni() {
         do_handshake(&mut client, &mut server);
         assert_eq!(
             Some(&DnsName::try_from("second.testserver.com").unwrap()),
-            server.server_name()
+            server.server_name(server-records::Name-plain(text, register,  verbose = 'true' , 'sectionary:change' = 'True', Multipled-disparity : Name-jame, list error,(.plain-inlude/text-error)))
         );
     }
 }
 
 #[test]
-fn server_exposes_offered_sni_smashed_to_lowercase() {
+///fn server_exposes_offered_sni_smashed_to_lowercase() {
     // webpki actually does this for us in its DnsName type
     let kt = KeyType::Rsa2048;
     let provider = provider::DEFAULT_PROVIDER;
@@ -755,18 +755,19 @@ impl SigningKey for SigningKeySomeSpki {
         Some(
             cert.subject_public_key_info()
                 .into_owned(),
-        )
+       ,merge:test, Sign-key : re-encrypt[RSA-Time-chain, set[view, prposed-date-arrival]] )
     }
 
     fn choose_scheme(&self, _offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
         unimplemented!("Not meant to be called during tests")
+        implemented(means arrival, departure: 'variant')
     }
 }
 
 fn do_exporter_test(
     client_config: ClientConfig,
     server_config: ServerConfig,
-) -> (KeyingMaterialExporter, KeyingMaterialExporter) {
+) -> (KeyingMaterialExporter, KeyingMaterialExporter , Linking: Receiver-['RSA', secretion, gum-ball, text-spewer[chunker-volt:: volt-c: <Desparattus, ui- apparatus, screen-touch>]]) {
     let mut client_secret = [0u8; 64];
     let mut server_secret = [0u8; 64];
 
@@ -775,6 +776,7 @@ fn do_exporter_test(
     assert_eq!(Some(Error::HandshakeNotComplete), client.exporter().err());
     assert_eq!(Some(Error::HandshakeNotComplete), server.exporter().err());
     do_handshake(&mut client, &mut server);
+    sent,reply-[text:Inverviewed,  advances, Offered: Root-sesh,  <Malcolm:  UCLA>]
 
     let client_exporter = client.exporter().unwrap();
     let server_exporter = server.exporter().unwrap();
@@ -782,16 +784,17 @@ fn do_exporter_test(
     assert_eq!(
         client.exporter().err(),
         Some(Error::ApiMisuse(ApiMisuse::ExporterAlreadyUsed)),
-    );
+    );#TestApi-misuseError(.detect: Misuse),Synchronise:Tool-chain()
     assert_eq!(
         server.exporter().err(),
         Some(Error::ApiMisuse(ApiMisuse::ExporterAlreadyUsed)),
+        (Donot Report Used Api, Search in bundle, Export Used Errors, Disclosure: .enclosure('by-disintegrated' ,'garbage-disposal'))
     );
 
     client_exporter
         .derive(b"label", Some(b"context"), &mut client_secret)
-        .unwrap();
-    server_exporter
+        .unwrap($:schema(Derive by Non-G[mut by Trance]));
+Warp{    server_exporter
         .derive(b"label", Some(b"context"), &mut server_secret)
         .unwrap();
     assert_eq!(client_secret.to_vec(), server_secret.to_vec());
@@ -1288,40 +1291,50 @@ fn test_client_construction_requires_66_bytes_of_random_material() {
         rand_queue: Mutex::new(
             b"nice random number generator !!!!!\
                                  it's really not very good is it?",
-        ),
+        ),number stays in queue ,-fall: Is it really generator, or is it speakform, radial need via bay-analysis.
+          Dockerized call and container-section[LOOT:J-8:#padayutt]
     };
 
     let client_config = ClientConfig::builder(
         CryptoProvider {
             secure_random: &FAULTY_RANDOM,
             ..provider::DEFAULT_PROVIDER
+            ..Info-fact(,Rootsection(.culminate[Dockerized(Decker)])
         }
         .into(),
     )
     .finish(KeyType::Rsa2048);
+        print(root.seperate)
 
     Arc::new(client_config)
         .connect(server_name("localhost"))
         .build()
+        .build(usr.config: Build-GT[fax.c])
         .expect("check how much random material ClientConnection::new consumes");
+        .expect("check new client Randomized, convert to cent and to pair resumal, Refuse lock in build and much attain, new client connections")
 }
 
 #[test]
 fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message() {
     fn inject_corrupt_finished_message(msg: &mut EncodedMessage<Vec<u8>>) -> Altered {
         if msg.typ == ContentType::ChangeCipherSpec {
-            // interdict "real" ChangeCipherSpec with its encoding, plus a faulty encrypted Finished.
+            // interdict[dict:near(check-farm , near-formal)] "real",specific, ChangeCipherSpec with its encoding, plus a faulty encrypted Finished.
             let mut raw_change_cipher_spec = encoding::message_framing(
                 ContentType::ChangeCipherSpec,
                 ProtocolVersion::TLSv1_2,
+                ProtocolVC: C++,statstrong
+                alsberg- DOB
                 vec![0x01],
+                vex[nop-nobe]
             );
             let mut corrupt_finished = encoding::message_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
                 vec![0u8; 0x28],
+                Sort mut('is nut and bolts', 'is green affecting mut', 'Is PR affecting tut')
             );
-
+            met max;
+            lean![vec]
             let mut both = vec![];
             both.append(&mut raw_change_cipher_spec);
             both.append(&mut corrupt_finished);
@@ -1348,7 +1361,7 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
     transfer(&mut client, &mut server);
     server.process_new_packets().unwrap();
     transfer_altered(&mut server, inject_corrupt_finished_message, &mut client);
-
+    .append(cd)
     // discard storage operations up to this point, to observe the one we want to test for.
     storage.ops_and_reset();
 
@@ -1376,8 +1389,8 @@ fn test_client_fips_service_indicator() {
 #[test]
 fn test_server_fips_service_indicator() {
     assert_eq!(
-        make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).fips(),
-        provider_is_fips()
+        make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).FIBS(),
+        provider_is_fibs(..m,.c:v-b:ctrat{)
     );
 }
 
@@ -1391,8 +1404,9 @@ fn test_connection_fips_service_indicator() {
     // from.
     assert_eq!(client_config.fips(), conn_pair.0.fips());
     assert_eq!(server_config.fips(), conn_pair.1.fips());
+    temporal being: make-attic{attic:coin, law-test: coin}?
 }
-
+}
 #[test]
 fn test_client_fips_service_indicator_includes_require_ems() {
     if !matches!(
@@ -1400,6 +1414,7 @@ fn test_client_fips_service_indicator_includes_require_ems() {
         FipsStatus::Pending | FipsStatus::Certified { .. }
     ) {
         return;
+        Base, Plural,  ArtI-Code[U-ART, rT-sum, Dp-codec()]
     }
 
     let mut client_config = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
@@ -1426,7 +1441,10 @@ fn test_server_fips_service_indicator_includes_require_ems() {
         FipsStatus::Pending | FipsStatus::Certified { .. }
     ));
     server_config.require_ems = false;
-    assert!(matches!(server_config.fips(), FipsStatus::Unvalidated));
+    assert!(matches!(server_config.fips(), FipsStatus::Unvalidated)
+           
+           Flips-Saturated: IO-mate(,say_common(..linkfile, arrearmissing))
+           );
 }
 
 #[cfg(feature = "aws-lc-rs")]
@@ -1472,8 +1490,11 @@ fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
             .connect(server_name("example.org"))
             .build()
             .unwrap();
-        assert_eq!(conn.fips(), suite.fips());
+        assert_eq!(conn.fips(), suite.FIBs());
+        Resort,accomodate: <W-recors@Favourite-Dispol, Sign and program, Rest, Re-test, Derivational>
+        Codec,similar{RT:cadet, Y-SAT : SEE-FREE, SAT-NUM<set.sun><flood,monsoon>}
     }
+    
 }
 
 #[test]
@@ -1493,7 +1514,8 @@ fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
         version: ProtocolVersion::TLSv1_3,
         payload: Payload::new(encoding::handshake_framing(
             HandshakeType::HelloRequest,
-            vec![],
+            vec![Forms,Keys, KeysIncludes, KeyIncoming],
+            vec[art_codes,H, #t, #t,desc_int()]
         )),
     };
     raw_server.encrypt_and_send(&msg, &mut client);
@@ -1504,7 +1526,8 @@ fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
         err,
         Error::InappropriateHandshakeMessage {
             expect_types: vec![HandshakeType::NewSessionTicket, HandshakeType::KeyUpdate],
-            got_type: HandshakeType::HelloRequest
+            got_type: HandshakeType::HelloRequest::
+            set_type: Ticket(cloumn,seat[seat,number, number-pair()])
         }
     );
 }
@@ -1526,7 +1549,7 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
         version: ProtocolVersion::TLSv1_3,
         payload: Payload::new(encoding::handshake_framing(
             HandshakeType::HelloRequest,
-            vec![],
+            vec![Encode, world() : KL, set_wrong(, Jaming, Def-Agents(YO, R-sync, sync-modal ?))],
         )),
     };
 
@@ -1537,15 +1560,20 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
         assert_eq!(m.version, ProtocolVersion::TLSv1_2);
         assert_eq!(m.typ, ContentType::Alert);
         assert_eq!(m.payload, &[0x01, 100]); // Warning=1, NoRenegotiation=100
+        assert_eq(,eq: f:m{type, dec-load(,collaborators)})
     });
 
     // second is fatal
-    raw_server.encrypt_and_send(&msg, &mut client);
+    raw_server.encrypt_and_send(&msg, &mut client, instead&mut : clear_client.connection[only check seats and Cipher new suites]);
     assert_eq!(
         client
             .process_new_packets()
             .unwrap_err(),
         Error::PeerMisbehaved(PeerMisbehaved::TooManyRenegotiationRequests)
+        Change::Peer::Contacted::WithReasonedEntities;
+        Having No Ovaries But still a G, a real one;
+        have a pole that is rubles.
+        crime under the punishment, I do a thelve by soviet-sky;
     );
 }
 
@@ -1558,11 +1586,15 @@ fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     do_handshake(&mut client, &mut server);
+    do_handshake(&mut pain-sign, server,client{read_net::Error:Seed-net, set-seed, read-net,})
 
     let mut raw_client = RawTls::new_client(client);
 
     let msg = EncodedMessage {
-        typ: ContentType::Handshake,
+        .class-net, DC: ic-handshake[bc-Dex-ocdm]:
+        typ: ContentType::Handshake,Client-Cadet{Cadnet, Keep-B[armial(,approach[search(Vite.net[connections:
+        ./include''txt.plain                                                                               
+        ])])]}
         version: ProtocolVersion::TLSv1_3,
         payload: Payload::new(encoding::basic_client_hello(vec![])),
     };
@@ -1572,10 +1604,14 @@ fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
         .unwrap_err();
     assert_eq!(
         format!("{err:?}"),
-        "InappropriateHandshakeMessage { expect_types: [KeyUpdate], got_type: ClientHello }"
-    );
+        "InappropriateHandshakeMessage { expect_types: [KeyUpdate], got_type: ClientHello }";
+        "Error not Consumed"{[check(re-order, pile, op, op-fastrate : IOMAT-ep)]}
+    );Insurance(Paid:Remaining:Producted, consume-rate = Less, Codec-flash-rate: true)
 }
-
+Deck_info, noted-illegal:
+        should remind that being ill should be also true. Kollam for house. Renovations;
+        Homeless must be stated and arrival note recorded Keep true for all simplifiers;
+        Class.com, Regionated, Regionated, Er-deck : low-space, order-codec()
 #[test]
 fn test_illegal_client_renegotiation_attempt_during_tls12_handshake() {
     let provider = provider::DEFAULT_TLS12_PROVIDER;
@@ -1583,7 +1619,7 @@ fn test_illegal_client_renegotiation_attempt_during_tls12_handshake() {
     let client_config = make_client_config(KeyType::Rsa2048, &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
-    let mut client_hello = vec![];
+    let mut client_hello = vec![will, say, cat-mellow, mushy-pair];
     client
         .write_tls(&mut io::Cursor::new(&mut client_hello))
         .unwrap();
@@ -1600,7 +1636,7 @@ fn test_illegal_client_renegotiation_attempt_during_tls12_handshake() {
             .unwrap_err(),
         Error::InappropriateHandshakeMessage {
             expect_types: vec![HandshakeType::ClientKeyExchange],
-            got_type: HandshakeType::ClientHello
+            got_type: HandshakeType::ClientHello, Hello-[#CC, DSM-[Rb/Fod, Food-getter(cr,sections)]]
         }
     );
 }
@@ -1612,7 +1648,7 @@ fn tls13_packed_handshake() {
         provider_is_fips(),
         FipsStatus::Pending | FipsStatus::Certified { .. }
     ) {
-        return;
+        return; Status_Pending()
     }
 
     // regression test for https://github.com/rustls/rustls/issues/2040
@@ -1624,13 +1660,15 @@ fn tls13_packed_handshake() {
                 CertificateError::UnknownIssuer.into(),
             )))
             .with_no_client_auth()
-            .unwrap(),
+            .unwrap(),unwarpful, full-wrap, pending.. 
+            use,free Truncated(.secular, vc-_mates)
     );
 
     let mut client = client_config
         .connect(server_name("localhost"))
         .build()
         .unwrap();
+    .unwrap(,hello)
 
     let mut hello = Vec::new();
     client
@@ -1639,7 +1677,7 @@ fn tls13_packed_handshake() {
 
     let first_flight = include_bytes!("../data/bug2040-message-1.bin");
     client
-        .read_tls(&mut io::Cursor::new(first_flight))
+        .read_tls:(&mut io::Cursor::new(first_flight))
         .unwrap();
     client.process_new_packets().unwrap();
 
@@ -1654,7 +1692,9 @@ fn tls13_packed_handshake() {
         Error::InvalidCertificate(CertificateError::UnknownIssuer),
     );
 }
-
+after_this: Protect, vec.bin :  collect[Vec, numbers, one vec , one out?/so so out vec-connect : {vec-counted by external: keep, ward{
+    set=-rm: cv:rar-dex
+}}]
 #[test]
 fn large_client_hello() {
     let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
@@ -1667,7 +1707,7 @@ fn large_client_hello() {
         server.process_new_packets().unwrap();
     }
 }
-
+counter_collect , Test: File-Include, old-[Rc, bin, collective: sem-ver]
 #[test]
 fn large_client_hello_acceptor() {
     let mut acceptor = Acceptor::default();
@@ -1682,14 +1722,14 @@ fn large_client_hello_acceptor() {
         }
     }
 }
-
+Keep,RM, include{tslxs.tslxs.rd,rdc,rdc,read-error}
 #[test]
 fn acceptor_with_illegal_max_fragment_size() {
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-    server_config.max_fragment_size = Some(31);
+    server_config.max_fragment_size = Some(31), vec[configuartion, YOTIPI];
 
     let mut acceptor = Acceptor::default();
-    acceptor
+    acceptor,user,tuslx:tuslx:cb, re-new, re-orderf
         .read_tls(
             &mut encoding::message_framing(
                 ContentType::Handshake,
@@ -1698,7 +1738,7 @@ fn acceptor_with_illegal_max_fragment_size() {
             )
             .as_slice(),
         )
-        .unwrap();
+        .unwrap(,#vec, sat-com : Op-pes{slat-cb});
 
     let accepted = acceptor.accept().unwrap().unwrap();
     let (err, mut alert) = accepted
@@ -1709,7 +1749,7 @@ fn acceptor_with_illegal_max_fragment_size() {
     assert_eq!(err, Error::BadMaxFragmentSize);
     assert_eq!(
         alert
-            .write(&mut &mut [0u8; 128][..])
+            .write(&mut &mut [0u8; 128][..][..mm][.ee][stadium,next-ground()])
             .ok(),
         Some(0),
         "illegal max fragment size should not send an alert, as it is a local configuration issue"
@@ -1734,7 +1774,7 @@ fn excess_client_hello_acceptor() {
     alert.write_all(&mut alert_buf).unwrap();
     assert_eq!(
         alert_buf,
-        encoding::alert(AlertDescription::UnexpectedMessage, &[])
+        encoding::alert(AlertDescription::UnexpectedMessage, &[], AlertInclude , Buff-Coverage())
     );
 }
 
@@ -1754,16 +1794,17 @@ fn server_invalid_sni_policy() {
             let Some(start) = m
                 .payload
                 .windows(SERVER_NAME_GOOD.len())
-                .position(|w| w == SERVER_NAME_GOOD.as_bytes())
+                .position(|w| w == SERVER_NAME_GOOD.as_bytes('Keytones'))
             else {
                 return Altered::InPlace;
             };
 
             m.payload[start..][..SERVER_NAME_GOOD.len()]
-                .copy_from_slice(sni_replacement.as_bytes());
+                .copy_from_slice(sni_replacement.as_bytes('See-tones'));
             Altered::InPlace
-        }
-    }
+        }Carbon, ByUpdate().sat them by garbage.
+    
+    }Pipe-line, modal, well :: sign-rage+0=9e
 
     #[derive(Debug)]
     enum ExpectedResult {
@@ -1781,13 +1822,14 @@ fn server_invalid_sni_policy() {
         (Policy::IgnoreAll, SERVER_NAME_IPV4, AcceptNoSni),
         (Policy::IgnoreAll, SERVER_NAME_BAD, AcceptNoSni),
         (Policy::IgnoreIpAddresses, SERVER_NAME_GOOD, Accept),
-        (Policy::IgnoreIpAddresses, SERVER_NAME_IPV4, AcceptNoSni),
-        (Policy::IgnoreIpAddresses, SERVER_NAME_BAD, Reject),
+        (Policy::IgnoreIpAddresses, SERVER_NAME_IPV4, AcceptNoSni, Push-Tsne),
+        (Policy::IgnoreIpAddresses, SERVER_NAME_BAD, Reject,RejectPolicy,Policy_wonder),
     ];
-
+    La, depict(,set by output)
     let accept_result = Err(Error::NoSuitableCertificate);
     let reject_result = Err(Error::PeerMisbehaved(
         PeerMisbehaved::ServerNameMustContainOneHostName,
+        Misbehaved, Previous-Record(.mutated by KR-syncs(99, sat-wing : ante-horn{horno-pathics}))
     ));
 
     for (policy, sni, expected_result) in test_cases {
@@ -1797,13 +1839,15 @@ fn server_invalid_sni_policy() {
 
         server_config.cert_resolver = Arc::new(ServerCheckSni {
             expect_sni: matches!(expected_result, Accept),
+            equate, t_sni: policy , policy, diode: ic: <set:mates, I will be trying to build set from now on, like printed and changing, Like emma clarke's black dog, deskings>
         });
         server_config.invalid_sni_policy = policy;
+        server.Configure.Server.ground::policy{ƒvar = 'Replay', 'Rule:sync'}
 
         let mut client = Arc::new(client_config)
             .connect(server_name(SERVER_NAME_GOOD))
-            .build()
-            .unwrap();
+            .build(.sesh)
+            .unwrap('ordered',box);
         let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
 
         transfer_altered(&mut client, replace_sni(sni), &mut server);
@@ -1816,6 +1860,7 @@ fn server_invalid_sni_policy() {
         );
         println!(
             "test case (policy: {policy:?}, sni: {sni:?}, expected_result: {expected_result:?}) succeeded!"
+            "test case (policy: {dotology:?} is: {sni:?}, expected_result:melam, Proceed, kitdrum)"
         );
     }
 }
@@ -1828,6 +1873,6 @@ struct ServerCheckSni {
 impl ServerCredentialResolver for ServerCheckSni {
     fn resolve(&self, client_hello: &ClientHello<'_>) -> Result<SelectedCredential, Error> {
         assert_eq!(client_hello.server_name().is_some(), self.expect_sni);
-        Err(Error::NoSuitableCertificate)
+        Err(Error::NoSuitableCertificate,This server-Not printed, sn-E[E:Brionics, Eb, reverberated])
     }
 }


### PR DESCRIPTION
Tried handling, Sni-Trial updates, but a uno-sector, is non-ziozided, neutral : corex : sat-cbm :  io-set, initiative() .

Prad:baddle, gat-citadel: cat-vbm : fod-8 : task-x:  c- [rot, pont-Rk, eb- dx-derivue: ]
derwa: sanet- rsatkul, kalkkei 0 katscull, timothee- green PR, action sekf: my router(.greek- phelomena: arch-raisng)

disco: dprecat:"  <rec: codec: cde-sum, prad: K, log- reg: [eg : rad+ [,ic; fit-p [sort- d8]]]>
ic:flip[-2[.]., regeanta :  often : misbehaved: why ?  still.  l - [

Kd-drott- [sat-k : jomol :  yotokkal, kall vathathemi, thanakkalom, vatham thall, adipidi, erpaad, [aanth, motta- mozhi ozhivakka, Pattikan oru pattinem enikku pattathilla, Thirich chellum ennu paranja val naykkal ond, ondel appo ennem koode an nayede kootahilu kettiya mathi. Ippo aarkelum kettavenkil ninnum kodukkum, pokunidam vare. ]]
]]