### PR TITLE
conn: extract packet processing from ReceivePath

### DIFF
--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -8,7 +8,7 @@ use kernel::KernelConnection;
 use pki_types::FipsStatus;
 
 use crate::common_state::{
-    CommonState, ConnectionOutput, ConnectionOutputs, Event, Output, OutputEvent, UnborrowedPayload,
+    CommonState, ConnectionOutput, ConnectionOutputs, Event, Output, OutputEvent,
 };
 use crate::error::{ApiMisuse, Error};
 use crate::kernel::KernelState;
@@ -24,8 +24,7 @@ use crate::vecbuf::ChunkVecBuffer;
 pub mod kernel;
 
 mod receive;
-use receive::JoinOutput;
-pub(crate) use receive::{Input, ReceivePath, TrafficTemperCounters};
+pub(crate) use receive::{Input, MessageIter, ReceivePath, TrafficTemperCounters};
 pub use receive::{SliceInput, TlsInputBuffer, VecInput};
 
 mod send;
@@ -501,10 +500,8 @@ impl<Side: SideData> ConnectionCommon<Side> {
         }
 
         loop {
-            let Some(payload) = self
-                .core
-                .process_new_packets(buf, None)?
-            else {
+            let mut iter = MessageIter::new(buf, None, &mut self.core);
+            let Some(payload) = iter.next()? else {
                 break;
             };
 
@@ -713,24 +710,6 @@ impl<Side: SideData> ConnectionCore<Side> {
             side,
             common,
         }
-    }
-
-    #[inline]
-    pub(crate) fn process_new_packets<'a>(
-        &'a mut self,
-        buffer: &mut dyn TlsInputBuffer,
-        quic: Option<&'a mut dyn QuicOutput>,
-    ) -> Result<Option<UnborrowedPayload>, Error> {
-        let mut output = JoinOutput {
-            outputs: &mut self.common.outputs,
-            quic,
-            send: &mut self.common.send,
-            side: &mut self.side,
-        };
-
-        self.common
-            .recv
-            .process_new_packets::<Side>(buffer, &mut self.state, &mut output)
     }
 
     pub(crate) fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -316,7 +316,7 @@ impl ReceivePath {
 
             let message = unborrowed.reborrow(&Delocator::new(buffer));
             self.deframer
-                .input_message(message.version, message.payload, bounds);
+                .input_message(message.version, bounds, buffer);
             self.deframer.coalesce(buffer)?;
         }
     }

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -186,8 +186,6 @@ impl ReceivePath {
 
     /// Pull a message out of the deframer and send any messages that need to be sent as a result.
     fn deframe<'b>(&mut self, buffer: &'b mut [u8]) -> Result<Option<Decrypted<'b>>, Error> {
-        let version_is_tls13 = matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3));
-
         let locator = Locator::new(buffer);
 
         let mut want_close_before_decrypt = false;
