### PR TITLE
Caller-provided MessageEncrypter output buffer support

### DIFF
--- a/rustls-aws-lc-rs/src/tls12.rs
+++ b/rustls-aws-lc-rs/src/tls12.rs
@@ -3,9 +3,9 @@ use alloc::boxed::Box;
 use aws_lc_rs::{aead, tls_prf};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
-    NONCE_LEN, Nonce, OutboundOpaque, OutboundPlain, Tls12AeadAlgorithm, UnsupportedOperationError,
-    make_tls12_aad,
+    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter,
+    MessageEncrypter, NONCE_LEN, Nonce, OutboundPlain, Tls12AeadAlgorithm,
+    UnsupportedOperationError, make_tls12_aad,
 };
 use rustls::crypto::kx::{ActiveKeyExchange, KeyExchangeAlgorithm, SharedSecret};
 use rustls::crypto::tls12::{Prf, PrfSecret};
@@ -302,13 +302,14 @@ impl MessageDecrypter for GcmMessageDecrypter {
 }
 
 impl MessageEncrypter for GcmMessageEncrypter {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         msg: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
@@ -327,7 +328,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
         Ok(EncodedMessage {
             typ: msg.typ,
             version: msg.version,
-            payload,
+            payload: payload.into_written(),
         })
     }
 
@@ -392,27 +393,32 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
 }
 
 impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         msg: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce =
             aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
         payload.extend_from_chunks(&msg.payload);
 
-        self.enc_key
-            .seal_in_place_append_tag(nonce, aad, &mut payload)
-            .map_err(|_| Error::EncryptError)?;
+        match self
+            .enc_key
+            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
+        {
+            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+            Err(_) => return Err(Error::EncryptError),
+        }
 
         Ok(EncodedMessage {
             typ: msg.typ,
             version: msg.version,
-            payload,
+            payload: payload.into_written(),
         })
     }
 

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -4,8 +4,8 @@ use aws_lc_rs::hkdf::KeyType;
 use aws_lc_rs::{aead, hkdf, hmac};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter, Nonce,
-    OutboundOpaque, OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
+    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter,
+    Nonce, OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
 };
 use rustls::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use rustls::crypto::{self, CipherSuite};
@@ -219,29 +219,34 @@ struct AeadMessageDecrypter {
 }
 
 impl MessageEncrypter for AeadMessageEncrypter {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         msg: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(total_len));
         payload.extend_from_chunks(&msg.payload);
         payload.extend_from_slice(&msg.typ.to_array());
 
-        self.enc_key
-            .seal_in_place_append_tag(nonce, aad, &mut payload)
-            .map_err(|_| Error::EncryptError)?;
+        match self
+            .enc_key
+            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
+        {
+            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+            Err(_) => return Err(Error::EncryptError),
+        }
 
         Ok(EncodedMessage {
             typ: ContentType::ApplicationData,
             // Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
             // protocol version, see https://www.rfc-editor.org/rfc/rfc8446#section-5.1
             version: ProtocolVersion::TLSv1_2,
-            payload,
+            payload: payload.into_written(),
         })
     }
 
@@ -280,27 +285,32 @@ struct GcmMessageEncrypter {
 }
 
 impl MessageEncrypter for GcmMessageEncrypter {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         msg: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(total_len));
         payload.extend_from_chunks(&msg.payload);
         payload.extend_from_slice(&msg.typ.to_array());
 
