### PR TITLE
Externalise output buffer

### DIFF
--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -1677,8 +1677,10 @@ impl<C: Connection> io::Read for OtherSession<'_, C> {
 }
 
 impl<C: Connection> io::Write for OtherSession<'_, C> {
-    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
-        unreachable!()
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        self.buffer.push(data.to_vec());
+        self.flush()?;
+        Ok(data.len())
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -167,35 +167,6 @@ fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
 }
 
 #[test]
-fn server_respects_buffer_limit_post_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-
-    // this test will vary in behaviour depending on the default suites
-    do_handshake(&mut client, &mut server);
-    server.set_buffer_limit(Some(48));
-
-    assert_eq!(
-        server
-            .writer()
-            .write(b"01234567890123456789")
-            .unwrap(),
-        20
-    );
-    assert_eq!(
-        server
-            .writer()
-            .write(b"01234567890123456789")
-            .unwrap(),
-        6
-    );
-
-    transfer(&mut server, &mut client);
-    client.process_new_packets().unwrap();
-
-    check_read(&mut client.reader(), b"01234567890123456789012345");
-}
-
-#[test]
 fn client_respects_buffer_limit_pre_handshake() {
     let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
 
@@ -245,34 +216,6 @@ fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
     server.process_new_packets().unwrap();
 
     check_read(&mut server.reader(), b"01234567890123456789012345678901");
-}
-
-#[test]
-fn client_respects_buffer_limit_post_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
-
-    do_handshake(&mut client, &mut server);
-    client.set_buffer_limit(Some(48));
-
-    assert_eq!(
-        client
-            .writer()
-            .write(b"01234567890123456789")
-            .unwrap(),
-        20
-    );
-    assert_eq!(
-        client
-            .writer()
-            .write(b"01234567890123456789")
-            .unwrap(),
-        6
-    );
-
-    transfer(&mut client, &mut server);
-    server.process_new_packets().unwrap();
-
-    check_read(&mut server.reader(), b"01234567890123456789012345");
 }
 
 #[test]

--- a/rustls-test/tests/api/split.rs
+++ b/rustls-test/tests/api/split.rs
@@ -56,10 +56,11 @@ fn split_pairwise() {
             .map(|kxg| kxg.name()),
     );
 
