### PR TITLE
double map combinators -> two-arm match.

### DIFF
--- a/rustls-aws-lc-rs/src/tls12.rs
+++ b/rustls-aws-lc-rs/src/tls12.rs
@@ -315,10 +315,14 @@ impl MessageEncrypter for GcmMessageEncrypter {
         payload.extend_from_slice(&nonce.as_ref()[4..]);
         payload.extend_from_chunks(&msg.payload);
 
-        self.enc_key
-            .seal_in_place_separate_tag(nonce, aad, &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..])
-            .map(|tag| payload.extend_from_slice(tag.as_ref()))
-            .map_err(|_| Error::EncryptError)?;
+        match self.enc_key.seal_in_place_separate_tag(
+            nonce,
+            aad,
+            &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..],
+        ) {
+            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+            Err(_) => return Err(Error::EncryptError),
+        }
 
         Ok(EncodedMessage {
             typ: msg.typ,

--- a/rustls-ring/src/ticketer.rs
+++ b/rustls-ring/src/ticketer.rs
@@ -77,18 +77,14 @@ impl TicketProducer for AeadTicketer {
         ciphertext.extend(self.key_name);
         ciphertext.extend(nonce_buf);
         ciphertext.extend(message);
-        let ciphertext = self
-            .key
-            .seal_in_place_separate_tag(
-                nonce,
-                aad,
-                &mut ciphertext[self.key_name.len() + nonce_buf.len()..],
-            )
-            .map(|tag| {
-                ciphertext.extend(tag.as_ref());
-                ciphertext
-            })
-            .ok()?;
+        match self.key.seal_in_place_separate_tag(
+            nonce,
+            aad,
+            &mut ciphertext[self.key_name.len() + nonce_buf.len()..],
+        ) {
+            Ok(tag) => ciphertext.extend(tag.as_ref()),
+            Err(_) => return None,
+        }
 
         self.maximum_ciphertext_len
             .fetch_max(ciphertext.len(), Ordering::SeqCst);

--- a/rustls-ring/src/tls12.rs
+++ b/rustls-ring/src/tls12.rs
@@ -293,10 +293,14 @@ impl MessageEncrypter for GcmMessageEncrypter {
         payload.extend_from_slice(&nonce.as_ref()[4..]);
         payload.extend_from_chunks(&msg.payload);
 
-        self.enc_key
-            .seal_in_place_separate_tag(nonce, aad, &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..])
-            .map(|tag| payload.extend_from_slice(tag.as_ref()))
-            .map_err(|_| Error::EncryptError)?;
+        match self.enc_key.seal_in_place_separate_tag(
+            nonce,
+            aad,
+            &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..],
+        ) {
+            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+            Err(_) => return Err(Error::EncryptError),
+        }
 
         Ok(EncodedMessage {
             typ: msg.typ,


### PR DESCRIPTION
Following up from [this review suggestion on #3127](https://github.com/rustls/rustls/pull/3127#discussion_r3623656466), we had a few pre-existing instances of double-`map()` combinators that should be a two-arm `match` instead.