### PR TITLE
Dynamically set ECH config

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -7,6 +7,7 @@
 use core::any::Any;
 use core::fmt::{Debug, Formatter};
 use core::hash::Hasher;
+use core::slice;
 use std::borrow::Cow;
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex};
@@ -19,11 +20,10 @@ use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
 use rustls::client::danger::{HandshakeSignatureValid, ServerIdentity, ServerVerifier};
 use rustls::client::{
-    self, ClientConfig, ClientConnection, ClientSessionKey, CredentialRequest, EchConfig,
-    EchGreaseConfig, EchMode, EchStatus, Resumption, Tls12Resumption, Tls13Session,
-    WebPkiServerVerifier,
+    self, ClientConfig, ClientConnection, ClientSessionKey, CredentialRequest, EchStatus,
+    Resumption, Tls12Resumption, Tls13Session, WebPkiServerVerifier,
 };
-use rustls::crypto::hpke::{Hpke, HpkePublicKey};
+use rustls::crypto::hpke::Hpke;
 use rustls::crypto::kx::NamedGroup;
 use rustls::crypto::{
     Credentials, CryptoProvider, Identity, SelectedCredential, SignatureScheme, Signer, SigningKey,
@@ -112,10 +112,19 @@ pub fn main() {
                     .unwrap()
                     .to_owned();
                 let mut output = Vec::new();
-                let sess = config
-                    .connect(server_name)
-                    .build(&mut output)
-                    .unwrap();
+                let conn_cfg = config.connect(server_name);
+
+                let conn_cfg = if let Some(ech_config_list) = &opts.ech_config_list {
+                    conn_cfg
+                        .with_ech(slice::from_ref(ech_config_list))
+                        .unwrap_or_else(|_| quit(":INVALID_ECH_CONFIG_LIST:"))
+                } else if opts.enable_ech_grease {
+                    conn_cfg.with_ech_grease().unwrap()
+                } else {
+                    conn_cfg
+                };
+
+                let sess = conn_cfg.build(&mut output).unwrap();
                 exec(&opts, sess, output, &key_log, i);
             }
             SideConfig::Server(config) => {
@@ -1867,19 +1876,10 @@ fn make_client_cfg(opts: &Options, key_log: &Arc<KeyLogMemo>) -> Arc<ClientConfi
             .into(),
         );
 
-        if let Some(ech_config_list) = &opts.ech_config_list {
-            let ech_mode: EchMode = EchConfig::new(ech_config_list.clone(), ALL_HPKE_SUITES)
-                .unwrap_or_else(|_| quit(":INVALID_ECH_CONFIG_LIST:"))
-                .into();
-
-            ech_cfg.with_ech(ech_mode)
+        if opts.ech_config_list.is_some() {
+            ech_cfg.with_ech_hpke_suites(ALL_HPKE_SUITES)
         } else if opts.enable_ech_grease {
-            let ech_mode = EchMode::Grease(EchGreaseConfig::new(
-                GREASE_HPKE_SUITE,
-                HpkePublicKey(GREASE_25519_PUBKEY.to_vec()),
-            ));
-
-            ech_cfg.with_ech(ech_mode)
+            ech_cfg.with_ech_hpke_suites(&[GREASE_HPKE_SUITE])
         } else {
             cfg
         }
@@ -2400,11 +2400,6 @@ impl compress::CertCompressor for RandomAlgorithm {
 }
 
 static GREASE_HPKE_SUITE: &dyn Hpke = hpke::DH_KEM_X25519_HKDF_SHA256_AES_128;
-
-const GREASE_25519_PUBKEY: &[u8] = &[
-    0x67, 0x35, 0xCA, 0x50, 0x21, 0xFC, 0x4F, 0xE6, 0x29, 0x3B, 0x31, 0x2C, 0xB5, 0xE0, 0x97, 0xD8,
-    0xD0, 0x58, 0x97, 0xCF, 0x5C, 0x15, 0x12, 0x79, 0x4B, 0xEF, 0x1D, 0x98, 0x52, 0x74, 0xDC, 0x5E,
-];
 
 // nb. hpke::ALL_SUPPORTED_SUITES omits fips-incompatible options,
 // this includes them. bogo fips tests are activated by -fips-202205

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -41,7 +41,7 @@ use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::{Resolver, TokioResolver};
-use rustls::client::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
+use rustls::client::EchStatus;
 use rustls::crypto::hpke::Hpke;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, EchConfigListBytes, ServerName};
@@ -85,17 +85,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_ansi(stderr().is_terminal())
         .init();
 
-    let ech_mode = match server_ech_configs.is_empty() {
-        false => EchMode::from(
-            server_ech_configs
-                .into_iter()
-                .find_map(|list| EchConfig::new(list, ALL_SUPPORTED_SUITES).ok())
-                .ok_or("no supported ECH configs")?,
-        ),
-        true => {
-            let (public_key, _) = GREASE_HPKE_SUITE.generate_key_pair()?;
-            EchMode::from(EchGreaseConfig::new(GREASE_HPKE_SUITE, public_key))
-        }
+    let ech_hpke_suites: &[&dyn Hpke] = match server_ech_configs.is_empty() {
+        false => ALL_SUPPORTED_SUITES,
+        true => &[GREASE_HPKE_SUITE],
     };
 
     let root_store = match args.cafile {
@@ -116,7 +108,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Construct a rustls client config with a TLS1.3-only provider, and ECH enabled.
     #[cfg_attr(not(debug_assertions), expect(unused_mut))]
     let mut config = ClientConfig::builder(rustls_aws_lc_rs::DEFAULT_TLS13_PROVIDER.into())
-        .with_ech(ech_mode)
+        .with_ech_hpke_suites(ech_hpke_suites)
         .with_root_certificates(root_store)
         .with_no_client_auth()?;
 
@@ -133,9 +125,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
     for i in 0..args.num_reqs {
         trace!("\nRequest {} of {}", i + 1, args.num_reqs);
         let mut output = Vec::new();
-        let mut conn = config
-            .connect(server_name.clone())
-            .build(&mut output)?;
+        let mut conn = config.connect(server_name.clone());
+
+        conn = if !server_ech_configs.is_empty() {
+            conn.with_ech(&server_ech_configs)
+                .expect("no compatible ECH configuration found")
+        } else {
+            conn.with_ech_grease()
+                .expect("Hpke suite couldn't generate placeholder public key")
+        };
+
+        let mut conn = conn.build(&mut output)?;
         // The "outer" server that we're connecting to.
         let sock_addr = (args.outer_hostname.as_str(), args.port)
             .to_socket_addrs()?

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -17,18 +17,17 @@ use rustls::crypto::{
     SignatureScheme, Signer, SigningKey,
 };
 use rustls::enums::{ApplicationProtocol, ContentType, HandshakeType, ProtocolVersion};
+#[cfg(feature = "aws-lc-rs")]
+use rustls::error::EncryptedClientHelloError;
 use rustls::error::{AlertDescription, ApiMisuse, CertificateError, Error, PeerMisbehaved};
+#[cfg(feature = "aws-lc-rs")]
+use rustls::pki_types::EchConfigListBytes;
 use rustls::server::{
     ClientHello, ParsedCertificate, PreferServerOrder, ServerCredentialResolver, ServerHandshake,
 };
 use rustls::{
     ClientConfig, ClientConnection, Connection as _, HandshakeKind, KeyingMaterialExporter,
     ServerConfig, ServerConnection, SliceInput, SupportedCipherSuite, VecInput,
-};
-#[cfg(feature = "aws-lc-rs")]
-use rustls::{
-    client::{EchConfig, EchGreaseConfig, EchMode},
-    pki_types::EchConfigListBytes,
 };
 #[cfg(feature = "aws-lc-rs")]
 use rustls_aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
@@ -1746,25 +1745,36 @@ fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
             suite_id.kem, suite_id.sym.kdf_id, suite_id.sym.aead_id
         );
 
-        let ech_config = EchConfig::new(
-            EchConfigListBytes::from(std::fs::read(&config_path).unwrap()),
-            &[*suite],
-        )
-        .unwrap();
+        let ech_suites = &[*suite];
 
         // A ECH client configuration should only be considered FIPS approved if the
         // ECH HPKE suite is itself FIPS approved.
         let config = ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into())
-            .with_ech(EchMode::Enable(ech_config));
-        let config = config.finish(KeyType::default());
+            .with_ech_hpke_suites(ech_suites)
+            .finish(KeyType::default());
+        let config = Arc::new(config);
         assert_eq!(config.fips(), suite.fips());
 
-        // The same applies if an ECH GREASE client configuration is used.
-        let (public_key, _) = suite.generate_key_pair().unwrap();
-        let config = ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into())
-            .with_ech(EchMode::Grease(EchGreaseConfig::new(*suite, public_key)));
-        let config = Arc::new(config.finish(KeyType::default()));
-        assert_eq!(config.fips(), suite.fips());
+        // A connection with an ECH client configuration should only be considered
+        // FIPS approved if the ECH HPKE suite is itself FIPS approved.
+        let conn = config
+            .connect("example.com".try_into().unwrap())
+            .with_ech(&[EchConfigListBytes::from(
+                std::fs::read(&config_path).unwrap(),
+            )])
+            .unwrap()
+            .build(&mut Vec::new())
+            .unwrap();
+        assert_eq!(conn.fips(), suite.fips());
+
+        // The same applies if a connection with an ECH GREASE client configuration is used.
+        let conn = config
+            .connect("example.com".try_into().unwrap())
+            .with_ech_grease()
+            .unwrap()
+            .build(&mut Vec::new())
+            .unwrap();
+        assert_eq!(conn.fips(), suite.fips());
 
         // And a connection made from a client config should retain the fips status of the
         // config w.r.t the HPKE suite.
@@ -1774,6 +1784,82 @@ fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
             .unwrap();
         assert_eq!(conn.fips(), suite.fips());
     }