@@ -207,64 +205,10 @@ impl ReceivePath {
             }
 
             let (message, bounds) = loop {
-                let (message, bounds) = match self.deframer.deframe(buffer) {
-                    Some(Ok(Deframed { message, bounds })) => (message, bounds),
-                    Some(Err(err)) => return Err(err),
-                    None => return Ok(None),
-                };
-
-                let allowed_plaintext = match message.typ {
-                    // CCS messages are always plaintext.
-                    ContentType::ChangeCipherSpec => true,
-                    // Alerts are allowed to be plaintext if-and-only-if:
-                    // * The negotiated protocol version is TLS 1.3. - In TLS 1.2 it is unambiguous when
-                    //   keying changes based on the CCS message. Only TLS 1.3 requires these heuristics.
-                    // * We have not yet decrypted any messages from the peer - if we have we don't
-                    //   expect any plaintext.
-                    // * The payload size is indicative of a plaintext alert message.
-                    ContentType::Alert
-                        if version_is_tls13
-                            && !self.decrypt_state.has_decrypted()
-                            && message.payload.len() <= 2 =>
-                    {
-                        true
-                    }
-                    // In other circumstances, we expect all messages to be encrypted.
-                    _ => false,
-                };
-
-                if allowed_plaintext && !self.deframer.is_active() {
-                    break (
-                        Decrypted {
-                            plaintext: message.into_plain_message(),
-                            want_close_before_decrypt: false,
-                        },
-                        bounds,
-                    );
-                }
-
-                match self
-                    .decrypt_state
-                    .decrypt_incoming(message)
-                {
-                    // failed decryption during trial decryption is not allowed to be
-                    // interleaved with partial handshake data.
-                    Ok(None) if self.deframer.aligned().is_none() => {
-                        return Err(
-                            PeerMisbehaved::RejectedEarlyDataInterleavedWithHandshakeMessage.into(),
-                        );
-                    }
-
-                    // failed decryption during trial decryption.
-                    Ok(None) => continue,
-
-                    Ok(Some(decrypted)) => {
-                        // After decryption, the payload is shorter
-                        let bounds = locator.locate(decrypted.plaintext.payload);
-                        break (decrypted, bounds);
-                    }
-
-                    Err(err) => return Err(err),
+                match self.deframe_decrypted(buffer, &locator)? {
+                    DeframeResult::Decrypted(decrypted, bounds) => break (decrypted, bounds),
+                    DeframeResult::DecryptionFailed => continue,
+                    DeframeResult::None => return Ok(None),
                 }
             };
 
@@ -318,6 +262,68 @@ impl ReceivePath {
             self.deframer
                 .input_message(message.version, bounds, buffer);
             self.deframer.coalesce(buffer)?;
+        }
+    }
+
+    fn deframe_decrypted<'b>(
+        &mut self,
+        buffer: &'b mut [u8],
+        locator: &Locator,
+    ) -> Result<DeframeResult<'b>, Error> {
+        let (message, bounds) = match self.deframer.deframe(buffer) {
+            Some(Ok(Deframed { message, bounds })) => (message, bounds),
+            Some(Err(err)) => return Err(err),
+            None => return Ok(DeframeResult::None),
+        };
+
+        let allowed_plaintext = match message.typ {
+            // CCS messages are always plaintext.
+            ContentType::ChangeCipherSpec => true,
+            // Alerts are allowed to be plaintext if-and-only-if:
+            // * The negotiated protocol version is TLS 1.3. - In TLS 1.2 it is unambiguous when
+            //   keying changes based on the CCS message. Only TLS 1.3 requires these heuristics.
+            // * We have not yet decrypted any messages from the peer - if we have we don't
+            //   expect any plaintext.
+            // * The payload size is indicative of a plaintext alert message.
+            ContentType::Alert
+                if matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
+                    && !self.decrypt_state.has_decrypted()
+                    && message.payload.len() <= 2 =>
+            {
+                true
+            }
+            // In other circumstances, we expect all messages to be encrypted.
+            _ => false,
+        };
+
+        if allowed_plaintext && !self.deframer.is_active() {
+            return Ok(DeframeResult::Decrypted(
+                Decrypted {
+                    plaintext: message.into_plain_message(),
+                    want_close_before_decrypt: false,
+                },
+                bounds,
+            ));
+        }
+
+        match self
+            .decrypt_state
+            .decrypt_incoming(message)?
+        {
+            Some(decrypted) => {
+                // After decryption, the payload is shorter
+                let bounds = locator.locate(decrypted.plaintext.payload);
+                Ok(DeframeResult::Decrypted(decrypted, bounds))
+            }
+
+            // failed decryption during trial decryption is not allowed to be
+            // interleaved with partial handshake data.
+            None if self.deframer.aligned().is_none() => {
+                Err(PeerMisbehaved::RejectedEarlyDataInterleavedWithHandshakeMessage.into())
+            }
+
+            // failed decryption during trial decryption.
+            None => Ok(DeframeResult::DecryptionFailed),
         }
     }
 
@@ -445,6 +451,12 @@ impl ReceivePath {
 
         Err(err)
     }
+}
+
+enum DeframeResult<'b> {
+    Decrypted(Decrypted<'b>, Range<usize>),
+    DecryptionFailed,
+    None,
 }
 
 struct CaptureAppData<'a, 'j, 'm> {

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -316,7 +316,7 @@ impl ReceivePath {
 
             let message = unborrowed.reborrow(&Delocator::new(buffer));
             self.deframer
-                .input_message(message, bounds);
+                .input_message(message.version, message.payload, bounds);
             self.deframer.coalesce(buffer)?;
         }
     }

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -789,10 +789,6 @@ impl VecInput {
         self.used += len;
         Range { start, end }
     }
