### PR TITLE
conn: MessageIter tweaks

### DIFF
--- a/rustls-test/tests/api/kx.rs
+++ b/rustls-test/tests/api/kx.rs
@@ -416,8 +416,6 @@ fn test_server_rejects_clients_without_any_kx_groups() {
 
 #[test]
 fn test_server_rejects_clients_without_any_kx_group_overlap() {
-    let mut client_input = VecInput::default();
-    let mut server_input = VecInput::default();
     for version_provider in ALL_VERSIONS {
         let (mut client, mut server) = make_pair_for_configs(
             make_client_config_with_kx_groups(
@@ -434,6 +432,9 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
             )
             .finish(KeyType::Rsa2048),
         );
+
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
         transfer(&mut client, &mut server_input);
         assert_eq!(
             server.process_new_packets(&mut server_input),
@@ -441,6 +442,7 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
                 PeerIncompatible::NoKxGroupsInCommon
             ))
         );
+
         transfer(&mut server, &mut client_input);
         assert_eq!(
             client.process_new_packets(&mut client_input),

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -501,8 +501,10 @@ impl<Side: SideData> ConnectionCommon<Side> {
 
         loop {
             let mut iter = MessageIter::new(buf, None, &mut self.core);
-            let Some(payload) = iter.next()? else {
-                break;
+            let payload = match iter.next() {
+                Some(Ok(payload)) => payload,
+                Some(Err(err)) => return Err(err),
+                None => break,
             };
 
             let payload = payload.reborrow(&Delocator::new(buf.slice_mut()));

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -501,13 +501,19 @@ impl<Side: SideData> ConnectionCommon<Side> {
 
         let mut iter = MessageIter::new(buf, None, &mut self.core);
         while let Some(result) = iter.next() {
-            let payload = result?;
-            let payload = payload.reborrow(&Delocator::new(iter.input().slice_mut()));
+            let payload = result?.reborrow(&Delocator::new(iter.input().slice_mut()));
             self.buffers
                 .received_plaintext
                 .append(payload.into_vec());
-            iter.discard();
         }
+
+        buf.discard(
+            self.core
+                .common
+                .recv
+                .deframer
+                .take_discard(),
+        );
 
         // Release unsent buffered plaintext.
         if self.send.may_send_application_data

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -499,25 +499,14 @@ impl<Side: SideData> ConnectionCommon<Side> {
             return Err(ApiMisuse::ReceivedPlaintextBufferFull.into());
         }
 
-        loop {
-            let mut iter = MessageIter::new(buf, None, &mut self.core);
-            let payload = match iter.next() {
-                Some(Ok(payload)) => payload,
-                Some(Err(err)) => return Err(err),
-                None => break,
-            };
-
-            let payload = payload.reborrow(&Delocator::new(buf.slice_mut()));
+        let mut iter = MessageIter::new(buf, None, &mut self.core);
+        while let Some(result) = iter.next() {
+            let payload = result?;
+            let payload = payload.reborrow(&Delocator::new(iter.input().slice_mut()));
             self.buffers
                 .received_plaintext
                 .append(payload.into_vec());
-            buf.discard(
-                self.core
-                    .common
-                    .recv
-                    .deframer
-                    .take_discard(),
-            );
+            iter.discard();
         }
 
         // Release unsent buffered plaintext.

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -61,12 +61,12 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
         }
     }
 
-    pub(crate) fn next(&mut self) -> Result<Option<UnborrowedPayload>, Error> {
+    pub(crate) fn next(&mut self) -> Option<Result<UnborrowedPayload, Error>> {
         let mut st = match mem::replace(self.state, Err(Error::HandshakeNotComplete)) {
             Ok(state) => state,
             Err(e) => {
                 *self.state = Err(e.clone());
-                return Err(e);
+                return Some(Err(e));
             }
         };
 
@@ -94,7 +94,7 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
                     *self.state = Err(e.clone());
                     self.input
                         .discard(self.recv.deframer.take_discard());
-                    return Err(e);
+                    return Some(Err(e));
                 }
             };
 
@@ -120,7 +120,7 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
                     .other
                     .send
                     .send_alert(AlertLevel::Fatal, AlertDescription::UnexpectedMessage);
-                return Err(PeerMisbehaved::EmptyFragment.into());
+                return Some(Err(PeerMisbehaved::EmptyFragment.into()));
             }
 
             let hs_aligned = output.recv.deframer.aligned();
@@ -140,7 +140,7 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
                     *self.state = Err(e.clone());
                     self.input
                         .discard(self.recv.deframer.take_discard());
-                    return Err(e);
+                    return Some(Err(e));
                 }
             }
 
@@ -161,7 +161,7 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
 
             if let Some(payload) = plaintext.take() {
                 *self.state = Ok(st);
-                return Ok(Some(payload));
+                return Some(Ok(payload));
             }
 
             self.input
@@ -171,7 +171,7 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
         self.input
             .discard(self.recv.deframer.take_discard());
         *self.state = Ok(st);
-        Ok(None)
+        None
     }
 }
 

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -92,8 +92,6 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
                         st.handle_decrypt_error();
                     }
                     *self.state = Err(e.clone());
-                    self.input
-                        .discard(self.recv.deframer.take_discard());
                     return Some(Err(e));
                 }
             };
@@ -138,8 +136,6 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
                 Err(e) => {
                     maybe_send_fatal_alert(output.other.send, &e);
                     *self.state = Err(e.clone());
-                    self.input
-                        .discard(self.recv.deframer.take_discard());
                     return Some(Err(e));
                 }
             }
