### PR TITLE
Rework and clarify checks for excess data

### DIFF
--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -24,7 +24,7 @@ use crate::msgs::{
     ClientExtensions, ClientHelloPayload, Codec, EchConfigContents, EchConfigPayload, Encoding,
     EncryptedClientHello, EncryptedClientHelloOuter, ExtensionType, HandshakeAlignedProof,
     HandshakeMessagePayload, HandshakePayload, HelloRetryRequest, HpkeKeyConfig, Message,
-    MessagePayload, PresharedKeyBinder, PresharedKeyOffer, Random, Reader, ServerHelloPayload,
+    MessagePayload, PresharedKeyBinder, PresharedKeyOffer, Random, ServerHelloPayload,
     ServerNamePayload, SizedPayload,
 };
 use crate::tls13::Tls13CipherSuite;
@@ -101,10 +101,9 @@ impl EchConfig {
         ech_config_list: EchConfigListBytes<'_>,
         hpke_suites: &[&'static dyn Hpke],
     ) -> Result<Self, Error> {
-        let ech_configs = Vec::<EchConfigPayload>::read(&mut Reader::new(&ech_config_list))
-            .map_err(|_| {
-                Error::InvalidEncryptedClientHello(EncryptedClientHelloError::InvalidConfigList)
-            })?;
+        let ech_configs = Vec::<EchConfigPayload>::read_bytes(&ech_config_list).map_err(|_| {
+            Error::InvalidEncryptedClientHello(EncryptedClientHelloError::InvalidConfigList)
+        })?;
 
         Self::new_for_configs(ech_configs, hpke_suites)
     }

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -226,24 +226,25 @@ pub struct Tls12Session {
 impl Tls12Session {
     /// Decode a ticket from the given bytes.
     pub fn from_slice(bytes: &[u8], provider: &CryptoProvider) -> Result<Self, Error> {
-        let mut reader = Reader::new(bytes);
-        let suite = CipherSuite::read(&mut reader)?;
-        let suite = provider
-            .tls12_cipher_suites
-            .iter()
-            .find(|s| s.common.suite == suite)
-            .ok_or(ApiMisuse::ResumingFromUnknownCipherSuite(suite))?;
+        Reader::new(bytes).all("Tls12Session", |reader| {
+            let suite = CipherSuite::read(reader)?;
+            let suite = provider
+                .tls12_cipher_suites
+                .iter()
+                .find(|s| s.common.suite == suite)
+                .ok_or(ApiMisuse::ResumingFromUnknownCipherSuite(suite))?;
 
-        Ok(Self {
-            suite: *suite,
-            session_id: SessionId::read(&mut reader)?,
-            master_secret: Zeroizing::new(
-                reader
-                    .take_array("MasterSecret")
-                    .copied()?,
-            ),
-            extended_ms: matches!(u8::read(&mut reader)?, 1),
-            common: ClientSessionCommon::read(&mut reader)?,
+            Ok(Self {
+                suite: *suite,
+                session_id: SessionId::read(reader)?,
+                master_secret: Zeroizing::new(
+                    reader
+                        .take_array("MasterSecret")
+                        .copied()?,
+                ),
+                extended_ms: matches!(u8::read(reader)?, 1),
+                common: ClientSessionCommon::read(reader)?,
+            })
         })
     }
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -124,21 +124,22 @@ pub struct Tls13Session {
 impl Tls13Session {
     /// Decode a ticket from the given bytes.
     pub fn from_slice(bytes: &[u8], provider: &CryptoProvider) -> Result<Self, Error> {
-        let mut reader = Reader::new(bytes);
-        let suite = CipherSuite::read(&mut reader)?;
-        let suite = provider
-            .tls13_cipher_suites
-            .iter()
-            .find(|s| s.common.suite == suite)
-            .ok_or(ApiMisuse::ResumingFromUnknownCipherSuite(suite))?;
+        Reader::new(bytes).all("Tls13Session", |reader| {
+            let suite = CipherSuite::read(reader)?;
+            let suite = provider
+                .tls13_cipher_suites
+                .iter()
+                .find(|s| s.common.suite == suite)
+                .ok_or(ApiMisuse::ResumingFromUnknownCipherSuite(suite))?;
 
-        Ok(Self {
-            suite: *suite,
-            secret: Zeroizing::new(SizedPayload::<u8>::read(&mut reader)?.into_owned()),
-            age_add: u32::read(&mut reader)?,
-            max_early_data_size: u32::read(&mut reader)?,
-            common: ClientSessionCommon::read(&mut reader)?,
-            quic_params: SizedPayload::<u16, MaybeEmpty>::read(&mut reader)?.into_owned(),
+            Ok(Self {
+                suite: *suite,
+                secret: Zeroizing::new(SizedPayload::<u8>::read(reader)?.into_owned()),
+                age_add: u32::read(reader)?,
+                max_early_data_size: u32::read(reader)?,
+                common: ClientSessionCommon::read(reader)?,
+                quic_params: SizedPayload::<u16, MaybeEmpty>::read(reader)?.into_owned(),
+            })
         })
     }
 

--- a/rustls/src/msgs/client_hello.rs
+++ b/rustls/src/msgs/client_hello.rs
@@ -108,19 +108,16 @@ impl Codec<'_> for ClientHelloPayload {
     }
 
     fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
-        let ret = Self {
-            client_version: ProtocolVersion::read(r)?,
-            random: Random::read(r)?,
-            session_id: SessionId::read(r)?,
-            cipher_suites: Vec::read(r)?,
-            compression_methods: Vec::read(r)?,
-            extensions: Box::new(ClientExtensions::read(r)?.into_owned()),
-        };
-
-        match r.any_left() {
-            true => Err(InvalidMessage::TrailingData("ClientHelloPayload")),
-            false => Ok(ret),
-        }
+        r.all("ClientHelloPayload", |r| {
+            Ok(Self {
+                client_version: ProtocolVersion::read(r)?,
+                random: Random::read(r)?,
+                session_id: SessionId::read(r)?,
+                cipher_suites: Vec::read(r)?,
+                compression_methods: Vec::read(r)?,
+                extensions: Box::new(ClientExtensions::read(r)?.into_owned()),
+            })
+        })
     }
 }
 

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -512,13 +512,6 @@ impl<'a> Reader<'a> {
         mem::take(&mut self.buffer)
     }
 
-    pub(crate) fn expect_empty(&self, name: &'static str) -> Result<(), InvalidMessage> {
-        match self.any_left() {
-            true => Err(InvalidMessage::TrailingData(name)),
-            false => Ok(()),
-        }
-    }
-
     /// Whether the reader has any content left.
     pub(crate) fn any_left(&self) -> bool {
         !self.buffer.is_empty()

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -433,14 +433,10 @@ pub(crate) trait Codec<'a>: Debug + Sized {
     /// Function for wrapping a call to the read function in
     /// a Reader for the slice of bytes provided
     ///
-    /// Returns `Err(InvalidMessage::ExcessData(_))` if
+    /// Returns `Err(InvalidMessage::TrailingData(_))` if
     /// `Self::read` does not read the entirety of `bytes`.
     fn read_bytes(bytes: &'a [u8]) -> Result<Self, InvalidMessage> {
-        let mut reader = Reader::new(bytes);
-        Self::read(&mut reader).and_then(|r| {
-            reader.expect_empty("read_bytes")?;
-            Ok(r)
-        })
+        Reader::new(bytes).all("read_bytes", Self::read)
     }
 }
 

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -461,6 +461,19 @@ impl<'a> Reader<'a> {
         Self { buffer }
     }
 
+    /// Reads all of `buffer` into a type of `T`, checking for trailing data.
+    pub(crate) fn all<T, E: From<InvalidMessage>, F: FnOnce(&mut Self) -> Result<T, E>>(
+        &mut self,
+        type_name: &'static str,
+        f: F,
+    ) -> Result<T, E> {
+        let value = f(self)?;
+        match self.any_left() {
+            true => Err(InvalidMessage::TrailingData(type_name).into()),
+            false => Ok(value),
+        }
+    }
+
     /// Attempts to create a new Reader on a sub section of this
     /// readers bytes by taking a slice of the provided `length`
     /// will return `Err(InvalidMessage::MessageTooShort)` if there is not enough bytes

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -406,7 +406,7 @@ impl Codec<'_> for () {
     fn encode(&self, _: &mut Vec<u8>) {}
 
     fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
-        r.expect_empty("Empty")
+        r.all("Empty", |_| Ok(()))
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -220,15 +220,11 @@ impl Codec<'_> for SingleProtocolName {
 
     fn read(reader: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
         let len = Self::SIZE_LEN.read(reader)?;
-        let mut sub = reader.sub(len)?;
-
-        let item = ApplicationProtocol::read(&mut sub)?;
-
-        if sub.any_left() {
-            Err(InvalidMessage::TrailingData("SingleProtocolName"))
-        } else {
-            Ok(Self(item.to_owned()))
-        }
+        reader
+            .sub(len)?
+            .all("SingleProtocolName", |sub| {
+                Ok(Self(ApplicationProtocol::read(sub)?.to_owned()))
+            })
     }
 }
 

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -164,13 +164,13 @@ macro_rules! extension_struct {
             ) -> Result<ExtensionType, InvalidMessage> {
                 let typ = ExtensionType::read(r)?;
                 let len = usize::from(u16::read(r)?);
-                let mut ext_body = r.sub(len)?;
-                match self.read_extension_body(typ, &mut ext_body)? {
-                    true => ext_body.expect_empty(stringify!($struct_name))?,
-                    false => unknown(typ)?,
-
-                };
-                Ok(typ)
+                r.sub(len)?
+                    .all(stringify!($struct_name), |body| {
+                        if !self.read_extension_body(typ, body)? {
+                            unknown(typ)?;
+                        }
+                        Ok(typ)
+                    })
             }
 
             /// Reads one extension body for an extension named by `typ`.

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -673,13 +673,13 @@ impl Codec<'_> for ChangeCipherSpecPayload {
     }
 
     fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
-        let typ = u8::read(r)?;
-        if typ != 1 {
-            return Err(InvalidMessage::InvalidCcs);
-        }
-
-        r.expect_empty("ChangeCipherSpecPayload")
-            .map(|_| Self {})
+        r.all("ChangeCipherSpecPayload", |r| {
+            let typ = u8::read(r)?;
+            if typ != 1 {
+                return Err(InvalidMessage::InvalidCcs);
+            }
+            Ok(Self)
+        })
     }
 }
 

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -380,95 +380,91 @@ impl<'a> HandshakeMessagePayload<'a> {
     ) -> Result<Self, InvalidMessage> {
         let typ = HandshakeType::read(r)?;
         let len = U24::read(r)?.0 as usize;
-        let mut sub = r.sub(len)?;
+        r.sub(len)?
+            .all("HandshakeMessagePayload", |sub| {
+                Ok(Self(match typ {
+                    HandshakeType::HelloRequest if sub.left() == 0 => {
+                        HandshakePayload::HelloRequest
+                    }
+                    HandshakeType::ClientHello => {
+                        HandshakePayload::ClientHello(ClientHelloPayload::read(sub)?)
+                    }
+                    HandshakeType::ServerHello => {
+                        let version = ProtocolVersion::read(sub)?;
+                        let random = Random::read(sub)?;
 
-        let payload = match typ {
-            HandshakeType::HelloRequest if sub.left() == 0 => HandshakePayload::HelloRequest,
-            HandshakeType::ClientHello => {
-                HandshakePayload::ClientHello(ClientHelloPayload::read(&mut sub)?)
-            }
-            HandshakeType::ServerHello => {
-                let version = ProtocolVersion::read(&mut sub)?;
-                let random = Random::read(&mut sub)?;
-
-                if random == HELLO_RETRY_REQUEST_RANDOM {
-                    let mut hrr = HelloRetryRequest::read(&mut sub)?;
-                    hrr.legacy_version = version;
-                    HandshakePayload::HelloRetryRequest(hrr)
-                } else {
-                    let mut shp = ServerHelloPayload::read(&mut sub)?;
-                    shp.legacy_version = version;
-                    shp.random = random;
-                    HandshakePayload::ServerHello(shp)
-                }
-            }
-            HandshakeType::Certificate if vers == ProtocolVersion::TLSv1_3 => {
-                let p = CertificatePayloadTls13::read(&mut sub)?;
-                HandshakePayload::CertificateTls13(p)
-            }
-            HandshakeType::Certificate => {
-                HandshakePayload::Certificate(CertificateChain::read(&mut sub)?)
-            }
-            HandshakeType::ServerKeyExchange => {
-                let p = ServerKeyExchangePayload::read(&mut sub)?;
-                HandshakePayload::ServerKeyExchange(p)
-            }
-            HandshakeType::ServerHelloDone => {
-                sub.expect_empty("ServerHelloDone")?;
-                HandshakePayload::ServerHelloDone
-            }
-            HandshakeType::ClientKeyExchange => {
-                HandshakePayload::ClientKeyExchange(Payload::read(&mut sub))
-            }
-            HandshakeType::CertificateRequest if vers == ProtocolVersion::TLSv1_3 => {
-                let p = CertificateRequestPayloadTls13::read(&mut sub)?;
-                HandshakePayload::CertificateRequestTls13(p)
-            }
-            HandshakeType::CertificateRequest => {
-                let p = CertificateRequestPayload::read(&mut sub)?;
-                HandshakePayload::CertificateRequest(p)
-            }
-            HandshakeType::CompressedCertificate => HandshakePayload::CompressedCertificate(
-                CompressedCertificatePayload::read(&mut sub)?,
-            ),
-            HandshakeType::CertificateVerify => {
-                HandshakePayload::CertificateVerify(DigitallySignedStruct::read(&mut sub)?)
-            }
-            HandshakeType::NewSessionTicket if vers == ProtocolVersion::TLSv1_3 => {
-                let p = NewSessionTicketPayloadTls13::read(&mut sub)?;
-                HandshakePayload::NewSessionTicketTls13(p)
-            }
-            HandshakeType::NewSessionTicket => {
-                let p = NewSessionTicketPayload::read(&mut sub)?;
-                HandshakePayload::NewSessionTicket(p)
-            }
-            HandshakeType::EncryptedExtensions => {
-                HandshakePayload::EncryptedExtensions(Box::new(ServerExtensions::read(&mut sub)?))
-            }
-            HandshakeType::KeyUpdate => {
-                HandshakePayload::KeyUpdate(KeyUpdateRequest::read(&mut sub)?)
-            }
-            HandshakeType::EndOfEarlyData => {
-                sub.expect_empty("EndOfEarlyData")?;
-                HandshakePayload::EndOfEarlyData
-            }
-            HandshakeType::Finished => HandshakePayload::Finished(Payload::read(&mut sub)),
-            HandshakeType::CertificateStatus => {
-                HandshakePayload::CertificateStatus(CertificateStatus::read(&mut sub)?)
-            }
-            HandshakeType::MessageHash => {
-                // does not appear on the wire
-                return Err(InvalidMessage::UnexpectedMessage("MessageHash"));
-            }
-            HandshakeType::HelloRetryRequest => {
-                // not legal on wire
-                return Err(InvalidMessage::UnexpectedMessage("HelloRetryRequest"));
-            }
-            _ => HandshakePayload::Unknown((typ, Payload::read(&mut sub))),
-        };
-
-        sub.expect_empty("HandshakeMessagePayload")
-            .map(|_| Self(payload))
+                        if random == HELLO_RETRY_REQUEST_RANDOM {
+                            let mut hrr = HelloRetryRequest::read(sub)?;
+                            hrr.legacy_version = version;
+                            HandshakePayload::HelloRetryRequest(hrr)
+                        } else {
+                            let mut shp = ServerHelloPayload::read(sub)?;
+                            shp.legacy_version = version;
+                            shp.random = random;
+                            HandshakePayload::ServerHello(shp)
+                        }
+                    }
+                    HandshakeType::Certificate if vers == ProtocolVersion::TLSv1_3 => {
+                        let p = CertificatePayloadTls13::read(sub)?;
+                        HandshakePayload::CertificateTls13(p)
+                    }
+                    HandshakeType::Certificate => {
+                        HandshakePayload::Certificate(CertificateChain::read(sub)?)
+                    }
+                    HandshakeType::ServerKeyExchange => {
+                        let p = ServerKeyExchangePayload::read(sub)?;
+                        HandshakePayload::ServerKeyExchange(p)
+                    }
+                    HandshakeType::ServerHelloDone => HandshakePayload::ServerHelloDone,
+                    HandshakeType::ClientKeyExchange => {
+                        HandshakePayload::ClientKeyExchange(Payload::read(sub))
+                    }
+                    HandshakeType::CertificateRequest if vers == ProtocolVersion::TLSv1_3 => {
+                        let p = CertificateRequestPayloadTls13::read(sub)?;
+                        HandshakePayload::CertificateRequestTls13(p)
+                    }
+                    HandshakeType::CertificateRequest => {
+                        let p = CertificateRequestPayload::read(sub)?;
+                        HandshakePayload::CertificateRequest(p)
+                    }
+                    HandshakeType::CompressedCertificate => {
+                        HandshakePayload::CompressedCertificate(CompressedCertificatePayload::read(
+                            sub,
+                        )?)
+                    }
+                    HandshakeType::CertificateVerify => {
+                        HandshakePayload::CertificateVerify(DigitallySignedStruct::read(sub)?)
+                    }
+                    HandshakeType::NewSessionTicket if vers == ProtocolVersion::TLSv1_3 => {
+                        let p = NewSessionTicketPayloadTls13::read(sub)?;
+                        HandshakePayload::NewSessionTicketTls13(p)
+                    }
+                    HandshakeType::NewSessionTicket => {
+                        let p = NewSessionTicketPayload::read(sub)?;
+                        HandshakePayload::NewSessionTicket(p)
+                    }
+                    HandshakeType::EncryptedExtensions => HandshakePayload::EncryptedExtensions(
+                        Box::new(ServerExtensions::read(sub)?),
+                    ),
+                    HandshakeType::KeyUpdate => {
+                        HandshakePayload::KeyUpdate(KeyUpdateRequest::read(sub)?)
+                    }
+                    HandshakeType::EndOfEarlyData => HandshakePayload::EndOfEarlyData,
+                    HandshakeType::Finished => HandshakePayload::Finished(Payload::read(sub)),
+                    HandshakeType::CertificateStatus => {
+                        HandshakePayload::CertificateStatus(CertificateStatus::read(sub)?)
+                    }
+                    HandshakeType::MessageHash => {
+                        // does not appear on the wire
+                        return Err(InvalidMessage::UnexpectedMessage("MessageHash"));
+                    }
+                    HandshakeType::HelloRetryRequest => {
+                        // not legal on wire
+                        return Err(InvalidMessage::UnexpectedMessage("HelloRetryRequest"));
+                    }
+                    _ => HandshakePayload::Unknown((typ, Payload::read(sub))),
+                }))
+            })
     }
 
     pub(crate) fn encoding_for_binder_signing(&self) -> Vec<u8> {

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -655,10 +655,12 @@ impl Codec<'_> for AlertMessagePayload {
     }
 
     fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
-        let level = AlertLevel::read(r)?;
-        let description = AlertDescription::read(r)?;
-        r.expect_empty("AlertMessagePayload")
-            .map(|_| Self { level, description })
+        r.all("AlertMessagePayload", |r| {
+            Ok(Self {
+                level: AlertLevel::read(r)?,
+                description: AlertDescription::read(r)?,
+            })
+        })
     }
 }
 

