### PR TITLE
backport rfc 9149 ticket_request extension to rel-0.23

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -185,6 +185,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),
             cert_decompressors: compress::default_cert_decompressors().to_vec(),
             ech_mode: self.state.client_ech_mode,
+            send_ticket_request: None,
         }
     }
 }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -287,6 +287,22 @@ pub struct ClientConfig {
 
     /// How to offer Encrypted Client Hello (ECH). The default is to not offer ECH.
     pub(super) ech_mode: Option<EchMode>,
+
+    /// Request a specific number of TLS 1.3 session tickets via [RFC 9149].
+    ///
+    /// Set to `None` to disable sending the extension (the default).
+    ///
+    /// [RFC 9149]: https://datatracker.ietf.org/doc/html/rfc9149
+    pub send_ticket_request: Option<TicketRequest>,
+}
+
+/// Desired session ticket counts for the RFC 9149 `ticket_request` extension.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TicketRequest {
+    /// Tickets desired when the server negotiates a new connection.
+    pub new_session_count: u8,
+    /// Tickets desired when the server resumes using a presented ticket.
+    pub resumption_count: u8,
 }
 
 impl ClientConfig {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -30,9 +30,10 @@ use crate::msgs::base::Payload;
 use crate::msgs::enums::{Compression, ExtensionType};
 use crate::msgs::handshake::{
     CertificateStatusRequest, ClientExtensions, ClientExtensionsInput, ClientHelloPayload,
-    ClientSessionTicket, EncryptedClientHello, HandshakeMessagePayload, HandshakePayload,
-    HelloRetryRequest, KeyShareEntry, ProtocolName, PskKeyExchangeModes, Random, ServerNamePayload,
-    SessionId, SupportedEcPointFormats, SupportedProtocolVersions, TransportParameters,
+    ClientSessionTicket, ClientTicketRequest, EncryptedClientHello, HandshakeMessagePayload,
+    HandshakePayload, HelloRetryRequest, KeyShareEntry, ProtocolName, PskKeyExchangeModes, Random,
+    ServerNamePayload, SessionId, SupportedEcPointFormats, SupportedProtocolVersions,
+    TransportParameters,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -310,6 +311,13 @@ fn emit_client_hello_for_retry(
             psk: false,
             psk_dhe: true,
         });
+
+        if let Some(ticket_req) = &config.send_ticket_request {
+            exts.ticket_request = Some(ClientTicketRequest {
+                new_session_count: ticket_req.new_session_count,
+                resumption_count: ticket_req.resumption_count,
+            });
+        }
     }
 
     input.hello.offered_cert_compression =

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -595,7 +595,7 @@ pub mod client {
     pub use builder::WantsClientCert;
     pub use client_conn::{
         ClientConfig, ClientConnectionData, ClientSessionStore, EarlyDataError, ResolvesClientCert,
-        Resumption, Tls12Resumption, UnbufferedClientConnection,
+        Resumption, TicketRequest, Tls12Resumption, UnbufferedClientConnection,
     };
     #[cfg(feature = "std")]
     pub use client_conn::{ClientConnection, WriteEarlyData};

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -140,6 +140,7 @@ enum_builder! {
         SignatureAlgorithmsCert => 0x0032,
         KeyShare => 0x0033,
         TransportParameters => 0x0039,
+        TicketRequest => 0x003a,
         NextProtocolNegotiation => 0x3374,
         ChannelId => 0x754f,
         RenegotiationInfo => 0xff01,

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -827,6 +827,47 @@ impl TransportParameters<'_> {
     }
 }
 