@@ -154,7 +150,7 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
 
                 // Then the rest of any input data.
                 let entirety = self.input.slice_mut().len();
-                self.input.discard(entirety);
+                self.recv.deframer.set_discard(entirety);
                 self.input.received_close_notify();
                 break;
             }
@@ -163,20 +159,10 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
                 *self.state = Ok(st);
                 return Some(Ok(payload));
             }
-
-            self.input
-                .discard(self.recv.deframer.take_discard());
         }
 
-        self.input
-            .discard(self.recv.deframer.take_discard());
         *self.state = Ok(st);
         None
-    }
-
-    pub(super) fn discard(&mut self) {
-        self.input
-            .discard(self.recv.deframer.take_discard());
     }
 
     pub(super) fn input(&mut self) -> &mut dyn TlsInputBuffer {

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -173,6 +173,15 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side> {
         *self.state = Ok(st);
         None
     }
+
+    pub(super) fn discard(&mut self) {
+        self.input
+            .discard(self.recv.deframer.take_discard());
+    }
+
+    pub(super) fn input(&mut self) -> &mut dyn TlsInputBuffer {
+        self.input
+    }
 }
 
 pub(crate) struct ReceivePath {

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -221,6 +221,8 @@ impl<Side: SideData> ReceiveTraffic<Side> {
             }));
         }
 
+        received_tls.discard(recv.deframer.take_discard());
+
         // `SendAdapter` records whether a send-side action may be needed after the above
         // receive-side processing.  If the sender was not locked no change could be made to it.
         if let SendAdapter::Locked { send_required, .. } = send_adapter {

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -183,14 +183,18 @@ impl<Side: SideData> ReceiveTraffic<Side> {
         };
 
         let mut iter = MessageIter::<Side>::receive(received_tls, &mut state, &mut recv, output);
-        let received_plain = iter.next().map_err(|error| {
-            ErrorWithAlert::new(
-                error,
-                send_adapter
-                    .as_locked(false)
-                    .deref_mut(),
-            )
-        })?;
+        let received_plain = match iter.next() {
+            Some(Ok(payload)) => Some(payload),
+            Some(Err(error)) => {
+                return Err(ErrorWithAlert::new(
+                    error,
+                    send_adapter
+                        .as_locked(false)
+                        .deref_mut(),
+                ));
+            }
+            None => None,
+        };
 
         // nb. state consumed only on error.
         let state = state.unwrap();

--- a/rustls/src/msgs/deframer/mod.rs
+++ b/rustls/src/msgs/deframer/mod.rs
@@ -282,11 +282,8 @@ impl Deframer {
         next_span: FragmentSpan,
         containing_buffer: &'b [u8],
     ) -> EncodedMessage<&'b [u8]> {
-        // if this is the last handshake message, then we'll end
-        // up with an empty `spans` and can discard the remainder
-        // of the input buffer.
         if self.spans.is_empty() {
-            self.discard += self.processed;
+            self.discard = self.processed;
         }
 
         EncodedMessage {
@@ -306,18 +303,26 @@ impl Deframer {
 
     #[inline]
     pub(crate) fn take_discard(&mut self) -> usize {
-        // the caller is about to discard `discard` bytes
-        // from the front of the buffer.  adjust `processed`
-        // down by the same amount.
-        self.processed = self
-            .processed
-            .saturating_sub(self.discard);
-        mem::take(&mut self.discard)
+        let discard = mem::take(&mut self.discard);
+        self.processed = self.processed.saturating_sub(discard);
+        for span in &mut self.spans {
+            span.bounds.start = span
+                .bounds
+                .start
+                .saturating_sub(discard);
+            span.bounds.end = span.bounds.end.saturating_sub(discard);
+        }
+        discard
     }
 
     #[inline]
     pub(crate) fn discard_processed(&mut self) {
         self.discard = self.processed;
+    }
+
+    #[inline]
+    pub(crate) fn set_discard(&mut self, discard: usize) {
+        self.discard = discard;
     }
 
     /// We are "aligned" if there is no partial fragments of a handshake message.

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -522,10 +522,20 @@ impl<Side: SideData> ConnectionCommon<Side> {
             .input_quic(self.input.filled_mut(), range)?;
 
         let mut iter = MessageIter::new(&mut self.input, Some(&mut self.quic), &mut self.core);
-        match iter.next() {
+        let result = match iter.next() {
             Some(Ok(_)) | None => Ok(()),
             Some(Err(e)) => Err(e),
-        }
+        };
+
+        self.input.discard(
+            self.core
+                .common
+                .recv
+                .deframer
+                .take_discard(),
+        );
+
+        result
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<KeyChange> {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -521,9 +521,11 @@ impl<Side: SideData> ConnectionCommon<Side> {
             .deframer
             .input_quic(self.input.filled_mut(), range)?;
 
-        MessageIter::new(&mut self.input, Some(&mut self.quic), &mut self.core).next()?;
-
-        Ok(())
+        let mut iter = MessageIter::new(&mut self.input, Some(&mut self.quic), &mut self.core);
+        match iter.next() {
+            Some(Ok(_)) | None => Ok(()),
+            Some(Err(e)) => Err(e),
+        }
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<KeyChange> {


### PR DESCRIPTION
Following up from

- #3142 

(On the path to killing `ConnectionBuffers::received_plaintext`.)