+}
+
+#[test]
+fn test_client_ech_without_hpke_suites() {
+    let configs = [
+        (
+            Arc::new(
+                ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into())
+                    .finish(KeyType::default()),
+            ),
+            "config where with_ech_hpke_suites hadn't been called",
+        ),
+        (
+            Arc::new(
+                ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into())
+                    .with_ech_hpke_suites(&[])
+                    .finish(KeyType::default()),
+            ),
+            "config where with_ech_hpke_suites had been called",
+        ),
+    ];
+
+    for (config, config_msg) in configs {
+        // If no ECH HPKE suites have been provided, calling any method to
+        // configure ECH should result in an ApiMisuse error
+        assert_eq!(
+            config
+                .connect("example.com".try_into().unwrap())
+                // anything we put here shouldn't be processed before erroring
+                .with_ech(&[EchConfigListBytes::from(&[] as &[u8])])
+                .expect_err("ECH shouldn't be successfully configured without any ECH HPKE suites"),
+            Error::ApiMisuse(ApiMisuse::NoEchHpkeSuites),
+            "ApiMisuse error not found while calling with_ech method on {config_msg}",
+        );
+
+        assert_eq!(
+            config
+                .connect("example.com".try_into().unwrap())
+                .with_ech_grease()
+                .expect_err(
+                    "ECH GREASE shouldn't be successfully configured without any ECH HPKE suites"
+                ),
+            Error::ApiMisuse(ApiMisuse::NoEchHpkeSuites),
+            "ApiMisuse error not found while calling with_ech_grease method on {config_msg}",
+        );
+    }
+}
+
+#[cfg(feature = "aws-lc-rs")]
+#[test]
+fn test_client_ech_no_compatible_config() {
+    use rustls_aws_lc_rs::hpke::DH_KEM_P384_HKDF_SHA384_AES_256;
+
+    // One EchConfig, with cipher suite using ECDH X25519 for agreement,
+    // HKDF SHA-256 for key derivation, and AEAD AES-128-GCM for symmetric encryption.
+    static ECHCONFIG_LIST_LOCALHOST: &[u8] =
+        include_bytes!("../../../rustls/tests/data/localhost-echconfigs.bin");
+
+    let config = Arc::new(
+        ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into())
+            // we provide a suite that is not supported by the ECH configuration we will use
+            .with_ech_hpke_suites(&[DH_KEM_P384_HKDF_SHA384_AES_256])
+            .finish(KeyType::default()),
+    );
+
+    // If the provided ECH configuration isn't compatible with the HPKE provider's supported suites
+    // an EncryptedClientHelloError::NoCompatibleConfig error should be returned.
+    assert_eq!(
+        config
+            .connect("example.com".try_into().unwrap())
+            .with_ech(&[EchConfigListBytes::from(ECHCONFIG_LIST_LOCALHOST)])
+            .expect_err(
+                "ECH shouldn't be successfully configured with incompatible ECH HPKE suites"
+            ),
+        Error::InvalidEncryptedClientHello(EncryptedClientHelloError::NoCompatibleConfig),
+    );
 }
 
 #[test]

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -2,8 +2,8 @@ use alloc::format;
 use core::fmt;
 use core::marker::PhantomData;
 
