### PR TITLE
Update FIPS information for rustls-aws-lc-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ mio = { version = "1", features = ["net", "os-poll"] }
 num-bigint = "0.4.4"
 once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }
 openssl = "0.10"
-pki-types = { package = "rustls-pki-types", version = "1.14", features = ["alloc"] }
+pki-types = { package = "rustls-pki-types", version = "1.15", features = ["alloc"] }
 rayon = "1.7"
 rcgen = { version = "0.14.4", features = ["pem", "aws_lc_rs"], default-features = false }
 regex = "1"

--- a/rustls-aws-lc-rs/src/lib.rs
+++ b/rustls-aws-lc-rs/src/lib.rs
@@ -2,9 +2,12 @@
 //!
 //! # aws-lc-rs FIPS approval status
 //!
-//! This is covered by [FIPS 140-3 certificate #4816][cert-4816].
-//! See [the security policy][policy-4816] for precisely which
+//! This is covered by [FIPS 140-3 certificate #5314][cert-5314].
+//! See [the security policy][policy-5314] for precisely which
 //! environments and functions this certificate covers.
+//!
+//! Prior versions of aws-lc-rs were covered by [FIPS 140-3 certificate #4816][cert-4816]
+//! (see [its security policy][policy-4816]).
 //!
 //! Later releases of aws-lc-rs may be covered by later certificates,
 //! or be pending certification.
@@ -14,7 +17,9 @@
 //!
 //! [`aws-lc-fips-sys`]: https://crates.io/crates/aws-lc-fips-sys
 //! [cert-4816]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816
+//! [cert-5314]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5314
 //! [policy-4816]: https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4816.pdf
+//! [policy-5314]: https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp5314.pdf
 
 #![no_std]
 #![warn(clippy::exhaustive_enums, clippy::exhaustive_structs, missing_docs)]
