### PR TITLE
Unify Acceptor API with new server state handshake API

### DIFF
--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -16,10 +16,10 @@ use clap::Parser;
 use rcgen::{Issuer, KeyPair, SerialNumber};
 use rustls::crypto::{CryptoProvider, Identity};
 use rustls::pki_types::{CertificateRevocationListDer, PrivatePkcs8KeyDer};
-use rustls::server::{Acceptor, ClientHello, ServerConfig, WebPkiClientVerifier};
+use rustls::server::{ClientHello, ServerConfig, ServerHandshake, WebPkiClientVerifier};
 use rustls::{RootCertStore, VecInput};
 use rustls_aws_lc_rs::DEFAULT_PROVIDER;
-use rustls_util::{KeyLogFile, complete_io};
+use rustls_util::KeyLogFile;
 
 fn main() {
     let args = Args::parse();
@@ -77,44 +77,39 @@ fn main() {
     let listener = std::net::TcpListener::bind(format!("[::]:{}", args.port)).unwrap();
     for stream in listener.incoming() {
         let mut stream = stream.unwrap();
-        let mut acceptor = Acceptor::default();
+        let mut handshake = ServerHandshake::NeedsInput(ServerHandshake::start());
         let mut input = VecInput::default();
+        let mut output = vec![];
 
-        // Read TLS packets until we've consumed a full client hello and are ready to accept a
-        // connection.
-        let accepted = loop {
-            input.read(&mut stream).unwrap();
-            match acceptor.accept(&mut input) {
-                Ok(Some(accepted)) => break accepted,
-                Ok(None) => continue,
-                Err(mut error_with_alert) => {
-                    if let Some(alert) = error_with_alert.take_tls_data() {
-                        stream.write_all(&alert).unwrap();
+        let _connection = loop {
+            handshake = match handshake {
+                // Read TLS packets until we've completed the handshake.
+                ServerHandshake::NeedsInput(receive) => {
+                    input.read(&mut stream).unwrap();
+                    match receive.process(&mut input, &mut output) {
+                        Ok(next) => next,
+                        Err(error) => panic!("error completing handshake: {error}"),
                     }
-                    panic!("error accepting connection: {}", error_with_alert.error);
                 }
-            }
-        };
 
-        // Generate a server config for the accepted connection, optionally customizing the
-        // configuration based on the client hello.
-        let config = test_pki.server_config(&args.crl_path, accepted.client_hello());
-        let mut conn = match accepted.into_connection(config) {
-            Ok(conn) => conn,
-            Err(mut error_with_alert) => {
-                if let Some(alert) = error_with_alert.take_tls_data() {
-                    stream.write_all(&alert).unwrap();
+                // Generate a server config for the accepted connection, optionally customizing the
+                // configuration based on the client hello.
+                ServerHandshake::Accepted(accepted) => {
+                    let config = test_pki.server_config(&args.crl_path, accepted.client_hello());
+                    accepted
+                        .choose_config(config, &mut output)
+                        .expect("error choosing configuration for connection")
                 }
-                panic!(
-                    "error completing accepting connection: {}",
-                    error_with_alert.error
-                );
-            }
-        };
 
-        // Proceed with handling the ServerConnection
-        // Important: We do no error handling here, but you should!
-        _ = complete_io(&mut stream, &mut input, &mut conn);
+                ServerHandshake::Complete(connection) => break connection,
+
+                other => panic!("unexpected ServerHandshake state {other:?}"),
+            };
+
+            stream
+                .write_all(&output.concat())
+                .unwrap();
+        };
     }
 }
 

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -6,14 +6,14 @@ extern crate rustls;
 use std::io;
 use std::sync::Arc;
 
-use rustls::server::{Accepted, Acceptor};
+use rustls::server::{Accepted, ServerHandshake};
 use rustls::{Connection, ServerConfig, ServerConnection, VecInput};
 
 fuzz_target!(|data: &[u8]| {
     let _ = env_logger::try_init();
     match data.split_first() {
         Some((0x00, rest)) => fuzz_buffered_api(rest),
-        Some((0x01, rest)) => fuzz_acceptor_api(rest),
+        Some((0x01, rest)) => fuzz_handshake_api(rest),
         Some((_, _)) | None => {}
     }
 });
@@ -31,23 +31,26 @@ fn fuzz_buffered_api(data: &[u8]) {
     service_connection(&mut stream, &mut VecInput::default(), &mut server);
 }
 
-fn fuzz_acceptor_api(data: &[u8]) {
-    let mut server = Acceptor::default();
+fn fuzz_handshake_api(data: &[u8]) {
+    let mut server = ServerHandshake::start();
     let mut stream = io::Cursor::new(data);
     let mut input = VecInput::default();
+    let mut output = vec![];
 
     loop {
         let rd = input.read(&mut stream).unwrap_or(0);
-        match server.accept(&mut input) {
-            Ok(Some(accepted)) => {
+
+        server = match server.process(&mut input, &mut output) {
+            Ok(ServerHandshake::Accepted(accepted)) => {
                 fuzz_accepted(&mut stream, &mut input, accepted);
                 break;
             }
+            Ok(ServerHandshake::NeedsInput(next)) => next,
+            Ok(_) => unreachable!(),
             Err(_) => {
                 break;
             }
-            Ok(None) => {}
-        }
+        };
         if rd == 0 {
             break;
         }
@@ -55,15 +58,18 @@ fn fuzz_acceptor_api(data: &[u8]) {
 }
 
 fn fuzz_accepted(stream: &mut dyn io::Read, input: &mut VecInput, accepted: Accepted) {
-    let mut maybe_server = accepted.into_connection(Arc::new(
-        ServerConfig::builder(rustls_fuzzing_provider::PROVIDER.into())
-            .with_no_client_auth()
-            .with_server_credential_resolver(rustls_fuzzing_provider::server_cert_resolver())
-            .unwrap(),
-    ));
+    let maybe_server = accepted.choose_config(
+        Arc::new(
+            ServerConfig::builder(rustls_fuzzing_provider::PROVIDER.into())
+                .with_no_client_auth()
+                .with_server_credential_resolver(rustls_fuzzing_provider::server_cert_resolver())
+                .unwrap(),
+        ),
+        &mut vec![],
+    );
 
-    if let Ok(conn) = &mut maybe_server {
-        service_connection(stream, input, conn);
+    if let Ok(ServerHandshake::NeedsInput(next)) = maybe_server {
+        service_connection(stream, input, &mut next.into_buffered_connection());
     }
 }
 

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -19,7 +19,7 @@ use rustls::crypto::{
 use rustls::enums::{ApplicationProtocol, ContentType, HandshakeType, ProtocolVersion};
 use rustls::error::{AlertDescription, ApiMisuse, CertificateError, Error, PeerMisbehaved};
 use rustls::server::{
-    Acceptor, ClientHello, ParsedCertificate, PreferServerOrder, ServerCredentialResolver,
+    ClientHello, ParsedCertificate, PreferServerOrder, ServerCredentialResolver, ServerHandshake,
 };
 use rustls::{
     ClientConfig, ClientConnection, Connection as _, HandshakeKind, KeyingMaterialExporter,
@@ -1848,17 +1848,24 @@ fn large_client_hello() {
 
 #[test]
 fn large_client_hello_acceptor() {
-    let mut acceptor = Acceptor::default();
+    let mut state = ServerHandshake::NeedsInput(ServerHandshake::start());
     let mut input = VecInput::default();
     let hello = include_bytes!("../data/bug2227-clienthello.bin");
     let mut cursor = io::Cursor::new(hello);
+
     loop {
         input.read(&mut cursor).unwrap();
 
-        if let Some(accepted) = acceptor.accept(&mut input).unwrap() {
-            println!("{accepted:?}");
-            break;
-        }
+        state = match state {
+            ServerHandshake::NeedsInput(receive) => receive
+                .process(&mut input, &mut vec![])
+                .unwrap(),
+            ServerHandshake::Accepted(accepted) => {
+                println!("{accepted:?}");
+                break;
+            }
+            other => panic!("unexpected {other:?}"),
+        };
     }
 }
 
@@ -1867,7 +1874,7 @@ fn acceptor_with_illegal_max_fragment_size() {
     let mut server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
     server_config.max_fragment_size = Some(31);
 
-    let mut acceptor = Acceptor::default();
+    let receive = ServerHandshake::start();
     let mut input = VecInput::default();
     input
         .read(
@@ -1880,19 +1887,21 @@ fn acceptor_with_illegal_max_fragment_size() {
         )
         .unwrap();
 
-    let accepted = acceptor
-        .accept(&mut input)
+    let mut output = vec![];
+    let ServerHandshake::Accepted(accepted) = receive
+        .process(&mut input, &mut output)
         .unwrap()
-        .unwrap();
-    let mut error_with_alert = accepted
-        .into_connection(Arc::new(server_config))
+    else {
+        panic!("unexpected receive state");
+    };
+
+    accepted
+        .choose_config(Arc::new(server_config), &mut output)
         .err()
         .unwrap();
 
-    assert_eq!(error_with_alert.error, Error::BadMaxFragmentSize);
-    assert_eq!(
-        error_with_alert.take_tls_data(),
-        None,
+    assert!(
+        output.is_empty(),
         "illegal max fragment size should not send an alert, as it is a local configuration issue"
     );
 }
@@ -1905,16 +1914,14 @@ fn excess_client_hello_acceptor() {
     let mut hello =
         encoding::message_framing(ContentType::Handshake, ProtocolVersion::TLSv1_2, hello);
 
-    let mut acceptor = Acceptor::default();
-    let mut error_with_alert = acceptor
-        .accept(&mut SliceInput::new(&mut hello))
+    let receive = ServerHandshake::start();
+    let mut output = vec![];
+    let error = receive
+        .process(&mut SliceInput::new(&mut hello), &mut output)
         .unwrap_err();
+    assert_eq!(error, PeerMisbehaved::KeyEpochWithPendingFragment.into());
     assert_eq!(
-        error_with_alert.error,
-        PeerMisbehaved::KeyEpochWithPendingFragment.into()
-    );
-    assert_eq!(
-        error_with_alert.take_tls_data(),
+        output.pop(),
         Some(encoding::alert(AlertDescription::UnexpectedMessage, &[]))
     );
 }

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -12,10 +12,8 @@ use pki_types::DnsName;
 use rustls::crypto::CryptoProvider;
 use rustls::crypto::kx::NamedGroup;
 use rustls::enums::{ContentType, HandshakeType, ProtocolVersion};
-use rustls::error::{
-    AlertDescription, ApiMisuse, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved,
-};
-use rustls::server::Acceptor;
+use rustls::error::{AlertDescription, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
+use rustls::server::ServerHandshake;
 use rustls::{
     ClientConfig, Connection, HandshakeKind, ServerConfig, ServerConnection, SliceInput, VecInput,
 };
@@ -1763,7 +1761,69 @@ fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
 }
 
 #[test]
-fn test_acceptor() {
+fn test_full_server_handshake() {
+    let provider = provider::DEFAULT_PROVIDER;
+    let client_config = Arc::new(make_client_config(KeyType::Ed25519, &provider));
+    let mut client = client_config
+        .connect(server_name("localhost"))
+        .build()
+        .unwrap();
+    let mut buf = Vec::new();
+    client.write_tls(&mut buf).unwrap();
+
+    // client first flight
+    let receive = ServerHandshake::start();
+    let mut acceptor_input = VecInput::default();
+    acceptor_input
+        .read(&mut buf.as_slice())
+        .unwrap();
+
+    // server first flight and config choice
+    let mut server_output = vec![];
+    let ServerHandshake::Accepted(accepted) = receive
+        .process(&mut acceptor_input, &mut server_output)
+        .unwrap()
+    else {
+        panic!("unexpected state");
+    };
+    let mut server = accepted
+        .choose_config(
+            Arc::new(make_server_config(KeyType::Ed25519, &provider)),
+            &mut server_output,
+        )
+        .unwrap();
+    assert!(!server_output.is_empty());
+
+    // client receives server flight
+    let mut server_output = server_output.concat();
+    client
+        .process_new_packets(&mut SliceInput::new(&mut server_output))
+        .unwrap();
+    let mut client_output = vec![];
+    client
+        .write_tls(&mut client_output)
+        .unwrap();
+
+    // client second flight
+    let mut server_output = vec![];
+    server = if let ServerHandshake::NeedsInput(receive) = server {
+        receive
+            .process(&mut SliceInput::new(&mut client_output), &mut server_output)
+            .unwrap()
+    } else {
+        panic!("unexpected state");
+    };
+    let mut server_output = server_output.concat();
+    client
+        .process_new_packets(&mut SliceInput::new(&mut server_output))
+        .unwrap();
+
+    assert!(matches!(server, ServerHandshake::Complete(_)));
+    assert!(!client.is_handshaking());
+}
+
+#[test]
+fn test_server_handshake() {
     let provider = provider::DEFAULT_PROVIDER;
     let client_config = Arc::new(make_client_config(KeyType::Ed25519, &provider));
     let mut client = client_config
@@ -1774,15 +1834,18 @@ fn test_acceptor() {
     client.write_tls(&mut buf).unwrap();
 
     let server_config = Arc::new(make_server_config(KeyType::Ed25519, &provider));
-    let mut acceptor = Acceptor::default();
+    let receive = ServerHandshake::start();
     let mut acceptor_input = VecInput::default();
     acceptor_input
         .read(&mut buf.as_slice())
         .unwrap();
-    let accepted = acceptor
-        .accept(&mut acceptor_input)
+    let mut output = vec![];
+    let ServerHandshake::Accepted(accepted) = receive
+        .process(&mut acceptor_input, &mut output)
         .unwrap()
-        .unwrap();
+    else {
+        panic!("unexpected state");
+    };
     let ch = accepted.client_hello();
     assert_eq!(
         ch.server_name(),
@@ -1797,54 +1860,52 @@ fn test_acceptor() {
             .collect::<Vec<NamedGroup>>()
     );
 
-    let server = accepted
-        .into_connection(server_config)
+    let _server = accepted
+        .choose_config(server_config, &mut output)
         .unwrap();
-    assert!(server.wants_write());
+    assert!(!output.is_empty());
 
-    // Reusing an acceptor is not allowed
-    assert_eq!(
-        acceptor
-            .accept(&mut acceptor_input)
-            .err()
-            .unwrap()
-            .error,
-        ApiMisuse::AcceptorPolledAfterCompletion.into()
-    );
+    // (Reusing `accepted` is not possible)
 
-    let mut acceptor = Acceptor::default();
+    let receive = ServerHandshake::start();
     let mut acceptor_input = VecInput::default();
-    assert!(
-        acceptor
-            .accept(&mut acceptor_input)
-            .unwrap()
-            .is_none()
-    );
+    let mut output = vec![];
+    let ServerHandshake::NeedsInput(receive) = receive
+        .process(&mut acceptor_input, &mut output)
+        .unwrap()
+    else {
+        panic!("unexpected state");
+    };
+    assert!(output.is_empty());
+
     acceptor_input
         .read(&mut &buf[..3])
         .unwrap(); // incomplete message
-    assert!(
-        acceptor
-            .accept(&mut acceptor_input)
-            .unwrap()
-            .is_none()
-    );
+    let ServerHandshake::NeedsInput(receive) = receive
+        .process(&mut acceptor_input, &mut output)
+        .unwrap()
+    else {
+        panic!("unexpected state");
+    };
+    assert!(output.is_empty());
 
     acceptor_input
         .read(&mut [0x80, 0x00].as_ref())
         .unwrap(); // invalid message (len = 32k bytes)
-    let mut ea = acceptor
-        .accept(&mut acceptor_input)
+    let error = receive
+        .process(&mut acceptor_input, &mut output)
         .unwrap_err();
     assert_eq!(
-        ea.error,
+        error,
         Error::InvalidMessage(InvalidMessage::MessageTooLarge)
     );
-    let alert_content = ea.take_tls_data().unwrap();
+    let alert_content = output
+        .pop()
+        .expect("should've sent an alert");
     let expected = encoding::alert(AlertDescription::DecodeError, &[]);
     assert_eq!(alert_content, expected);
 
-    let mut acceptor = Acceptor::default();
+    let receive = ServerHandshake::start();
     let mut acceptor_input = VecInput::default();
     // Minimal valid 1-byte application data message is not a handshake message
     acceptor_input
@@ -1857,19 +1918,17 @@ fn test_acceptor() {
             .as_slice(),
         )
         .unwrap();
-    let mut ea = acceptor
-        .accept(&mut acceptor_input)
+    let error = receive
+        .process(&mut acceptor_input, &mut output)
         .unwrap_err();
-    assert!(matches!(ea.error, Error::InappropriateMessage { .. }));
-    let alert_content = ea.take_tls_data().unwrap();
+    assert!(matches!(error, Error::InappropriateMessage { .. }));
+    let alert_content = output
+        .pop()
+        .expect("should've sent an alert");
     let expected = encoding::alert(AlertDescription::UnexpectedMessage, &[]);
     assert_eq!(alert_content, expected);
-    assert_eq!(
-        format!("{ea:?}"),
-        "ErrorWithAlert { error: InappropriateMessage { expect_types: [Handshake], got_type: ApplicationData }, data: 0, .. }"
-    );
 
-    let mut acceptor = Acceptor::default();
+    let receive = ServerHandshake::start();
     let mut acceptor_input = VecInput::default();
     // Minimal 1-byte ClientHello message is not a legal handshake message
     acceptor_input
@@ -1882,14 +1941,14 @@ fn test_acceptor() {
             .as_slice(),
         )
         .unwrap();
-    let mut ea = acceptor
-        .accept(&mut acceptor_input)
+    let error = receive
+        .process(&mut acceptor_input, &mut output)
         .unwrap_err();
     assert!(matches!(
-        ea.error,
+        error,
         Error::InvalidMessage(InvalidMessage::MissingData(_))
     ));
-    let alert_content = ea.take_tls_data().unwrap();
+    let alert_content = output.pop().unwrap();
     let expected = encoding::alert(AlertDescription::DecodeError, &[]);
     assert_eq!(alert_content, expected);
 }
@@ -1923,16 +1982,27 @@ fn test_acceptor_continues_tls13_hrr_with_compatibility_ccs() {
         .read(&mut client_hello.as_slice())
         .unwrap();
 
-    let mut acceptor = Acceptor::default();
-    let accepted = acceptor
-        .accept(&mut server_input)
+    let receive = ServerHandshake::start();
+    let mut output = vec![];
+    let ServerHandshake::Accepted(accepted) = receive
+        .process(&mut server_input, &mut output)
         .unwrap()
-        .unwrap();
-    let mut server = accepted
-        .into_connection(server_config)
-        .unwrap();
+    else {
+        panic!("unexpected state");
+    };
+    let ServerHandshake::NeedsInput(receive) = accepted
+        .choose_config(server_config, &mut output)
+        .unwrap()
+    else {
+        panic!("unexpected state");
+    };
+    let mut server = receive.into_buffered_connection();
 
     let mut client_input = VecInput::default();
+    client_input
+        .read(&mut io::Cursor::new(output.concat()))
+        .unwrap();
+
     do_handshake(
         &mut client_input,
         &mut client,
@@ -1964,30 +2034,35 @@ fn test_acceptor_rejected_handshake() {
 
     let server_config =
         ServerConfig::builder(provider::DEFAULT_TLS12_PROVIDER.into()).finish(KeyType::Ed25519);
-    let mut acceptor = Acceptor::default();
+    let receive = ServerHandshake::start();
     let mut acceptor_input = VecInput::default();
     acceptor_input
         .read(&mut buf.as_slice())
         .unwrap();
-    let accepted = acceptor
-        .accept(&mut acceptor_input)
+    let mut output = vec![];
+    let ServerHandshake::Accepted(accepted) = receive
+        .process(&mut acceptor_input, &mut output)
         .unwrap()
-        .unwrap();
+    else {
+        panic!("unexpected state");
+    };
     let ch = accepted.client_hello();
     assert_eq!(
         ch.server_name(),
         Some(&DnsName::try_from("localhost").unwrap())
     );
 
-    let mut ea = accepted
-        .into_connection(server_config.into())
+    let error = accepted
+        .choose_config(server_config.into(), &mut output)
         .unwrap_err();
     assert_eq!(
-        ea.error,
+        error,
         Error::PeerIncompatible(PeerIncompatible::Tls12NotOfferedOrEnabled)
     );
 
-    let alert_content = ea.take_tls_data().unwrap();
+    let alert_content = output
+        .pop()
+        .expect("should've sent an alert");
     let expected = encoding::alert(AlertDescription::ProtocolVersion, &[]);
     assert_eq!(alert_content, expected);
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -62,6 +62,14 @@ impl StateMachine for ClientState {
         true
     }
 
+    fn is_traffic(&self) -> bool {
+        matches!(
+            self,
+            Self::Tls12(tls12::Tls12State::Traffic(..))
+                | Self::Tls13(tls13::Tls13State::Traffic(..) | tls13::Tls13State::QuicTraffic(..))
+        )
+    }
+
     fn handle_decrypt_error(&mut self) {
         if let Self::Tls12(tls12::Tls12State::Finished(e)) = self {
             e.handle_decrypt_error();

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -872,6 +872,7 @@ use private::SideOutput;
 pub(crate) trait StateMachine: Sized {
     fn handle<'m>(self, input: Input<'m>, output: &mut dyn Output<'m>) -> Result<Self, Error>;
     fn wants_input(&self) -> bool;
+    fn is_traffic(&self) -> bool;
     fn handle_decrypt_error(&mut self);
     fn into_external_state(
         self,

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -168,6 +168,10 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
     pub(super) fn input(&mut self) -> &mut dyn TlsInputBuffer {
         self.input
     }
+
+    pub(crate) fn state(&self) -> &Result<Side::State, Error> {
+        self.state
+    }
 }
 
 pub(crate) struct ReceivePath {

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1396,10 +1396,8 @@ pub enum ApiMisuse {
     /// [`KeyingMaterialExporter::derive()`]: crate::KeyingMaterialExporter::derive()
     ExporterOutputZeroLength,
 
-    /// A server [`Acceptor::accept()`][] or QUIC [`quic::Acceptor::accept()`][] called after it
-    /// yielded a connection.
+    /// A QUIC server [`quic::Acceptor::accept()`][] called after it yielded a connection.
     ///
-    /// [`Acceptor::accept()`]: crate::server::Acceptor::accept()
     /// [`quic::Acceptor::accept()`]: crate::quic::Acceptor::accept()
     AcceptorPolledAfterCompletion,
 

--- a/rustls/src/server/config.rs
+++ b/rustls/src/server/config.rs
@@ -112,7 +112,6 @@ pub struct ServerConfig {
 
     /// How to choose a server cert and key. This is usually set by
     /// [ConfigBuilder::with_single_cert] or [ConfigBuilder::with_server_credential_resolver].
-    /// For async applications, see also [`Acceptor`][super::Acceptor].
     pub cert_resolver: Arc<dyn ServerCredentialResolver>,
 
     /// Protocol names we support, most preferred first.
@@ -378,10 +377,6 @@ pub trait StoresServerSessions: Debug + Send + Sync {
 ///
 /// This is suitable when selecting a certificate does not require
 /// I/O or when the application is using blocking I/O anyhow.
-///
-/// For applications that use async I/O and need to do I/O to choose
-/// a certificate (for instance, fetching a certificate from a data store),
-/// the [`Acceptor`][super::Acceptor] interface is more suitable.
 pub trait ServerCredentialResolver: Debug + Send + Sync {
     /// Choose a certificate chain and matching key given simplified ClientHello information.
     ///

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -1,6 +1,5 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::fmt::{Debug, Formatter};
 use core::ops::Deref;
 use core::{fmt, mem};
 use std::io;
@@ -8,17 +7,19 @@ use std::io;
 use pki_types::{DnsName, FipsStatus};
 
 use super::config::{ClientHello, ServerConfig};
-use crate::common_state::{CommonState, ConnectionOutputs, EarlyDataEvent, Event, Protocol, Side};
+use crate::common_state::{
+    CommonState, ConnectionOutputs, EarlyDataEvent, Event, Protocol, Side, maybe_send_fatal_alert,
+};
 use crate::conn::private::SideOutput;
 use crate::conn::split::SplitConnection;
 use crate::conn::{
-    Connection, ConnectionCommon, ConnectionCore, KeyingMaterialExporter, Reader, SideData,
-    TlsInputBuffer, Writer,
+    Connection, ConnectionCommon, ConnectionCore, KeyingMaterialExporter, MessageIter, Reader,
+    SideData, StateMachine, TlsInputBuffer, Writer,
 };
 #[cfg(doc)]
 use crate::crypto;
 use crate::crypto::cipher::Payload;
-use crate::error::{ApiMisuse, Error, ErrorWithAlert};
+use crate::error::Error;
 use crate::log::trace;
 use crate::msgs::ServerExtensionsInput;
 use crate::server::hs::{ChooseConfig, ExpectClientHello, ReadClientHello, ServerState};
@@ -208,129 +209,216 @@ impl Deref for ServerConnection {
     }
 }
 
-impl Debug for ServerConnection {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Debug for ServerConnection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ServerConnection")
             .finish_non_exhaustive()
     }
 }
 
-/// Handle a server-side connection before configuration is available.
-///
-/// `Acceptor` allows the caller to choose a [`ServerConfig`] after reading
-/// the [`ClientHello`] of an incoming connection. This is useful for
-/// servers that choose different certificates or cipher suites based on the
-/// characteristics of the `ClientHello`. In particular it is useful for
-/// servers that need to do some I/O to load a certificate and its private key
-/// and don't want to use the blocking interface provided by
-/// [`ServerCredentialResolver`][crate::server::ServerCredentialResolver].
-///
-/// Create an Acceptor with [`Acceptor::default()`].
-///
-/// # Example
-///
-/// ```no_run
-/// # fn choose_server_config(
-/// #     _: rustls::server::ClientHello,
-/// # ) -> std::sync::Arc<rustls::ServerConfig> {
-/// #     unimplemented!();
-/// # }
-/// # use std::io::Write;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use rustls::server::{Acceptor, ServerConfig};
-///
-/// let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-/// let mut input = rustls::VecInput::default();
-///
-/// for stream in listener.incoming() {
-///     let mut stream = stream?;
-///     let mut acceptor = Acceptor::default();
-///     let accepted = loop {
-///         input.read(&mut stream)?;
-///         match acceptor.accept(&mut input) {
-///             Ok(Some(accepted)) => break accepted,
-///             Ok(None) => continue,
-///             Err(mut error_with_alert) => {
-///                 if let Some(alert) = error_with_alert.take_tls_data() {
-///                     stream.write_all(&alert)?;
-///                 }
-///                 return Err(Box::new(error_with_alert.error));
-///             }
-///         };
-///     };
-///
-///     // For some user-defined choose_server_config:
-///     let config = choose_server_config(accepted.client_hello());
-///     let conn = match accepted.into_connection(config) {
-///         Ok(conn) => conn,
-///         Err(mut error_with_alert) => {
-///             if let Some(alert) = error_with_alert.take_tls_data() {
-///                 stream.write_all(&alert)?;
-///             }
-///             return Err(Box::new(error_with_alert.error));
-///         }
-///     };
-///
-///     // Proceed with handling the ServerConnection.
-/// }
-/// #   Ok(())
-/// # }
-/// ```
-pub struct Acceptor {
-    inner: Option<ConnectionCommon<ServerSide>>,
+/// An in-progress TLS server handshake.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum ServerHandshake {
+    /// More data needs to be received to make progress.
+    NeedsInput(NeedsInput),
+
+    /// A complete `ClientHello` has been received.
+    ///
+    /// The handshake can be progressed by choosing a [`ServerConfig`] based on
+    /// [`Accepted::client_hello()`] and providing it to [`Accepted::choose_config()`].
+    Accepted(Accepted),
+
+    /// The handshake is complete.
+    ///
+    /// Now see [`SplitConnection`] to continue the connection.
+    Complete(SplitConnection<ServerSide>),
 }
 
-impl Default for Acceptor {
-    /// Return an empty Acceptor, ready to receive bytes from a new client connection.
-    fn default() -> Self {
-        Self {
-            inner: Some(ConnectionCommon::new(ConnectionCore::for_acceptor(
-                Protocol::Tcp,
-            ))),
+impl ServerHandshake {
+    /// Creates a new [`ServerHandshake`] via the payload of the [`ServerHandshake::NeedsInput`] variant.
+    ///
+    /// It is a fundamental fact of server TLS connections that the server reads first; this is reflected
+    /// in the returned type.
+    ///
+    /// You may wrap this in the [`ServerHandshake::NeedsInput`] variant to generalise the type to a
+    /// [`ServerHandshake`].
+    ///
+    /// The returned object should be fed data from a single potential client.
+    pub fn start() -> NeedsInput {
+        NeedsInput {
+            inner: ConnectionCore::for_acceptor(Protocol::Tcp),
         }
     }
 }
 
-impl Acceptor {
-    /// Check if a `ClientHello` message has been received.
+impl TryFrom<ConnectionCore<ServerSide>> for ServerHandshake {
+    type Error = Error;
+
+    fn try_from(mut inner: ConnectionCore<ServerSide>) -> Result<Self, Error> {
+        const MISUSED: Error = Error::Unreachable("forgot to restore state");
+
+        Ok(match mem::replace(&mut inner.state, Err(MISUSED))? {
+            ServerState::ChooseConfig(choose_config) => Self::Accepted(Accepted {
+                inner,
+                choose_config,
+            }),
+
+            state if state.is_traffic() => {
+                inner.state = Ok(state);
+                Self::Complete(SplitConnection::try_from(inner)?)
+            }
+
+            state => {
+                inner.state = Ok(state);
+                Self::NeedsInput(NeedsInput { inner })
+            }
+        })
+    }
+}
+
+/// More data needs to be received to make progress.
+///
+/// Provide this to [`Self::process()`].
+pub struct NeedsInput {
+    inner: ConnectionCore<ServerSide>,
+}
+
+impl NeedsInput {
+    /// Progress the handshake by receiving further data.
     ///
-    /// Returns `Ok(None)` if the complete `ClientHello` has not yet been received.
-    /// Do more I/O and then call this function again.
+    /// The data is obtained via `input`.  Any output produced is appended to `output` and
+    /// should be sent to the peer (including if this function returns an error, because
+    /// the `output` may contain an alert.)
     ///
-    /// Returns `Ok(Some(accepted))` if the connection has been accepted. Call
-    /// `accepted.into_connection()` to continue. Do not call this function again.
+    /// An error from this function is otherwise fatal to the connection, as it consumes
+    /// the [`NeedsInput`] object.
     ///
-    /// Returns `Err(_)` if an error occurred. The error type optionally carries a TLS alert;
-    /// the application should obtain and write these bytes to the client.
+    /// On success, this returns:
     ///
-    /// Don't call `accept()` again after an error.
-    pub fn accept(
-        &mut self,
+    /// - a [`ServerHandshake::NeedsInput`] if more data is required.
+    /// - a [`ServerHandshake::Accepted`] if a whole `ClientHello` has been received, requiring
+    ///   and a choice of [`ServerConfig`] is required to continue.
+    /// - a [`ServerHandshake::Complete`] if the handshake is complete.
+    pub fn process(
+        mut self,
         input: &mut dyn TlsInputBuffer,
-    ) -> Result<Option<Accepted>, ErrorWithAlert> {
-        let Some(mut connection) = self.inner.take() else {
-            return Err(ErrorWithAlert::from(Error::ApiMisuse(
-                ApiMisuse::AcceptorPolledAfterCompletion,
-            )));
+        output: &mut Vec<Vec<u8>>,
+    ) -> Result<ServerHandshake, Error> {
+        let mut iter = MessageIter::new(input, None, &mut self.inner);
+        let r = loop {
+            match iter.next() {
+                Some(Ok(_)) => {}
+                Some(Err(e)) => break Err(e),
+                None => break Ok(()),
+            };
+
+            // end loop as soon as traffic state is entered, as the above loop drops
+            // incoming appdata.
+            if iter
+                .state()
+                .as_ref()
+                .map(|st| st.is_traffic())
+                .unwrap_or_default()
+            {
+                break Ok(());
+            }
         };
 
-        if let Err(e) = connection.process_new_packets(input) {
-            return Err(ErrorWithAlert::new(e, &mut connection.core.common.send));
+        input.discard(
+            self.inner
+                .common
+                .recv
+                .deframer
+                .take_discard(),
+        );
+
+        while let Some(chunk) = self
+            .inner
+            .common
+            .send
+            .sendable_tls
+            .pop()
+        {
+            output.push(chunk);
+        }
+        r?;
+        ServerHandshake::try_from(self.inner)
+    }
+
+    /// Temporary escape hatch during migration to new API.
+    pub fn into_buffered_connection(self) -> ServerConnection {
+        ServerConnection {
+            inner: ConnectionCommon::new(self.inner),
+        }
+    }
+}
+
+impl fmt::Debug for NeedsInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NeedsInput")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Represents a `ClientHello` message.
+///
+/// The handshake can be progressed by choosing a [`ServerConfig`] based on
+/// [`Accepted::client_hello()`] and providing it to [`Accepted::choose_config()`].
+pub struct Accepted {
+    // invariant: `inner.state` is `Err(_)` and requires restoring
+    inner: ConnectionCore<ServerSide>,
+    choose_config: Box<ChooseConfig>,
+}
+
+impl Accepted {
+    /// Get the [`ClientHello`] for this connection.
+    pub fn client_hello(&self) -> ClientHello<'_> {
+        let ch = self.choose_config.client_hello();
+        trace!("Accepted::client_hello(): {ch:#?}");
+        ch
+    }
+
+    /// Choose a [`ServerConfig`] to progress the handshake.
+    ///
+    /// Output to send to the peer is appended to `output`.  Typically, this is the `ServerHello`,
+    /// but it may also be an `Alert` if an error is returned.
+    ///
+    /// Returns an error if configuration-dependent validation of the received `ClientHello` message fails.
+    pub fn choose_config(
+        mut self,
+        config: Arc<ServerConfig>,
+        output: &mut Vec<Vec<u8>>,
+    ) -> Result<ServerHandshake, Error> {
+        let result = self.inner.accepted(
+            self.choose_config,
+            ServerExtensionsInput::default(),
+            None,
+            config,
+        );
+
+        let send_path = &mut self.inner.common.send;
+
+        if let Err(err) = &result {
+            maybe_send_fatal_alert(send_path, err);
         }
 
-        const MISUSED: Error = Error::Unreachable("Accepted misused state");
-        match mem::replace(&mut connection.core.state, Err(MISUSED)) {
-            Ok(ServerState::ChooseConfig(choose_config)) => Ok(Some(Accepted {
-                connection,
-                choose_config,
-            })),
-            Ok(state) => {
-                connection.core.state = Ok(state);
-                self.inner = Some(connection);
-                Ok(None)
-            }
-            Err(e) => Err(ErrorWithAlert::new(e, &mut connection.core.common.send)),
+        while let Some(chunk) = send_path.sendable_tls.pop() {
+            output.push(chunk);
         }
+
+        result?;
+
+        Ok(ServerHandshake::NeedsInput(NeedsInput {
+            inner: self.inner,
+        }))
+    }
+}
+
+impl fmt::Debug for Accepted {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Accepted")
+            .finish_non_exhaustive()
     }
 }
 
@@ -379,58 +467,6 @@ impl io::Read for ReadEarlyData<'_> {
             .side
             .early_data
             .read(buf)
-    }
-}
-
-/// Represents a `ClientHello` message received through the [`Acceptor`].
-///
-/// Contains the state required to resume the connection through [`Accepted::into_connection()`].
-pub struct Accepted {
-    // invariant: `connection.core.state` is `Err(_)` and requires restoring
-    connection: ConnectionCommon<ServerSide>,
-    choose_config: Box<ChooseConfig>,
-}
-
-impl Accepted {
-    /// Get the [`ClientHello`] for this connection.
-    pub fn client_hello(&self) -> ClientHello<'_> {
-        let ch = self.choose_config.client_hello();
-        trace!("Accepted::client_hello(): {ch:#?}");
-        ch
-    }
-
-    /// Convert the [`Accepted`] into a [`ServerConnection`].
-    ///
-    /// Takes the state returned from [`Acceptor::accept()`] as well as the [`ServerConfig`] that
-    /// should be used for the session. Returns an error if configuration-dependent validation of
-    /// the received `ClientHello` message fails.
-    pub fn into_connection(
-        mut self,
-        config: Arc<ServerConfig>,
-    ) -> Result<ServerConnection, ErrorWithAlert> {
-        let result = self.connection.core.accepted(
-            self.choose_config,
-            ServerExtensionsInput::default(),
-            None,
-            config,
-        );
-
-        match result {
-            Ok(()) => Ok(ServerConnection {
-                inner: self.connection,
-            }),
-            Err(e) => Err(ErrorWithAlert::new(
-                e,
-                &mut self.connection.core.common.send,
-            )),
-        }
-    }
-}
-
-impl Debug for Accepted {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Accepted")
-            .finish_non_exhaustive()
     }
 }
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -75,6 +75,14 @@ impl crate::conn::StateMachine for ServerState {
         !matches!(self, Self::ChooseConfig(_))
     }
 
+    fn is_traffic(&self) -> bool {
+        matches!(
+            self,
+            Self::Tls12(tls12::Tls12State::Traffic(..))
+                | Self::Tls13(tls13::Tls13State::Traffic(..) | tls13::Tls13State::QuicTraffic(..))
+        )
+    }
+
     fn handle_decrypt_error(&mut self) {}
 
     fn into_external_state(

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -20,7 +20,9 @@ pub use config::{
 };
 
 mod connection;
-pub use connection::{Accepted, Acceptor, ReadEarlyData, ServerConnection, ServerSide};
+pub use connection::{
+    Accepted, NeedsInput, ReadEarlyData, ServerConnection, ServerHandshake, ServerSide,
+};
 
 pub(crate) mod handy;
 #[cfg(feature = "webpki")]


### PR DESCRIPTION
Subsequent plans continuing along this line:

- [x] also do this to `quic::Acceptor`, and thereby externalise buffers for that API #3152 
- [ ] add `ServerHandshake::VerifyClientCert` which follows the shape of `ServerHandshake::Accepted` (for resolution of `ServerConfig`) and something like https://github.com/rustls/rustls/pull/2713 (a prior client-side attempt at something similar) and externalises use of the cert verification trait
- [ ] follow the same for client handshakes
- [ ] insert this and the components of `SplitConnection` under `ServerConnection`?