### PR TITLE
client: fix accidental bitwise and

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ lto = true
 alloc_instead_of_core = "warn"
 cloned_instead_of_copied = "warn"
 manual_let_else = "warn"
+needless_bitwise_bool = "warn"
 needless_collect = "warn"
 needless_pass_by_ref_mut = "warn"
 or_fun_call = "warn"

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -704,7 +704,7 @@ fn emit_client_hello_for_retry(
     // If this is a second client hello we're constructing in response to an HRR, and
     // we've rejected ECH or sent GREASE ECH, then we need to carry forward the
     // exact same ECH extension we used in the first hello.
-    if matches!(ech_status, EchStatus::Rejected | EchStatus::Grease) & retryreq.is_some() {
+    if matches!(ech_status, EchStatus::Rejected | EchStatus::Grease) && retryreq.is_some() {
         if let Some(prev_ech_ext) = input.prev_ech_ext.take() {
             exts.encrypted_client_hello = Some(prev_ech_ext);
         }


### PR DESCRIPTION
For two `bool`'s bitwise-and and logical-and produce the same truth table, and evaluating `retryreq.is_some()` unlazily is cheap, but we should use logical-and anyway for clarity of purpose.

Additionally enable a non-default clippy lint that would have caught this sooner.

Thanks to [darkcat09](https://gts.dc09.xyz/@darkcat09) for pointing out the mistake.