-        self.enc_key
-            .seal_in_place_append_tag(nonce, aad, &mut payload)
-            .map_err(|_| Error::EncryptError)?;
+        match self
+            .enc_key
+            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
+        {
+            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+            Err(_) => return Err(Error::EncryptError),
+        }
 
         Ok(EncodedMessage {
             typ: ContentType::ApplicationData,
             version: ProtocolVersion::TLSv1_2,
-            payload,
+            payload: payload.into_written(),
         })
     }
 

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::ServerVerifier;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
-    OutboundOpaque, OutboundPlain, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
+    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter,
+    MessageEncrypter, OutboundPlain, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
     UnsupportedOperationError,
 };
 use rustls::crypto::kx::{
@@ -318,13 +318,14 @@ impl Tls12AeadAlgorithm for Aead {
 struct Tls13Cipher;
 
 impl MessageEncrypter for Tls13Cipher {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         m: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(m.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         payload.extend_from_chunks(&m.payload);
         payload.extend_from_slice(&m.typ.to_array());
@@ -343,7 +344,7 @@ impl MessageEncrypter for Tls13Cipher {
         Ok(EncodedMessage {
             typ: ContentType::ApplicationData,
             version: ProtocolVersion::TLSv1_2,
-            payload,
+            payload: payload.into_written(),
         })
     }
 
@@ -387,13 +388,14 @@ impl MessageDecrypter for Tls13Cipher {
 struct Tls12Cipher;
 
 impl MessageEncrypter for Tls12Cipher {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         m: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(m.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
         payload.extend_from_chunks(&m.payload);
 
         for (p, mask) in payload
@@ -410,7 +412,7 @@ impl MessageEncrypter for Tls12Cipher {
         Ok(EncodedMessage {
             typ: m.typ,
             version: m.version,
-            payload,
+            payload: payload.into_written(),
         })
     }
 

--- a/rustls-ring/src/tls12.rs
+++ b/rustls-ring/src/tls12.rs
@@ -3,9 +3,9 @@ use alloc::boxed::Box;
 use pki_types::FipsStatus;
 use ring::aead;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
-    NONCE_LEN, Nonce, OutboundOpaque, OutboundPlain, Tls12AeadAlgorithm, UnsupportedOperationError,
-    make_tls12_aad,
+    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter,
+    MessageEncrypter, NONCE_LEN, Nonce, OutboundPlain, Tls12AeadAlgorithm,
+    UnsupportedOperationError, make_tls12_aad,
 };
 use rustls::crypto::kx::KeyExchangeAlgorithm;
 use rustls::crypto::tls12::PrfUsingHmac;
@@ -280,13 +280,14 @@ impl MessageDecrypter for GcmMessageDecrypter {
 }
 
 impl MessageEncrypter for GcmMessageEncrypter {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         msg: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
@@ -305,7 +306,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
         Ok(EncodedMessage {
             typ: msg.typ,
             version: msg.version,
-            payload,
+            payload: payload.into_written(),
         })
     }
 
@@ -370,27 +371,32 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
 }
 
 impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         msg: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce =
             aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
         payload.extend_from_chunks(&msg.payload);
 
-        self.enc_key
-            .seal_in_place_append_tag(nonce, aad, &mut payload)
-            .map_err(|_| Error::EncryptError)?;
+        match self
+            .enc_key
+            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
+        {
+            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+            Err(_) => return Err(Error::EncryptError),
+        }
 
         Ok(EncodedMessage {
             typ: msg.typ,
             version: msg.version,
-            payload,
+            payload: payload.into_written(),
         })
     }
 

--- a/rustls-ring/src/tls13.rs
+++ b/rustls-ring/src/tls13.rs
@@ -5,8 +5,8 @@ use ring::hkdf::{self, KeyType};
 use ring::{aead, hmac};
 use rustls::crypto::CipherSuite;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter, Nonce,
-    OutboundOpaque, OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
+    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter,
+    Nonce, OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
 };
 use rustls::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use rustls::enums::{ContentType, ProtocolVersion};
@@ -195,29 +195,34 @@ struct Tls13MessageDecrypter {
 }
 
 impl MessageEncrypter for Tls13MessageEncrypter {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         msg: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(total_len));
         payload.extend_from_chunks(&msg.payload);
         payload.extend_from_slice(&msg.typ.to_array());
 
-        self.enc_key
-            .seal_in_place_append_tag(nonce, aad, &mut payload)
-            .map_err(|_| Error::EncryptError)?;
+        match self
+            .enc_key
+            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
+        {
+            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+            Err(_) => return Err(Error::EncryptError),
+        }
 
         Ok(EncodedMessage {
             typ: ContentType::ApplicationData,
             // Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
             // protocol version, see https://www.rfc-editor.org/rfc/rfc8446#section-5.1
             version: ProtocolVersion::TLSv1_2,
-            payload,
+            payload: payload.into_written(),
         })
     }
 

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -1372,14 +1372,32 @@ impl RawTls {
         msg: &EncodedMessage<Payload<'_>>,
         peer_input: &mut VecInput,
     ) {
-        let data = self
+        /// The length of a TLS record header: 1 byte type, 2 bytes version, 2 bytes length.
+        const HEADER_SIZE: usize = 5;
+
+        let msg = msg.borrow_outbound();
+        let mut record = vec![
+            0u8;
+            HEADER_SIZE
+                + self
+                    .encrypter
+                    .encrypted_payload_len(msg.payload.len())
+        ];
+        let encrypted = self
             .encrypter
-            .encrypt(msg.borrow_outbound(), self.enc_seq)
-            .unwrap()
-            .encode();
+            .encrypt(msg, self.enc_seq, &mut record[HEADER_SIZE..])
+            .unwrap();
+
+        // Encode the TLS record header: 1 byte type, 2 bytes version, 2 bytes length
+        let (typ, version, len) = (encrypted.typ, encrypted.version, encrypted.payload.len());
+        record.truncate(HEADER_SIZE + len);
+        record[0] = typ.into();
+        record[1..3].copy_from_slice(&version.to_array());
+        record[3..5].copy_from_slice(&(len as u16).to_be_bytes());
+
         self.enc_seq += 1;
         peer_input
-            .read(&mut io::Cursor::new(data))
+            .read(&mut io::Cursor::new(record))
             .unwrap();
     }
 
@@ -1791,7 +1809,7 @@ pub fn certificate_error_expecting_name(expected: &str) -> CertificateError {
 mod plaintext {
     use rustls::ConnectionTrafficSecrets;
     use rustls::crypto::cipher::{
-        AeadKey, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter, OutboundOpaque,
+        AeadKey, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter,
         OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError,
     };
 
@@ -1824,18 +1842,19 @@ mod plaintext {
     struct Encrypter;
 
     impl MessageEncrypter for Encrypter {
-        fn encrypt(
+        fn encrypt<'a>(
             &mut self,
             msg: EncodedMessage<OutboundPlain<'_>>,
             _seq: u64,
-        ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
-            let mut payload = OutboundOpaque::with_capacity(msg.payload.len());
+            out: &'a mut [u8],
+        ) -> Result<EncodedMessage<&'a [u8]>, Error> {
+            let mut payload = EncryptBuffer::new(out, msg.payload.len())?;
             payload.extend_from_chunks(&msg.payload);
 
             Ok(EncodedMessage {
                 typ: ContentType::ApplicationData,
                 version: ProtocolVersion::TLSv1_2,
-                payload,
+                payload: payload.into_written(),
             })
         }
 

--- a/rustls-test/tests/api/split.rs
+++ b/rustls-test/tests/api/split.rs
@@ -7,7 +7,7 @@
 use std::io::{Cursor, Write};
 
 use rustls::error::{AlertDescription, ApiMisuse, InvalidMessage};
-use rustls::split::{ReceiveTraffic, ReceiveTrafficState, SplitConnection};
+use rustls::split::{ReceiveTraffic, ReceiveTrafficState, SplitConnection, WrittenInto};
 use rustls::{Connection, Error, SideData, SliceInput, VecInput};
 use rustls_test::{KeyType, do_handshake, make_pair};
 
@@ -125,6 +125,112 @@ fn split_incremental() {
         flight,
         ExpectData {
             expected: b"client to server",
+            then: ExpectReadMore,
+        },
+    );
+}
+
+#[test]
+fn split_write_tls_into() {
+    let (mut client, mut server) =
+        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
+
+    let SplitConnection {
+        send: mut client_send,
+        ..
+    } = client.split().unwrap();
+    let SplitConnection {
+        receive: server_recv,
+        ..
+    } = server.split().unwrap();
+
+    let mut out = [0u8; 128];
+    let written = client_send
+        .write_tls_into(b"client to server".as_slice().into(), &mut out)
+        .unwrap();
+    assert_eq!(written.plaintext_consumed, b"client to server".len());
+    assert!(written.tls_written > b"client to server".len());
+
+    check_receive_all(
+        server_recv,
+        out[..written.tls_written].to_vec(),
+        ExpectData {
+            expected: b"client to server",
+            then: ExpectReadMore,
+        },
+    );
+}
+
+#[test]
+fn split_write_tls_into_limited_space() {
+    let (mut client, mut server) =
+        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
+
+    let SplitConnection {
+        send: mut client_send,
+        ..
+    } = client.split().unwrap();
+    let SplitConnection {
+        receive: server_recv,
+        ..
+    } = server.split().unwrap();
+
+    let data = vec![0x42u8; 20_000];
+
+    // nothing fits in a buffer smaller than one record
+    let mut tiny = [0u8; 32];
+    let WrittenInto {
+        plaintext_consumed,
+        tls_written,
+        ..
+    } = client_send
+        .write_tls_into(data.as_slice().into(), &mut tiny)
+        .unwrap();
+    assert_eq!(plaintext_consumed, 0);
+    assert_eq!(tls_written, 0);
+
+    // one max-size record fits; the second fragment must wait
+    let mut out = vec![0u8; 16_384 + 128];
+    let first = client_send
+        .write_tls_into(data.as_slice().into(), &mut out)
+        .unwrap();
+    assert_eq!(first.plaintext_consumed, 16_384);
+
+    let server_recv = check_receive_all(
+        server_recv,
+        out[..first.tls_written].to_vec(),
+        ExpectData {
+            expected: &data[..16_384],
+            then: ExpectReadMore,
+        },
+    )
+    .unwrap();
+
+    // the remainder is consumed by a second call
+    let second = client_send
+        .write_tls_into((&data[first.plaintext_consumed..]).into(), &mut out)
+        .unwrap();
+    assert_eq!(second.plaintext_consumed, 20_000 - 16_384);
+
+    check_receive_all(
+        server_recv,
+        out[..second.tls_written].to_vec(),
+        ExpectData {
+            expected: &data[16_384..],
             then: ExpectReadMore,
         },
     );

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -11,7 +11,7 @@ use pki_types::{CertificateDer, FipsStatus, ServerName, UnixTime};
 
 use super::{Tls12Session, Tls13ClientSessionInput, Tls13Session};
 use crate::client::{ClientConfig, Resumption, Tls12Resumption};
-use crate::crypto::cipher::{EncodedMessage, MessageEncrypter, Payload};
+use crate::crypto::cipher::{EncodedMessage, MessageEncrypter, Payload, encode_record_header};
 use crate::crypto::kx::{self, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup};
 use crate::crypto::test_provider::FakeKeyExchangeGroup;
 use crate::crypto::tls13::OkmBlock;
@@ -23,11 +23,11 @@ use crate::enums::{CertificateType, ProtocolVersion};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::msgs::{
     CertificateChain, ClientHelloPayload, Codec, Compression, ECCurveType, EcParameters,
-    HandshakeMessagePayload, HandshakePayload, HelloRetryRequest, HelloRetryRequestExtensions,
-    KeyShareEntry, MaybeEmpty, Message, MessagePayload, NewSessionTicketExtensions,
-    NewSessionTicketPayloadTls13, Random, Reader, ServerEcdhParams, ServerExtensions,
-    ServerHelloPayload, ServerKeyExchange, ServerKeyExchangeParams, ServerKeyExchangePayload,
-    SessionId, SizedPayload,
+    HEADER_SIZE, HandshakeMessagePayload, HandshakePayload, HelloRetryRequest,
+    HelloRetryRequestExtensions, KeyShareEntry, MaybeEmpty, Message, MessagePayload,
+    NewSessionTicketExtensions, NewSessionTicketPayloadTls13, Random, Reader, ServerEcdhParams,
+    ServerExtensions, ServerHelloPayload, ServerKeyExchange, ServerKeyExchangeParams,
+    ServerKeyExchangePayload, SessionId, SizedPayload,
 };
 use crate::pki_types::PrivateKeyDer;
 use crate::pki_types::pem::PemObject;
@@ -548,11 +548,23 @@ fn client_requiring_rpk_receives_server_ee(
     };
 
     let mut encrypter = fake_server_crypto.server_handshake_encrypter();
-    let enc_ee = encrypter
-        .encrypt(EncodedMessage::<Payload<'_>>::from(ee).borrow_outbound(), 0)
+    let ee = EncodedMessage::<Payload<'_>>::from(ee);
+    let ee = ee.borrow_outbound();
+    let mut enc_ee = vec![0u8; HEADER_SIZE + encrypter.encrypted_payload_len(ee.payload.len())];
+    let encrypted = encrypter
+        .encrypt(ee, 0, &mut enc_ee[HEADER_SIZE..])
         .unwrap();
+
+    let (typ, version, len) = (encrypted.typ, encrypted.version, encrypted.payload.len());
+    enc_ee.truncate(HEADER_SIZE + len);
+    enc_ee[..HEADER_SIZE].copy_from_slice(&encode_record_header(
+        typ,
+        version,
+        u16::try_from(len).unwrap(),
+    ));
+
     input
-        .read(&mut enc_ee.encode().as_slice())
+        .read(&mut enc_ee.as_slice())
         .unwrap();
 
     assert_eq!(

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -550,7 +550,7 @@ impl Read for Reader<'_> {
     /// You may learn the number of bytes available at any time by inspecting
     /// the return of [`Connection::process_new_packets()`].
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let len = self.received_plaintext.read(buf)?;
+        let len = self.received_plaintext.read(buf);
         if len > 0 || buf.is_empty() {
             return Ok(len);
         }

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -29,6 +29,7 @@ pub use receive::{SliceInput, TlsInputBuffer, VecInput};
 
 mod send;
 use send::DEFAULT_BUFFER_LIMIT;
+pub use send::WrittenInto;
 pub(crate) use send::{SendOutput, SendPath};
 
 pub(crate) mod split;

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -91,8 +91,10 @@ impl SendPath {
             }
 
             self.perhaps_write_key_update();
-            self.sendable_tls
-                .append(self.encrypt_state.encrypt_outgoing(m));
+            let record = self
+                .encrypt_state
+                .encrypt_outgoing(m, self.sendable_tls.take_spare());
+            self.sendable_tls.append(record);
         }
     }
 
@@ -241,7 +243,7 @@ impl SendPath {
         let message = EncodedMessage::<Payload<'static>>::from(Message::build_key_update_notify());
         self.queued_key_update_message = Some(
             self.encrypt_state
-                .encrypt_outgoing(message.borrow_outbound()),
+                .encrypt_outgoing(message.borrow_outbound(), Vec::new()),
         );
 
         if let Some(mut ks) = self.tls13_key_schedule.take() {
@@ -329,7 +331,7 @@ impl Default for SendPath {
             has_sent_fatal_alert: false,
             has_sent_close_notify: false,
             message_fragmenter: MessageFragmenter::default(),
-            sendable_tls: ChunkVecBuffer::new(Some(DEFAULT_BUFFER_LIMIT)),
+            sendable_tls: ChunkVecBuffer::new_recycling(Some(DEFAULT_BUFFER_LIMIT)),
             queued_key_update_message: None,
             refresh_traffic_keys_pending: false,
             negotiated_version: None,

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -91,11 +91,8 @@ impl SendPath {
             }
 
             self.perhaps_write_key_update();
-            self.sendable_tls.append(
-                self.encrypt_state
-                    .encrypt_outgoing(m)
-                    .encode(),
-            );
+            self.sendable_tls
+                .append(self.encrypt_state.encrypt_outgoing(m));
         }
     }
 
@@ -190,8 +187,7 @@ impl SendPath {
         let message = EncodedMessage::<Payload<'static>>::from(Message::build_key_update_notify());
         self.queued_key_update_message = Some(
             self.encrypt_state
-                .encrypt_outgoing(message.borrow_outbound())
-                .encode(),
+                .encrypt_outgoing(message.borrow_outbound()),
         );
 
         if let Some(mut ks) = self.tls13_key_schedule.take() {

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -7,7 +7,7 @@ use crate::crypto::cipher::{
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{AlertDescription, Error};
 use crate::log::{debug, error};
-use crate::msgs::{AlertLevel, Message, MessageFragmenter};
+use crate::msgs::{AlertLevel, HEADER_SIZE, Message, MessageFragmenter};
 use crate::tls13::key_schedule::KeyScheduleTrafficSend;
 use crate::vecbuf::ChunkVecBuffer;
 
@@ -124,6 +124,60 @@ impl SendPath {
             // Refuse to wrap counter at all costs. This is basically untestable unfortunately.
             Some(PreEncryptAction::Refuse) => Err(Error::EncryptError),
         }
+    }
+
+    /// Encrypt application data from `payload` directly into `out`.
+    ///
+    /// Any records already queued inside the connection (for example, a
+    /// pending `key_update`) are written to `out` first.
+    ///
+    /// Records are written while `out` has space for them. The returned
+    /// [`WrittenInto`] indicates how much of `payload` was consumed and how many
+    /// bytes were written. The caller should call `write_appdata_into()` again with
+    /// the unconsumed remainder of `payload` once it has disposed of the written bytes.
+    pub(crate) fn write_appdata_into(
+        &mut self,
+        payload: OutboundPlain<'_>,
+        out: &mut [u8],
+    ) -> Result<WrittenInto, Error> {
+        debug_assert!(self.encrypt_state.is_encrypting());
+        let mut written = self.sendable_tls.read(out);
+        let mut consumed = 0;
+
+        for m in self
+            .message_fragmenter
+            .fragment_payload(
+                ContentType::ApplicationData,
+                ProtocolVersion::TLSv1_2,
+                payload,
+            )
+        {
+            self.preflight_encrypt(0)?;
+            self.perhaps_write_key_update();
+            written += self
+                .sendable_tls
+                .read(&mut out[written..]);
+
+            let fragment_len = m.payload.len();
+            if out.len() - written
+                < HEADER_SIZE
+                    + self
+                        .encrypt_state
+                        .encrypted_len(fragment_len)
+            {
+                break;
+            }
+
+            written += self
+                .encrypt_state
+                .encrypt_outgoing_into(m, &mut out[written..]);
+            consumed += fragment_len;
+        }
+
+        Ok(WrittenInto {
+            plaintext_consumed: consumed,
+            tls_written: written,
+        })
     }
 
     /// Send plaintext application data, fragmenting and
@@ -298,6 +352,21 @@ pub(crate) trait SendOutput {
     fn start_traffic(&mut self);
 
     fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool);
+}
+
+/// The outcome of encrypting application data into a caller-provided buffer.
+///
+/// Returned by [`SendTraffic::write_tls_into()`].
+///
+/// [`SendTraffic::write_tls_into()`]: crate::split::SendTraffic::write_tls_into()
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct WrittenInto {
+    /// How many plaintext bytes were consumed from the input payload.
+    pub plaintext_consumed: usize,
+
+    /// How many TLS bytes were written to the output buffer.
+    pub tls_written: usize,
 }
 
 pub(super) const DEFAULT_BUFFER_LIMIT: usize = 64 * 1024;

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -261,7 +261,7 @@ impl SendOutput for SendPath {
         self.perhaps_write_key_update();
         for m in iter {
             self.sendable_tls
-                .append(m.to_unencrypted_opaque().encode());
+                .append(m.to_unencrypted_bytes());
         }
     }
 }

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -7,7 +7,9 @@ use std::sync::MutexGuard;
 use super::receive::{Discard, JoinOutput};
 use crate::client::ClientSide;
 use crate::common_state::UnborrowedPayload;
-use crate::conn::{ConnectionCore, MessageIter, ReceivePath, SendOutput, SendPath, TlsInputBuffer};
+use crate::conn::{
+    ConnectionCore, MessageIter, ReceivePath, SendOutput, SendPath, TlsInputBuffer, WrittenInto,
+};
 use crate::crypto::cipher::{MessageEncrypter, OutboundPlain};
 use crate::enums::ProtocolVersion;
 use crate::error::{AlertDescription, ErrorWithAlert};
@@ -67,6 +69,33 @@ impl SendTraffic {
         inner.maybe_refresh_traffic_keys();
         inner.send_appdata_encrypt(application_data);
         inner.sendable_tls.take()
+    }
+
+    /// Write application data to the peer, encrypting directly into `out`.
+    ///
+    /// Unlike [`SendTraffic::write()`], this does not allocate or buffer
+    /// internally. Encrypted records are written straight into the caller's
+    /// buffer, along with any internally-queued records (such as a pending
+    /// `key_update`).
+    ///
+    /// Records are written while `out` has space for them. The returned
+    /// [`WrittenInto`] indicates how much of `application_data` was consumed and
+    /// how many bytes were written to `out`. Once the written bytes have been
+    /// communicated to the peer, call again with the unconsumed remainder of
+    /// `application_data`.
+    ///
+    /// There is deliberately no way to ask how large `out` needs to be:
+    /// the receive half of the connection shares the send state and may
+    /// queue records concurrently, so any such answer could be stale
+    /// before it was used. Instead, loop on the returned [`WrittenInto`].
+    pub fn write_tls_into(
+        &mut self,
+        application_data: OutboundPlain<'_>,
+        out: &mut [u8],
+    ) -> Result<WrittenInto, Error> {
+        let mut inner = self.0.lock().unwrap();
+        inner.maybe_refresh_traffic_keys();
+        inner.write_appdata_into(application_data, out)
     }
 
     /// Conclude sending traffic by sending a `close_notify` alert.

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -49,15 +49,6 @@ impl<'a> EncodedMessage<Payload<'a>> {
         })
     }
 
-    /// Convert into an unencrypted [`EncodedMessage<OutboundOpaque>`] (without decrypting).
-    pub fn into_unencrypted_opaque(self) -> EncodedMessage<OutboundOpaque> {
-        EncodedMessage {
-            typ: self.typ,
-            version: self.version,
-            payload: OutboundOpaque::from_byte_slice(self.payload.bytes()),
-        }
-    }
-
     /// Borrow as an [`EncodedMessage<OutboundPlain<'a>>`].
     pub fn borrow_outbound(&'a self) -> EncodedMessage<OutboundPlain<'a>> {
         EncodedMessage {
@@ -144,34 +135,20 @@ impl<'a> EncodedMessage<InboundOpaque<'a>> {
 }
 
 impl EncodedMessage<OutboundPlain<'_>> {
-    pub(crate) fn to_unencrypted_opaque(&self) -> EncodedMessage<OutboundOpaque> {
-        let mut payload = OutboundOpaque::with_capacity(self.payload.len());
-        payload.extend_from_chunks(&self.payload);
-        EncodedMessage {
-            typ: self.typ,
-            version: self.version,
-            payload,
-        }
+    /// Encode this message into its unencrypted wire representation, including
+    /// its record header.
+    pub(crate) fn to_unencrypted_bytes(&self) -> Vec<u8> {
+        let len = self.payload.len();
+        debug_assert!(len <= usize::from(u16::MAX));
+        let mut buf = Vec::with_capacity(HEADER_SIZE + len);
+        buf.extend_from_slice(&encode_record_header(self.typ, self.version, len as u16));
+        self.payload.copy_to_vec(&mut buf);
+        buf
     }
 
     #[expect(dead_code)]
     pub(crate) fn encoded_len(&self, record_layer: &EncryptionState) -> usize {
         HEADER_SIZE + record_layer.encrypted_len(self.payload.len())
-    }
-}
-
-impl EncodedMessage<OutboundOpaque> {
-    /// Encode this message to a vector of bytes.
-    pub fn encode(self) -> Vec<u8> {
-        let length = self.payload.len();
-        debug_assert!(length <= usize::from(u16::MAX));
-        let mut encoded_payload = self.payload.payload;
-        encoded_payload[..HEADER_SIZE].copy_from_slice(&encode_record_header(
-            self.typ,
-            self.version,
-            length as u16,
-        ));
-        encoded_payload
     }
 }
 
@@ -363,74 +340,6 @@ impl<'a> From<&'a [u8]> for OutboundPlain<'a> {
     }
 }
 
-/// A payload buffer with space reserved at the front for a TLS message header.
-///
-/// `EncodedMessage<OutboundOpaque>` is named `TLSCiphertext` in the standard.
-///
-/// This outbound type owns all memory for its interior parts.
-/// It is usually, but not always, encrypted and is used for io write.
-#[derive(Clone, Debug)]
-pub struct OutboundOpaque {
-    /// Encoded payload of the record.
-    payload: Vec<u8>,
-}
-
-impl OutboundOpaque {
-    /// Create a new value with the given payload capacity.
-    ///
-    /// (The actual capacity of the returned value will be at least `HEADER_SIZE + capacity`.)
-    pub fn with_capacity(capacity: usize) -> Self {
-        let mut payload = Vec::with_capacity(HEADER_SIZE + capacity);
-        payload.resize(HEADER_SIZE, 0);
-        Self { payload }
-    }
-
-    /// Create a new value containing the given bytes. The capacity will be
-    /// sufficient for `content` plus the record header.
-    pub(crate) fn from_byte_slice(content: &[u8]) -> Self {
-        let mut value = Self::with_capacity(content.len());
-        value.payload.extend(content);
-        value
-    }
-
-    /// Append bytes from a slice.
-    pub fn extend_from_slice(&mut self, slice: &[u8]) {
-        self.payload.extend_from_slice(slice)
-    }
-
-    /// Append bytes from an `OutboundPlain`.
-    pub fn extend_from_chunks(&mut self, chunks: &OutboundPlain<'_>) {
-        chunks.copy_to_vec(&mut self.payload)
-    }
-
-    /// Truncate the payload to the given length (plus header).
-    pub fn truncate(&mut self, len: usize) {
-        self.payload.truncate(len + HEADER_SIZE)
-    }
-
-    fn len(&self) -> usize {
-        self.payload.len() - HEADER_SIZE
-    }
-}
-
-impl AsRef<[u8]> for OutboundOpaque {
-    fn as_ref(&self) -> &[u8] {
-        &self.payload[HEADER_SIZE..]
-    }
-}
-
-impl AsMut<[u8]> for OutboundOpaque {
-    fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.payload[HEADER_SIZE..]
-    }
-}
-
-impl<'a> Extend<&'a u8> for OutboundOpaque {
-    fn extend<T: IntoIterator<Item = &'a u8>>(&mut self, iter: T) {
-        self.payload.extend(iter)
-    }
-}
-
 /// A fixed-size buffer into which a [`MessageEncrypter`][] writes an encrypted message payload.
 ///
 /// This wraps the output buffer passed to [`MessageEncrypter::encrypt()`][], tracking how
@@ -512,8 +421,9 @@ impl AsMut<[u8]> for EncryptBuffer<'_> {
 /// An externally length'd payload
 ///
 /// When encountered in an [`EncodedMessage`], it represents a plaintext payload. It can be
-/// decrypted from an [`InboundOpaque`] or encrypted into an [`OutboundOpaque`],
-/// and it is also used for joining and fragmenting.
+/// decrypted from an [`InboundOpaque`] or encrypted by a
+/// [`MessageEncrypter`](crate::crypto::cipher::MessageEncrypter), and it is also used for
+/// joining and fragmenting.
 #[non_exhaustive]
 #[derive(Clone, Eq, PartialEq)]
 pub enum Payload<'a> {

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -1,10 +1,10 @@
 use alloc::vec::Vec;
-use core::fmt;
 use core::ops::{Deref, DerefMut, Range};
+use core::{fmt, slice};
 
 use crate::crypto::cipher::EncryptionState;
 use crate::enums::{ContentType, ProtocolVersion};
-use crate::error::{Error, InvalidMessage, PeerMisbehaved};
+use crate::error::{ApiMisuse, Error, InvalidMessage, PeerMisbehaved};
 use crate::msgs::{Codec, HEADER_SIZE, MAX_FRAGMENT_LEN, Reader, hex, read_opaque_message_header};
 
 /// A TLS message with encoded (but not necessarily encrypted) payload.
@@ -203,9 +203,15 @@ pub enum OutboundPlain<'a> {
     Multiple {
         /// A collection of byte slices that hold the buffered data.
         chunks: &'a [&'a [u8]],
-        /// The start cursor into the first chunk.
+        /// Offset of the payload's first byte within the logical
+        /// concatenation of all `chunks`.
+        ///
+        /// This may point beyond the first chunk (for example, after
+        /// `split_at()`).
         start: usize,
-        /// The end cursor into the last chunk.
+        /// Offset one past the payload's last byte within the logical
+        /// concatenation of all `chunks`, so `end - start` is the payload's
+        /// length in bytes.
         end: usize,
     },
 }
@@ -242,22 +248,22 @@ impl<'a> OutboundPlain<'a> {
 
     /// Append all bytes to a vector
     pub fn copy_to_vec(&self, vec: &mut Vec<u8>) {
-        match *self {
-            Self::Single(chunk) => vec.extend_from_slice(chunk),
-            Self::Multiple { chunks, start, end } => {
-                let mut size = 0;
-                for chunk in chunks.iter() {
-                    let psize = size;
-                    let len = chunk.len();
-                    size += len;
-                    if size <= start || psize >= end {
-                        continue;
-                    }
-                    let start = start.saturating_sub(psize);
-                    let end = if end - psize < len { end - psize } else { len };
-                    vec.extend_from_slice(&chunk[start..end]);
-                }
-            }
+        for chunk in self.chunks() {
+            vec.extend_from_slice(chunk);
+        }
+    }
+
+    /// Iterate over the payload's chunks of bytes, in order.
+    ///
+    /// Empty chunks are not yielded.
+    pub fn chunks(&self) -> impl Iterator<Item = &[u8]> + '_ {
+        match self {
+            Self::Single(chunk) => Chunks::Single((!chunk.is_empty()).then_some(*chunk)),
+            Self::Multiple { chunks, start, end } => Chunks::Multiple {
+                chunks: chunks.iter(),
+                skip: *start,
+                remaining: end - start,
+            },
         }
     }
 
@@ -298,6 +304,55 @@ impl<'a> OutboundPlain<'a> {
         match self {
             Self::Single(chunk) => chunk.len(),
             Self::Multiple { start, end, .. } => end - start,
+        }
+    }
+}
+
+/// Iterator over an [`OutboundPlain`]'s chunks, returned by [`OutboundPlain::chunks()`].
+enum Chunks<'a> {
+    Single(Option<&'a [u8]>),
+    Multiple {
+        /// Chunks not yet visited, including any leading ones `skip` covers.
+        chunks: slice::Iter<'a, &'a [u8]>,
+        /// How many leading bytes remain to be skipped.
+        skip: usize,
+        /// How many bytes remain to be yielded.
+        remaining: usize,
+    },
+}
+
+impl<'a> Iterator for Chunks<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (chunks, skip, remaining) = match self {
+            Self::Single(chunk) => return chunk.take(),
+            Self::Multiple {
+                chunks,
+                skip,
+                remaining,
+            } => (chunks, skip, remaining),
+        };
+
+        loop {
+            if *remaining == 0 {
+                return None;
+            }
+
+            let chunk = chunks.next()?;
+            let Some((_, chunk)) = chunk.split_at_checked(*skip) else {
+                *skip -= chunk.len();
+                continue;
+            };
+
+            *skip = 0;
+            if chunk.is_empty() {
+                continue;
+            }
+
+            let take = Ord::min(chunk.len(), *remaining);
+            *remaining -= take;
+            return Some(&chunk[..take]);
         }
     }
 }
