### PR TITLE
Account for encryption overhead in `max_fragment_size` fragmentation

### DIFF
--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1643,8 +1643,6 @@ fn test_server_mtu_reduction() {
         .write_all(&big_data)
         .unwrap();
 
-    let encryption_overhead = 20; // FIXME: see issue #991
-
     transfer(&mut client, &mut server_input);
     server
         .process_new_packets(&mut server_input)
@@ -1656,7 +1654,7 @@ fn test_server_mtu_reduction() {
         assert!(
             pipe.message_lengths()
                 .iter()
-                .all(|x| *x <= 64 + encryption_overhead)
+                .all(|x| *x <= 64)
         );
     }
 
@@ -1674,7 +1672,7 @@ fn test_server_mtu_reduction() {
         assert!(
             pipe.message_lengths()
                 .iter()
-                .all(|x| *x <= 64 + encryption_overhead)
+                .all(|x| *x <= 64)
         );
     }
 

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -65,15 +65,27 @@ impl SendPath {
         );
     }
 
+    fn max_plaintext_fragment(&self, encrypt: bool) -> usize {
+        if encrypt {
+            self.message_fragmenter.max_plaintext_for_encrypted(
+                self.encrypt_state.encrypted_record_overhead(),
+            )
+        } else {
+            self.message_fragmenter.max_plaintext()
+        }
+    }
+
     /// Like send_msg_encrypt, but operate on an appdata directly.
     pub(crate) fn send_appdata_encrypt(&mut self, payload: OutboundPlain<'_>) -> usize {
         let len = payload.len();
+        let max_plaintext = self.max_plaintext_fragment(true);
         self.send_messages(
             self.message_fragmenter
-                .fragment_payload(
+                .fragment_payload_with_max(
                     ContentType::ApplicationData,
                     ProtocolVersion::TLSv1_2,
                     payload,
+                    max_plaintext,
                 ),
         );
         len
@@ -252,9 +264,10 @@ impl SendOutput for SendPath {
     fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool) {
         let encoded = EncodedMessage::from(m);
         if must_encrypt {
+            let max_plaintext = self.max_plaintext_fragment(true);
             self.send_messages(
                 self.message_fragmenter
-                    .fragment_message(&encoded),
+                    .fragment_message_with_max(&encoded, max_plaintext),
             );
             return;
         }

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -77,6 +77,11 @@ impl EncryptionState {
             .unwrap_or_default()
     }
 
+    /// Number of bytes added to a plaintext fragment by record protection.
+    pub(crate) fn encrypted_record_overhead(&self) -> usize {
+        self.encrypted_len(0)
+    }
+
     pub(crate) fn is_encrypting(&self) -> bool {
         self.message_encrypter.is_some()
     }

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -40,23 +40,59 @@ impl MessageFragmenter {
     /// Return an iterator across those messages.
     ///
     /// Payloads are borrowed from `payload`.
+    pub(crate) fn max_plaintext(&self) -> usize {
+        self.max_frag
+    }
+
+    /// Maximum plaintext per fragment when records will be encrypted.
+    ///
+    /// `encrypted_overhead` is the number of bytes added to the plaintext by the
+    /// record protection layer (for example, the TLS 1.3 content-type byte and AEAD tag).
+    pub(crate) fn max_plaintext_for_encrypted(&self, encrypted_overhead: usize) -> usize {
+        self.max_frag.saturating_sub(encrypted_overhead)
+    }
+
     pub(crate) fn fragment_payload<'a>(
         &self,
         typ: ContentType,
         version: ProtocolVersion,
         payload: OutboundPlain<'a>,
     ) -> impl ExactSizeIterator<Item = EncodedMessage<OutboundPlain<'a>>> {
-        Chunker::new(payload, self.max_frag).map(move |payload| EncodedMessage {
+        self.fragment_payload_with_max(typ, version, payload, self.max_frag)
+    }
+
+    pub(crate) fn fragment_payload_with_max<'a>(
+        &self,
+        typ: ContentType,
+        version: ProtocolVersion,
+        payload: OutboundPlain<'a>,
+        max_plaintext: usize,
+    ) -> impl ExactSizeIterator<Item = EncodedMessage<OutboundPlain<'a>>> {
+        Chunker::new(payload, max_plaintext).map(move |payload| EncodedMessage {
             typ,
             version,
             payload,
         })
     }
 
+    pub(crate) fn fragment_message_with_max<'a>(
+        &self,
+        msg: &'a EncodedMessage<Payload<'_>>,
+        max_plaintext: usize,
+    ) -> impl ExactSizeIterator<Item = EncodedMessage<OutboundPlain<'a>>> + 'a {
+        self.fragment_payload_with_max(
+            msg.typ,
+            msg.version,
+            msg.payload.bytes().into(),
+            max_plaintext,
+        )
+    }
+
     /// Set the maximum fragment size that will be produced.
     ///
-    /// This includes overhead. A `max_fragment_size` of 10 will produce TLS fragments
-    /// up to 10 bytes long.
+    /// This is the maximum size of each TLS record on the wire, including the
+    /// five-byte record header. When records are encrypted, plaintext is fragmented
+    /// more aggressively so the protected record still fits in this limit.
     ///
     /// A `max_fragment_size` of `None` sets the highest allowable fragment size.
     ///
@@ -129,6 +165,14 @@ mod tests {
         let buf = m.to_unencrypted_opaque().encode();
 
         assert_eq!(total_len, buf.len());
+    }
+
+    #[test]
+    fn max_plaintext_for_encrypted() {
+        let mut frag = MessageFragmenter::default();
+        frag.set_max_fragment_size(Some(64)).unwrap();
+        assert_eq!(frag.max_plaintext(), 59);
+        assert_eq!(frag.max_plaintext_for_encrypted(17), 42);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #991.

`max_fragment_size` is meant to cap the **wire size** of each TLS record (5-byte header + payload). Encrypted records were exceeding that limit because fragmentation only limited plaintext, not AEAD overhead.

This subtracts the cipher-specific encryption overhead (via `encrypted_record_overhead()`) before fragmenting encrypted traffic. Unencrypted handshake messages are unchanged.

- `test_server_mtu_reduction` now asserts `<= 64` without the old `+ 20` workaround
- New unit test for `max_plaintext_for_encrypted