### PR TITLE
reject trailing data in v18 ech config contents

### DIFF
--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -861,6 +861,29 @@ fn test_echconfig_serialization() {
     assert_round_trip_eq(ECHCONFIG_LIST_WITH_UNSUPPORTED);
 }
 
+#[test]
+fn rejects_trailing_data_in_v18_echconfig() {
+    // version(2) | length(2) | ECHConfigContents(length)
+    let mut encoded = get_ech_config(ECHCONFIG_LIST_LOCALHOST)
+        .remove(0)
+        .get_encoding();
+    assert!(matches!(
+        EchConfigPayload::read_bytes(&encoded).unwrap(),
+        EchConfigPayload::V18(_)
+    ));
+
+    // Grow the contents length prefix to cover an extra byte after the
+    // extensions vector, which for a recognized version is the final field.
+    encoded.push(0);
+    let len = u16::from_be_bytes([encoded[2], encoded[3]]) + 1;
+    encoded[2..4].copy_from_slice(&len.to_be_bytes());
+
+    assert_eq!(
+        EchConfigPayload::read_bytes(&encoded).unwrap_err(),
+        InvalidMessage::TrailingData("EchConfigContents")
+    );
+}
+
 fn sample_hello_retry_request() -> HelloRetryRequest {
     HelloRetryRequest {
         legacy_version: ProtocolVersion::TLSv1_2,

--- a/rustls/src/msgs/server_hello.rs
+++ b/rustls/src/msgs/server_hello.rs
@@ -294,7 +294,9 @@ impl Codec<'_> for EchConfigPayload {
         let mut contents = r.sub(length as usize)?;
 
         Ok(match version {
-            EchVersion::V18 => Self::V18(EchConfigContents::read(&mut contents)?),
+            EchVersion::V18 => {
+                Self::V18(contents.all("EchConfigContents", EchConfigContents::read)?)
+            }
             _ => {
                 // Note: we don't SizedPayload::read() here because we've already read the length prefix.
                 let data = SizedPayload::from(Payload::new(contents.rest()));


### PR DESCRIPTION
EchConfigPayload::read takes each config's body from a u16 length-delimited sub-reader, but the recognized-version (V18) branch parses EchConfigContents without checking that sub-reader is drained. A config whose declared length runs past the encoded ECHConfigContents is accepted and the extra bytes are dropped. This is reachable both when a client parses an EchConfigList from DNS and when it parses the server's retry_configs. The recent EchConfigList change tightened the outer list buffer, but the per-config contents were left unchecked.

Route the V18 branch through contents.all(...) so leftover bytes return TrailingData, matching how the sibling Unknown branch and the other message readers already treat their length-delimited regions. Keeping the check on the contents sub-reader means the bound lives next to the field whose length prefix defines it.