@@ -373,6 +428,84 @@ impl AsMut<[u8]> for OutboundOpaque {
 impl<'a> Extend<&'a u8> for OutboundOpaque {
     fn extend<T: IntoIterator<Item = &'a u8>>(&mut self, iter: T) {
         self.payload.extend(iter)
+    }
+}
+
+/// A fixed-size buffer into which a [`MessageEncrypter`][] writes an encrypted message payload.
+///
+/// This wraps the output buffer passed to [`MessageEncrypter::encrypt()`][], tracking how
+/// much of it has been written as the append methods fill it front-to-back. It writes
+/// into caller-owned memory and cannot grow. [`Self::new()`] checks that the caller's
+/// buffer can hold the `len` bytes the encrypter declared, and the append methods then
+/// panic if the writes exceed that length.
+///
+/// Such a panic always indicates a bug in the `MessageEncrypter` implementation, not a
+/// runtime condition the caller can handle. The same implementation declares the total
+/// length up front (via [`MessageEncrypter::encrypted_payload_len()`]) and performs the
+/// writes, so overflowing the buffer means the two disagree. The record layer also
+/// relies on that declared length for framing, so there is no way to recover from the
+/// mismatch after the fact.
+///
+/// [`MessageEncrypter`]: crate::crypto::cipher::MessageEncrypter
+/// [`MessageEncrypter::encrypt()`]: crate::crypto::cipher::MessageEncrypter::encrypt()
+/// [`MessageEncrypter::encrypted_payload_len()`]: crate::crypto::cipher::MessageEncrypter::encrypted_payload_len()
+pub struct EncryptBuffer<'a> {
+    buf: &'a mut [u8],
+    used: usize,
+}
+
+impl<'a> EncryptBuffer<'a> {
+    /// Wrap the first `len` bytes of `out`, all of which are as yet unwritten.
+    ///
+    /// Returns [`ApiMisuse::EncryptBufferTooSmall`] if `out` is shorter than `len` bytes.
+    pub fn new(out: &'a mut [u8], len: usize) -> Result<Self, Error> {
+        let provided = out.len();
+        match out.get_mut(..len) {
+            Some(buf) => Ok(Self { buf, used: 0 }),
+            None => Err(ApiMisuse::EncryptBufferTooSmall {
+                required: len,
+                provided,
+            }
+            .into()),
+        }
+    }
+
+    /// Append bytes from an `OutboundPlain`'s chunks.
+    ///
+    /// Panics if the write would extend beyond the `len` given to [`Self::new()`],
+    /// which indicates a bug in the calling `MessageEncrypter` implementation (see
+    /// the type-level documentation).
+    pub fn extend_from_chunks(&mut self, chunks: &OutboundPlain<'_>) {
+        match chunks {
+            // for the common case with a single chunk we want to avoid iteration overhead.
+            OutboundPlain::Single(chunk) => self.extend_from_slice(chunk),
+            chunks => {
+                for chunk in chunks.chunks() {
+                    self.extend_from_slice(chunk);
+                }
+            }
+        }
+    }
+
+    /// Append bytes from a slice.
+    ///
+    /// Panics if the write would extend beyond the `len` given to [`Self::new()`],
+    /// which indicates a bug in the calling `MessageEncrypter` implementation (see
+    /// the type-level documentation).
+    pub fn extend_from_slice(&mut self, slice: &[u8]) {
+        self.buf[self.used..self.used + slice.len()].copy_from_slice(slice);
+        self.used += slice.len();
+    }
+
+    /// Consume this value, returning the written prefix of the wrapped buffer.
+    pub fn into_written(self) -> &'a [u8] {
+        &self.buf[..self.used]
+    }
+}
+
+impl AsMut<[u8]> for EncryptBuffer<'_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[..self.used]
     }
 }
 
