### PR TITLE
docs: fix unterminated code spans in extended_master_secret docs

### DIFF
--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -156,8 +156,8 @@ impl ConnectionOutputs {
     /// Returns:
     /// - `None` until the handshake reaches the point where this is known.
     /// - `None` for TLS 1.3, where the extension does not apply.
-    /// - `Some(true) for TLS 1.2 if the extension was negotiated.
-    /// - `Some(false) otherwise.
+    /// - `Some(true)` for TLS 1.2 if the extension was negotiated.
+    /// - `Some(false)` otherwise.
     pub fn extended_master_secret(&self) -> Option<bool> {
         self.extended_master_secret
     }


### PR DESCRIPTION
Doc-only fix in `rustls/src/common_state.rs`: the `Some(true)`/`Some(false)` bullets in the `extended_master_secret()` return docs open an inline code span with a backtick but never close it, so they mis-render on docs.rs. The `None` bullets above them are already correctly delimited. No code/behavior change.