### PR TITLE
ci-bench: add Windows support by replacing from_raw_handle on Windows

### DIFF
--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -3,7 +3,10 @@ use core::mem;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Write};
+#[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, FromRawHandle};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -210,8 +213,14 @@ fn main() -> anyhow::Result<()> {
 
             // safety: the file descriptor is valid and we have exclusive access to it for the
             // duration of the lock
+            #[cfg(unix)]
             let mut stdin = unsafe { File::from_raw_fd(stdin_lock.as_raw_fd()) };
+            #[cfg(windows)]
+            let mut stdin = unsafe { File::from_raw_handle(stdin_lock.as_raw_handle()) };
+            #[cfg(unix)]
             let mut stdout = unsafe { File::from_raw_fd(stdout_lock.as_raw_fd()) };
+            #[cfg(windows)]
+            let mut stdout = unsafe { File::from_raw_handle(stdout_lock.as_raw_handle()) };
 
             // When measuring instructions, we do multiple resumed handshakes, for
             // reasons explained in the comments to `RESUMED_HANDSHAKE_RUNS`.


### PR DESCRIPTION
add Windows support by replacing from_raw_handle on Windows