+/// RFC 9149: ClientTicketRequest extension payload.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct ClientTicketRequest {
+    /// Tickets desired when the server negotiates a new connection.
+    pub new_session_count: u8,
+    /// Tickets desired when the server resumes using a presented ticket.
+    pub resumption_count: u8,
+}
+
+impl Codec<'_> for ClientTicketRequest {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.new_session_count.encode(bytes);
+        self.resumption_count.encode(bytes);
+    }
+
+    fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
+        Ok(Self {
+            new_session_count: u8::read(r)?,
+            resumption_count: u8::read(r)?,
+        })
+    }
+}
+
+/// RFC 9149: ServerTicketRequestHint extension payload.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct ServerTicketRequestHint {
+    pub(crate) expected_count: u8,
+}
+
+impl Codec<'_> for ServerTicketRequestHint {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.expected_count.encode(bytes);
+    }
+
+    fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
+        Ok(Self {
+            expected_count: u8::read(r)?,
+        })
+    }
+}
+
 extension_struct! {
     /// A representation of extensions present in a `ClientHello` message
     ///
@@ -912,6 +953,10 @@ extension_struct! {
         ExtensionType::TransportParameters =>
             pub(crate) transport_parameters: Option<Payload<'a>>,
 
+        /// Ticket request (RFC9149)
+        ExtensionType::TicketRequest =>
+            pub(crate) ticket_request: Option<ClientTicketRequest>,
+
         /// Secure renegotiation (RFC5746)
         ExtensionType::RenegotiationInfo =>
             pub(crate) renegotiation_info: Option<PayloadU8>,
@@ -958,6 +1003,7 @@ impl ClientExtensions<'_> {
             certificate_authority_names,
             key_shares,
             transport_parameters,
+            ticket_request,
             renegotiation_info,
             transport_parameters_draft,
             encrypted_client_hello,
@@ -985,6 +1031,7 @@ impl ClientExtensions<'_> {
             certificate_authority_names,
             key_shares,
             transport_parameters: transport_parameters.map(|x| x.into_owned()),
+            ticket_request,
             renegotiation_info,
             transport_parameters_draft: transport_parameters_draft.map(|x| x.into_owned()),
             encrypted_client_hello,
@@ -1192,6 +1239,10 @@ extension_struct! {
         ExtensionType::EarlyData =>
             pub(crate) early_data_ack: Option<()>,
 
+        /// Ticket request hint (RFC9149)
+        ExtensionType::TicketRequest =>
+            pub(crate) ticket_request: Option<ServerTicketRequestHint>,
+
         /// Encrypted inner client hello response (draft-ietf-tls-esni)
         ExtensionType::EncryptedClientHello =>
             pub(crate) encrypted_client_hello_ack: Option<ServerEncryptedClientHello>,
@@ -1218,6 +1269,7 @@ impl ServerExtensions<'_> {
             transport_parameters,
             transport_parameters_draft,
             early_data_ack,
+            ticket_request,
             encrypted_client_hello_ack,
             unknown_extensions,
         } = self;
@@ -1237,6 +1289,7 @@ impl ServerExtensions<'_> {
             transport_parameters: transport_parameters.map(|x| x.into_owned()),
             transport_parameters_draft: transport_parameters_draft.map(|x| x.into_owned()),
             early_data_ack,
+            ticket_request,
             encrypted_client_hello_ack,
             unknown_extensions,
         }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -831,6 +831,7 @@ fn sample_server_hello_payload() -> ServerHelloPayload {
             key_share: Some(KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3][..])),
             preshared_key: Some(3),
             early_data_ack: Some(()),
+            ticket_request: None,
             encrypted_client_hello_ack: Some(ServerEncryptedClientHello {
                 retry_configs: vec![],
             }),

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -121,6 +121,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             max_early_data_size: 0,
             send_half_rtt_data: false,
             send_tls13_tickets: 2,