-use crate::client::EchMode;
 use crate::crypto::CryptoProvider;
+use crate::crypto::hpke::Hpke;
 use crate::sync::Arc;
 use crate::time_provider::TimeProvider;
 #[cfg(doc)]
@@ -158,7 +158,7 @@ impl<Side: ConfigSide, State: fmt::Debug> fmt::Debug for ConfigBuilder<Side, Sta
 /// For more information, see the [`ConfigBuilder`] documentation.
 #[derive(Clone, Debug)]
 pub struct WantsVerifier {
-    pub(crate) client_ech_mode: Option<EchMode>,
+    pub(crate) client_ech_hpke_suites: Arc<[&'static dyn Hpke]>,
 }
 
 /// Helper trait to abstract [`ConfigBuilder`] over building a [`ClientConfig`] or [`ServerConfig`].

--- a/rustls/src/client/config.rs
+++ b/rustls/src/client/config.rs
@@ -1,14 +1,13 @@
 use alloc::vec::Vec;
 use core::any::Any;
-use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
+use core::{fmt, iter};
 
 #[cfg(feature = "webpki")]
 use pki_types::PrivateKeyDer;
 use pki_types::{FipsStatus, ServerName, UnixTime};
 
-use super::ech::EchMode;
 use super::handy::{ClientSessionMemoryCache, FailResolveClientCert, NoClientSessionStorage};
 use super::{Tls12Session, Tls13Session};
 use crate::builder::{ConfigBuilder, WantsVerifier};
@@ -16,6 +15,7 @@ use crate::client::connection::ClientConnectionBuilder;
 use crate::common_state::Protocol;
 #[cfg(doc)]
 use crate::crypto;
+use crate::crypto::hpke::Hpke;
 use crate::crypto::kx::NamedGroup;
 use crate::crypto::{CipherSuite, CryptoProvider, SelectedCredential, SignatureScheme, hash};
 #[cfg(feature = "webpki")]
@@ -40,12 +40,6 @@ use crate::{DistinguishedName, DynHasher, KeyLog, compress};
 ///
 /// These must be created via the [`ClientConfig::builder()`] or [`ClientConfig::builder_with_details()`]
 /// function.
-///
-/// Note that using [`ConfigBuilder<ClientConfig, WantsVersions>::with_ech()`] will produce a common
-/// configuration specific to the provided [`crate::client::EchConfig`] that may not be appropriate
-/// for all connections made by the program. In this case the configuration should only be shared
-/// by connections intended for domains that offer the provided [`crate::client::EchConfig`] in
-/// their DNS zone.
 ///
 /// # Defaults
 ///
@@ -183,8 +177,11 @@ pub struct ClientConfig {
     /// a cache that does no caching.
     pub cert_compression_cache: Arc<compress::CompressionCache>,
 
-    /// How to offer Encrypted Client Hello (ECH). The default is to not offer ECH.
-    pub(super) ech_mode: Option<EchMode>,
+    /// List of supported HPKE suites to use when offering Encrypted Client Hello (ECH).
+    ///
+    /// This is optional: If this is empty, attempting to configure ECH will result
+    /// in a [`ApiMisuse::NoEchHpkeSuites`] error.
+    pub(super) ech_hpke_suites: Arc<[&'static dyn Hpke]>,
 }
 
 impl ClientConfig {
@@ -212,7 +209,7 @@ impl ClientConfig {
     ) -> ConfigBuilder<Self, WantsVerifier> {
         ConfigBuilder {
             state: WantsVerifier {
-                client_ech_mode: None,
+                client_ech_hpke_suites: Arc::default(),
             },
             provider,
             time_provider,
@@ -229,6 +226,7 @@ impl ClientConfig {
             config: self.clone(),
             name: server_name,
             alpn_protocols: None,
+            ech_mode: None,
         }
     }
 
@@ -242,17 +240,21 @@ impl ClientConfig {
     ///
     /// This is different from [`CryptoProvider::fips()`]: [`CryptoProvider::fips()`]
     /// is concerned only with cryptography, whereas this _also_ covers TLS-level
-    /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
+    /// configuration that NIST recommends.
+    ///
+    /// ECH HPKE suites' FIPS status will be taken into account: the minimum FIPS status
+    /// of both the [`CryptoProvider`] and of the ECH HPKE suites will be returned.
     pub fn fips(&self) -> FipsStatus {
         if !self.require_ems {
             return FipsStatus::Unvalidated;
         }
 
-        let status = self.domain.provider.fips();
-        match &self.ech_mode {
-            Some(ech) => Ord::min(status, ech.fips()),
-            None => status,
-        }
+        self.ech_hpke_suites
+            .iter()
+            .map(|suite| suite.fips())
+            .chain(iter::once(self.domain.provider.fips()))
+            .min()
+            .unwrap()
     }
 
     /// Return the crypto provider used to construct this client configuration.
@@ -675,7 +677,7 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
         ConfigBuilder {
             state: WantsClientCert {
                 verifier,
-                client_ech_mode: self.state.client_ech_mode,
+                client_ech_hpke_suites: self.state.client_ech_hpke_suites,
             },
             provider: self.provider,
             time_provider: self.time_provider,
@@ -683,18 +685,15 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
         }
     }
 
-    /// Enable Encrypted Client Hello (ECH) in the given mode.
+    /// Pass a slice of HPKE suites to use in case ECH is configured later on
+    /// with [`ClientConnectionBuilder::with_ech`] or [`ClientConnectionBuilder::with_ech_grease`].
     ///
     /// This requires TLS 1.3 as the only supported protocol version to meet the requirement
     /// to support ECH.  At the end, the config building process will return an error if either
     /// TLS1.3 _is not_ supported by the provider, or TLS1.2 _is_ supported.
-    ///
-    /// The `ClientConfig` that will be produced by this builder will be specific to the provided
-    /// [`crate::client::EchConfig`] and may not be appropriate for all connections made by the program.
-    /// In this case the configuration should only be shared by connections intended for domains
-    /// that offer the provided [`crate::client::EchConfig`] in their DNS zone.
-    pub fn with_ech(mut self, mode: EchMode) -> Self {
-        self.state.client_ech_mode = Some(mode);
+    pub fn with_ech_hpke_suites(mut self, hpke_suites: &[&'static dyn Hpke]) -> Self {
+        self.state.client_ech_hpke_suites = Arc::from(hpke_suites);
+
         self
     }
 
@@ -712,7 +711,7 @@ impl ConfigBuilder<ClientConfig, WantsVerifier> {
 #[derive(Clone)]
 pub struct WantsClientCert {
     verifier: Arc<dyn ServerVerifier>,
-    client_ech_mode: Option<EchMode>,
+    client_ech_hpke_suites: Arc<[&'static dyn Hpke]>,
 }
 
 impl ConfigBuilder<ClientConfig, WantsClientCert> {
@@ -747,7 +746,11 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
     ) -> Result<ClientConfig, Error> {
         self.provider.consistency_check()?;
 
-        if self.state.client_ech_mode.is_some() {
+        if !self
+            .state
+            .client_ech_hpke_suites
+            .is_empty()
+        {
             match (
                 self.provider
                     .tls12_cipher_suites
@@ -783,7 +786,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             cert_decompressors: compress::default_cert_decompressors().to_vec(),
             cert_compressors: compress::default_cert_compressors().to_vec(),
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),
-            ech_mode: self.state.client_ech_mode,
+            ech_hpke_suites: self.state.client_ech_hpke_suites,
         })
     }
 }
@@ -828,7 +831,7 @@ pub(super) mod danger {
             ConfigBuilder {
                 state: WantsClientCert {
                     verifier,
-                    client_ech_mode: self.cfg.state.client_ech_mode,
+                    client_ech_hpke_suites: self.cfg.state.client_ech_hpke_suites,
                 },
                 provider: self.cfg.provider,
                 time_provider: self.cfg.time_provider,

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -2,12 +2,13 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::ops::Deref;
 
-use pki_types::{FipsStatus, ServerName};
+use pki_types::{EchConfigListBytes, FipsStatus, ServerName};
 
 use super::config::ClientConfig;
 use super::hs::ClientHelloInput;
 use crate::TlsInputBuffer;
 use crate::client::EchStatus;
+use crate::client::ech::{EchConfig, EchMode};
 use crate::common_state::{CommonState, ConnectionOutputs, EarlyDataEvent, Event, Protocol, Side};
 use crate::conn::private::SideOutput;
 use crate::conn::split::SplitConnection;
@@ -19,7 +20,7 @@ use crate::conn::{
 use crate::crypto;
 use crate::crypto::cipher::OutboundPlain;
 use crate::enums::ApplicationProtocol;
-use crate::error::Error;
+use crate::error::{ApiMisuse, Error, RejectedEch};
 use crate::msgs::ClientExtensionsInput;
 use crate::quic::QuicOutput;
 use crate::suites::ExtractedSecrets;
@@ -165,10 +166,12 @@ impl Deref for ClientConnection {
 /// Builder for [`ClientConnection`] values.
 ///
 /// Create one with [`ClientConfig::connect()`].
+#[derive(Debug)]
 pub struct ClientConnectionBuilder {
     pub(crate) config: Arc<ClientConfig>,
     pub(crate) name: ServerName<'static>,
     pub(crate) alpn_protocols: Option<Vec<ApplicationProtocol<'static>>>,
+    pub(crate) ech_mode: Option<EchMode>,
 }
 
 impl ClientConnectionBuilder {
@@ -178,12 +181,97 @@ impl ClientConnectionBuilder {
         self
     }
 
+    /// Provide a slice of [`EchConfigListBytes`] configurations to use to
+    /// connect using ECH. The slice's elements will be iterated until an ECH
+    /// configuration that is compatible with the HPKE provider's supported
+    /// suites is found.
+    ///
+    /// # Errors
+    ///
+    /// One of the provided ECH configurations must be compatible with the HPKE provider's supported
+    /// suites or an [`EncryptedClientHelloError::NoCompatibleConfig`](crate::error::EncryptedClientHelloError::NoCompatibleConfig)
+    /// error will be returned.
+    ///
+    /// If no ECH HPKE suites were provided with
+    /// [`ConfigBuilder::with_ech_hpke_suites`](crate::builder::ConfigBuilder::with_ech_hpke_suites),
+    /// [`ApiMisuse::NoEchHpkeSuites`] will be returned instead.
+    pub fn with_ech(
+        mut self,
+        ech_config_list_slice: &[EchConfigListBytes<'_>],
+    ) -> Result<Self, Error> {
+        if self.config.ech_hpke_suites.is_empty() {
+            return Err(Error::ApiMisuse(ApiMisuse::NoEchHpkeSuites));
+        }
+
+        self.ech_mode = Some(EchMode::from_ech_config_list(
+            ech_config_list_slice,
+            &self.config.ech_hpke_suites,
+        )?);
+
+        Ok(self)
+    }
+
+    /// Configure the builder to use ECH GREASE.
+    ///
+    /// ECH GREASE is a mechanism to make a non-ECH connection appear as if it is one.
+    /// This way, the extent to which ECH connections stick out is reduced and
+    /// thus, network ossification is mitigated.
+    ///
+    /// If your client uses ECH but doesn't have a configuration for a server it
+    /// wants to connect to, it is recommended per ECH's RFC 9849 to instead
+    /// GREASE the connection for the reasons listed above.
+    ///
+    /// # Note
+    ///
+    /// In order to not stick out, this method will use the first one of the
+    /// provided HPKE and stick with it. ECH's RFC 9849 says that "The selection SHOULD vary",
+    /// however, since both Google's BoringSSL & Mozilla's NSS apparently don't
+    /// do that, we follow similar behavior in order to blend in with them.
+    ///
+    /// # Errors
+    ///
+    /// This method will error if the HPKE provider fails to generate a placeholder public key.
+    ///
+    /// If no ECH HPKE suites were provided with
+    /// [`ConfigBuilder::with_ech_hpke_suites`](crate::builder::ConfigBuilder::with_ech_hpke_suites),
+    /// [`ApiMisuse::NoEchHpkeSuites`] will be returned instead.
+    pub fn with_ech_grease(mut self) -> Result<Self, Error> {
+        if self.config.ech_hpke_suites.is_empty() {
+            return Err(Error::ApiMisuse(ApiMisuse::NoEchHpkeSuites));
+        }
+
+        // just pick the first HPKE suite and stick with it
+        //
+        // the RFC says that the suites should vary to prevent fingerprinting,
+        // but both BoringSSL + NSS seem to do what we do here, so in order to
+        // not stick out, we just copy that behavior
+        self.ech_mode = Some(EchMode::grease_from_suite(self.config.ech_hpke_suites[0])?);
+
+        Ok(self)
+    }
+
+    /// Retrying ECH using a retry config from a server's previous rejection
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the server provided no retry configurations in [`RejectedEch`], or if
+    /// none of the retry configurations are compatible with the HPKE provider's supported suites.
+    pub fn with_ech_for_retry(mut self, rejection: RejectedEch) -> Result<Self, Error> {
+        self.ech_mode = Some(EchMode::Enable(EchConfig::for_retry(
+            rejection,
+            &self.config.ech_hpke_suites,
+        )?));
+
+        Ok(self)
+    }
+
     /// Finalize the builder and create the `ClientConnection`.
     pub fn build(self, tls: &mut Vec<u8>) -> Result<ClientConnection, Error> {
         let Self {
             config,
             name,
             alpn_protocols,
+            ech_mode,
         } = self;
 
         let alpn_protocols = alpn_protocols.unwrap_or_else(|| config.alpn_protocols.clone());
@@ -194,6 +282,7 @@ impl ClientConnectionBuilder {
                 ClientExtensionsInput::from_alpn(alpn_protocols),
                 None,
                 Protocol::Tcp,
+                ech_mode,
                 tls,
             )?,
         })
@@ -269,6 +358,7 @@ impl ConnectionCommon<ClientSide> {
         extra_exts: ClientExtensionsInput,
         quic: Option<&mut dyn QuicOutput>,
         protocol: Protocol,
+        ech_mode: Option<EchMode>,
         tls: &mut Vec<u8>,
     ) -> Result<Self, Error> {
         let mut common_state = CommonState::new(Side::Client, config.fips());
@@ -284,7 +374,8 @@ impl ConnectionCommon<ClientSide> {
             tls,
         };
 
-        let input = ClientHelloInput::new(name, &extra_exts, protocol, &mut output, config)?;
+        let input =
+            ClientHelloInput::new(name, &extra_exts, protocol, &mut output, config, ech_mode)?;
         let state = input.start_handshake(extra_exts, &mut output)?;
 
         Ok(Self::new(state, data, common_state))

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -3,7 +3,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::iter;
 
-use pki_types::{DnsName, EchConfigListBytes, FipsStatus, ServerName};
+use pki_types::{DnsName, EchConfigListBytes, ServerName};
 use subtle::ConstantTimeEq;
 
 use super::config::ClientConfig;
@@ -35,7 +35,7 @@ use crate::tracing::{debug, trace, warn};
 /// Controls how Encrypted Client Hello (ECH) is used in a client handshake.
 #[non_exhaustive]
 #[derive(Clone, Debug)]
-pub enum EchMode {
+pub(crate) enum EchMode {
     /// ECH is enabled and the ClientHello will be encrypted based on the provided
     /// configuration.
     Enable(EchConfig),
@@ -48,12 +48,45 @@ pub enum EchMode {
 }
 
 impl EchMode {
-    /// Returns true if the ECH mode will use a FIPS approved HPKE suite.
-    pub fn fips(&self) -> FipsStatus {
-        match self {
-            Self::Enable(ech_config) => ech_config.suite.fips(),
-            Self::Grease(grease_config) => grease_config.suite.fips(),
+    /// Create a new [`EchMode`] from a list of supported suites and a list of
+    /// ECH configurations to try.
+    ///
+    /// Each suite-configuration pair will be tried, beginning at the first
+    /// ECH configuration, until a valid [`EchConfig`] is constructed
+    ///
+    /// # Errors
+    ///
+    /// If all pairs have been exhausted, an [`EncryptedClientHelloError::NoCompatibleConfig`]
+    /// error will be raised
+    pub(crate) fn from_ech_config_list(
+        ech_config_list_slice: &[EchConfigListBytes<'_>],
+        suites: &[&'static dyn Hpke],
+    ) -> Result<Self, Error> {
+        for ech_config_list in ech_config_list_slice {
+            match EchConfig::new(ech_config_list, suites) {
+                Ok(ech_config) => return Ok(ech_config.into()),
+                Err(Error::InvalidEncryptedClientHello(
+                    EncryptedClientHelloError::NoCompatibleConfig,
+                )) => {
+                    // silently reject NoCompatibleConfig errors
+                }
+                Err(err) => return Err(err),
+            }
         }
+
+        // if we have yet to return, no compatible ECH config has been found
+        Err(Error::InvalidEncryptedClientHello(
+            EncryptedClientHelloError::NoCompatibleConfig,
+        ))
+    }
+
+    /// Create a new GREASE [`EchMode`] from a supported suite.
+    ///
+    /// # Errors
+    ///
+    /// This method will error if the HPKE provider fails to generate a placeholder public key.
+    pub(crate) fn grease_from_suite(suite: &'static dyn Hpke) -> Result<Self, Error> {
+        Ok(EchGreaseConfig::new(suite)?.into())
     }
 }
 
@@ -73,7 +106,7 @@ impl From<EchGreaseConfig> for EchMode {
 ///
 /// Note: differs from the protocol-encoded EchConfig (`EchConfigMsg`).
 #[derive(Clone, Debug)]
-pub struct EchConfig {
+pub(crate) struct EchConfig {
     /// The selected EchConfig.
     pub(crate) config: EchConfigPayload,
 
@@ -92,16 +125,16 @@ impl EchConfig {
     /// be base64 decoded to yield the `EchConfigListBytes` you provide to rustls.
     ///
     /// One of the provided ECH configurations must be compatible with the HPKE provider's supported
-    /// suites or an error will be returned.
+    /// suites or an [`EncryptedClientHelloError::InvalidConfigList`] error will be returned.
     ///
     /// See the [`ech-client.rs`] example for a complete example of fetching ECH configs from DNS.
     ///
     /// [`ech-client.rs`]: https://github.com/rustls/rustls/blob/main/examples/src/bin/ech-client.rs
-    pub fn new(
-        ech_config_list: EchConfigListBytes<'_>,
+    pub(crate) fn new(
+        ech_config_list: &EchConfigListBytes<'_>,
         hpke_suites: &[&'static dyn Hpke],
     ) -> Result<Self, Error> {
-        let ech_configs = Vec::<EchConfigPayload>::read_bytes(&ech_config_list).map_err(|_| {
+        let ech_configs = Vec::<EchConfigPayload>::read_bytes(ech_config_list).map_err(|_| {
             Error::InvalidEncryptedClientHello(EncryptedClientHelloError::InvalidConfigList)
         })?;
 
@@ -112,7 +145,7 @@ impl EchConfig {
     ///
     /// Returns an error if the server provided no retry configurations in `RejectedEch`, or if
     /// none of the retry configurations are compatible with the supported `hpke_suites`.
-    pub fn for_retry(
+    pub(crate) fn for_retry(
         rejection: RejectedEch,
         hpke_suites: &[&'static dyn Hpke],
     ) -> Result<Self, Error> {
@@ -201,7 +234,7 @@ impl EchConfig {
 
 /// Configuration for GREASE Encrypted Client Hello.
 #[derive(Clone, Debug)]
-pub struct EchGreaseConfig {
+pub(crate) struct EchGreaseConfig {
     pub(crate) suite: &'static dyn Hpke,
     pub(crate) placeholder_key: HpkePublicKey,
 }
@@ -213,14 +246,16 @@ impl EchGreaseConfig {
     /// but doesn't have a real ECH configuration to use for the remote server. In this case
     /// a placeholder or "GREASE"[^0] extension is used.
     ///
-    /// Returns an error if the HPKE provider does not support the given suite.
+    /// # Errors
+    ///
+    /// Returns an error if the HPKE provider fails to generate a placeholder public key.
     ///
     /// [^0]: <https://www.rfc-editor.org/rfc/rfc8701>
-    pub fn new(suite: &'static dyn Hpke, placeholder_key: HpkePublicKey) -> Self {
-        Self {
+    pub(crate) fn new(suite: &'static dyn Hpke) -> Result<Self, Error> {
+        Ok(Self {
             suite,
-            placeholder_key,
-        }
+            placeholder_key: suite.generate_key_pair()?.0,
+        })
     }
 
     /// Build a GREASE ECH extension based on the placeholder configuration.
@@ -996,20 +1031,7 @@ mod tests {
         provider.secure_random = &CountingRandom;
 
         let config = ClientConfig::builder(Arc::new(provider))
-            .with_ech(EchMode::Enable(EchConfig {
-                config: EchConfigPayload::V18(EchConfigContents {
-                    key_config: HpkeKeyConfig {
-                        config_id: 0,
-                        kem_id: MockHpke::SUITE.kem,
-                        public_key: vec![0; 32].into(),
-                        symmetric_cipher_suites: vec![MockHpke::SUITE.sym],
-                    },
-                    maximum_name_length: 255,
-                    public_name: DnsName::try_from("public.example.com").unwrap(),
-                    extensions: vec![],
-                }),
-                suite: &MockHpke,
-            }))
+            .with_ech_hpke_suites(&[&MockHpke])
             .with_root_certificates(roots)
             .with_no_client_auth()
             .unwrap();
@@ -1048,6 +1070,24 @@ mod tests {
         let mut first_flight = Vec::new();
         let mut conn = config
             .connect(server_name)
+            .with_ech(&[{
+                let mut bytes = Vec::new();
+                vec![EchConfigPayload::V18(EchConfigContents {
+                    key_config: HpkeKeyConfig {
+                        config_id: 0,
+                        kem_id: MockHpke::SUITE.kem,
+                        public_key: vec![0; 32].into(),
+                        symmetric_cipher_suites: vec![MockHpke::SUITE.sym],
+                    },
+                    maximum_name_length: 255,
+                    public_name: DnsName::try_from("public.example.com").unwrap(),
+                    extensions: vec![],
+                })]
+                .encode(&mut bytes);
+
+                EchConfigListBytes::from(bytes)
+            }])
+            .unwrap()
             .build(&mut first_flight)
             .unwrap();
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -444,6 +444,7 @@ impl ClientHelloInput {
         protocol: Protocol,
         output: &mut dyn Output<'_>,
         config: Arc<ClientConfig>,
+        ech_mode: Option<EchMode>,
     ) -> Result<Self, Error> {
         let session_key = ClientSessionKey {
             config_hash: config.config_hash(),
@@ -489,6 +490,7 @@ impl ClientHelloInput {
                 .clone()
                 .unwrap_or_default(),
             rand::random_u16(config.provider().secure_random)?,
+            ech_mode,
         );
 
         let random = Random::new(config.provider().secure_random)?;
@@ -529,7 +531,7 @@ impl ClientHelloInput {
             None
         };
 
-        let ech_state = match self.config.ech_mode.as_ref() {
+        let ech_state = match self.hello.ech_mode.as_ref() {
             Some(EchMode::Enable(ech_config)) => {
                 Some(ech_config.state(self.session_key.server_name.clone(), &self.config)?)
             }
@@ -778,7 +780,8 @@ fn emit_client_hello_for_retry(
         extensions: exts,
     };
 
-    let ech_grease_ext = config
+    let ech_grease_ext = input
+        .hello
         .ech_mode
         .as_ref()
         .and_then(|mode| match mode {

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -34,7 +34,8 @@ mod connection;
 pub use connection::{ClientConnection, ClientConnectionBuilder, ClientSide, WriteEarlyData};
 
 mod ech;
-pub use ech::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
+use ech::EchMode;
+pub use ech::EchStatus;
 
 mod handy;
 pub use handy::ClientSessionMemoryCache;
@@ -371,16 +372,22 @@ struct ClientHelloDetails {
     extension_order_seed: u16,
     offered_cert_compression: bool,
     offered_cipher_suites: Vec<CipherSuite>,
+    ech_mode: Option<EchMode>,
 }
 
 impl ClientHelloDetails {
-    fn new(alpn_protocols: Vec<ApplicationProtocol<'static>>, extension_order_seed: u16) -> Self {
+    fn new(
+        alpn_protocols: Vec<ApplicationProtocol<'static>>,
+        extension_order_seed: u16,
+        ech_mode: Option<EchMode>,
+    ) -> Self {
         Self {
             alpn_protocols,
             sent_extensions: Vec::new(),
             extension_order_seed,
             offered_cert_compression: false,
             offered_cipher_suites: Vec::new(),
+            ech_mode,
         }
     }
 

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -125,7 +125,7 @@ pub enum Error {
     /// It may have returned new ECH configurations that could be used to retry negotiation
     /// with a fresh connection.
     ///
-    /// See [`RejectedEch::can_retry()`] and [`crate::client::EchConfig::for_retry()`].
+    /// See [`RejectedEch::can_retry()`] and [`crate::client::ClientConnectionBuilder::with_ech_for_retry()`].
     RejectedEch(RejectedEch),
 
     /// Errors of this variant should never be produced by the library.
@@ -1501,7 +1501,7 @@ pub enum EncryptedClientHelloError {
 /// The server rejected the request to enable Encrypted Client Hello (ECH)
 ///
 /// If [`RejectedEch::can_retry()`] is true, then you may use this with
-/// [`crate::client::EchConfig::for_retry()`] to build a new `EchConfig` for a fresh client
+/// [`crate::client::ClientConnectionBuilder::with_ech_for_retry()`] to build a new `EchConfig` for a fresh client
 /// connection that will use a compatible ECH configuration provided by the server for a retry.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
@@ -1512,7 +1512,7 @@ pub struct RejectedEch {
 impl RejectedEch {
     /// Returns true if the server provided new ECH configurations to use for a fresh retry connection
     ///
-    /// The `RejectedEch` error can be provided to [`crate::client::EchConfig::for_retry()`]
+    /// The `RejectedEch` error can be provided to [`crate::client::ClientConnectionBuilder::with_ech_for_retry()`]
     /// to build a new `EchConfig` for a fresh client connection that will use a compatible ECH
     /// configuration provided by the server for a retry.
     pub fn can_retry(&self) -> bool {
@@ -1624,6 +1624,12 @@ pub enum ApiMisuse {
 
     /// ECH attempted with a configuration that also supports TLS1.2.
     EchForbidsTls12Support,
+
+    /// ECH attempted without any provided HPKE suites to use when offering ECH
+    NoEchHpkeSuites,
+
+    /// The received plaintext buffer is full; read out some plaintext before receiving more.
+    ReceivedPlaintextBufferFull,
 
     /// Secret extraction operation attempted without opting-in to secret extraction.
     ///

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -120,6 +120,7 @@ impl ClientConnection {
             exts,
             Some(&mut quic),
             Protocol::Quic(version),
+            None,
             &mut tls,
         )?;
 

--- a/rustls/src/server/config.rs
+++ b/rustls/src/server/config.rs
@@ -265,7 +265,7 @@ impl ServerConfig {
     ) -> ConfigBuilder<Self, WantsVerifier> {
         ConfigBuilder {
             state: WantsVerifier {
-                client_ech_mode: None,
+                client_ech_hpke_suites: Arc::default(),
             },
             provider,
             time_provider,


### PR DESCRIPTION
Related to #3119 

I've introduced some new methods and enums: `with_ech_hpke_suites` on `ConfigBuilder` to provide a list of supported HPKE suites and signal the use of ECH (use TLS 1.3 or error out, etc.). `EchMode` has be kept and can be passed to `ClientConnectionBuilder` using the `with_ech_mode` method (any suites in there will override what has been set by `with_ech_hpke_suites`, so someone can pass an empty array to `with_ech_hpke_suites` and then pass the suite of their choice using this method. On the other hand, if these suites stay the same for the lifetime of a program (as they should for most of them), they can be passed using `with_ech_hpke_suites` and then these standalone parameters (`EchParams`) can be passed to `ClientConnectionBuilder` using the `with_ech_params` method.

Notes:
- I implemented a simple `random_usize_range` function to randomly obtain a `usize` within a range which uses [rejection sampling](https://dimitri.xyz/random-ints-from-random-bits/), however I worry that the running time from it might be pretty bad. Originally I had used a remainder division method, but this can introduce a bias towards small numbers, which becomes worse as the upper limit of the range increases. Perhaps a hybrid approach would be better?
- `EchParams` is a name I chose to merely distinguish it from `EchMode`, feel free to change it to a more descriptive one.
- There was a suggestion in #3119 to backport these changes to the 0.23 branch, but since these changes are breaking, I doubt that can be done without violating semantic versioning.