@@ -374,7 +379,9 @@ mod ring_shim {
 /// Are we in FIPS mode?
 fn fips() -> FipsStatus {
     match aws_lc_rs::try_fips_mode().is_ok() {
-        true => FipsStatus::Pending,
+        true => FipsStatus::certified(
+            "https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5314",
+        ),
         false => FipsStatus::Unvalidated,
     }
 }

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -2000,8 +2000,8 @@ pub mod macros {
                 true
             }
             #[allow(dead_code)]
-            const fn provider_is_fips() -> rustls::pki_types::FipsStatus {
-                rustls::pki_types::FipsStatus::Unvalidated
+            const fn provider_is_fips() -> bool {
+                false
             }
             #[allow(dead_code)]
             const ALL_VERSIONS: [rustls::crypto::CryptoProvider; 2] = [
@@ -2025,12 +2025,8 @@ pub mod macros {
                 false
             }
             #[allow(dead_code)]
-            const fn provider_is_fips() -> rustls::pki_types::FipsStatus {
-                if cfg!(feature = "fips") {
-                    rustls::pki_types::FipsStatus::Pending
-                } else {
-                    rustls::pki_types::FipsStatus::Unvalidated
-                }
+            const fn provider_is_fips() -> bool {
+                cfg!(feature = "fips")
             }
             #[allow(dead_code)]
             const ALL_VERSIONS: [rustls::crypto::CryptoProvider; 2] = [

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -986,7 +986,7 @@ fn test_ciphersuites() -> Vec<(ProtocolVersion, KeyType, CipherSuite)> {
         ),
     ];
 
-    if matches!(provider_is_fips(), FipsStatus::Unvalidated) {
+    if !provider_is_fips() {
         v.extend_from_slice(&[
             (
                 ProtocolVersion::TLSv1_3,
@@ -1107,11 +1107,7 @@ fn negotiated_ciphersuite_server_ignoring_client_preference() {
 }
 
 fn expected_kx_for_version(version: ProtocolVersion) -> NamedGroup {
-    let is_fips = matches!(
-        provider_is_fips(),
-        FipsStatus::Pending | FipsStatus::Certified { .. }
-    );
-    match (version, provider_is_aws_lc_rs(), is_fips) {
+    match (version, provider_is_aws_lc_rs(), provider_is_fips()) {
         (ProtocolVersion::TLSv1_3, true, _) => NamedGroup::X25519MLKEM768,
         (_, _, true) => NamedGroup::secp256r1,
         (_, _, _) => NamedGroup::X25519,
@@ -1367,18 +1363,26 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
 
 #[test]
 fn test_client_fips_service_indicator() {
-    assert_eq!(
-        make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).fips(),
-        provider_is_fips()
-    );
+    match make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).fips() {
+        FipsStatus::Pending | FipsStatus::Certified { .. } if provider_is_fips() => {}
+        FipsStatus::Unvalidated if !provider_is_fips() => {}
+        other => panic!(
+            "unexpected fips status {other:?} (expected fips={:?})",
+            provider_is_fips()
+        ),
+    }
 }
 
 #[test]
 fn test_server_fips_service_indicator() {
-    assert_eq!(
-        make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).fips(),
-        provider_is_fips()
-    );
+    match make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).fips() {
+        FipsStatus::Pending | FipsStatus::Certified { .. } if provider_is_fips() => {}
+        FipsStatus::Unvalidated if !provider_is_fips() => {}
+        other => panic!(
+            "unexpected fips status {other:?} (expected fips={:?})",
+            provider_is_fips()
+        ),
+    }
 }
 
 #[test]
@@ -1395,10 +1399,7 @@ fn test_connection_fips_service_indicator() {
 
 #[test]
 fn test_client_fips_service_indicator_includes_require_ems() {
-    if !matches!(
-        provider_is_fips(),
-        FipsStatus::Pending | FipsStatus::Certified { .. }
-    ) {
+    if !provider_is_fips() {
         return;
     }
 
@@ -1413,10 +1414,7 @@ fn test_client_fips_service_indicator_includes_require_ems() {
 
 #[test]
 fn test_server_fips_service_indicator_includes_require_ems() {
-    if !matches!(
-        provider_is_fips(),
-        FipsStatus::Pending | FipsStatus::Certified { .. }
-    ) {
+    if !provider_is_fips() {
         return;
     }
 
@@ -1432,10 +1430,7 @@ fn test_server_fips_service_indicator_includes_require_ems() {
 #[cfg(feature = "aws-lc-rs")]
 #[test]
 fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
-    if !matches!(
-        provider_is_fips(),
-        FipsStatus::Pending | FipsStatus::Certified { .. }
-    ) {
+    if !provider_is_fips() {
         return;
     }
 
@@ -1608,10 +1603,7 @@ fn test_illegal_client_renegotiation_attempt_during_tls12_handshake() {
 #[test]
 fn tls13_packed_handshake() {
     // transcript requires selection of X25519
-    if matches!(
-        provider_is_fips(),
-        FipsStatus::Pending | FipsStatus::Certified { .. }
-    ) {
+    if provider_is_fips() {
         return;
     }
 

--- a/rustls-test/tests/api/resume.rs
+++ b/rustls-test/tests/api/resume.rs
@@ -7,7 +7,6 @@ use std::fmt;
 use std::io::{Read, Write};
 use std::sync::Arc;
 
-use pki_types::FipsStatus;
 use rustls::client::Resumption;
 use rustls::crypto::kx::NamedGroup;
 use rustls::crypto::{CertificateIdentity, Identity};
@@ -164,11 +163,11 @@ fn resumption_combinations() {
 }
 
 fn expected_kx_for_version(version: ProtocolVersion) -> NamedGroup {
-    let is_fips = matches!(
+    match (
+        version,
+        super::provider_is_aws_lc_rs(),
         super::provider_is_fips(),
-        FipsStatus::Pending | FipsStatus::Certified { .. }
-    );
-    match (version, super::provider_is_aws_lc_rs(), is_fips) {
+    ) {
         (ProtocolVersion::TLSv1_3, true, _) => NamedGroup::X25519MLKEM768,
         (_, _, true) => NamedGroup::secp256r1,
         (_, _, _) => NamedGroup::X25519,


### PR DESCRIPTION
The first commit alone is going to be sensitive (in terms of correctness) to the actual version of aws-lc-fips-sys (see https://github.com/aws/aws-lc-rs/releases/tag/v1.17.1 for explanation.)

Pinning the aws-lc-rs version seems egregious at where we sit in the stack.

~~The second commit addresses that, but in a way which doesn't seem palatable. Probably the best way is to ask for an API for this information from `aws-lc-rs` -- thoughts?~~ -- see #3116 