### PR TITLE
Align `ClientConfig` with `ServerConfig::crypto_provider()`

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -1701,7 +1701,7 @@ fn make_server_cfg(opts: &Options, key_log: &Arc<KeyLogMemo>) -> Arc<ServerConfi
 
     if opts.tickets {
         cfg.ticketer = Some(
-            cfg.crypto_provider()
+            cfg.provider()
                 .ticketer_factory
                 .ticketer()
                 .unwrap(),

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -741,7 +741,7 @@ impl Parameters {
             }
             ResumptionParam::Tickets => {
                 cfg.ticketer = Some(
-                    cfg.crypto_provider()
+                    cfg.provider()
                         .ticketer_factory
                         .ticketer()
                         .unwrap(),

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -134,7 +134,7 @@ pub struct ConfigBuilder<Side: ConfigSide, State> {
 
 impl<Side: ConfigSide, State> ConfigBuilder<Side, State> {
     /// Return the crypto provider used to construct this builder.
-    pub fn crypto_provider(&self) -> &Arc<CryptoProvider> {
+    pub fn provider(&self) -> &Arc<CryptoProvider> {
         &self.provider
     }
 }

--- a/rustls/src/server/config.rs
+++ b/rustls/src/server/config.rs
@@ -282,7 +282,7 @@ impl ServerConfig {
     }
 
     /// Return the crypto provider used to construct this server configuration.
-    pub fn crypto_provider(&self) -> &Arc<CryptoProvider> {
+    pub fn provider(&self) -> &Arc<CryptoProvider> {
         &self.provider
     }
 
@@ -671,7 +671,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
         identity: Arc<Identity<'static>>,
         key_der: PrivateKeyDer<'static>,
     ) -> Result<ServerConfig, Error> {
-        let credentials = Credentials::from_der(identity, key_der, self.crypto_provider())?;
+        let credentials = Credentials::from_der(identity, key_der, self.provider())?;
         self.with_server_credential_resolver(Arc::new(SingleCredential::from(credentials)))
     }
 
@@ -695,7 +695,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
         key_der: PrivateKeyDer<'static>,
         ocsp: Arc<[u8]>,
     ) -> Result<ServerConfig, Error> {
-        let mut credentials = Credentials::from_der(identity, key_der, self.crypto_provider())?;
+        let mut credentials = Credentials::from_der(identity, key_der, self.provider())?;
         if !ocsp.is_empty() {
             credentials.ocsp = Some(ocsp);
         }


### PR DESCRIPTION
We have `ClientConfig::provider()` plus `ServerConfig::crypto_provider()`. Correct the inconsistency.

(Don't much mind which way this goes.)