### PR TITLE
Prove `ExpectCertificateVerify` comes after chain verification

### DIFF
--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -32,7 +32,7 @@ use crate::suites::PartiallyExtractedSecrets;
 use crate::sync::Arc;
 use crate::tls12::{self, ConnectionSecrets, Tls12CipherSuite};
 use crate::tls13::key_schedule::KeyScheduleTrafficSend;
-use crate::verify::{ClientIdentity, SignatureVerificationInput};
+use crate::verify::{ClientIdentity, PeerVerified, SignatureVerificationInput};
 use crate::{ConnectionTrafficSecrets, verify};
 
 #[expect(private_interfaces)]
@@ -559,14 +559,15 @@ impl ExpectCertificate {
                 None
             }
             Some(identity) => {
-                self.hs
+                let verified = self
+                    .hs
                     .config
                     .verifier
                     .verify_identity(&ClientIdentity {
                         identity: &identity,
                         now: self.hs.config.current_time()?,
                     })?;
-                Some(identity.into_owned())
+                Some((identity.into_owned(), verified))
             }
         };
 
@@ -593,7 +594,7 @@ struct ExpectClientKx {
     randoms: ConnectionRandoms,
     suite: &'static Tls12CipherSuite,
     server_kx: GroupAndKeyExchange,
-    peer_identity: Option<Identity<'static>>,
+    peer_identity: Option<(Identity<'static>, PeerVerified)>,
 }
 
 impl ExpectClientKx {
@@ -634,13 +635,14 @@ impl ExpectClientKx {
         );
 
         match self.peer_identity {
-            Some(peer_identity) => Ok(Box::new(ExpectCertificateVerify {
+            Some((peer_identity, peer_verified)) => Ok(Box::new(ExpectCertificateVerify {
                 hs: self.hs,
                 secrets,
                 peer_identity,
+                _peer_verified: peer_verified,
             })
             .into()),
-            _ => Ok(Box::new(ExpectCcs {
+            None => Ok(Box::new(ExpectCcs {
                 hs: self.hs,
                 secrets,
                 peer_identity: None,
@@ -662,6 +664,7 @@ struct ExpectCertificateVerify {
     hs: HandshakeState,
     secrets: ConnectionSecrets,
     peer_identity: Identity<'static>,
+    _peer_verified: PeerVerified,
 }
 
 impl ExpectCertificateVerify {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -39,7 +39,7 @@ use crate::tls13::key_schedule::{
 use crate::tls13::{
     Tls13CipherSuite, construct_client_verify_message, construct_server_verify_message,
 };
-use crate::verify::ClientIdentity;
+use crate::verify::{ClientIdentity, PeerVerified};
 use crate::{ConnectionTrafficSecrets, compress, verify};
 
 #[expect(private_interfaces)]
@@ -1066,7 +1066,8 @@ impl ExpectCertificate {
             return Err(PeerMisbehaved::NoCertificatesPresented.into());
         };
 
-        self.hs
+        let peer_verified = self
+            .hs
             .config
             .verifier
             .verify_identity(&ClientIdentity {
@@ -1078,6 +1079,7 @@ impl ExpectCertificate {
             hs: self.hs,
             key_schedule: self.key_schedule,
             peer_identity: peer_identity.into_owned(),
+            _peer_verified: peer_verified,
         })
         .into())
     }
@@ -1103,6 +1105,7 @@ struct ExpectCertificateVerify {
     hs: HandshakeState,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
     peer_identity: Identity<'static>,
+    _peer_verified: PeerVerified,
 }
 
 impl ExpectCertificateVerify {


### PR DESCRIPTION
It is a logic error to verify a signature with an unidentified key.

This is a structural robustness improvement, with no runtime effect.