--- a/rustls/src/msgs/server_hello.rs
+++ b/rustls/src/msgs/server_hello.rs
@@ -37,34 +37,33 @@ impl Codec<'_> for ServerHelloPayload {
 
     // minus version and random, which have already been read.
     fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
-        let session_id = SessionId::read(r)?;
-        let suite = CipherSuite::read(r)?;
-        let compression = Compression::read(r)?;
+        r.all("ServerHelloPayload", |r| {
+            let session_id = SessionId::read(r)?;
+            let suite = CipherSuite::read(r)?;
+            let compression = Compression::read(r)?;
 
-        // RFC5246:
-        // "The presence of extensions can be detected by determining whether
-        //  there are bytes following the compression_method field at the end of
-        //  the ServerHello."
-        let extensions = Box::new(
-            if r.any_left() {
-                ServerExtensions::read(r)?
-            } else {
-                ServerExtensions::default()
-            }
-            .into_owned(),
-        );
+            // RFC5246:
+            // "The presence of extensions can be detected by determining whether
+            //  there are bytes following the compression_method field at the end of
+            //  the ServerHello."
+            let extensions = Box::new(
+                if r.any_left() {
+                    ServerExtensions::read(r)?
+                } else {
+                    ServerExtensions::default()
+                }
+                .into_owned(),
+            );
 
-        let ret = Self {
-            legacy_version: ProtocolVersion(0),
-            random: ZERO_RANDOM,
-            session_id,
-            cipher_suite: suite,
-            compression_method: compression,
-            extensions,
-        };
-
-        r.expect_empty("ServerHelloPayload")
-            .map(|_| ret)
+            Ok(Self {
+                legacy_version: ProtocolVersion(0),
+                random: ZERO_RANDOM,
+                session_id,
+                cipher_suite: suite,
+                compression_method: compression,
+                extensions,
+            })
+        })
     }
 }
 

--- a/rustls/src/msgs/server_hello.rs
+++ b/rustls/src/msgs/server_hello.rs
@@ -413,15 +413,13 @@ impl Codec<'_> for EchConfigExtension {
     fn read(r: &mut Reader<'_>) -> Result<Self, InvalidMessage> {
         let typ = ExtensionType::read(r)?;
         let len = u16::read(r)? as usize;
-        let mut sub = r.sub(len)?;
-
-        #[expect(clippy::match_single_binding)] // Future-proofing.
-        let ext = match typ {
-            _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
-        };
-
-        sub.expect_empty("EchConfigExtension")
-            .map(|_| ext)
+        r.sub(len)?
+            .all("EchConfigExtension", |sub| {
+                #[expect(clippy::match_single_binding)] // Future-proofing.
+                match typ {
+                    _ => Ok(Self::Unknown(UnknownExtension::read(typ, sub))),
+                }
+            })
     }
 }
 


### PR DESCRIPTION
Following on from #3162 this fixes additional similar issues, as found by Opus 4.8. Then refactors exhaustive reading following the closure-based approach of `untrusted` to improve robustness. All actual changes here are by hand.

Recommend reviewing without whitespace.

fixes #642