-    let flight = client_send.write(b"client to server".as_slice().into());
+    let mut flight = Vec::new();
+    client_send.write(b"client to server".as_slice().into(), &mut flight);
     server_recv = check_receive_all(
         server_recv,
-        single(flight),
+        flight,
         ExpectData {
             expected: b"client to server",
             then: ExpectReadMore,
@@ -67,10 +68,11 @@ fn split_pairwise() {
     )
     .unwrap();
 
-    let flight = server_send.write(b"server to client".as_slice().into());
+    let mut flight = Vec::new();
+    server_send.write(b"server to client".as_slice().into(), &mut flight);
     client_recv = check_receive_all(
         client_recv,
-        single(flight),
+        flight,
         ExpectData {
             expected: b"server to client",
             then: ExpectReadMore,
@@ -78,8 +80,13 @@ fn split_pairwise() {
     )
     .unwrap();
 
-    check_receive_all(server_recv, single(client_send.close()), ExpectCloseNotify);
-    check_receive_all(client_recv, single(server_send.close()), ExpectCloseNotify);
+    let mut flight = Vec::new();
+    client_send.close(&mut flight);
+    check_receive_all(server_recv, flight, ExpectCloseNotify);
+
+    let mut flight = Vec::new();
+    server_send.close(&mut flight);
+    check_receive_all(client_recv, flight, ExpectCloseNotify);
 }
 
 #[test]
@@ -99,8 +106,8 @@ fn split_incremental() {
         outputs: _,
     } = server.split().unwrap();
 
-    let flight = client_send.write(b"client to server".as_slice().into());
-    let flight = single(flight);
+    let mut flight = Vec::new();
+    client_send.write(b"client to server".as_slice().into(), &mut flight);
 
     // messages are not consumed until they are fully provided.
     for ll in 1..flight.len() - 1 {
@@ -182,32 +189,36 @@ fn key_update() {
         ..
     } = server.split().unwrap();
 
+    let mut flight = Vec::new();
     client_send
-        .refresh_traffic_keys()
+        .refresh_traffic_keys(&mut flight)
         .unwrap();
+    client_send.take_data(&mut flight);
     server_recv = check_receive_all(
         server_recv,
-        single(client_send.take_data()),
+        flight,
         ExpectFlushSender {
             then: ExpectReadMore,
         },
     )
     .unwrap();
 
-    let flight = server_send.write(b"server to client".as_slice().into());
+    let mut flight = Vec::new();
+    server_send.write(b"server to client".as_slice().into(), &mut flight);
     check_receive_all(
         client_recv,
-        flight.concat(),
+        flight,
         ExpectData {
             expected: b"server to client",
             then: ExpectReadMore,
         },
     );
 
-    let flight = client_send.write(b"client to server".as_slice().into());
+    let mut flight = Vec::new();
+    client_send.write(b"client to server".as_slice().into(), &mut flight);
     check_receive_all(
         server_recv,
-        single(flight),
+        flight,
         ExpectData {
             expected: b"client to server",
             then: ExpectReadMore,
@@ -232,13 +243,14 @@ fn key_update_alongside_data() {
 
     // arrange a flight that contains a key-update followed by application data.
     // both the application data and `FlushSender` should be emitted.
+    let mut flight = Vec::new();
     client_send
-        .refresh_traffic_keys()
+        .refresh_traffic_keys(&mut flight)
         .unwrap();
-    let flight = client_send.write(b"client to server".as_slice().into());
+    client_send.write(b"client to server".as_slice().into(), &mut flight);
     check_receive_all(
         server_recv,
-        flight.concat(),
+        flight,
         ExpectData {
             expected: b"client to server",
             then: ExpectFlushSender {
@@ -263,9 +275,9 @@ fn close_alongside_data() {
         ..
     } = server.split().unwrap();
 
-    let mut flight = client_send.write(b"client to server".as_slice().into());
-    flight.extend(client_send.close());
-    let mut flight = flight.concat();
+    let mut flight = Vec::new();
+    client_send.write(b"client to server".as_slice().into(), &mut flight);
+    client_send.close(&mut flight);
     flight.extend(b"rubbish");
 
     // receive of appdata does not consume subsequent data
@@ -404,10 +416,4 @@ impl ConsumeReceiveState for ExpectCloseNotify {
             other => panic!("unexpected state for ExpectCloseNotify: got {other:?}"),
         }
     }
-}
-
-#[track_caller]
-fn single(mut flight: Vec<Vec<u8>>) -> Vec<u8> {
-    assert_eq!(flight.len(), 1);
-    flight.remove(0)
 }

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -13,7 +13,7 @@ use crate::conn::private::SideOutput;
 use crate::conn::split::SplitConnection;
 use crate::conn::{
     Connection, ConnectionCommon, ConnectionCore, IoState, KeyingMaterialExporter, Reader,
-    SideCommonOutput, SideData, Writer,
+    SendContext, SideCommonOutput, SideData, Writer,
 };
 #[cfg(doc)]
 use crate::crypto;
@@ -111,7 +111,9 @@ impl ClientConnection {
             .check_write(data.len())
             .map(|sz| {
                 self.inner
-                    .send
+                    .core
+                    .common
+                    .send_context()
                     .send_early_plaintext(&data[..sz])
             })
     }
@@ -310,7 +312,12 @@ impl ConnectionCore<ClientSide> {
         let mut output = SideCommonOutput {
             side: &mut data,
             quic,
-            common: &mut common_state,
+            send: SendContext {
+                send: &mut common_state.send,
+                sendable_tls: &mut common_state.sendable_tls,
+            },
+            recv: &mut common_state.recv,
+            outputs: &mut common_state.outputs,
         };
 
         let input = ClientHelloInput::new(name, &extra_exts, protocol, &mut output, config)?;

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -6,7 +6,7 @@ use core::ops::{Deref, DerefMut, Range};
 use pki_types::{DnsName, FipsStatus};
 
 use crate::client::EchStatus;
-use crate::conn::{DEFAULT_BUFFER_LIMIT, Exporter, ReceivePath, SendContext, SendOutput, SendPath};
+use crate::conn::{Exporter, ReceivePath, SendContext, SendOutput, SendPath};
 use crate::crypto::Identity;
 use crate::crypto::cipher::Payload;
 use crate::crypto::kx::SupportedKxGroup;
@@ -18,13 +18,12 @@ use crate::msgs::{
 };
 use crate::quic::{self, QuicOutput};
 use crate::suites::SupportedCipherSuite;
-use crate::vecbuf::ChunkVecBuffer;
 
 /// Connection state common to both client and server connections.
 pub struct CommonState {
     pub(crate) outputs: ConnectionOutputs,
     pub(crate) send: SendPath,
-    pub(crate) sendable_tls: ChunkVecBuffer,
+    pub(crate) sendable_tls: Vec<u8>,
     pub(crate) recv: ReceivePath,
     pub(crate) fips: FipsStatus,
 }
@@ -34,7 +33,7 @@ impl CommonState {
         Self {
             outputs: ConnectionOutputs::default(),
             send: SendPath::default(),
-            sendable_tls: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
+            sendable_tls: Vec::new(),
             recv: ReceivePath::new(side),
             fips,
         }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -6,7 +6,7 @@ use core::ops::{Deref, DerefMut, Range};
 use pki_types::{DnsName, FipsStatus};
 
 use crate::client::EchStatus;
-use crate::conn::{Exporter, ReceivePath, SendOutput, SendPath};
+use crate::conn::{DEFAULT_BUFFER_LIMIT, Exporter, ReceivePath, SendContext, SendOutput, SendPath};
 use crate::crypto::Identity;
 use crate::crypto::cipher::Payload;
 use crate::crypto::kx::SupportedKxGroup;
@@ -18,11 +18,13 @@ use crate::msgs::{
 };
 use crate::quic::{self, QuicOutput};
 use crate::suites::SupportedCipherSuite;
+use crate::vecbuf::ChunkVecBuffer;
 
 /// Connection state common to both client and server connections.
 pub struct CommonState {
     pub(crate) outputs: ConnectionOutputs,
     pub(crate) send: SendPath,
+    pub(crate) sendable_tls: ChunkVecBuffer,
     pub(crate) recv: ReceivePath,
     pub(crate) fips: FipsStatus,
 }
@@ -32,8 +34,17 @@ impl CommonState {
         Self {
             outputs: ConnectionOutputs::default(),
             send: SendPath::default(),
+            sendable_tls: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
             recv: ReceivePath::new(side),
             fips,
+        }
+    }
+
+    /// Pair the [`SendPath`] with its output buffer for an emit operation.
+    pub(crate) fn send_context(&mut self) -> SendContext<'_> {
+        SendContext {
+            send: &mut self.send,
+            sendable_tls: &mut self.sendable_tls,
         }
     }
 
@@ -41,7 +52,7 @@ impl CommonState {
     ///
     /// [`Connection::write_tls`]: crate::Connection::write_tls
     pub fn wants_write(&self) -> bool {
-        !self.send.sendable_tls.is_empty()
+        !self.sendable_tls.is_empty()
     }
 
     /// Queues a `close_notify` warning alert to be sent in the next
@@ -52,7 +63,7 @@ impl CommonState {
     ///
     /// [`Connection::write_tls`]: crate::Connection::write_tls
     pub fn send_close_notify(&mut self) {
-        self.send.send_close_notify()
+        self.send_context().send_close_notify()
     }
 
     /// Returns true if the connection is currently performing the TLS handshake.

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -684,10 +684,13 @@ impl<Side: SideData> ConnectionCommon<Side> {
     }
 
     pub(crate) fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
+        // extremely inefficient!
+        let len = wr.write(&self.core.common.sendable_tls)?;
         self.core
             .common
             .sendable_tls
-            .write_to(wr)
+            .drain(..len);
+        Ok(len)
     }
 }
 

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -29,8 +29,7 @@ use receive::JoinOutput;
 pub(crate) use receive::{Input, ReceivePath, TrafficTemperCounters};
 
 mod send;
-use send::DEFAULT_BUFFER_LIMIT;
-pub(crate) use send::{SendOutput, SendPath};
+pub(crate) use send::{DEFAULT_BUFFER_LIMIT, SendContext, SendOutput, SendPath};
 
 pub(crate) mod split;
 use split::SplitConnection;
@@ -393,9 +392,12 @@ impl<Side: SideData> PlaintextSink for ConnectionCommon<Side> {
         let len = self
             .core
             .common
-            .send
+            .send_context()
             .buffer_plaintext(buf.into(), &mut self.buffers.sendable_plaintext);
-        self.send.maybe_refresh_traffic_keys();
+        self.core
+            .common
+            .send_context()
+            .maybe_refresh_traffic_keys();
         Ok(len)
     }
 
@@ -416,9 +418,12 @@ impl<Side: SideData> PlaintextSink for ConnectionCommon<Side> {
         let len = self
             .core
             .common
-            .send
+            .send_context()
             .buffer_plaintext(payload, &mut self.buffers.sendable_plaintext);
-        self.send.maybe_refresh_traffic_keys();
+        self.core
+            .common
+            .send_context()
+            .maybe_refresh_traffic_keys();
         Ok(len)
     }
 
@@ -563,7 +568,7 @@ impl<Side: SideData> ConnectionCommon<Side> {
         {
             self.core
                 .common
-                .send
+                .send_context()
                 .send_buffered_plaintext(&mut self.buffers.sendable_plaintext);
         }
 
@@ -581,7 +586,7 @@ impl<Side: SideData> ConnectionCommon<Side> {
             .received_plaintext
             .is_empty()
             && !self.recv.has_received_close_notify
-            && (self.send.may_send_application_data || self.send.sendable_tls.is_empty())
+            && (self.send.may_send_application_data || self.sendable_tls.is_empty())
     }
 
     pub(crate) fn exporter(&mut self) -> Result<KeyingMaterialExporter, Error> {
@@ -598,7 +603,7 @@ impl<Side: SideData> ConnectionCommon<Side> {
         self.buffers
             .sendable_plaintext
             .set_limit(limit);
-        self.send.sendable_tls.set_limit(limit);
+        self.sendable_tls.set_limit(limit);
     }
 
     pub(crate) fn set_plaintext_buffer_limit(&mut self, limit: Option<usize>) {
@@ -610,14 +615,14 @@ impl<Side: SideData> ConnectionCommon<Side> {
     pub(crate) fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
         self.core
             .common
-            .send
+            .send_context()
             .refresh_traffic_keys()
     }
 
     pub(crate) fn current_io_state(&self) -> IoState {
         let common_state = &self.core.common;
         IoState {
-            tls_bytes_to_write: common_state.send.sendable_tls.len(),
+            tls_bytes_to_write: common_state.sendable_tls.len(),
             plaintext_bytes_to_read: self.buffers.received_plaintext.len(),
             peer_has_closed: common_state
                 .recv
@@ -680,7 +685,10 @@ impl<Side: SideData> ConnectionCommon<Side> {
     }
 
     pub(crate) fn write_tls(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
-        self.send.sendable_tls.write_to(wr)
+        self.core
+            .common
+            .sendable_tls
+            .write_to(wr)
     }
 }
 
@@ -783,10 +791,14 @@ impl<Side: SideData> ConnectionCore<Side> {
         buffer: &mut dyn TlsInputBuffer,
         quic: Option<&'a mut dyn QuicOutput>,
     ) -> Result<Option<UnborrowedPayload>, Error> {
+        let mut send = SendContext {
+            send: &mut self.common.send,
+            sendable_tls: &mut self.common.sendable_tls,
+        };
         let mut output = JoinOutput {
             outputs: &mut self.common.outputs,
             quic,
-            send: &mut self.common.send,
+            send: &mut send,
             side: &mut self.side,
         };
 
@@ -807,6 +819,9 @@ impl<Side: SideData> ConnectionCore<Side> {
         if self.common.is_handshaking() {
             return Err(Error::HandshakeNotComplete);
         }
+        if !self.common.sendable_tls.is_empty() {
+            return Err(ApiMisuse::SecretExtractionWithPendingSendableData.into());
+        }
         Self::from_parts_into_kernel_connection(
             &mut self.common.send,
             self.common.recv,
@@ -821,10 +836,6 @@ impl<Side: SideData> ConnectionCore<Side> {
         outputs: ConnectionOutputs,
         state: Side::State,
     ) -> Result<(ExtractedSecrets, KernelConnection<Side>), Error> {
-        if !send.sendable_tls.is_empty() {
-            return Err(ApiMisuse::SecretExtractionWithPendingSendableData.into());
-        }
-
         let read_seq = recv.decrypt_state.read_seq();
         let write_seq = send.encrypt_state.write_seq();
 
@@ -872,7 +883,12 @@ impl ConnectionCore<ServerSide> {
         let mut output = SideCommonOutput {
             side: &mut self.side,
             quic,
-            common: &mut self.common,
+            send: SendContext {
+                send: &mut self.common.send,
+                sendable_tls: &mut self.common.sendable_tls,
+            },
+            recv: &mut self.common.recv,
+            outputs: &mut self.common.outputs,
         };
 
         self.state = Ok(choose.use_config(config, exts, &mut output)?);
@@ -883,7 +899,9 @@ impl ConnectionCore<ServerSide> {
 pub(crate) struct SideCommonOutput<'a, 'q> {
     pub(crate) side: &'a mut dyn SideOutput,
     pub(crate) quic: Option<&'q mut dyn QuicOutput>,
-    pub(crate) common: &'a mut CommonState,
+    pub(crate) send: SendContext<'a>,
+    pub(crate) recv: &'a mut ReceivePath,
+    pub(crate) outputs: &'a mut ConnectionOutputs,
 }
 
 impl<'q> Output<'_> for SideCommonOutput<'_, 'q> {
@@ -893,19 +911,16 @@ impl<'q> Output<'_> for SideCommonOutput<'_, 'q> {
 
     fn output(&mut self, ev: OutputEvent<'_>) {
         if let OutputEvent::ProtocolVersion(ver) = ev {
-            self.common.recv.negotiated_version = Some(ver);
-            self.common.send.negotiated_version(ver);
+            self.recv.negotiated_version = Some(ver);
+            self.send.negotiated_version(ver);
         }
-        self.common.outputs.handle(ev);
+        self.outputs.handle(ev);
     }
 
     fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool) {
         match self.quic() {
             Some(quic) => quic.send_msg(m, must_encrypt),
-            None => self
-                .common
-                .send
-                .send_msg(m, must_encrypt),
+            None => self.send.send_msg(m, must_encrypt),
         }
     }
 
@@ -917,20 +932,16 @@ impl<'q> Output<'_> for SideCommonOutput<'_, 'q> {
     }
 
     fn start_traffic(&mut self) {
-        self.common
-            .recv
-            .may_receive_application_data = true;
-        self.common
-            .send
-            .start_outgoing_traffic();
+        self.recv.may_receive_application_data = true;
+        self.send.send.start_outgoing_traffic();
     }
 
     fn receive(&mut self) -> &mut ReceivePath {
-        &mut self.common.recv
+        self.recv
     }
 
     fn send(&mut self) -> &mut dyn SendOutput {
-        &mut self.common.send
+        &mut self.send
     }
 }
 

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -603,7 +603,6 @@ impl<Side: SideData> ConnectionCommon<Side> {
         self.buffers
             .sendable_plaintext
             .set_limit(limit);
-        self.sendable_tls.set_limit(limit);
     }
 
     pub(crate) fn set_plaintext_buffer_limit(&mut self, limit: Option<usize>) {

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -73,7 +73,7 @@ impl ReceivePath {
         &mut self,
         input: &'m mut dyn TlsInputBuffer,
         state: &mut Result<Side::State, Error>,
-        output: &mut JoinOutput<'a>,
+        output: &mut JoinOutput<'a, '_>,
     ) -> Result<Option<UnborrowedPayload>, Error> {
         let mut st = match mem::replace(state, Err(Error::HandshakeNotComplete)) {
             Ok(state) => state,
@@ -445,9 +445,9 @@ impl ReceivePath {
     }
 }
 
-struct CaptureAppData<'a, 'j, 'm> {
+struct CaptureAppData<'a, 'j, 's, 'm> {
     recv: &'a mut ReceivePath,
-    other: &'a mut JoinOutput<'j>,
+    other: &'a mut JoinOutput<'j, 's>,
     /// Store a [`Locator`] initialized from the current receive buffer
     ///
     /// Allows received plaintext data to be unborrowed and stored in
@@ -463,7 +463,7 @@ struct CaptureAppData<'a, 'j, 'm> {
     _message_lifetime: PhantomData<&'m ()>,
 }
 
-impl<'m> Output<'m> for CaptureAppData<'_, '_, 'm> {
+impl<'m> Output<'m> for CaptureAppData<'_, '_, '_, 'm> {
     fn emit(&mut self, ev: Event<'_>) {
         self.other.side.emit(ev)
     }
@@ -520,10 +520,10 @@ impl<'m> Output<'m> for CaptureAppData<'_, '_, 'm> {
     }
 }
 
-pub(super) struct JoinOutput<'a> {
+pub(super) struct JoinOutput<'a, 's> {
     pub(super) outputs: &'a mut dyn ConnectionOutput,
     pub(super) quic: Option<&'a mut dyn QuicOutput>,
-    pub(super) send: &'a mut dyn SendOutput,
+    pub(super) send: &'s mut dyn SendOutput,
     pub(super) side: &'a mut dyn SideOutput,
 }
 

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -65,17 +65,12 @@ impl SendContext<'_> {
     pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
         debug_assert!(self.send.encrypt_state.is_encrypting());
 
-        // Limit on `sendable_tls` should apply to encrypted data but is enforced
-        // for plaintext data instead which does not include cipher+record overhead.
-        let len = self
-            .sendable_tls
-            .apply_limit(data.len());
-        if len == 0 {
+        if data.is_empty() {
             // Don't send empty fragments.
             return 0;
         }
 
-        self.send_appdata_encrypt(data[..len].into())
+        self.send_appdata_encrypt(data.into())
     }
 
     pub(crate) fn send_close_notify(&mut self) {
@@ -183,18 +178,13 @@ impl SendContext<'_> {
             return sendable_plaintext.append_limited_copy(payload);
         }
 
-        // Limit on `sendable_tls` should apply to encrypted data but is enforced
-        // for plaintext data instead which does not include cipher+record overhead.
-        let len = self
-            .sendable_tls
-            .apply_limit(payload.len());
-        if len == 0 {
+        if payload.is_empty() {
             // Don't send empty fragments.
             return 0;
         }
 
         debug_assert!(self.send.encrypt_state.is_encrypting());
-        self.send_appdata_encrypt(payload.split_at(len).0)
+        self.send_appdata_encrypt(payload)
     }
 
     pub(crate) fn send_buffered_plaintext(&mut self, plaintext: &mut ChunkVecBuffer) {

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -20,7 +20,6 @@ pub(crate) struct SendPath {
     /// If we signaled end of stream.
     pub(crate) has_sent_close_notify: bool,
     message_fragmenter: MessageFragmenter,
-    pub(crate) sendable_tls: ChunkVecBuffer,
     queued_key_update_message: Option<Vec<u8>>,
     pub(crate) refresh_traffic_keys_pending: bool,
     negotiated_version: Option<ProtocolVersion>,
@@ -28,8 +27,43 @@ pub(crate) struct SendPath {
 }
 
 impl SendPath {
-    pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
+    pub(crate) fn start_outgoing_traffic(&mut self) {
+        self.may_send_application_data = true;
         debug_assert!(self.encrypt_state.is_encrypting());
+    }
+
+    pub(crate) fn set_max_fragment_size(&mut self, new: Option<usize>) -> Result<(), Error> {
+        self.message_fragmenter
+            .set_max_fragment_size(new)
+    }
+}
+
+impl Default for SendPath {
+    fn default() -> Self {
+        Self {
+            encrypt_state: EncryptionState::new(),
+            may_send_application_data: false,
+            may_send_half_rtt_data: false,
+            has_sent_fatal_alert: false,
+            has_sent_close_notify: false,
+            message_fragmenter: MessageFragmenter::default(),
+            queued_key_update_message: None,
+            refresh_traffic_keys_pending: false,
+            negotiated_version: None,
+            tls13_key_schedule: None,
+        }
+    }
+}
+
+/// Pairs a [`SendPath`] with the buffer it emits encoded TLS records into.
+pub(crate) struct SendContext<'a> {
+    pub(crate) send: &'a mut SendPath,
+    pub(crate) sendable_tls: &'a mut ChunkVecBuffer,
+}
+
+impl SendContext<'_> {
+    pub(crate) fn send_early_plaintext(&mut self, data: &[u8]) -> usize {
+        debug_assert!(self.send.encrypt_state.is_encrypting());
 
         // Limit on `sendable_tls` should apply to encrypted data but is enforced
         // for plaintext data instead which does not include cipher+record overhead.
@@ -45,23 +79,23 @@ impl SendPath {
     }
 
     pub(crate) fn send_close_notify(&mut self) {
-        if self.has_sent_close_notify {
+        if self.send.has_sent_close_notify {
             return;
         }
         debug!("Sending warning alert {:?}", AlertDescription::CloseNotify);
-        self.has_sent_close_notify = true;
+        self.send.has_sent_close_notify = true;
         self.send_alert(AlertLevel::Warning, AlertDescription::CloseNotify);
     }
 
     pub(crate) fn send_alert(&mut self, level: AlertLevel, desc: AlertDescription) {
         match level {
-            AlertLevel::Fatal if self.has_sent_fatal_alert => return,
-            AlertLevel::Fatal => self.has_sent_fatal_alert = true,
+            AlertLevel::Fatal if self.send.has_sent_fatal_alert => return,
+            AlertLevel::Fatal => self.send.has_sent_fatal_alert = true,
             _ => {}
         };
         self.send_msg(
             Message::build_alert(level, desc),
-            self.encrypt_state.is_encrypting(),
+            self.send.encrypt_state.is_encrypting(),
         );
     }
 
@@ -69,7 +103,8 @@ impl SendPath {
     pub(crate) fn send_appdata_encrypt(&mut self, payload: OutboundPlain<'_>) -> usize {
         let len = payload.len();
         self.send_messages(
-            self.message_fragmenter
+            self.send
+                .message_fragmenter
                 .fragment_payload(
                     ContentType::ApplicationData,
                     ProtocolVersion::TLSv1_2,
@@ -92,7 +127,8 @@ impl SendPath {
 
             self.perhaps_write_key_update();
             self.sendable_tls.append(
-                self.encrypt_state
+                self.send
+                    .encrypt_state
                     .encrypt_outgoing(m)
                     .encode(),
             );
@@ -101,6 +137,7 @@ impl SendPath {
 
     fn preflight_encrypt(&mut self, n: usize) -> Result<(), Error> {
         match self
+            .send
             .encrypt_state
             .pre_encrypt_action(n as u64)
         {
@@ -108,10 +145,10 @@ impl SendPath {
 
             // Close connection once we start to run out of sequence space.
             Some(PreEncryptAction::RefreshOrClose) => {
-                match self.negotiated_version {
+                match self.send.negotiated_version {
                     // driven by caller, as we don't have the `State` here
                     Some(ProtocolVersion::TLSv1_3) => {
-                        self.refresh_traffic_keys_pending = true;
+                        self.send.refresh_traffic_keys_pending = true;
                         Ok(())
                     }
                     _ => {
@@ -140,7 +177,7 @@ impl SendPath {
         sendable_plaintext: &mut ChunkVecBuffer,
     ) -> usize {
         self.perhaps_write_key_update();
-        if !self.may_send_application_data {
+        if !self.send.may_send_application_data {
             // If we haven't completed handshaking, buffer
             // plaintext to send once we do.
             return sendable_plaintext.append_limited_copy(payload);
@@ -156,7 +193,7 @@ impl SendPath {
             return 0;
         }
 
-        debug_assert!(self.encrypt_state.is_encrypting());
+        debug_assert!(self.send.encrypt_state.is_encrypting());
         self.send_appdata_encrypt(payload.split_at(len).0)
     }
 
@@ -166,64 +203,63 @@ impl SendPath {
         }
     }
 
-    pub(crate) fn start_outgoing_traffic(&mut self) {
-        self.may_send_application_data = true;
-        debug_assert!(self.encrypt_state.is_encrypting());
-    }
-
     fn perhaps_write_key_update(&mut self) {
-        if let Some(message) = self.queued_key_update_message.take() {
+        if let Some(message) = self
+            .send
+            .queued_key_update_message
+            .take()
+        {
             self.sendable_tls.append(message);
         }
     }
 
-    pub(crate) fn set_max_fragment_size(&mut self, new: Option<usize>) -> Result<(), Error> {
-        self.message_fragmenter
-            .set_max_fragment_size(new)
-    }
-
     pub(crate) fn ensure_key_update_queued(&mut self) {
-        if self.queued_key_update_message.is_some() {
+        if self
+            .send
+            .queued_key_update_message
+            .is_some()
+        {
             return;
         }
 
         let message = EncodedMessage::<Payload<'static>>::from(Message::build_key_update_notify());
-        self.queued_key_update_message = Some(
-            self.encrypt_state
+        self.send.queued_key_update_message = Some(
+            self.send
+                .encrypt_state
                 .encrypt_outgoing(message.borrow_outbound())
                 .encode(),
         );
 
-        if let Some(mut ks) = self.tls13_key_schedule.take() {
+        if let Some(mut ks) = self.send.tls13_key_schedule.take() {
             ks.update_encrypter_for_key_update(self);
-            self.tls13_key_schedule = Some(ks);
+            self.send.tls13_key_schedule = Some(ks);
         }
     }
 
     /// Trigger a `refresh_traffic_keys` if required.
     pub(crate) fn maybe_refresh_traffic_keys(&mut self) {
-        if self.refresh_traffic_keys_pending {
+        if self.send.refresh_traffic_keys_pending {
             let _ = self.refresh_traffic_keys();
         }
     }
 
     pub(crate) fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
-        let ks = self.tls13_key_schedule.take();
+        let ks = self.send.tls13_key_schedule.take();
 
         let Some(mut ks) = ks else {
             return Err(Error::HandshakeNotComplete);
         };
 
         ks.request_key_update_and_update_encrypter(self);
-        self.refresh_traffic_keys_pending = false;
-        self.tls13_key_schedule = Some(ks);
+        self.send.refresh_traffic_keys_pending = false;
+        self.send.tls13_key_schedule = Some(ks);
         Ok(())
     }
 }
 
-impl SendOutput for SendPath {
+impl SendOutput for SendContext<'_> {
     fn negotiated_version(&mut self, version: ProtocolVersion) {
-        self.negotiated_version = Some(version);
+        self.send.negotiated_version = Some(version);
     }
 
     fn ensure_key_update_queued(&mut self) {
@@ -231,12 +267,13 @@ impl SendOutput for SendPath {
     }
 
     fn set_encrypter(&mut self, encrypter: Box<dyn MessageEncrypter>, max_messages: u64) {
-        self.encrypt_state
+        self.send
+            .encrypt_state
             .set_message_encrypter(encrypter, max_messages);
     }
 
     fn update_key_schedule(&mut self, schedule: Box<KeyScheduleTrafficSend>) {
-        self.tls13_key_schedule = Some(schedule);
+        self.send.tls13_key_schedule = Some(schedule);
     }
 
     fn send_alert(&mut self, level: AlertLevel, desc: AlertDescription) {
@@ -244,8 +281,8 @@ impl SendOutput for SendPath {
     }
 
     fn start_traffic(&mut self) {
-        self.may_send_half_rtt_data = true;
-        self.start_outgoing_traffic();
+        self.send.may_send_half_rtt_data = true;
+        self.send.start_outgoing_traffic();
     }
 
     /// Send a raw TLS message, fragmenting it if needed.
@@ -253,37 +290,21 @@ impl SendOutput for SendPath {
         let encoded = EncodedMessage::from(m);
         if must_encrypt {
             self.send_messages(
-                self.message_fragmenter
+                self.send
+                    .message_fragmenter
                     .fragment_message(&encoded),
             );
             return;
         }
 
         let iter = self
+            .send
             .message_fragmenter
             .fragment_message(&encoded);
         self.perhaps_write_key_update();
         for m in iter {
             self.sendable_tls
                 .append(m.to_unencrypted_opaque().encode());
-        }
-    }
-}
-
-impl Default for SendPath {
-    fn default() -> Self {
-        Self {
-            encrypt_state: EncryptionState::new(),
-            may_send_application_data: false,
-            may_send_half_rtt_data: false,
-            has_sent_fatal_alert: false,
-            has_sent_close_notify: false,
-            message_fragmenter: MessageFragmenter::default(),
-            sendable_tls: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
-            queued_key_update_message: None,
-            refresh_traffic_keys_pending: false,
-            negotiated_version: None,
-            tls13_key_schedule: None,
         }
     }
 }
@@ -304,4 +325,4 @@ pub(crate) trait SendOutput {
     fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool);
 }
 
-pub(super) const DEFAULT_BUFFER_LIMIT: usize = 64 * 1024;
+pub(crate) const DEFAULT_BUFFER_LIMIT: usize = 64 * 1024;

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -58,7 +58,7 @@ impl Default for SendPath {
 /// Pairs a [`SendPath`] with the buffer it emits encoded TLS records into.
 pub(crate) struct SendContext<'a> {
     pub(crate) send: &'a mut SendPath,
-    pub(crate) sendable_tls: &'a mut ChunkVecBuffer,
+    pub(crate) sendable_tls: &'a mut Vec<u8>,
 }
 
 impl SendContext<'_> {
@@ -121,7 +121,7 @@ impl SendContext<'_> {
             }
 
             self.perhaps_write_key_update();
-            self.sendable_tls.append(
+            self.sendable_tls.extend(
                 self.send
                     .encrypt_state
                     .encrypt_outgoing(m)
@@ -199,7 +199,7 @@ impl SendContext<'_> {
             .queued_key_update_message
             .take()
         {
-            self.sendable_tls.append(message);
+            self.sendable_tls.extend(message);
         }
     }
 
@@ -294,7 +294,7 @@ impl SendOutput for SendContext<'_> {
         self.perhaps_write_key_update();
         for m in iter {
             self.sendable_tls
-                .append(m.to_unencrypted_opaque().encode());
+                .extend(m.to_unencrypted_opaque().encode());
         }
     }
 }

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -6,7 +6,7 @@ use std::sync::MutexGuard;
 
 use crate::client::ClientSide;
 use crate::common_state::UnborrowedPayload;
-use crate::conn::{ConnectionCore, ReceivePath, SendOutput, SendPath};
+use crate::conn::{ConnectionCore, ReceivePath, SendContext, SendOutput, SendPath};
 use crate::crypto::cipher::{MessageEncrypter, OutboundPlain};
 use crate::enums::ProtocolVersion;
 use crate::error::{AlertDescription, ErrorWithAlert};
@@ -14,7 +14,23 @@ use crate::lock::Mutex;
 use crate::msgs::{AlertLevel, Delocator, Message, TlsInputBuffer};
 use crate::sync::Arc;
 use crate::tls13::key_schedule::KeyScheduleTrafficSend;
+use crate::vecbuf::ChunkVecBuffer;
 use crate::{ConnectionOutputs, Error, SideData};
+
+/// A [`SendPath`] paired with an output buffer.
+pub(crate) struct SendInner {
+    pub(crate) path: SendPath,
+    pub(crate) sendable_tls: ChunkVecBuffer,
+}
+
+impl SendInner {
+    fn context(&mut self) -> SendContext<'_> {
+        SendContext {
+            send: &mut self.path,
+            sendable_tls: &mut self.sendable_tls,
+        }
+    }
+}
 
 /// A post-handshake connection which has been split by direction.
 ///
@@ -35,7 +51,10 @@ impl<Side: SideData> TryFrom<ConnectionCore<Side>> for SplitConnection<Side> {
     type Error = Error;
 
     fn try_from(conn: ConnectionCore<Side>) -> Result<Self, Error> {
-        let send = Arc::new(Mutex::new(conn.common.send));
+        let send = Arc::new(Mutex::new(SendInner {
+            path: conn.common.send,
+            sendable_tls: conn.common.sendable_tls,
+        }));
         let state = conn.state?;
 
         Ok(Self {
@@ -54,7 +73,7 @@ impl<Side: SideData> TryFrom<ConnectionCore<Side>> for SplitConnection<Side> {
 /// The send-side of a connection, after a successful handshake.
 ///
 /// You can use this object to send data to the peer.
-pub struct SendTraffic(pub(crate) Arc<Mutex<SendPath>>);
+pub struct SendTraffic(pub(crate) Arc<Mutex<SendInner>>);
 
 impl SendTraffic {
     /// Write application data to the peer.
@@ -63,8 +82,12 @@ impl SendTraffic {
     /// be communicated to the peer, in order.
     pub fn write(&mut self, application_data: OutboundPlain<'_>) -> Vec<Vec<u8>> {
         let mut inner = self.0.lock().unwrap();
-        inner.maybe_refresh_traffic_keys();
-        inner.send_appdata_encrypt(application_data);
+        inner
+            .context()
+            .maybe_refresh_traffic_keys();
+        inner
+            .context()
+            .send_appdata_encrypt(application_data);
         inner.sendable_tls.take()
     }
 
@@ -76,7 +99,7 @@ impl SendTraffic {
     /// This is the final possible operation with a [`SendTraffic`].
     pub fn close(mut self) -> Vec<Vec<u8>> {
         let mut inner = self.0.lock().unwrap();
-        inner.send_close_notify();
+        inner.context().send_close_notify();
         drop(inner);
         self.take_data()
     }
@@ -94,7 +117,9 @@ impl SendTraffic {
     /// where you don't have any plaintext to send.
     pub fn take_data(&mut self) -> Vec<Vec<u8>> {
         let mut inner = self.0.lock().unwrap();
-        inner.maybe_refresh_traffic_keys();
+        inner
+            .context()
+            .maybe_refresh_traffic_keys();
         inner.sendable_tls.take()
     }
 
@@ -127,6 +152,7 @@ impl SendTraffic {
         self.0
             .lock()
             .unwrap()
+            .context()
             .refresh_traffic_keys()
     }
 }
@@ -144,7 +170,7 @@ impl fmt::Debug for SendTraffic {
 pub struct ReceiveTraffic<Side: SideData> {
     pub(crate) state: Side::State,
     pub(crate) recv: ReceivePath,
-    pub(crate) send: Arc<Mutex<SendPath>>,
+    pub(crate) send: Arc<Mutex<SendInner>>,
     pub(crate) pending_flush_sender: bool,
 }
 
@@ -178,12 +204,7 @@ impl<Side: SideData> ReceiveTraffic<Side> {
             match recv.process_recv_traffic::<Side>(received_tls, &mut state, &mut send_adapter) {
                 Ok(received_plain) => received_plain,
                 Err(err) => {
-                    return Err(ErrorWithAlert::new(
-                        err,
-                        send_adapter
-                            .as_locked(false)
-                            .deref_mut(),
-                    ));
+                    return Err(ErrorWithAlert::new(err, &mut send_adapter.context(false)));
                 }
             };
         // nb. state consumed only on error.
@@ -402,15 +423,15 @@ impl<Side: SideData> FlushSender<Side> {
 /// a sequence of sent messages is not interleaved with others from another
 /// thread.
 enum SendAdapter<'a> {
-    Unlocked(&'a Mutex<SendPath>),
+    Unlocked(&'a Mutex<SendInner>),
     Locked {
-        guard: MutexGuard<'a, SendPath>,
+        guard: MutexGuard<'a, SendInner>,
         send_required: bool,
     },
 }
 
 impl<'a> SendAdapter<'a> {
-    fn as_locked<'b>(&'b mut self, may_send: bool) -> &'b mut MutexGuard<'a, SendPath> {
+    fn as_locked<'b>(&'b mut self, may_send: bool) -> &'b mut MutexGuard<'a, SendInner> {
         if let Self::Unlocked(m) = self {
             *self = Self::Locked {
                 guard: m.lock().unwrap(),
@@ -427,42 +448,50 @@ impl<'a> SendAdapter<'a> {
         *send_required |= may_send;
         guard
     }
+
+    fn context<'b>(&'b mut self, may_send: bool) -> SendContext<'b> {
+        let state = self.as_locked(may_send).deref_mut();
+        SendContext {
+            send: &mut state.path,
+            sendable_tls: &mut state.sendable_tls,
+        }
+    }
 }
 
 impl SendOutput for SendAdapter<'_> {
     fn negotiated_version(&mut self, version: ProtocolVersion) {
-        self.as_locked(false)
+        self.context(false)
             .negotiated_version(version);
     }
 
     fn ensure_key_update_queued(&mut self) {
         // waking the sender here is a policy decision to encourage timely execution of
         // the write-side key update, it is not strictly required at a protocol level.
-        self.as_locked(true)
+        self.context(true)
             .ensure_key_update_queued();
     }
 
     fn set_encrypter(&mut self, cipher: Box<dyn MessageEncrypter>, max_messages: u64) {
-        self.as_locked(false)
+        self.context(false)
             .set_encrypter(cipher, max_messages);
     }
 
     fn update_key_schedule(&mut self, schedule: Box<KeyScheduleTrafficSend>) {
-        self.as_locked(false)
+        self.context(false)
             .update_key_schedule(schedule);
     }
 
     fn send_alert(&mut self, level: AlertLevel, desc: AlertDescription) {
-        self.as_locked(true)
+        self.context(true)
             .send_alert(level, desc)
     }
 
     fn start_traffic(&mut self) {
-        self.as_locked(false).start_traffic();
+        self.context(false).start_traffic();
     }
 
     fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool) {
-        self.as_locked(true)
+        self.context(true)
             .send_msg(m, must_encrypt)
     }
 }
@@ -493,8 +522,12 @@ mod tests {
     }
 
     fn send_flag_for(f: impl FnOnce(&mut SendAdapter<'_>)) -> bool {
-        let mut send = SendPath::default();
-        send.set_encrypter(Box::new(Tls13Cipher), 1234);
+        let mut send = SendInner {
+            path: SendPath::default(),
+            sendable_tls: ChunkVecBuffer::new(None),
+        };
+        send.context()
+            .set_encrypter(Box::new(Tls13Cipher), 1234);
 
         let send = Mutex::new(send);
 

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -1,5 +1,4 @@
 use alloc::boxed::Box;
-use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::{DerefMut, Range};
 use core::{fmt, mem};
@@ -18,18 +17,13 @@ use crate::tls13::key_schedule::KeyScheduleTrafficSend;
 use crate::{ConnectionOutputs, Error, SideData};
 
 /// A [`SendPath`] paired with an output buffer.
+///
+/// The buffer is used for collating sendable data produced as the result of receive-side
+/// actions.  The buffer is emptied into the caller's buffer on each actual [`SendTraffic`]
+/// operation.
 pub(crate) struct SendInner {
     pub(crate) path: SendPath,
-    pub(crate) buffer: Vec<u8>,
-}
-
-impl SendInner {
-    fn context(&mut self) -> SendContext<'_> {
-        SendContext {
-            send: &mut self.path,
-            sendable_tls: &mut self.buffer,
-        }
-    }
+    pub(crate) pending_buffer: Vec<u8>,
 }
 
 /// A post-handshake connection which has been split by direction.
@@ -53,7 +47,7 @@ impl<Side: SideData> TryFrom<ConnectionCore<Side>> for SplitConnection<Side> {
     fn try_from(conn: ConnectionCore<Side>) -> Result<Self, Error> {
         let send = Arc::new(Mutex::new(SendInner {
             path: conn.common.send,
-            buffer: conn.common.sendable_tls,
+            pending_buffer: conn.common.sendable_tls,
         }));
         let state = conn.state?;
 
@@ -78,30 +72,33 @@ pub struct SendTraffic(pub(crate) Arc<Mutex<SendInner>>);
 impl SendTraffic {
     /// Write application data to the peer.
     ///
-    /// The TLS data to send to the peer is returned. This data should then
+    /// The TLS data to send to the peer is appended onto `output`. This data should then
     /// be communicated to the peer, in order.
-    pub fn write(&mut self, application_data: OutboundPlain<'_>) -> Vec<Vec<u8>> {
+    pub fn write(&mut self, application_data: OutboundPlain<'_>, output: &mut Vec<u8>) {
         let mut inner = self.0.lock().unwrap();
-        inner
-            .context()
-            .maybe_refresh_traffic_keys();
-        inner
-            .context()
-            .send_appdata_encrypt(application_data);
-        wrap_single(mem::take(&mut inner.buffer))
+        output.extend(mem::take(&mut inner.pending_buffer));
+        let mut ctx = SendContext {
+            send: &mut inner.path,
+            sendable_tls: output,
+        };
+        ctx.maybe_refresh_traffic_keys();
+        ctx.send_appdata_encrypt(application_data);
     }
 
     /// Conclude sending traffic by sending a `close_notify` alert.
     ///
-    /// The alert is written into a Vec which is returned along with any pending data.
+    /// Any pending data is appended onto `output`, followed by the alert itself.
     /// This data should then be communicated to the peer.
     ///
     /// This is the final possible operation with a [`SendTraffic`].
-    pub fn close(mut self) -> Vec<Vec<u8>> {
+    pub fn close(self, output: &mut Vec<u8>) {
         let mut inner = self.0.lock().unwrap();
-        inner.context().send_close_notify();
-        drop(inner);
-        self.take_data()
+        output.extend(mem::take(&mut inner.pending_buffer));
+        SendContext {
+            send: &mut inner.path,
+            sendable_tls: output,
+        }
+        .send_close_notify();
     }
 
     /// Obtain any pending data to write to the peer.
@@ -110,17 +107,19 @@ impl SendTraffic {
     /// so there is no need to call this function if you have recently written data
     /// using this.
     ///
-    /// The TLS data to send to the peer is returned. This data should then
+    /// The TLS data to send to the peer is appended onto `output`. This data should then
     /// be communicated to the peer.
     ///
     /// This is useful to handle a [`ReceiveTrafficState::FlushSender`] event, but
     /// where you don't have any plaintext to send.
-    pub fn take_data(&mut self) -> Vec<Vec<u8>> {
+    pub fn take_data(&mut self, output: &mut Vec<u8>) {
         let mut inner = self.0.lock().unwrap();
-        inner
-            .context()
-            .maybe_refresh_traffic_keys();
-        wrap_single(mem::take(&mut inner.buffer))
+        output.extend(mem::take(&mut inner.pending_buffer));
+        SendContext {
+            send: &mut inner.path,
+            sendable_tls: output,
+        }
+        .maybe_refresh_traffic_keys();
     }
 
     /// Sends a TLS1.3 `key_update` message to refresh a connection's keys.
@@ -148,12 +147,14 @@ impl SendTraffic {
     /// Note that other implementations (including rustls) may enforce limits on
     /// the number of `key_update` messages allowed on a given connection to prevent
     /// denial of service. Therefore, this should be called sparingly.
-    pub fn refresh_traffic_keys(&mut self) -> Result<(), Error> {
-        self.0
-            .lock()
-            .unwrap()
-            .context()
-            .refresh_traffic_keys()
+    pub fn refresh_traffic_keys(&mut self, output: &mut Vec<u8>) -> Result<(), Error> {
+        let mut inner = self.0.lock().unwrap();
+        output.extend(mem::take(&mut inner.pending_buffer));
+        SendContext {
+            send: &mut inner.path,
+            sendable_tls: output,
+        }
+        .refresh_traffic_keys()
     }
 }
 
@@ -161,13 +162,6 @@ impl fmt::Debug for SendTraffic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("SendTraffic")
             .finish_non_exhaustive()
-    }
-}
-
-fn wrap_single(single: Vec<u8>) -> Vec<Vec<u8>> {
-    match single.is_empty() {
-        true => Vec::new(),
-        false => vec![single],
     }
 }
 
@@ -460,7 +454,7 @@ impl<'a> SendAdapter<'a> {
         let state = self.as_locked(may_send).deref_mut();
         SendContext {
             send: &mut state.path,
-            sendable_tls: &mut state.buffer,
+            sendable_tls: &mut state.pending_buffer,
         }
     }
 }
@@ -531,10 +525,13 @@ mod tests {
     fn send_flag_for(f: impl FnOnce(&mut SendAdapter<'_>)) -> bool {
         let mut send = SendInner {
             path: SendPath::default(),
-            buffer: Vec::new(),
+            pending_buffer: Vec::new(),
         };
-        send.context()
-            .set_encrypter(Box::new(Tls13Cipher), 1234);
+        SendContext {
+            send: &mut send.path,
+            sendable_tls: &mut send.pending_buffer,
+        }
+        .set_encrypter(Box::new(Tls13Cipher), 1234);
 
         let send = Mutex::new(send);
 

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -1,7 +1,8 @@
 use alloc::boxed::Box;
+use alloc::vec;
 use alloc::vec::Vec;
-use core::fmt;
 use core::ops::{DerefMut, Range};
+use core::{fmt, mem};
 use std::sync::MutexGuard;
 
 use crate::client::ClientSide;
@@ -14,20 +15,19 @@ use crate::lock::Mutex;
 use crate::msgs::{AlertLevel, Delocator, Message, TlsInputBuffer};
 use crate::sync::Arc;
 use crate::tls13::key_schedule::KeyScheduleTrafficSend;
-use crate::vecbuf::ChunkVecBuffer;
 use crate::{ConnectionOutputs, Error, SideData};
 
 /// A [`SendPath`] paired with an output buffer.
 pub(crate) struct SendInner {
     pub(crate) path: SendPath,
-    pub(crate) sendable_tls: ChunkVecBuffer,
+    pub(crate) buffer: Vec<u8>,
 }
 
 impl SendInner {
     fn context(&mut self) -> SendContext<'_> {
         SendContext {
             send: &mut self.path,
-            sendable_tls: &mut self.sendable_tls,
+            sendable_tls: &mut self.buffer,
         }
     }
 }
@@ -53,7 +53,7 @@ impl<Side: SideData> TryFrom<ConnectionCore<Side>> for SplitConnection<Side> {
     fn try_from(conn: ConnectionCore<Side>) -> Result<Self, Error> {
         let send = Arc::new(Mutex::new(SendInner {
             path: conn.common.send,
-            sendable_tls: conn.common.sendable_tls,
+            buffer: conn.common.sendable_tls,
         }));
         let state = conn.state?;
 
@@ -88,7 +88,7 @@ impl SendTraffic {
         inner
             .context()
             .send_appdata_encrypt(application_data);
-        inner.sendable_tls.take()
+        wrap_single(mem::take(&mut inner.buffer))
     }
 
     /// Conclude sending traffic by sending a `close_notify` alert.
@@ -120,7 +120,7 @@ impl SendTraffic {
         inner
             .context()
             .maybe_refresh_traffic_keys();
-        inner.sendable_tls.take()
+        wrap_single(mem::take(&mut inner.buffer))
     }
 
     /// Sends a TLS1.3 `key_update` message to refresh a connection's keys.
@@ -161,6 +161,13 @@ impl fmt::Debug for SendTraffic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("SendTraffic")
             .finish_non_exhaustive()
+    }
+}
+
+fn wrap_single(single: Vec<u8>) -> Vec<Vec<u8>> {
+    match single.is_empty() {
+        true => Vec::new(),
+        false => vec![single],
     }
 }
 
@@ -247,7 +254,7 @@ impl<Side: SideData> ReceiveTraffic<Side> {
             pending_flush_sender,
         };
 
-        if core::mem::take(&mut rt.pending_flush_sender) {
+        if mem::take(&mut rt.pending_flush_sender) {
             return Ok(ReceiveTrafficState::FlushSender(FlushSender { rt }));
         }
 
@@ -382,7 +389,7 @@ impl<Side: SideData> ReceivedApplicationData<'_, Side> {
         self.received_tls
             .discard(self.pending_discard);
 
-        if core::mem::take(&mut self.rt.pending_flush_sender) {
+        if mem::take(&mut self.rt.pending_flush_sender) {
             return ReceiveTrafficState::FlushSender(FlushSender { rt: self.rt });
         }
 
@@ -453,7 +460,7 @@ impl<'a> SendAdapter<'a> {
         let state = self.as_locked(may_send).deref_mut();
         SendContext {
             send: &mut state.path,
-            sendable_tls: &mut state.sendable_tls,
+            sendable_tls: &mut state.buffer,
         }
     }
 }
@@ -524,7 +531,7 @@ mod tests {
     fn send_flag_for(f: impl FnOnce(&mut SendAdapter<'_>)) -> bool {
         let mut send = SendInner {
             path: SendPath::default(),
-            sendable_tls: ChunkVecBuffer::new(None),
+            buffer: Vec::new(),
         };
         send.context()
             .set_encrypter(Box::new(Tls13Cipher), 1234);

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -12,7 +12,7 @@ use pki_types::{AlgorithmIdentifier, EchConfigListBytes, ServerName, UnixTime};
 use webpki::ExtendedKeyUsage;
 
 use crate::common_state::maybe_send_fatal_alert;
-use crate::conn::SendPath;
+use crate::conn::SendContext;
 use crate::crypto::kx::KeyExchangeAlgorithm;
 use crate::crypto::{CipherSuite, GetRandomFailed, InconsistentKeys};
 use crate::enums::{ContentType, HandshakeType};
@@ -1584,11 +1584,11 @@ pub struct ErrorWithAlert {
 }
 
 impl ErrorWithAlert {
-    pub(crate) fn new(error: Error, send_path: &mut SendPath) -> Self {
-        maybe_send_fatal_alert(send_path, &error);
+    pub(crate) fn new(error: Error, send: &mut SendContext<'_>) -> Self {
+        maybe_send_fatal_alert(send, &error);
         Self {
             error,
-            data: send_path.sendable_tls.take_one_vec(),
+            data: send.sendable_tls.take_one_vec(),
         }
     }
 

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1588,7 +1588,7 @@ impl ErrorWithAlert {
         maybe_send_fatal_alert(send, &error);
         Self {
             error,
-            data: send.sendable_tls.take_one_vec(),
+            data: mem::take(send.sendable_tls),
         }
     }
 

--- a/rustls/src/error/tests.rs
+++ b/rustls/src/error/tests.rs
@@ -1,4 +1,5 @@
 use alloc::string::ToString;
+use alloc::vec::Vec;
 use core::time::Duration;
 use std::{println, vec};
 
@@ -11,7 +12,6 @@ use super::{
 use crate::conn::{SendContext, SendPath};
 use crate::crypto::GetRandomFailed;
 use crate::msgs::test_enum8_display;
-use crate::vecbuf::ChunkVecBuffer;
 
 #[test]
 fn certificate_error_equality() {
@@ -318,7 +318,7 @@ fn time_error_mapping() {
 #[test]
 fn error_with_alert() {
     let mut path = SendPath::default();
-    let mut sendable_tls = ChunkVecBuffer::new(None);
+    let mut sendable_tls = Vec::new();
     let mut e = ErrorWithAlert::new(
         Error::NoApplicationProtocol,
         &mut SendContext {

--- a/rustls/src/error/tests.rs
+++ b/rustls/src/error/tests.rs
@@ -8,9 +8,10 @@ use super::{
     AlertDescription, CertRevocationListError, Error, ErrorWithAlert, InconsistentKeys,
     InvalidMessage, OtherError, UnixTime,
 };
-use crate::conn::SendPath;
+use crate::conn::{SendContext, SendPath};
 use crate::crypto::GetRandomFailed;
 use crate::msgs::test_enum8_display;
+use crate::vecbuf::ChunkVecBuffer;
 
 #[test]
 fn certificate_error_equality() {
@@ -316,7 +317,15 @@ fn time_error_mapping() {
 
 #[test]
 fn error_with_alert() {
-    let mut e = ErrorWithAlert::new(Error::NoApplicationProtocol, &mut SendPath::default());
+    let mut path = SendPath::default();
+    let mut sendable_tls = ChunkVecBuffer::new(None);
+    let mut e = ErrorWithAlert::new(
+        Error::NoApplicationProtocol,
+        &mut SendContext {
+            send: &mut path,
+            sendable_tls: &mut sendable_tls,
+        },
+    );
     assert_eq!(
         std::format!("{e:?}"),
         "ErrorWithAlert { error: NoApplicationProtocol, data: 7, .. }"

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -354,7 +354,7 @@ impl AcceptedAlert {
     pub(super) fn from_error(
         error: Error,
         mut send: SendPath,
-        mut sendable_tls: ChunkVecBuffer,
+        mut sendable_tls: Vec<u8>,
     ) -> (Error, Self) {
         let ErrorWithAlert { error, data } = ErrorWithAlert::new(
             error,

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -12,8 +12,8 @@ use crate::common_state::{CommonState, ConnectionOutputs, EarlyDataEvent, Event,
 use crate::conn::private::SideOutput;
 use crate::conn::split::SplitConnection;
 use crate::conn::{
-    Connection, ConnectionCommon, ConnectionCore, KeyingMaterialExporter, Reader, SendPath,
-    SideData, Writer,
+    Connection, ConnectionCommon, ConnectionCore, KeyingMaterialExporter, Reader, SendContext,
+    SendPath, SideData, Writer,
 };
 #[cfg(doc)]
 use crate::crypto;
@@ -313,7 +313,11 @@ impl Acceptor {
         };
 
         if let Err(e) = connection.process_new_packets() {
-            return Err(AcceptedAlert::from_error(e, connection.core.common.send));
+            return Err(AcceptedAlert::from_error(
+                e,
+                connection.core.common.send,
+                connection.core.common.sendable_tls,
+            ));
         }
 
         const MISUSED: Error = Error::Unreachable("Accepted misused state");
@@ -329,7 +333,12 @@ impl Acceptor {
             }
             Err(e) => Err((
                 e.clone(),
-                AcceptedAlert::from_error(e, connection.core.common.send).1,
+                AcceptedAlert::from_error(
+                    e,
+                    connection.core.common.send,
+                    connection.core.common.sendable_tls,
+                )
+                .1,
             )),
         }
     }
@@ -342,8 +351,18 @@ impl Acceptor {
 pub struct AcceptedAlert(ChunkVecBuffer);
 
 impl AcceptedAlert {
-    pub(super) fn from_error(error: Error, mut send: SendPath) -> (Error, Self) {
-        let ErrorWithAlert { error, data } = ErrorWithAlert::new(error, &mut send);
+    pub(super) fn from_error(
+        error: Error,
+        mut send: SendPath,
+        mut sendable_tls: ChunkVecBuffer,
+    ) -> (Error, Self) {
+        let ErrorWithAlert { error, data } = ErrorWithAlert::new(
+            error,
+            &mut SendContext {
+                send: &mut send,
+                sendable_tls: &mut sendable_tls,
+            },
+        );
         let mut output = ChunkVecBuffer::new(None);
         output.append(data);
         (error, Self(output))
@@ -464,7 +483,12 @@ impl Accepted {
             }),
             Err(e) => Err((
                 e.clone(),
-                AcceptedAlert::from_error(e, self.connection.core.common.send).1,
+                AcceptedAlert::from_error(
+                    e,
+                    self.connection.core.common.send,
+                    self.connection.core.common.sendable_tls,
+                )
+                .1,
             )),
         }
     }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -92,25 +92,6 @@ impl ChunkVecBuffer {
             .front()
             .map(|ch| ch.as_slice())
     }
-
-    pub(crate) fn take(&mut self) -> Vec<Vec<u8>> {
-        if self.chunks.is_empty() {
-            return Vec::new();
-        }
-        mem::take(&mut self.chunks).into()
-    }
-
-    pub(crate) fn take_one_vec(&mut self) -> Vec<u8> {
-        let Some(mut first) = self.chunks.pop_front() else {
-            return Vec::new();
-        };
-
-        while let Some(chunk) = self.chunks.pop_front() {
-            first.extend_from_slice(&chunk);
-        }
-
-        first
-    }
 }
 
 impl ChunkVecBuffer {


### PR DESCRIPTION
This is a sketch of how the internals can be rejigged to accommodate external output buffers for the split API, rather than internal buffers that are immediately returned.

The same kind of ideas can be used for the "buffered" API also. I haven't tried this direction yet, but it should be somewhat possible (with allowances for any caller using `std::io::Write`, or anyone using pre-handshake buffering.)

On the third commit, I have currently declared test bankruptcy, as using a flat output buffer breaks everything related to vectored writes.

Currently this also will have disastrous performance consequences, as everything will be copied more times than prior. However, it provides a route to potentially eliminating all copies and clears in conjunction with #3068.

So: this is for discussion, rather than imminent landing. Compliments #2940.