@@ -519,6 +652,57 @@ mod tests {
     use std::{println, vec};
 
     use super::*;
+
+    #[test]
+    fn encrypt_buffer_appends() {
+        let mut space = [0u8; 8];
+        let mut buf = EncryptBuffer::new(&mut space[..], 6).unwrap();
+        buf.extend_from_slice(&[1, 2]);
+        buf.extend_from_chunks(&OutboundPlain::new(&[&[3u8, 4][..], &[5][..]]));
+        buf.extend_from_slice(&[6]);
+        assert_eq!(buf.as_mut(), &mut [1, 2, 3, 4, 5, 6]);
+        assert_eq!(buf.into_written(), &[1, 2, 3, 4, 5, 6]);
+        assert_eq!(space, [1, 2, 3, 4, 5, 6, 0, 0]);
+    }
+
+    #[test]
+    fn encrypt_buffer_rejects_short_buffer() {
+        let mut space = [0u8; 4];
+        assert!(matches!(
+            EncryptBuffer::new(&mut space[..], 5),
+            Err(Error::ApiMisuse(ApiMisuse::EncryptBufferTooSmall {
+                required: 5,
+                provided: 4,
+            }))
+        ));
+    }
+
+    #[test]
+    fn chunks_iteration() {
+        // `Single` yields its chunk, unless empty
+        assert_eq!(
+            OutboundPlain::Single(&[1, 2, 3])
+                .chunks()
+                .collect::<Vec<_>>(),
+            [&[1u8, 2, 3][..]],
+        );
+        assert_eq!(
+            OutboundPlain::new_empty()
+                .chunks()
+                .count(),
+            0
+        );
+
+        // `Multiple` yields the in-window part of each chunk, skipping
+        // empty chunks
+        let owner: Vec<&[u8]> = vec![&[], &[1, 2, 3], &[], &[4, 5], &[], &[6, 7], &[]];
+        let (_, tail) = OutboundPlain::new(&owner).split_at(1);
+        let (window, _) = tail.split_at(5);
+        assert_eq!(
+            window.chunks().collect::<Vec<_>>(),
+            [&[2u8, 3][..], &[4, 5][..], &[6][..]],
+        );
+    }
 
     #[test]
     fn split_at_with_single_slice() {

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -163,13 +163,31 @@ impl EncodedMessage<OutboundPlain<'_>> {
 impl EncodedMessage<OutboundOpaque> {
     /// Encode this message to a vector of bytes.
     pub fn encode(self) -> Vec<u8> {
-        let length = self.payload.len() as u16;
+        let length = self.payload.len();
         let mut encoded_payload = self.payload.payload;
-        encoded_payload[0] = self.typ.into();
-        encoded_payload[1..3].copy_from_slice(&self.version.to_array());
-        encoded_payload[3..5].copy_from_slice(&(length).to_be_bytes());
+        encoded_payload[..HEADER_SIZE].copy_from_slice(&encode_record_header(
+            self.typ,
+            self.version,
+            length,
+        ));
         encoded_payload
     }
+}
+
+/// Encode a TLS record header.
+///
+/// `typ`, `version` and `len` describe the record's payload.  `len` is
+/// debug-asserted to fit the header's 16-bit length field, and truncated to
+/// 16 bits in release builds.
+pub(crate) fn encode_record_header(
+    typ: ContentType,
+    version: ProtocolVersion,
+    len: usize,
+) -> [u8; HEADER_SIZE] {
+    debug_assert!(len <= usize::from(u16::MAX));
+    let [version_hi, version_lo] = version.to_array();
+    let [len_hi, len_lo] = (len as u16).to_be_bytes();
+    [typ.into(), version_hi, version_lo, len_hi, len_lo]
 }
 
 /// A collection of borrowed plaintext slices.

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -164,11 +164,12 @@ impl EncodedMessage<OutboundOpaque> {
     /// Encode this message to a vector of bytes.
     pub fn encode(self) -> Vec<u8> {
         let length = self.payload.len();
+        debug_assert!(length <= usize::from(u16::MAX));
         let mut encoded_payload = self.payload.payload;
         encoded_payload[..HEADER_SIZE].copy_from_slice(&encode_record_header(
             self.typ,
             self.version,
-            length,
+            length as u16,
         ));
         encoded_payload
     }
@@ -176,17 +177,14 @@ impl EncodedMessage<OutboundOpaque> {
 
 /// Encode a TLS record header.
 ///
-/// `typ`, `version` and `len` describe the record's payload.  `len` is
-/// debug-asserted to fit the header's 16-bit length field, and truncated to
-/// 16 bits in release builds.
+/// `typ`, `version` and `len` describe the record's payload.
 pub(crate) fn encode_record_header(
     typ: ContentType,
     version: ProtocolVersion,
-    len: usize,
+    len: u16,
 ) -> [u8; HEADER_SIZE] {
-    debug_assert!(len <= usize::from(u16::MAX));
     let [version_hi, version_lo] = version.to_array();
-    let [len_hi, len_lo] = (len as u16).to_be_bytes();
+    let [len_hi, len_lo] = len.to_be_bytes();
     [typ.into(), version_hi, version_lo, len_hi, len_lo]
 }
 

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -11,8 +11,10 @@ use crate::msgs::{put_u16, put_u64};
 use crate::suites::ConnectionTrafficSecrets;
 
 mod messages;
+pub(crate) use messages::encode_record_header;
 pub use messages::{
-    EncodedMessage, InboundOpaque, MessageError, OutboundOpaque, OutboundPlain, Payload,
+    EncodedMessage, EncryptBuffer, InboundOpaque, MessageError, OutboundOpaque, OutboundPlain,
+    Payload,
 };
 
 mod record_layer;
@@ -157,13 +159,25 @@ pub trait MessageDecrypter: Send + Sync {
 
 /// Objects with this trait can encrypt TLS messages.
 pub trait MessageEncrypter: Send + Sync {
-    /// Encrypt the given TLS message `msg`, using the sequence number
+    /// Encrypt the given TLS message `msg` into `out`, using the sequence number
     /// `seq` which can be used to derive a unique [`Nonce`].
-    fn encrypt(
+    ///
+    /// The encrypted payload including all framing the ciphersuite requires, such
+    /// as any explicit nonce, padding and/or authentication tag, is written to the
+    /// front of `out`. `out` must be at least [`Self::encrypted_payload_len()`] bytes
+    /// long. See [`EncryptBuffer`] for a convenient wrapper.
+    ///
+    /// The returned message describes the resulting record: its payload borrows the
+    /// written prefix of `out`, and its `typ` and `version` are what the record
+    /// header should carry on the wire. Encoding the record header is the caller's
+    /// responsibility and implementations of the `MessageEncrypter` trait must not
+    /// write it to `out` themselves.
+    fn encrypt<'a>(
         &mut self,
         msg: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error>;
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error>;
 
     /// Return the length of the ciphertext that results from encrypting plaintext of
     /// length `payload_len`

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -13,8 +13,7 @@ use crate::suites::ConnectionTrafficSecrets;
 mod messages;
 pub(crate) use messages::encode_record_header;
 pub use messages::{
-    EncodedMessage, EncryptBuffer, InboundOpaque, MessageError, OutboundOpaque, OutboundPlain,
-    Payload,
+    EncodedMessage, EncryptBuffer, InboundOpaque, MessageError, OutboundPlain, Payload,
 };
 
 mod record_layer;

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -1,13 +1,15 @@
 use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
 use core::cmp::min;
 
 use crate::crypto::cipher::{
-    EncodedMessage, InboundOpaque, MessageDecrypter, MessageEncrypter, OutboundOpaque,
-    OutboundPlain,
+    EncodedMessage, InboundOpaque, MessageDecrypter, MessageEncrypter, OutboundPlain,
+    encode_record_header,
 };
 use crate::error::Error;
 use crate::log::trace;
-use crate::msgs::HandshakeAlignedProof;
+use crate::msgs::{HEADER_SIZE, HandshakeAlignedProof};
 
 /// Record layer that tracks encryption keys.
 pub(crate) struct EncryptionState {
@@ -26,22 +28,39 @@ impl EncryptionState {
         }
     }
 
-    /// Encrypt a TLS message.
+    /// Encrypt a TLS message, returning the fully-encoded record.
     ///
     /// `plain` is a TLS message we'd like to send.  This function
     /// panics if the requisite keying material hasn't been established yet.
-    pub(crate) fn encrypt_outgoing(
-        &mut self,
-        plain: EncodedMessage<OutboundPlain<'_>>,
-    ) -> EncodedMessage<OutboundOpaque> {
+    pub(crate) fn encrypt_outgoing(&mut self, plain: EncodedMessage<OutboundPlain<'_>>) -> Vec<u8> {
         assert!(self.pre_encrypt_action(0) != Some(PreEncryptAction::Refuse));
+        let encrypter = self.message_encrypter.as_mut().unwrap();
+
         let seq = self.write_seq;
         self.write_seq += 1;
-        self.message_encrypter
-            .as_mut()
-            .unwrap()
-            .encrypt(plain, seq)
-            .unwrap()
+
+        let needed = HEADER_SIZE + encrypter.encrypted_payload_len(plain.payload.len());
+        let mut record = vec![0u8; needed];
+        let out_ptr = record.as_ptr();
+        let encrypted = encrypter
+            .encrypt(plain, seq, &mut record[HEADER_SIZE..])
+            .unwrap();
+
+        // `MessageEncrypter::encrypt()` requires the returned payload to be
+        // the written prefix of the passed-in buffer. Try to catch misbehaving
+        // implementations in debug mode. In release builds a violation would corrupt
+        // the sent stream.
+        debug_assert_eq!(
+            encrypted.payload.as_ptr(),
+            out_ptr.wrapping_add(HEADER_SIZE)
+        );
+        debug_assert!(encrypted.payload.len() <= needed - HEADER_SIZE);
+
+        let (typ, version, len) = (encrypted.typ, encrypted.version, encrypted.payload.len());
+        record.truncate(HEADER_SIZE + len);
+        debug_assert!(len <= usize::from(u16::MAX));
+        record[..HEADER_SIZE].copy_from_slice(&encode_record_header(typ, version, len as u16));
+        record
     }
 
     /// Set and start using the given `MessageEncrypter` for future outgoing

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -32,9 +32,25 @@ impl EncryptionState {
     ///
     /// `plain` is a TLS message we'd like to send.  This function
     /// panics if the requisite keying material hasn't been established yet.
-    pub(crate) fn encrypt_outgoing(&mut self, plain: EncodedMessage<OutboundPlain<'_>>) -> Vec<u8> {
+    ///
+    /// `record` is a spent buffer to reuse for the output (it may have any
+    /// length and contents, which are wholly overwritten). Pass an empty
+    /// vector if none is available.
+    pub(crate) fn encrypt_outgoing(
+        &mut self,
+        plain: EncodedMessage<OutboundPlain<'_>>,
+        mut record: Vec<u8>,
+    ) -> Vec<u8> {
+        // Contents are fully overwritten below, so zeroing is pure cost.
+        // A fresh buffer gets pre-zeroed memory straight from the allocator
+        // while a reused one zeroes only what `resize` grows.
         let needed = HEADER_SIZE + self.encrypted_len(plain.payload.len());
-        let mut record = vec![0u8; needed];
+        if record.capacity() == 0 {
+            record = vec![0u8; needed];
+        } else {
+            record.resize(needed, 0);
+        }
+
         let written = self.encrypt_outgoing_into(plain, &mut record);
         record.truncate(written);
         record

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -33,34 +33,56 @@ impl EncryptionState {
     /// `plain` is a TLS message we'd like to send.  This function
     /// panics if the requisite keying material hasn't been established yet.
     pub(crate) fn encrypt_outgoing(&mut self, plain: EncodedMessage<OutboundPlain<'_>>) -> Vec<u8> {
+        let needed = HEADER_SIZE + self.encrypted_len(plain.payload.len());
+        let mut record = vec![0u8; needed];
+        let written = self.encrypt_outgoing_into(plain, &mut record);
+        record.truncate(written);
+        record
+    }
+
+    /// Encrypt a TLS message directly into `out`, returning the encoded
+    /// record's length.
+    ///
+    /// The record, header included, is written to the front of `out`,
+    /// which must be at least `HEADER_SIZE` plus
+    /// [`Self::encrypted_len()`](Self::encrypted_len) bytes long.
+    ///
+    /// This function panics if the requisite keying material hasn't been
+    /// established yet.
+    pub(crate) fn encrypt_outgoing_into(
+        &mut self,
+        plain: EncodedMessage<OutboundPlain<'_>>,
+        out: &mut [u8],
+    ) -> usize {
         assert!(self.pre_encrypt_action(0) != Some(PreEncryptAction::Refuse));
         let encrypter = self.message_encrypter.as_mut().unwrap();
 
         let seq = self.write_seq;
         self.write_seq += 1;
 
-        let needed = HEADER_SIZE + encrypter.encrypted_payload_len(plain.payload.len());
-        let mut record = vec![0u8; needed];
-        let out_ptr = record.as_ptr();
+        #[cfg(debug_assertions)]
+        let (out_ptr, out_len) = (out.as_ptr(), out.len());
         let encrypted = encrypter
-            .encrypt(plain, seq, &mut record[HEADER_SIZE..])
+            .encrypt(plain, seq, &mut out[HEADER_SIZE..])
             .unwrap();
 
-        // `MessageEncrypter::encrypt()` requires the returned payload to be
-        // the written prefix of the passed-in buffer. Try to catch misbehaving
-        // implementations in debug mode. In release builds a violation would corrupt
-        // the sent stream.
-        debug_assert_eq!(
-            encrypted.payload.as_ptr(),
-            out_ptr.wrapping_add(HEADER_SIZE)
-        );
-        debug_assert!(encrypted.payload.len() <= needed - HEADER_SIZE);
+        #[cfg(debug_assertions)]
+        {
+            // `MessageEncrypter::encrypt()` requires the returned payload to be
+            // the written prefix of the passed-in buffer. Try to catch misbehaving
+            // implementations in debug mode. In release builds a violation would corrupt
+            // the sent stream.
+            debug_assert_eq!(
+                encrypted.payload.as_ptr(),
+                out_ptr.wrapping_add(HEADER_SIZE)
+            );
+            debug_assert!(encrypted.payload.len() <= out_len - HEADER_SIZE);
+        }
 
         let (typ, version, len) = (encrypted.typ, encrypted.version, encrypted.payload.len());
-        record.truncate(HEADER_SIZE + len);
         debug_assert!(len <= usize::from(u16::MAX));
-        record[..HEADER_SIZE].copy_from_slice(&encode_record_header(typ, version, len as u16));
-        record
+        out[..HEADER_SIZE].copy_from_slice(&encode_record_header(typ, version, len as u16));
+        HEADER_SIZE + len
     }
 
     /// Set and start using the given `MessageEncrypter` for future outgoing

--- a/rustls/src/crypto/test_provider.rs
+++ b/rustls/src/crypto/test_provider.rs
@@ -5,8 +5,8 @@ use core::time::Duration;
 use std::borrow::Cow;
 
 use crate::crypto::cipher::{
-    AeadKey, EncodedMessage, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
-    OutboundOpaque, OutboundPlain, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
+    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter,
+    MessageEncrypter, OutboundPlain, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
     UnsupportedOperationError,
 };
 use crate::crypto::kx::{
@@ -366,13 +366,14 @@ impl Tls12AeadAlgorithm for Aead {
 pub(crate) struct Tls13Cipher;
 
 impl MessageEncrypter for Tls13Cipher {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         m: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(m.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         payload.extend_from_chunks(&m.payload);
         payload.extend_from_slice(&m.typ.to_array());
@@ -391,7 +392,7 @@ impl MessageEncrypter for Tls13Cipher {
         Ok(EncodedMessage {
             typ: ContentType::ApplicationData,
             version: ProtocolVersion::TLSv1_2,
-            payload,
+            payload: payload.into_written(),
         })
     }
 
@@ -435,13 +436,14 @@ impl MessageDecrypter for Tls13Cipher {
 struct Tls12Cipher;
 
 impl MessageEncrypter for Tls12Cipher {
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         m: EncodedMessage<OutboundPlain<'_>>,
         seq: u64,
-    ) -> Result<EncodedMessage<OutboundOpaque>, Error> {
+        out: &'a mut [u8],
+    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(m.payload.len());
-        let mut payload = OutboundOpaque::with_capacity(total_len);
+        let mut payload = EncryptBuffer::new(out, total_len)?;
         payload.extend_from_chunks(&m.payload);
 
         for (p, mask) in payload
@@ -458,7 +460,7 @@ impl MessageEncrypter for Tls12Cipher {
         Ok(EncodedMessage {
             typ: m.typ,
             version: m.version,
-            payload,
+            payload: payload.into_written(),
         })
     }
 

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1687,6 +1687,14 @@ pub enum ApiMisuse {
     /// [`ServerConnection::split()`]: crate::server::ServerConnection::split()
     /// [`ClientConnection::split()`]: crate::client::ClientConnection::split()
     SplitWithPendingBuffers,
+
+    /// An output buffer provided for encryption was too small.
+    EncryptBufferTooSmall {
+        /// The minimum required buffer length
+        required: usize,
+        /// The buffer length actually provided
+        provided: usize,
+    },
 }
 
 impl fmt::Display for ApiMisuse {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -390,6 +390,7 @@ pub use crate::conn::{
 ///
 /// See [`split::SplitConnection`] for more information.
 pub mod split {
+    pub use crate::conn::WrittenInto;
     pub use crate::conn::split::{
         FlushSender, ReceiveTraffic, ReceiveTrafficState, ReceivedApplicationData, SendTraffic,
         SplitConnection,

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -126,7 +126,7 @@ mod tests {
         assert_eq!(&m.version, version);
         assert_eq!(m.payload.to_vec(), bytes);
 
-        let buf = m.to_unencrypted_opaque().encode();
+        let buf = m.to_unencrypted_bytes();
 
         assert_eq!(total_len, buf.len());
     }

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -136,8 +136,8 @@ pub mod fuzzing {
 
         //println!("msg = {:#?}", m);
         let enc = EncodedMessage::<Payload<'_>>::from(msg)
-            .into_unencrypted_opaque()
-            .encode();
+            .borrow_outbound()
+            .to_unencrypted_bytes();
         //println!("data = {:?}", &data[..rdr.used()]);
         assert_eq!(enc, data[..data.len() - rdr.left()]);
     }
@@ -195,8 +195,8 @@ impl Message<'_> {
     #[cfg(test)]
     pub(crate) fn into_wire_bytes(self) -> Vec<u8> {
         EncodedMessage::<Payload<'_>>::from(self)
-            .into_unencrypted_opaque()
-            .encode()
+            .borrow_outbound()
+            .to_unencrypted_bytes()
     }
 
     pub(crate) fn handshake_type(&self) -> Option<HandshakeType> {
@@ -698,7 +698,6 @@ mod tests {
     use std::{format, fs, println};
 
     use super::*;
-    use crate::crypto::cipher::OutboundOpaque;
     use crate::error::AlertDescription;
 
     #[test]
@@ -728,8 +727,8 @@ mod tests {
             };
 
             let enc = EncodedMessage::<Payload<'_>>::from(msg)
-                .into_unencrypted_opaque()
-                .encode();
+                .borrow_outbound()
+                .to_unencrypted_bytes();
             assert_eq!(bytes.to_vec(), enc);
             assert_eq!(bytes[..bytes.len() - rd.left()].to_vec(), enc);
         }
@@ -826,12 +825,9 @@ mod tests {
         while r.any_left() {
             let m = EncodedMessage::<Payload<'_>>::read(&mut r).unwrap();
 
-            let out = EncodedMessage {
-                typ: m.typ,
-                version: m.version,
-                payload: OutboundOpaque::from_byte_slice(m.payload.bytes()),
-            }
-            .encode();
+            let out = m
+                .borrow_outbound()
+                .to_unencrypted_bytes();
             assert!(!out.is_empty());
 
             Message::try_from(&m).unwrap();

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -508,7 +508,7 @@ impl EarlyDataState {
 
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
-            Self::Accepted { received, .. } => received.read(buf),
+            Self::Accepted { received, .. } => Ok(received.read(buf)),
             _ => Err(io::Error::from(io::ErrorKind::BrokenPipe)),
         }
     }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -20,6 +20,15 @@ pub(crate) struct ChunkVecBuffer {
 
     /// The total upper limit (in bytes) of this object.
     limit: Option<usize>,
+
+    /// Fully-consumed chunks retained for reuse via `take_spare()`.
+    ///
+    /// `None` means recycling is disabled and spent chunks are freed.
+    /// Retention is opt-in (via `new_recycling()`) because it only pays
+    /// off for a buffer whose owner takes chunks back out, i.e. the send
+    /// path's `sendable_tls`. Elsewhere it would hold dead memory for
+    /// the connection's lifetime.
+    spare: Option<Vec<Vec<u8>>>,
 }
 
 impl ChunkVecBuffer {
@@ -28,7 +37,38 @@ impl ChunkVecBuffer {
             prefix_used: 0,
             chunks: VecDeque::new(),
             limit,
+            spare: None,
         }
+    }
+
+    /// Like `new()`, but fully-consumed chunks are retained and can be
+    /// reused via `take_spare()`.
+    ///
+    /// The total capacity retained this way is bounded by `limit`. The
+    /// `ChunkVecBuffer` never holds more spare capacity than it is allowed
+    /// to hold queued data. An unlimited buffer retains every spent chunk,
+    /// so its spare capacity is bounded by its peak queued size.
+    ///
+    /// Since chunks are only spent by being consumed, retained chunks only
+    /// ever contain data that has already been written to the wire.
+    pub(crate) fn new_recycling(limit: Option<usize>) -> Self {
+        Self {
+            prefix_used: 0,
+            chunks: VecDeque::new(),
+            limit,
+            spare: Some(Vec::new()),
+        }
+    }
+
+    /// Take a previously-spent chunk for reuse, if one is available.
+    ///
+    /// The returned vector has unspecified length and contents. Callers
+    /// must resize it and overwrite its contents before use.
+    pub(crate) fn take_spare(&mut self) -> Vec<u8> {
+        self.spare
+            .as_mut()
+            .and_then(|spare| spare.pop())
+            .unwrap_or_default()
     }
 
     /// Sets the upper limit on how many bytes this
@@ -184,9 +224,11 @@ impl ChunkVecBuffer {
         while let Some(buf) = self.chunks.front() {
             if self.prefix_used < buf.len() {
                 return;
-            } else {
-                self.prefix_used -= buf.len();
-                self.chunks.pop_front();
+            }
+
+            self.prefix_used -= buf.len();
+            if let Some(spent) = self.chunks.pop_front() {
+                self.recycle(spent);
             }
         }
 
@@ -194,6 +236,26 @@ impl ChunkVecBuffer {
             self.prefix_used, 0,
             "attempted to `ChunkVecBuffer::consume` more than available"
         );
+    }
+
+    /// Retain `spent` for reuse via `take_spare()`, if recycling is enabled and there is capacity
+    /// relative to the limit.
+    fn recycle(&mut self, spent: Vec<u8>) {
+        let Some(spare) = &mut self.spare else {
+            return;
+        };
+
+        if let Some(limit) = self.limit {
+            let retained = spare
+                .iter()
+                .map(|chunk| chunk.capacity())
+                .sum::<usize>();
+            if retained + spent.capacity() > limit {
+                return;
+            }
+        }
+
+        spare.push(spent);
     }
 
     /// Read data out of this object, passing it `wr`
@@ -253,6 +315,41 @@ mod tests {
         let mut buf = [0u8; 12];
         assert_eq!(cvb.read(&mut buf), 12);
         assert_eq!(buf.to_vec(), b"helloworldhe".to_vec());
+    }
+
+    #[test]
+    fn recycling_retains_spent_chunks() {
+        let mut cvb = ChunkVecBuffer::new_recycling(None);
+        assert!(cvb.take_spare().is_empty());
+
+        cvb.append(b"first".to_vec());
+        cvb.append(b"second".to_vec());
+        let mut buf = [0u8; 11];
+        assert_eq!(cvb.read(&mut buf), 11);
+
+        // spent chunks are returned most-recently-spent first, unaltered
+        assert_eq!(cvb.take_spare(), b"second");
+        assert_eq!(cvb.take_spare(), b"first");
+        assert!(cvb.take_spare().is_empty());
+
+        // no retention without recycling enabled
+        let mut cvb = ChunkVecBuffer::new(None);
+        cvb.append(b"first".to_vec());
+        assert_eq!(cvb.read(&mut buf), 5);
+        assert!(cvb.take_spare().is_empty());
+    }
+
+    #[test]
+    fn recycling_bounded_by_limit() {
+        let mut cvb = ChunkVecBuffer::new_recycling(Some(8));
+        cvb.append(vec![1u8; 6]);
+        cvb.append(vec![2u8; 6]);
+        let mut buf = [0u8; 12];
+        assert_eq!(cvb.read(&mut buf), 12);
+
+        // only the first spent chunk fits under the 8-byte cap
+        assert_eq!(cvb.take_spare(), vec![1u8; 6]);
+        assert!(cvb.take_spare().is_empty());
     }
 
     #[test]

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -2,7 +2,6 @@ use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use core::mem;
 use std::io;
-use std::io::Read;
 
 use crate::crypto::cipher::OutboundPlain;
 
@@ -142,17 +141,19 @@ impl ChunkVecBuffer {
 
     /// Read data out of this object, writing it into `buf`
     /// and returning how many bytes were written there.
-    pub(crate) fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    pub(crate) fn read(&mut self, buf: &mut [u8]) -> usize {
         let mut offs = 0;
 
         while offs < buf.len() && !self.is_empty() {
-            let used = (&self.chunks[0][self.prefix_used..]).read(&mut buf[offs..])?;
+            let chunk = &self.chunks[0][self.prefix_used..];
+            let used = Ord::min(chunk.len(), buf.len() - offs);
+            buf[offs..offs + used].copy_from_slice(&chunk[..used]);
 
             self.consume(used);
             offs += used;
         }
 
-        Ok(offs)
+        offs
     }
 
     pub(crate) fn consume_first_chunk(&mut self, used: usize) {
@@ -244,7 +245,7 @@ mod tests {
         assert_eq!(cvb.append_limited_copy(b"world"[..].into()), 0);
 
         let mut buf = [0u8; 12];
-        assert_eq!(cvb.read(&mut buf).unwrap(), 12);
+        assert_eq!(cvb.read(&mut buf), 12);
         assert_eq!(buf.to_vec(), b"helloworldhe".to_vec());
     }
 
@@ -255,11 +256,11 @@ mod tests {
         assert!(!cvb.is_empty());
         for expect in b"test fixture data" {
             let mut byte = [0];
-            assert_eq!(cvb.read(&mut byte).unwrap(), 1);
+            assert_eq!(cvb.read(&mut byte), 1);
             assert_eq!(byte[0], *expect);
         }
 
-        assert_eq!(cvb.read(&mut [0]).unwrap(), 0);
+        assert_eq!(cvb.read(&mut [0]), 0);
     }
 
     #[test]
@@ -281,11 +282,11 @@ mod tests {
                 let mut buf = vec![0u8; output_chunk_len];
 
                 for expect in input.chunks(output_chunk_len) {
-                    assert_eq!(expect.len(), cvb.read(&mut buf).unwrap());
+                    assert_eq!(expect.len(), cvb.read(&mut buf));
                     assert_eq!(expect, &buf[..expect.len()]);
                 }
 
-                assert_eq!(cvb.read(&mut [0]).unwrap(), 0);
+                assert_eq!(cvb.read(&mut [0]), 0);
             }
         }
     }
@@ -302,7 +303,7 @@ mod benchmarks {
         b.iter(|| {
             let mut cvb = ChunkVecBuffer::new(None);
             cvb.append(vec![0u8; 16_384]);
-            assert_eq!(1, cvb.read(&mut [0u8]).unwrap());
+            assert_eq!(1, cvb.read(&mut [0u8]));
         });
     }
 
@@ -312,7 +313,7 @@ mod benchmarks {
             let mut cvb = ChunkVecBuffer::new(None);
             cvb.append(vec![0u8; 16_384]);
             loop {
-                if let Ok(0) = cvb.read(&mut [0u8]) {
+                if cvb.read(&mut [0u8]) == 0 {
                     break;
                 }
             }
@@ -324,8 +325,8 @@ mod benchmarks {
         b.iter(|| {
             let mut cvb = ChunkVecBuffer::new(None);
             cvb.append(vec![0u8; 16_384]);
-            assert_eq!(8192, cvb.read(&mut [0u8; 8192]).unwrap());
-            assert_eq!(8192, cvb.read(&mut [0u8; 8192]).unwrap());
+            assert_eq!(8192, cvb.read(&mut [0u8; 8192]));
+            assert_eq!(8192, cvb.read(&mut [0u8; 8192]));
         });
     }
 
@@ -334,7 +335,7 @@ mod benchmarks {
         b.iter(|| {
             let mut cvb = ChunkVecBuffer::new(None);
             cvb.append(vec![0u8; 16_384]);
-            assert_eq!(16_384, cvb.read(&mut [0u8; 16_384]).unwrap());
+            assert_eq!(16_384, cvb.read(&mut [0u8; 16_384]));
         });
     }
 }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -70,6 +70,31 @@ impl ChunkVecBuffer {
         len
     }
 
+    pub(crate) fn take(&mut self) -> Vec<Vec<u8>> {
+        if self.chunks.is_empty() {
+            return Vec::new();
+        }
+
+        let mut chunks = Vec::from(mem::take(&mut self.chunks));
+        // slice off `prefix_used` if needed (uncommon)
+        let prefix = mem::take(&mut self.prefix_used);
+        chunks[0].drain(0..prefix);
+        chunks
+    }
+
+    pub(crate) fn take_one_vec(&mut self) -> Vec<u8> {
+        // `pop()` slices off `prefix_used`
+        let Some(mut first) = self.pop() else {
+            return Vec::new();
+        };
+
+        while let Some(chunk) = self.chunks.pop_front() {
+            first.extend_from_slice(&chunk);
+        }
+
+        first
+    }
+
     /// Take one of the chunks from this object.
     ///
     /// This function returns `None` if the object `is_empty`.
@@ -90,25 +115,6 @@ impl ChunkVecBuffer {
         self.chunks
             .front()
             .map(|ch| ch.as_slice())
-    }
-
-    pub(crate) fn take(&mut self) -> Vec<Vec<u8>> {
-        if self.chunks.is_empty() {
-            return Vec::new();
-        }
-        mem::take(&mut self.chunks).into()
-    }
-
-    pub(crate) fn take_one_vec(&mut self) -> Vec<u8> {
-        let Some(mut first) = self.chunks.pop_front() else {
-            return Vec::new();
-        };
-
-        while let Some(chunk) = self.chunks.pop_front() {
-            first.extend_from_slice(&chunk);
-        }
-
-        first
     }
 }
 
@@ -247,6 +253,23 @@ mod tests {
         let mut buf = [0u8; 12];
         assert_eq!(cvb.read(&mut buf), 12);
         assert_eq!(buf.to_vec(), b"helloworldhe".to_vec());
+    }
+
+    #[test]
+    fn take_slices_off_consumed_prefix() {
+        let mut cvb = ChunkVecBuffer::new(None);
+        cvb.append(b"hello".to_vec());
+        cvb.append(b"world".to_vec());
+        assert_eq!(cvb.read(&mut [0u8; 3]), 3);
+        assert_eq!(cvb.take(), [b"lo".to_vec(), b"world".to_vec()]);
+        assert_eq!(cvb.len(), 0);
+
+        let mut cvb = ChunkVecBuffer::new(None);
+        cvb.append(b"hello".to_vec());
+        cvb.append(b"world".to_vec());
+        assert_eq!(cvb.read(&mut [0u8; 3]), 3);
+        assert_eq!(cvb.take_one_vec(), b"loworld");
+        assert_eq!(cvb.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
This PR reworks `MessageEncrypter::encrypt()` to write encrypted records into a caller-provided `&mut [u8]` instead of returning a freshly-allocated `OutboundOpaque`, mirroring how `MessageDecrypter::decrypt()` already operates in-place over a borrowed buffer. The plaintext input stays borrowed and immutable as both `*ring*` and `aws-lc-rs` only offer in-place sealing, so one plaintext copy is inherent regardless. The new contract removes the per-record allocation and gives callers control over where ciphertext lands.

Implementations size their output with `encrypted_payload_len()`, write whatever framing their suite needs (explicit nonce, padding, tag) anywhere within the `out` buffer (a small `EncryptBuffer` cursor keeps the provider impls near-identical to their previous form), and return an `EncodedMessage` whose payload borrows the written prefix. Encoding the record header becomes the internal caller's job, via `encode_record_header()`. With nothing producing `OutboundOpaque` any more, the type is removed from the public API. 

Inside the buffered send path we feed encryption with recycled spent record buffers, and the split-mode API gains `SendTraffic::write_into()`, which fragments and encrypts application data directly into a caller's buffer with no internal queueing or allocation. The buffered API gains code to reuse previous buffers to also benefit from the new API design, but this may be too speculative or better to remove in favour of a larger plan to rearchitect the buffered API in terms of the new split-mode unbuffered API. With that in mind I left those commits at the end, easy to drop from the series.

Resolves https://github.com/rustls/rustls/issues/3068