### PR TITLE
reject trailing data in decompressed certificate messages

### DIFF
--- a/rustls-test/tests/api/compress.rs
+++ b/rustls-test/tests/api/compress.rs
@@ -260,6 +260,65 @@ fn test_cert_decompression_by_server_produces_invalid_cert_payload() {
 }
 
 #[test]
+fn test_cert_decompression_by_client_rejects_trailing_data() {
+    let provider = provider::DEFAULT_PROVIDER;
+    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    server_config.cert_compressors = vec![&IdentityCompressor];
+    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    client_config.cert_decompressors = vec![&TrailingDataDecompressor];
+
+    let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    assert_eq!(
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server
+        ),
+        Err(ErrorFromPeer::Client(Error::InvalidMessage(
+            InvalidMessage::TrailingData("read_bytes")
+        )))
+    );
+    transfer(&mut client, &mut server_input);
+    assert_eq!(
+        server.process_new_packets(&mut server_input),
+        Err(Error::AlertReceived(AlertDescription::DecodeError))
+    );
+}
+
+#[test]
+fn test_cert_decompression_by_server_rejects_trailing_data() {
+    let provider = provider::DEFAULT_PROVIDER;
+    let mut server_config =
+        make_server_config_with_mandatory_client_auth(KeyType::Rsa2048, &provider);
+    server_config.cert_decompressors = vec![&TrailingDataDecompressor];
+    let mut client_config = make_client_config_with_auth(KeyType::Rsa2048, &provider);
+    client_config.cert_compressors = vec![&IdentityCompressor];
+
+    let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    assert_eq!(
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server
+        ),
+        Err(ErrorFromPeer::Server(Error::InvalidMessage(
+            InvalidMessage::TrailingData("read_bytes")
+        )))
+    );
+    transfer(&mut server, &mut client_input);
+    assert_eq!(
+        client.process_new_packets(&mut client_input),
+        Err(Error::AlertReceived(AlertDescription::DecodeError))
+    );
+}
+
+#[test]
 fn test_cert_decompression_by_server_fails() {
     let provider = provider::DEFAULT_PROVIDER;
     let mut server_config =
@@ -340,6 +399,27 @@ impl rustls::compress::CertDecompressor for GarbageDecompressor {
         output: &mut [u8],
     ) -> Result<(), rustls::compress::DecompressionFailed> {
         output.fill(0xff);
+        Ok(())
+    }
+
+    fn algorithm(&self) -> CertificateCompressionAlgorithm {
+        CertificateCompressionAlgorithm::Zlib
+    }
+}
+
+#[derive(Debug)]
+struct TrailingDataDecompressor;
+
+impl rustls::compress::CertDecompressor for TrailingDataDecompressor {
+    fn decompress(
+        &self,
+        _input: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), rustls::compress::DecompressionFailed> {
+        // A zeroed buffer decodes as a valid but empty `CertificatePayloadTls13`
+        // (empty context, empty entry list) in its first four bytes; the rest is
+        // trailing data that a strict decoder must reject.
+        output.fill(0);
         Ok(())
     }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -35,7 +35,7 @@ use crate::msgs::{
     Codec, EchConfigPayload, ExtensionType, HandshakeMessagePayload, HandshakePayload,
     KeyShareEntry, KeyUpdateRequest, MaybeEmpty, Message, MessagePayload,
     NewSessionTicketPayloadTls13, PresharedKeyBinder, PresharedKeyIdentity, PresharedKeyOffer,
-    Reader, ServerExtensions, ServerHelloPayload, SizedPayload,
+    ServerExtensions, ServerHelloPayload, SizedPayload,
 };
 use crate::sealed::Sealed;
 use crate::suites::PartiallyExtractedSecrets;
@@ -1021,7 +1021,7 @@ impl ExpectCompressedCertificate {
             return Err(PeerMisbehaved::InvalidCertCompression.into());
         }
 
-        let cert_payload = CertificatePayloadTls13::read(&mut Reader::new(&decompress_buffer))?;
+        let cert_payload = CertificatePayloadTls13::read_bytes(&decompress_buffer)?;
         trace!(
             "Server certificate decompressed using {:?} ({} bytes -> {})",
             compressed_cert.alg,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -994,7 +994,7 @@ impl ExpectCompressedCertificate {
             return Err(PeerMisbehaved::InvalidCertCompression.into());
         }
 
-        let cert_payload = CertificatePayloadTls13::read(&mut Reader::new(&decompress_buffer))?;
+        let cert_payload = CertificatePayloadTls13::read_bytes(&decompress_buffer)?;
         trace!(
             "Client certificate decompressed using {:?} ({} bytes -> {})",
             compressed_cert.alg,


### PR DESCRIPTION
The TLS1.3 compressed-certificate handlers decompress the peer's certificate
into a buffer sized to its declared uncompressed length, then parse it with
`CertificatePayloadTls13::read`. That returns as soon as the context and
certificate_list are consumed and drops anything after them. Running the new
test against the current code:

    left:  Err(Server(PeerMisbehaved(NoCertificatesPresented)))
    right: Err(Server(InvalidMessage(TrailingData("read_bytes"))))

`decompress()` fills the output buffer exactly, so a peer can decompress to a
valid Certificate followed by arbitrary trailing bytes and have them accepted.
The uncompressed path rejects the same bytes in
`HandshakeMessagePayload::read_version` via `expect_empty`. Switch both sites
(client reading the server certificate, server reading the client certificate)
to `read_bytes`, which requires the buffer to be fully consumed.
