### PR TITLE
Use `SliceInput` in tests where possible

### DIFF
--- a/rustls-fuzzing-provider/tests/smoke.rs
+++ b/rustls-fuzzing-provider/tests/smoke.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::sync::Arc;
 
 use rustls::crypto::CryptoProvider;
-use rustls::{ClientConfig, Connection, ServerConfig, ServerConnection, VecInput};
+use rustls::{ClientConfig, Connection, ServerConfig, ServerConnection, SliceInput};
 
 // These tests exercise rustls_fuzzing_provider and makes sure it can
 // handshake with itself without errors.
@@ -103,7 +103,6 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         .unwrap();
 
     let mut transcript = Transcript::default();
-    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
 
     while client.is_handshaking() || server.is_handshaking() {
         let mut buffer = vec![];
@@ -113,11 +112,8 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         transcript
             .client_wrote
             .extend_from_slice(&buffer);
-        server_input
-            .read(&mut &buffer[..])
-            .unwrap();
         server
-            .process_new_packets(&mut server_input)
+            .process_new_packets(&mut SliceInput::new(&mut buffer))
             .unwrap();
 
         let mut buffer = vec![];
@@ -127,11 +123,8 @@ fn test_version(provider: CryptoProvider) -> Transcript {
         transcript
             .server_wrote
             .extend_from_slice(&buffer);
-        client_input
-            .read(&mut &buffer[..])
-            .unwrap();
         client
-            .process_new_packets(&mut client_input)
+            .process_new_packets(&mut SliceInput::new(&mut buffer))
             .unwrap();
     }
 

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -1810,28 +1810,21 @@ fn tls13_packed_handshake() {
         .connect(server_name("localhost"))
         .build()
         .unwrap();
-    let mut client_input = VecInput::default();
 
     let mut hello = Vec::new();
     client
         .write_tls(&mut io::Cursor::new(&mut hello))
         .unwrap();
 
-    let first_flight = include_bytes!("../data/bug2040-message-1.bin");
-    client_input
-        .read(&mut io::Cursor::new(first_flight))
-        .unwrap();
+    let mut first_flight = include_bytes!("../data/bug2040-message-1.bin").to_vec();
     client
-        .process_new_packets(&mut client_input)
+        .process_new_packets(&mut SliceInput::new(&mut first_flight))
         .unwrap();
 
-    let second_flight = include_bytes!("../data/bug2040-message-2.bin");
-    client_input
-        .read(&mut io::Cursor::new(second_flight))
-        .unwrap();
+    let mut second_flight = include_bytes!("../data/bug2040-message-2.bin").to_vec();
     assert_eq!(
         client
-            .process_new_packets(&mut client_input)
+            .process_new_packets(&mut SliceInput::new(&mut second_flight))
             .unwrap_err(),
         Error::InvalidCertificate(CertificateError::UnknownIssuer),
     );

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -23,7 +23,7 @@ use rustls::server::{
 };
 use rustls::{
     ClientConfig, ClientConnection, Connection as _, HandshakeKind, KeyingMaterialExporter,
-    ServerConfig, ServerConnection, SupportedCipherSuite, VecInput,
+    ServerConfig, ServerConnection, SliceInput, SupportedCipherSuite, VecInput,
 };
 #[cfg(feature = "aws-lc-rs")]
 use rustls::{
@@ -1929,14 +1929,13 @@ fn excess_client_hello_acceptor() {
     // this is a trivial ClientHello, followed by a fragment of a ClientHello
     let mut hello = encoding::basic_client_hello(vec![]);
     hello.extend(&hello[..10].to_vec());
-    let hello = encoding::message_framing(ContentType::Handshake, ProtocolVersion::TLSv1_2, hello);
+    let mut hello =
+        encoding::message_framing(ContentType::Handshake, ProtocolVersion::TLSv1_2, hello);
 
     let mut acceptor = Acceptor::default();
-    let mut input = VecInput::default();
-    input
-        .read(&mut io::Cursor::new(hello))
-        .unwrap();
-    let mut error_with_alert = acceptor.accept(&mut input).unwrap_err();
+    let mut error_with_alert = acceptor
+        .accept(&mut SliceInput::new(&mut hello))
+        .unwrap_err();
     assert_eq!(
         error_with_alert.error,
         PeerMisbehaved::KeyEpochWithPendingFragment.into()

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -1783,22 +1783,17 @@ fn test_illegal_client_renegotiation_attempt_during_tls12_handshake() {
     let server_config = make_server_config(KeyType::Rsa2048, &provider);
     let client_config = make_client_config(KeyType::Rsa2048, &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-    let mut server_input = VecInput::default();
 
     let mut client_hello = vec![];
     client
         .write_tls(&mut io::Cursor::new(&mut client_hello))
         .unwrap();
 
-    server_input
-        .read(&mut io::Cursor::new(&client_hello))
-        .unwrap();
-    server_input
-        .read(&mut io::Cursor::new(&client_hello))
-        .unwrap();
+    // two copies of the same hello
+    let mut input = [&client_hello[..], &client_hello[..]].concat();
     assert_eq!(
         server
-            .process_new_packets(&mut server_input)
+            .process_new_packets(&mut SliceInput::new(&mut input))
             .unwrap_err(),
         Error::InappropriateHandshakeMessage {
             expect_types: vec![HandshakeType::ClientKeyExchange],

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -590,16 +590,11 @@ fn test_tls13_valid_early_plaintext_alert() {
     //  * The message content type is Alert.
     //  * The payload size is indicative of a plaintext alert message.
     //  * The negotiated protocol version is TLS 1.3.
-    server_input
-        .read(&mut io::Cursor::new(&encoding::alert(
-            AlertDescription::UnknownCa,
-            &[],
-        )))
-        .unwrap();
+    let mut alert = encoding::alert(AlertDescription::UnknownCa, &[]);
 
     // The server should process the plaintext alert without error.
     assert_eq!(
-        server.process_new_packets(&mut server_input),
+        server.process_new_packets(&mut SliceInput::new(&mut alert)),
         Err(Error::AlertReceived(AlertDescription::UnknownCa)),
     );
 }
@@ -618,16 +613,11 @@ fn test_tls13_too_short_early_plaintext_alert() {
 
     // Inject a plaintext alert from the client. The server should attempt to decrypt this message
     // because the payload length is too large to be considered an early plaintext alert.
-    server_input
-        .read(&mut io::Cursor::new(&encoding::alert(
-            AlertDescription::UnknownCa,
-            &[0xff],
-        )))
-        .unwrap();
+    let mut alert = encoding::alert(AlertDescription::UnknownCa, &[0xff]);
 
     // The server should produce a decrypt error trying to decrypt the plaintext alert.
     assert_eq!(
-        server.process_new_packets(&mut server_input),
+        server.process_new_packets(&mut SliceInput::new(&mut alert)),
         Err(Error::DecryptError),
     );
 }
@@ -648,16 +638,11 @@ fn test_tls13_late_plaintext_alert() {
     );
 
     // Inject a plaintext alert from the client. The server should attempt to decrypt this message.
-    server_input
-        .read(&mut io::Cursor::new(&encoding::alert(
-            AlertDescription::UnknownCa,
-            &[],
-        )))
-        .unwrap();
+    let mut alert = encoding::alert(AlertDescription::UnknownCa, &[]);
 
     // The server should produce a decrypt error, trying to decrypt a plaintext alert.
     assert_eq!(
-        server.process_new_packets(&mut server_input),
+        server.process_new_packets(&mut SliceInput::new(&mut alert)),
         Err(Error::DecryptError)
     );
 }

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -16,7 +16,9 @@ use rustls::error::{
     AlertDescription, ApiMisuse, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved,
 };
 use rustls::server::Acceptor;
-use rustls::{ClientConfig, Connection, HandshakeKind, ServerConfig, ServerConnection, VecInput};
+use rustls::{
+    ClientConfig, Connection, HandshakeKind, ServerConfig, ServerConnection, SliceInput, VecInput,
+};
 use rustls_test::{
     ClientConfigExt, KeyType, OtherSession, ServerConfigExt, TestNonBlockIo, check_fill_buf,
     check_fill_buf_err, check_read, check_read_and_close, check_read_err, do_handshake, encoding,
@@ -2435,14 +2437,12 @@ fn test_junk_after_close_notify_received() {
     // after the close_notify
     client_buffer.extend_from_slice(&[0x17, 0x03, 0x03, 0x01]);
 
-    server_input
-        .read(&mut io::Cursor::new(&client_buffer[..]))
+    let mut final_input = SliceInput::new(&mut client_buffer);
+    server
+        .process_new_packets(&mut final_input)
         .unwrap();
     server
-        .process_new_packets(&mut server_input)
-        .unwrap();
-    server
-        .process_new_packets(&mut server_input)
+        .process_new_packets(&mut final_input)
         .unwrap(); // check for desync
 
     // can read data received prior to close_notify


### PR DESCRIPTION
Some tests use `VecInput` where a simpler option is possible.