-
-    pub(crate) fn filled(&self) -> &[u8] {
-        &self.buf[..self.used]
-    }
 }
 
 impl TlsInputBuffer for VecInput {

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -9,8 +9,8 @@ use crate::SideData;
 use crate::common_state::{
     ConnectionOutput, Event, Output, OutputEvent, Side, UnborrowedPayload, maybe_send_fatal_alert,
 };
-use crate::conn::StateMachine;
 use crate::conn::private::SideOutput;
+use crate::conn::{ConnectionCore, StateMachine};
 use crate::crypto::cipher::{Decrypted, DecryptionState, EncodedMessage, Payload};
 use crate::enums::{ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{AlertDescription, Error, PeerMisbehaved};
@@ -21,79 +21,64 @@ use crate::msgs::{
 };
 use crate::quic::QuicOutput;
 
-pub(crate) struct ReceivePath {
-    side: Side,
-    pub(crate) decrypt_state: DecryptionState,
-    pub(crate) may_receive_application_data: bool,
-    /// If the peer has signaled end of stream.
-    pub(crate) has_received_close_notify: bool,
-    temper_counters: TemperCounters,
-    pub(crate) negotiated_version: Option<ProtocolVersion>,
-    pub(crate) deframer: Deframer,
-
-    /// We limit consecutive empty fragments to avoid a route for the peer to send
-    /// us significant but fruitless traffic.
-    seen_consecutive_empty_fragments: u8,
-
-    pub(crate) tls13_tickets_received: u32,
+pub(crate) struct MessageIter<'a, 'm, Side: SideData> {
+    input: &'m mut dyn TlsInputBuffer,
+    recv: &'a mut ReceivePath,
+    state: &'a mut Result<Side::State, Error>,
+    output: JoinOutput<'a>,
 }
 
-impl ReceivePath {
-    pub(crate) fn new(side: Side) -> Self {
+impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
+    pub(crate) fn new(
+        input: &'m mut dyn TlsInputBuffer,
+        quic: Option<&'a mut dyn QuicOutput>,
+        conn: &'a mut ConnectionCore<Side>,
+    ) -> Self {
         Self {
-            side,
-            decrypt_state: DecryptionState::new(),
-            may_receive_application_data: false,
-            has_received_close_notify: false,
-            temper_counters: TemperCounters::default(),
-            negotiated_version: None,
-            deframer: Deframer::default(),
-            seen_consecutive_empty_fragments: 0,
-            tls13_tickets_received: 0,
+            recv: &mut conn.common.recv,
+            input,
+            state: &mut conn.state,
+            output: JoinOutput {
+                outputs: &mut conn.common.outputs,
+                quic,
+                send: &mut conn.common.send,
+                side: &mut conn.side,
+            },
         }
     }
 
-    pub(crate) fn process_recv_traffic<Side: SideData>(
-        &mut self,
-        input: &mut dyn TlsInputBuffer,
-        state: &mut Result<Side::State, Error>,
-        send: &mut dyn SendOutput,
-    ) -> Result<Option<UnborrowedPayload>, Error> {
-        self.process_new_packets::<Side>(
+    pub(super) fn receive(
+        input: &'m mut dyn TlsInputBuffer,
+        state: &'a mut Result<Side::State, Error>,
+        recv: &'a mut ReceivePath,
+        output: JoinOutput<'a>,
+    ) -> Self {
+        Self {
+            recv,
             input,
             state,
-            &mut JoinOutput {
-                outputs: &mut Discard,
-                quic: None,
-                send,
-                side: &mut Discard,
-            },
-        )
+            output,
+        }
     }
 
-    pub(super) fn process_new_packets<'a, 'm, Side: SideData>(
-        &mut self,
-        input: &'m mut dyn TlsInputBuffer,
-        state: &mut Result<Side::State, Error>,
-        output: &mut JoinOutput<'a>,
-    ) -> Result<Option<UnborrowedPayload>, Error> {
-        let mut st = match mem::replace(state, Err(Error::HandshakeNotComplete)) {
+    pub(crate) fn next(&mut self) -> Result<Option<UnborrowedPayload>, Error> {
+        let mut st = match mem::replace(self.state, Err(Error::HandshakeNotComplete)) {
             Ok(state) => state,
             Err(e) => {
-                *state = Err(e.clone());
+                *self.state = Err(e.clone());
                 return Err(e);
             }
         };
 
         let mut plaintext = None;
         while st.wants_input() {
-            let buffer = input.slice_mut();
+            let buffer = self.input.slice_mut();
             let locator = Locator::new(buffer);
-            let res = self.deframe(buffer);
+            let res = self.recv.deframe(buffer);
 
             let mut output = CaptureAppData {
-                recv: self,
-                other: &mut *output,
+                recv: self.recv,
+                other: &mut self.output,
                 plaintext_locator: &locator,
                 received_plaintext: &mut plaintext,
                 _message_lifetime: PhantomData,
@@ -106,8 +91,9 @@ impl ReceivePath {
                     if let Error::DecryptError = e {
                         st.handle_decrypt_error();
                     }
-                    *state = Err(e.clone());
-                    input.discard(self.deframer.take_discard());
+                    *self.state = Err(e.clone());
+                    self.input
+                        .discard(self.recv.deframer.take_discard());
                     return Err(e);
                 }
             };
@@ -151,37 +137,74 @@ impl ReceivePath {
                 Ok(new) => st = new,
                 Err(e) => {
                     maybe_send_fatal_alert(output.other.send, &e);
-                    *state = Err(e.clone());
-                    input.discard(self.deframer.take_discard());
+                    *self.state = Err(e.clone());
+                    self.input
+                        .discard(self.recv.deframer.take_discard());
                     return Err(e);
                 }
             }
 
-            if self.has_received_close_notify {
+            if self.recv.has_received_close_notify {
                 // "Any data received after a closure alert has been received MUST be ignored."
                 // -- <https://datatracker.ietf.org/doc/html/rfc8446#section-6.1>
 
                 // First, discard actually-processed bytes.
-                input.discard(self.deframer.take_discard());
+                self.input
+                    .discard(self.recv.deframer.take_discard());
 
                 // Then the rest of any input data.
-                let entirety = input.slice_mut().len();
-                input.discard(entirety);
-                input.received_close_notify();
+                let entirety = self.input.slice_mut().len();
+                self.input.discard(entirety);
+                self.input.received_close_notify();
                 break;
             }
 
             if let Some(payload) = plaintext.take() {
-                *state = Ok(st);
+                *self.state = Ok(st);
                 return Ok(Some(payload));
             }
 
-            input.discard(self.deframer.take_discard());
+            self.input
+                .discard(self.recv.deframer.take_discard());
         }
 
-        input.discard(self.deframer.take_discard());
-        *state = Ok(st);
+        self.input
+            .discard(self.recv.deframer.take_discard());
+        *self.state = Ok(st);
         Ok(None)
+    }
+}
+
+pub(crate) struct ReceivePath {
+    side: Side,
+    pub(crate) decrypt_state: DecryptionState,
+    pub(crate) may_receive_application_data: bool,
+    /// If the peer has signaled end of stream.
+    pub(crate) has_received_close_notify: bool,
+    temper_counters: TemperCounters,
+    pub(crate) negotiated_version: Option<ProtocolVersion>,
+    pub(crate) deframer: Deframer,
+
+    /// We limit consecutive empty fragments to avoid a route for the peer to send
+    /// us significant but fruitless traffic.
+    seen_consecutive_empty_fragments: u8,
+
+    pub(crate) tls13_tickets_received: u32,
+}
+
+impl ReceivePath {
+    pub(crate) fn new(side: Side) -> Self {
+        Self {
+            side,
+            decrypt_state: DecryptionState::new(),
+            may_receive_application_data: false,
+            has_received_close_notify: false,
+            temper_counters: TemperCounters::default(),
+            negotiated_version: None,
+            deframer: Deframer::default(),
+            seen_consecutive_empty_fragments: 0,
+            tls13_tickets_received: 0,
+        }
     }
 
     /// Pull a message out of the deframer and send any messages that need to be sent as a result.
@@ -541,7 +564,7 @@ pub(super) struct JoinOutput<'a> {
     pub(super) side: &'a mut dyn SideOutput,
 }
 
-struct Discard;
+pub(super) struct Discard;
 
 impl ConnectionOutput for Discard {
     fn handle(&mut self, _ev: OutputEvent<'_>) {}

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -4,9 +4,10 @@ use core::fmt;
 use core::ops::{DerefMut, Range};
 use std::sync::MutexGuard;
 
+use super::receive::{Discard, JoinOutput};
 use crate::client::ClientSide;
 use crate::common_state::UnborrowedPayload;
-use crate::conn::{ConnectionCore, ReceivePath, SendOutput, SendPath, TlsInputBuffer};
+use crate::conn::{ConnectionCore, MessageIter, ReceivePath, SendOutput, SendPath, TlsInputBuffer};
 use crate::crypto::cipher::{MessageEncrypter, OutboundPlain};
 use crate::enums::ProtocolVersion;
 use crate::error::{AlertDescription, ErrorWithAlert};
@@ -174,18 +175,23 @@ impl<Side: SideData> ReceiveTraffic<Side> {
 
         let mut send_adapter = SendAdapter::Unlocked(&send);
         let mut state = Ok(state);
-        let received_plain =
-            match recv.process_recv_traffic::<Side>(received_tls, &mut state, &mut send_adapter) {
-                Ok(received_plain) => received_plain,
-                Err(err) => {
-                    return Err(ErrorWithAlert::new(
-                        err,
-                        send_adapter
-                            .as_locked(false)
-                            .deref_mut(),
-                    ));
-                }
-            };
+        let output = JoinOutput {
+            outputs: &mut Discard,
+            quic: None,
+            send: &mut send_adapter,
+            side: &mut Discard,
+        };
+
+        let mut iter = MessageIter::<Side>::receive(received_tls, &mut state, &mut recv, output);
+        let received_plain = iter.next().map_err(|error| {
+            ErrorWithAlert::new(
+                error,
+                send_adapter
+                    .as_locked(false)
+                    .deref_mut(),
+            )
+        })?;
+
         // nb. state consumed only on error.
         let state = state.unwrap();
 

--- a/rustls/src/msgs/deframer/mod.rs
+++ b/rustls/src/msgs/deframer/mod.rs
@@ -85,6 +85,31 @@ impl Deframer {
         }))
     }
 
+    /// Accepts a QUIC frame into the deframer.
+    ///
+    /// QUIC omits the outer frames and only uses TLS for handshake messages. Therefore,
+    /// this exposes a simpler API for accepting handshake messages directly.
+    ///
+    /// `buf` is the containing buffer, and `bounds` is the range of the received frame
+    /// within that buffer.
+    pub(crate) fn input_quic(
+        &mut self,
+        buf: &mut [u8],
+        bounds: Range<usize>,
+    ) -> Result<(), InvalidMessage> {
+        self.processed += bounds.len();
+        self.input_message(
+            EncodedMessage {
+                typ: ContentType::Handshake,
+                version: ProtocolVersion::TLSv1_3,
+                payload: &buf[bounds.start..bounds.end],
+            },
+            bounds,
+        );
+        self.coalesce(buf)?;
+        Ok(())
+    }
+
     /// Accepts a message into the deframer.
     ///
     /// `containing_buffer` allows mapping the message payload to its position
@@ -285,11 +310,6 @@ impl Deframer {
     #[inline]
     pub(crate) fn discard_processed(&mut self) {
         self.discard = self.processed;
-    }
-
-    #[inline]
-    pub(crate) fn add_processed(&mut self, processed: usize) {
-        self.processed += processed;
     }
 
     /// We are "aligned" if there is no partial fragments of a handshake message.

--- a/rustls/src/msgs/deframer/mod.rs
+++ b/rustls/src/msgs/deframer/mod.rs
@@ -99,11 +99,8 @@ impl Deframer {
     ) -> Result<(), InvalidMessage> {
         self.processed += bounds.len();
         self.input_message(
-            EncodedMessage {
-                typ: ContentType::Handshake,
-                version: ProtocolVersion::TLSv1_3,
-                payload: &buf[bounds.start..bounds.end],
-            },
+            ProtocolVersion::TLSv1_3,
+            &buf[bounds.start..bounds.end],
             bounds,
         );
         self.coalesce(buf)?;
@@ -122,9 +119,12 @@ impl Deframer {
     /// `CryptoProvider` interface).  `coalesce()` arranges for that to happen, but
     /// to do so it needs to move the fragments together in the original buffer.
     /// This would not be possible if the messages were borrowing from that buffer.
-    pub(crate) fn input_message(&mut self, msg: EncodedMessage<&'_ [u8]>, bounds: Range<usize>) {
-        debug_assert_eq!(msg.typ, ContentType::Handshake);
-
+    pub(crate) fn input_message(
+        &mut self,
+        version: ProtocolVersion,
+        payload: &[u8],
+        bounds: Range<usize>,
+    ) {
         // if our last span is incomplete, we can blindly add this as a new span --
         // no need to attempt parsing it with `DissectHandshakeIter`.
         //
@@ -139,7 +139,7 @@ impl Deframer {
             .filter(|span| !span.is_complete())
         {
             self.spans.push_back(FragmentSpan {
-                version: msg.version,
+                version,
                 size: None,
                 bounds,
             });
@@ -149,8 +149,8 @@ impl Deframer {
         // otherwise, we can expect `msg` to contain a handshake header introducing
         // a new message (and perhaps several of them.)
         let iter = DissectHandshakeIter {
-            version: msg.version,
-            payload: msg.payload,
+            version,
+            payload,
             bounds,
         };
 
@@ -465,14 +465,12 @@ mod tests {
     }
 
     fn add_bytes(deframer: &mut Deframer, range: Range<usize>, within: &[u8]) {
-        let msg = EncodedMessage {
-            typ: ContentType::Handshake,
-            version: ProtocolVersion::TLSv1_3,
-            payload: &within[range.start..range.end],
-        };
-
         deframer.processed = range.end;
-        deframer.input_message(msg, range);
+        deframer.input_message(
+            ProtocolVersion::TLSv1_3,
+            &within[range.start..range.end],
+            range,
+        );
     }
 
     #[test]
@@ -570,7 +568,11 @@ mod tests {
             let plain = message.into_plain_message();
             std::println!("message {plain:?}");
 
-            deframer.input_message(plain, bounds.start + HEADER_SIZE..bounds.end);
+            deframer.input_message(
+                plain.version,
+                plain.payload,
+                bounds.start + HEADER_SIZE..bounds.end,
+            );
         }
 
         deframer

--- a/rustls/src/msgs/deframer/mod.rs
+++ b/rustls/src/msgs/deframer/mod.rs
@@ -98,11 +98,7 @@ impl Deframer {
         bounds: Range<usize>,
     ) -> Result<(), InvalidMessage> {
         self.processed += bounds.len();
-        self.input_message(
-            ProtocolVersion::TLSv1_3,
-            &buf[bounds.start..bounds.end],
-            bounds,
-        );
+        self.input_message(ProtocolVersion::TLSv1_3, bounds, buf);
         self.coalesce(buf)?;
         Ok(())
     }
@@ -122,8 +118,8 @@ impl Deframer {
     pub(crate) fn input_message(
         &mut self,
         version: ProtocolVersion,
-        payload: &[u8],
         bounds: Range<usize>,
+        buf: &[u8],
     ) {
         // if our last span is incomplete, we can blindly add this as a new span --
         // no need to attempt parsing it with `DissectHandshakeIter`.
@@ -150,7 +146,7 @@ impl Deframer {
         // a new message (and perhaps several of them.)
         let iter = DissectHandshakeIter {
             version,
-            payload,
+            payload: &buf[bounds.start..bounds.end],
             bounds,
         };
 
@@ -466,11 +462,7 @@ mod tests {
 
     fn add_bytes(deframer: &mut Deframer, range: Range<usize>, within: &[u8]) {
         deframer.processed = range.end;
-        deframer.input_message(
-            ProtocolVersion::TLSv1_3,
-            &within[range.start..range.end],
-            range,
-        );
+        deframer.input_message(ProtocolVersion::TLSv1_3, range, within);
     }
 
     #[test]
@@ -570,8 +562,8 @@ mod tests {
 
             deframer.input_message(
                 plain.version,
-                plain.payload,
                 bounds.start + HEADER_SIZE..bounds.end,
+                &input,
             );
         }
 

--- a/rustls/src/msgs/deframer/mod.rs
+++ b/rustls/src/msgs/deframer/mod.rs
@@ -148,7 +148,13 @@ impl Deframer {
 
         // otherwise, we can expect `msg` to contain a handshake header introducing
         // a new message (and perhaps several of them.)
-        for span in DissectHandshakeIter::new(msg, bounds) {
+        let iter = DissectHandshakeIter {
+            version: msg.version,
+            payload: msg.payload,
+            bounds,
+        };
+
+        for span in iter {
             self.spans.push_back(span);
         }
     }
@@ -251,8 +257,14 @@ impl Deframer {
                 payload: delocator.slice_from_range(&first.bounds),
             };
 
+            let iter = DissectHandshakeIter {
+                version: first.version,
+                payload: msg.payload,
+                bounds: first.bounds.start..first.bounds.end,
+            };
+
             let mut too_large = false;
-            for (i, span) in DissectHandshakeIter::new(msg, first.bounds).enumerate() {
+            for (i, span) in iter.enumerate() {
                 if span.size.unwrap_or_default() > MAX_HANDSHAKE_SIZE {
                     too_large = true;
                 }
@@ -347,16 +359,6 @@ struct DissectHandshakeIter<'b> {
     version: ProtocolVersion,
     payload: &'b [u8],
     bounds: Range<usize>,
-}
-
-impl<'b> DissectHandshakeIter<'b> {
-    fn new(msg: EncodedMessage<&'b [u8]>, bounds: Range<usize>) -> Self {
-        Self {
-            version: msg.version,
-            payload: msg.payload,
-            bounds,
-        }
-    }
 }
 
 impl Iterator for DissectHandshakeIter<'_> {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -11,9 +11,9 @@ use crate::client::{ClientConfig, ClientSide};
 pub use crate::common_state::Side;
 use crate::common_state::{CommonState, ConnectionOutputs, Protocol};
 use crate::conn::{ConnectionCore, KeyingMaterialExporter, SideData, VecInput};
-use crate::crypto::cipher::{AeadKey, EncodedMessage, Iv, Payload};
+use crate::crypto::cipher::{AeadKey, Iv, Payload};
 use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock};
-use crate::enums::{ApplicationProtocol, ContentType, ProtocolVersion};
+use crate::enums::ApplicationProtocol;
 use crate::error::{ApiMisuse, Error};
 use crate::msgs::{
     ClientExtensionsInput, Message, MessagePayload, ServerExtensionsInput, TransportParameters,
@@ -515,27 +515,13 @@ impl<Side: SideData> ConnectionCommon<Side> {
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), Error> {
         let range = self.input.extend(plaintext);
-
-        let deframer = &mut self.core.common.recv.deframer;
-        deframer.add_processed(range.len());
-        deframer.input_message(
-            EncodedMessage {
-                typ: ContentType::Handshake,
-                version: ProtocolVersion::TLSv1_3,
-                payload: &self.input.filled()[range.start..range.end],
-            },
-            range,
-        );
-
         self.core
             .common
             .recv
             .deframer
-            .coalesce(self.input.filled_mut())?;
-
+            .input_quic(self.input.filled_mut(), range)?;
         self.core
             .process_new_packets(&mut self.input, Some(&mut self.quic))?;
-
         Ok(())
     }
 

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -10,7 +10,7 @@ use pki_types::{DnsName, FipsStatus, ServerName};
 use crate::client::{ClientConfig, ClientSide};
 pub use crate::common_state::Side;
 use crate::common_state::{CommonState, ConnectionOutputs, Protocol};
-use crate::conn::{ConnectionCore, KeyingMaterialExporter, SideData, VecInput};
+use crate::conn::{ConnectionCore, KeyingMaterialExporter, MessageIter, SideData, VecInput};
 use crate::crypto::cipher::{AeadKey, Iv, Payload};
 use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock};
 use crate::enums::ApplicationProtocol;
@@ -520,8 +520,9 @@ impl<Side: SideData> ConnectionCommon<Side> {
             .recv
             .deframer
             .input_quic(self.input.filled_mut(), range)?;
-        self.core
-            .process_new_packets(&mut self.input, Some(&mut self.quic))?;
+
+        MessageIter::new(&mut self.input, Some(&mut self.quic), &mut self.core).next()?;
+
         Ok(())
     }
 


### PR DESCRIPTION
Part of a branch from a few months ago working towards dropping `Buffers::received_plaintext`.