### PR TITLE
Use `ErrorWithAlert` in `Acceptor` API surface

### DIFF
--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -87,9 +87,11 @@ fn main() {
             match acceptor.accept(&mut input) {
                 Ok(Some(accepted)) => break accepted,
                 Ok(None) => continue,
-                Err((e, mut alert)) => {
-                    alert.write_all(&mut stream).unwrap();
-                    panic!("error accepting connection: {e}");
+                Err(mut error_with_alert) => {
+                    if let Some(alert) = error_with_alert.take_tls_data() {
+                        stream.write_all(&alert).unwrap();
+                    }
+                    panic!("error accepting connection: {}", error_with_alert.error);
                 }
             }
         };
@@ -99,9 +101,14 @@ fn main() {
         let config = test_pki.server_config(&args.crl_path, accepted.client_hello());
         let mut conn = match accepted.into_connection(config) {
             Ok(conn) => conn,
-            Err((e, mut alert)) => {
-                alert.write_all(&mut stream).unwrap();
-                panic!("error completing accepting connection: {e}");
+            Err(mut error_with_alert) => {
+                if let Some(alert) = error_with_alert.take_tls_data() {
+                    stream.write_all(&alert).unwrap();
+                }
+                panic!(
+                    "error completing accepting connection: {}",
+                    error_with_alert.error
+                );
             }
         };
 

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -1911,17 +1911,15 @@ fn acceptor_with_illegal_max_fragment_size() {
         .accept(&mut input)
         .unwrap()
         .unwrap();
-    let (err, mut alert) = accepted
+    let mut error_with_alert = accepted
         .into_connection(Arc::new(server_config))
         .err()
         .unwrap();
 
-    assert_eq!(err, Error::BadMaxFragmentSize);
+    assert_eq!(error_with_alert.error, Error::BadMaxFragmentSize);
     assert_eq!(
-        alert
-            .write(&mut &mut [0u8; 128][..])
-            .ok(),
-        Some(0),
+        error_with_alert.take_tls_data(),
+        None,
         "illegal max fragment size should not send an alert, as it is a local configuration issue"
     );
 }
@@ -1938,14 +1936,14 @@ fn excess_client_hello_acceptor() {
     input
         .read(&mut io::Cursor::new(hello))
         .unwrap();
-    let (error, mut alert) = acceptor.accept(&mut input).unwrap_err();
-    assert_eq!(error, PeerMisbehaved::KeyEpochWithPendingFragment.into());
-
-    let mut alert_buf = vec![];
-    alert.write_all(&mut alert_buf).unwrap();
+    let mut error_with_alert = acceptor.accept(&mut input).unwrap_err();
     assert_eq!(
-        alert_buf,
-        encoding::alert(AlertDescription::UnexpectedMessage, &[])
+        error_with_alert.error,
+        PeerMisbehaved::KeyEpochWithPendingFragment.into()
+    );
+    assert_eq!(
+        error_with_alert.take_tls_data(),
+        Some(encoding::alert(AlertDescription::UnexpectedMessage, &[]))
     );
 }
 

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1806,7 +1806,7 @@ fn test_acceptor() {
             .accept(&mut acceptor_input)
             .err()
             .unwrap()
-            .0,
+            .error,
         ApiMisuse::AcceptorPolledAfterCompletion.into()
     );
 
@@ -1831,12 +1831,14 @@ fn test_acceptor() {
     acceptor_input
         .read(&mut [0x80, 0x00].as_ref())
         .unwrap(); // invalid message (len = 32k bytes)
-    let (err, mut alert) = acceptor
+    let mut ea = acceptor
         .accept(&mut acceptor_input)
         .unwrap_err();
-    assert_eq!(err, Error::InvalidMessage(InvalidMessage::MessageTooLarge));
-    let mut alert_content = Vec::new();
-    let _ = alert.write(&mut alert_content);
+    assert_eq!(
+        ea.error,
+        Error::InvalidMessage(InvalidMessage::MessageTooLarge)
+    );
+    let alert_content = ea.take_tls_data().unwrap();
     let expected = encoding::alert(AlertDescription::DecodeError, &[]);
     assert_eq!(alert_content, expected);
 
@@ -1853,17 +1855,17 @@ fn test_acceptor() {
             .as_slice(),
         )
         .unwrap();
-    let (err, mut alert) = acceptor
+    let mut ea = acceptor
         .accept(&mut acceptor_input)
         .unwrap_err();
-    assert!(matches!(err, Error::InappropriateMessage { .. }));
-    let mut alert_content = Vec::new();
-    alert
-        .write_all(&mut alert_content)
-        .unwrap();
+    assert!(matches!(ea.error, Error::InappropriateMessage { .. }));
+    let alert_content = ea.take_tls_data().unwrap();
     let expected = encoding::alert(AlertDescription::UnexpectedMessage, &[]);
     assert_eq!(alert_content, expected);
-    assert_eq!(format!("{alert:?}"), "AcceptedAlert { .. }");
+    assert_eq!(
+        format!("{ea:?}"),
+        "ErrorWithAlert { error: InappropriateMessage { expect_types: [Handshake], got_type: ApplicationData }, data: 0, .. }"
+    );
 
     let mut acceptor = Acceptor::default();
     let mut acceptor_input = VecInput::default();
@@ -1878,17 +1880,14 @@ fn test_acceptor() {
             .as_slice(),
         )
         .unwrap();
-    let (err, mut alert) = acceptor
+    let mut ea = acceptor
         .accept(&mut acceptor_input)
         .unwrap_err();
     assert!(matches!(
-        err,
+        ea.error,
         Error::InvalidMessage(InvalidMessage::MissingData(_))
     ));
-    let mut alert_content = Vec::new();
-    alert
-        .write_all(&mut alert_content)
-        .unwrap();
+    let alert_content = ea.take_tls_data().unwrap();
     let expected = encoding::alert(AlertDescription::DecodeError, &[]);
     assert_eq!(alert_content, expected);
 }
@@ -1978,18 +1977,15 @@ fn test_acceptor_rejected_handshake() {
         Some(&DnsName::try_from("localhost").unwrap())
     );
 
-    let (err, mut alert) = accepted
+    let mut ea = accepted
         .into_connection(server_config.into())
         .unwrap_err();
     assert_eq!(
-        err,
+        ea.error,
         Error::PeerIncompatible(PeerIncompatible::Tls12NotOfferedOrEnabled)
     );
 
-    let mut alert_content = Vec::new();
-    alert
-        .write_all(&mut alert_content)
-        .unwrap();
+    let alert_content = ea.take_tls_data().unwrap();
     let expected = encoding::alert(AlertDescription::ProtocolVersion, &[]);
     assert_eq!(alert_content, expected);
 }

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -12,8 +12,8 @@ use crate::common_state::{CommonState, ConnectionOutputs, EarlyDataEvent, Event,
 use crate::conn::private::SideOutput;
 use crate::conn::split::SplitConnection;
 use crate::conn::{
-    Connection, ConnectionCommon, ConnectionCore, KeyingMaterialExporter, Reader, SendPath,
-    SideData, TlsInputBuffer, Writer,
+    Connection, ConnectionCommon, ConnectionCore, KeyingMaterialExporter, Reader, SideData,
+    TlsInputBuffer, Writer,
 };
 #[cfg(doc)]
 use crate::crypto;
@@ -235,6 +235,7 @@ impl Debug for ServerConnection {
 /// # ) -> std::sync::Arc<rustls::ServerConfig> {
 /// #     unimplemented!();
 /// # }
+/// # use std::io::Write;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use rustls::server::{Acceptor, ServerConfig};
 ///
@@ -249,9 +250,11 @@ impl Debug for ServerConnection {
 ///         match acceptor.accept(&mut input) {
 ///             Ok(Some(accepted)) => break accepted,
 ///             Ok(None) => continue,
-///             Err((err, mut alert)) => {
-///                 alert.write(&mut stream)?;
-///                 return Err(Box::new(err));
+///             Err(mut error_with_alert) => {
+///                 if let Some(alert) = error_with_alert.take_tls_data() {
+///                     stream.write_all(&alert)?;
+///                 }
+///                 return Err(Box::new(error_with_alert.error));
 ///             }
 ///         };
 ///     };
@@ -260,9 +263,11 @@ impl Debug for ServerConnection {
 ///     let config = choose_server_config(accepted.client_hello());
 ///     let conn = match accepted.into_connection(config) {
 ///         Ok(conn) => conn,
-///         Err((err, mut alert)) => {
-///             alert.write(&mut stream)?;
-///             return Err(Box::new(err));
+///         Err(mut error_with_alert) => {
+///             if let Some(alert) = error_with_alert.take_tls_data() {
+///                 stream.write_all(&alert)?;
+///             }
+///             return Err(Box::new(error_with_alert.error));
 ///         }
 ///     };
 ///
@@ -295,22 +300,22 @@ impl Acceptor {
     /// Returns `Ok(Some(accepted))` if the connection has been accepted. Call
     /// `accepted.into_connection()` to continue. Do not call this function again.
     ///
-    /// Returns `Err((err, alert))` if an error occurred. If an alert is returned, the
-    /// application should call `alert.write()` to send the alert to the client. It should
-    /// not call `accept()` again.
+    /// Returns `Err(_)` if an error occurred. The error type optionally carries a TLS alert;
+    /// the application should obtain and write these bytes to the client.
+    ///
+    /// Don't call `accept()` again after an error.
     pub fn accept(
         &mut self,
         buf: &mut dyn TlsInputBuffer,
-    ) -> Result<Option<Accepted>, (Error, AcceptedAlert)> {
+    ) -> Result<Option<Accepted>, ErrorWithAlert> {
         let Some(mut connection) = self.inner.take() else {
-            return Err((
-                ApiMisuse::AcceptorPolledAfterCompletion.into(),
-                AcceptedAlert::empty(),
-            ));
+            return Err(ErrorWithAlert::from(Error::ApiMisuse(
+                ApiMisuse::AcceptorPolledAfterCompletion,
+            )));
         };
 
         if let Err(e) = connection.process_new_packets(buf) {
-            return Err(AcceptedAlert::from_error(e, connection.core.common.send));
+            return Err(ErrorWithAlert::new(e, &mut connection.core.common.send));
         }
 
         const MISUSED: Error = Error::Unreachable("Accepted misused state");
@@ -324,53 +329,8 @@ impl Acceptor {
                 self.inner = Some(connection);
                 Ok(None)
             }
-            Err(e) => Err((
-                e.clone(),
-                AcceptedAlert::from_error(e, connection.core.common.send).1,
-            )),
+            Err(e) => Err(ErrorWithAlert::new(e, &mut connection.core.common.send)),
         }
-    }
-}
-
-/// Represents a TLS alert resulting from handling the client's `ClientHello` message.
-///
-/// When [`Acceptor::accept()`] returns an error, it yields an `AcceptedAlert` such that the
-/// application can communicate failure to the client via [`AcceptedAlert::write()`].
-pub struct AcceptedAlert(ChunkVecBuffer);
-
-impl AcceptedAlert {
-    pub(super) fn from_error(error: Error, mut send: SendPath) -> (Error, Self) {
-        let ErrorWithAlert { error, data } = ErrorWithAlert::new(error, &mut send);
-        let mut output = ChunkVecBuffer::new(None);
-        output.append(data);
-        (error, Self(output))
-    }
-
-    pub(super) fn empty() -> Self {
-        Self(ChunkVecBuffer::new(None))
-    }
-
-    /// Send the alert to the client.
-    ///
-    /// To account for short writes this function should be called repeatedly until it
-    /// returns `Ok(0)` or an error.
-    pub fn write(&mut self, wr: &mut dyn io::Write) -> Result<usize, io::Error> {
-        self.0.write_to(wr)
-    }
-
-    /// Send the alert to the client.
-    ///
-    /// This function will invoke the writer until the buffer is empty.
-    pub fn write_all(&mut self, wr: &mut dyn io::Write) -> Result<(), io::Error> {
-        while self.write(wr)? != 0 {}
-        Ok(())
-    }
-}
-
-impl Debug for AcceptedAlert {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AcceptedAlert")
-            .finish_non_exhaustive()
     }
 }
 
@@ -447,7 +407,7 @@ impl Accepted {
     pub fn into_connection(
         mut self,
         config: Arc<ServerConfig>,
-    ) -> Result<ServerConnection, (Error, AcceptedAlert)> {
+    ) -> Result<ServerConnection, ErrorWithAlert> {
         let result = self.connection.core.accepted(
             self.choose_config,
             ServerExtensionsInput::default(),
@@ -459,9 +419,9 @@ impl Accepted {
             Ok(()) => Ok(ServerConnection {
                 inner: self.connection,
             }),
-            Err(e) => Err((
-                e.clone(),
-                AcceptedAlert::from_error(e, self.connection.core.common.send).1,
+            Err(e) => Err(ErrorWithAlert::new(
+                e,
+                &mut self.connection.core.common.send,
             )),
         }
     }

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -20,9 +20,7 @@ pub use config::{
 };
 
 mod connection;
-pub use connection::{
-    Accepted, AcceptedAlert, Acceptor, ReadEarlyData, ServerConnection, ServerSide,
-};
+pub use connection::{Accepted, Acceptor, ReadEarlyData, ServerConnection, ServerSide};
 
 pub(crate) mod handy;
 #[cfg(feature = "webpki")]


### PR DESCRIPTION
This removes `std::io` dependency from here.