+            max_tls13_tickets: 0,
             #[cfg(feature = "tls12")]
             require_ems,
             time_provider: self.time_provider,

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -398,6 +398,18 @@ pub struct ServerConfig {
     /// do any resumption.
     pub send_tls13_tickets: usize,
 
+    /// Upper bound on the number of TLS 1.3 tickets sent in response to a
+    /// client [RFC 9149] `ticket_request` extension.
+    ///
+    /// A client requesting `n` tickets receives `min(n, max_tls13_tickets)`.
+    /// Set to 0 to ignore client requests entirely (clients get
+    /// `send_tls13_tickets` regardless).
+    ///
+    /// The default is 0 (extension is ignored, preserving current behavior).
+    ///
+    /// [RFC 9149]: https://datatracker.ietf.org/doc/html/rfc9149
+    pub max_tls13_tickets: usize,
+
     /// If set to `true`, requires the client to support the extended
     /// master secret extraction method defined in [RFC 7627].
     ///

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -48,7 +48,8 @@ mod client_hello {
     use crate::msgs::handshake::{
         CertificatePayloadTls13, CertificateRequestExtensions, CertificateRequestPayloadTls13,
         ClientHelloPayload, HelloRetryRequest, HelloRetryRequestExtensions, KeyShareEntry, Random,
-        ServerExtensions, ServerExtensionsInput, ServerHelloPayload, SessionId,
+        ServerExtensions, ServerExtensionsInput, ServerHelloPayload, ServerTicketRequestHint,
+        SessionId,
     };
     use crate::server::common::ActiveCertifiedKey;
     use crate::sign;
@@ -327,7 +328,22 @@ mod client_hello {
                 chosen_psk_index = None;
                 resumedata = None;
             } else {
-                self.send_tickets = self.config.send_tls13_tickets;
+                // RFC 9149: if the client sent a ticket_request extension and the
+                // server has configured a max, honor the client's request.
+                self.send_tickets = if self.config.max_tls13_tickets > 0 {
+                    if let Some(req) = &client_hello.ticket_request {
+                        let requested = usize::from(if resumedata.is_some() {
+                            req.resumption_count
+                        } else {
+                            req.new_session_count
+                        });
+                        Ord::min(requested, self.config.max_tls13_tickets)
+                    } else {
+                        self.config.send_tls13_tickets
+                    }
+                } else {
+                    self.config.send_tls13_tickets
+                };
             }
 
             if let Some(resume) = &resumedata {
@@ -375,6 +391,7 @@ mod client_hello {
                 resumedata.as_ref(),
                 self.extra_exts,
                 &self.config,
+                self.send_tickets,
             )?;
 
             let doing_client_auth = if full_handshake {
@@ -674,9 +691,17 @@ mod client_hello {
         resumedata: Option<&persist::ServerSessionValue>,
         extra_exts: ServerExtensionsInput<'static>,
         config: &ServerConfig,
+        send_tickets: usize,
     ) -> Result<EarlyDataDecision, Error> {
         let mut ep = hs::ExtensionProcessing::new(extra_exts);
         ep.process_common(config, cx, ocsp_response, hello, resumedata)?;
+
+        // RFC 9149: echo the expected ticket count if the client sent the extension.
+        if hello.ticket_request.is_some() && config.max_tls13_tickets > 0 {
+            ep.extensions.ticket_request = Some(ServerTicketRequestHint {
+                expected_count: Ord::min(send_tickets, usize::from(u8::MAX)) as u8,
+            });
+        }
 
         let early_data = decide_if_early_data_allowed(cx, hello, resumedata, suite, config);
         if early_data == EarlyDataDecision::Accepted {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -10,7 +10,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{fmt, mem};
 
 use pki_types::{CertificateDer, IpAddr, ServerName, UnixTime};
-use rustls::client::{ResolvesClientCert, Resumption, verify_server_cert_signed_by_trust_anchor};
+use rustls::client::{
+    ResolvesClientCert, Resumption, TicketRequest, verify_server_cert_signed_by_trust_anchor,
+};
 use rustls::crypto::{ActiveKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup};
 use rustls::internal::msgs::base::Payload;
 use rustls::internal::msgs::codec::Codec;
@@ -8183,3 +8185,134 @@ impl ActiveKeyExchange for FakeHybridActive {
 }
 
 const CONFIDENTIALITY_LIMIT: u64 = 1024;
+
+#[test]
+fn tls13_ticket_request_new_vs_resumed() {
+    let provider = provider::default_provider();
+    let shared_storage = Arc::new(ClientStorage::new());
+
+    let mut client_config =
+        make_client_config_with_versions(KeyType::Rsa2048, &[&rustls::version::TLS13], &provider);
+    client_config.resumption = Resumption::store(shared_storage.clone());
+    client_config.send_ticket_request = Some(TicketRequest {
+        new_session_count: 3,
+        resumption_count: 1,
+    });
+    let client_config = Arc::new(client_config);
+
+    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    server_config.max_tls13_tickets = 5;
+    let server_config = Arc::new(server_config);
+
+    // new connection: server sends new_session_count (3)
+    let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+    do_handshake(&mut client, &mut server);
+    assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
+
+    let ops = shared_storage.ops_and_reset();
+    let ticket_inserts = ops
+        .iter()
+        .filter(|op| matches!(op, ClientStorageOp::InsertTls13Ticket(_)))
+        .count();
+    assert_eq!(ticket_inserts, 3);
+
+    // resumed connection: server sends resumption_count (1)
+    let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+    do_handshake(&mut client, &mut server);
+    assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
+
+    let ops = shared_storage.ops_and_reset();
+    let ticket_inserts = ops
+        .iter()
+        .filter(|op| matches!(op, ClientStorageOp::InsertTls13Ticket(_)))
+        .count();
+    assert_eq!(ticket_inserts, 1);
+}
+
+#[test]
+fn tls13_ticket_request_zero_means_no_tickets() {
+    let provider = provider::default_provider();
+    let shared_storage = Arc::new(ClientStorage::new());
+
+    let mut client_config =
+        make_client_config_with_versions(KeyType::Rsa2048, &[&rustls::version::TLS13], &provider);
+    client_config.resumption = Resumption::store(shared_storage.clone());
+    client_config.send_ticket_request = Some(TicketRequest {
+        new_session_count: 0,
+        resumption_count: 0,
+    });
+    let client_config = Arc::new(client_config);
+
+    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    server_config.max_tls13_tickets = 5;
+    let server_config = Arc::new(server_config);
+
+    let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+    do_handshake(&mut client, &mut server);
+    assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
+
+    let ops = shared_storage.ops_and_reset();
+    let ticket_inserts = ops
+        .iter()
+        .filter(|op| matches!(op, ClientStorageOp::InsertTls13Ticket(_)))
+        .count();
+    assert_eq!(ticket_inserts, 0);
+}
+
+#[test]
+fn tls13_ticket_request_capped_by_server() {
+    let provider = provider::default_provider();
+    let shared_storage = Arc::new(ClientStorage::new());
+
+    let mut client_config =
+        make_client_config_with_versions(KeyType::Rsa2048, &[&rustls::version::TLS13], &provider);
+    client_config.resumption = Resumption::store(shared_storage.clone());
+    client_config.send_ticket_request = Some(TicketRequest {
+        new_session_count: 10,
+        resumption_count: 10,
+    });
+    let client_config = Arc::new(client_config);
+
+    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    server_config.max_tls13_tickets = 3;
+    let server_config = Arc::new(server_config);
+
+    let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+    do_handshake(&mut client, &mut server);
+    assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
+
+    let ops = shared_storage.ops_and_reset();
+    let ticket_inserts = ops
+        .iter()
+        .filter(|op| matches!(op, ClientStorageOp::InsertTls13Ticket(_)))
+        .count();
+    assert_eq!(ticket_inserts, 3);
+}
+
+#[test]
+fn tls13_ticket_request_not_sent_when_none() {
+    let provider = provider::default_provider();
+    let shared_storage = Arc::new(ClientStorage::new());
+
+    let mut client_config =
+        make_client_config_with_versions(KeyType::Rsa2048, &[&rustls::version::TLS13], &provider);
+    client_config.resumption = Resumption::store(shared_storage.clone());
+    client_config.send_ticket_request = None;
+    let client_config = Arc::new(client_config);
+
+    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    server_config.max_tls13_tickets = 8;
+    let server_config = Arc::new(server_config);
+
+    // without the extension, server uses send_tls13_tickets (default 2)
+    let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+    do_handshake(&mut client, &mut server);
+    assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
+
+    let ops = shared_storage.ops_and_reset();
+    let ticket_inserts = ops
+        .iter()
+        .filter(|op| matches!(op, ClientStorageOp::InsertTls13Ticket(_)))
+        .count();
+    assert_eq!(ticket_inserts, 2);
+}


### PR DESCRIPTION
## summary

backport of #3126 (merged to main) adapted for the rel-0.23 API surface.

the main difference from the `main` implementation: instead of replacing
`send_tls13_tickets: usize` with `Tls13Tickets { default, max }` (breaking),
this adds a new `max_tls13_tickets: usize` field that defaults to 0 (disabled).
when non-zero and a client sends the ticket_request extension, the server
sends `min(requested, max_tls13_tickets)` tickets.

no breaking changes to the public API.

## what's here

- `ExtensionType::TicketRequest` (0x003a)
- `ClientTicketRequest` / `ServerTicketRequestHint` wire format types
- `ClientConfig::send_ticket_request: Option<TicketRequest>` (client opt-in)
- `ServerConfig::max_tls13_tickets: usize` (server opt-in, 0 = disabled)
- server honors the request when max_tls13_tickets > 0, echoes expected_count in EncryptedExtensions
