### PR TITLE
Improve multi-dimension testing

### DIFF
--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -549,6 +549,11 @@ impl MultiTest {
             key_types,
         }
     }
+
+    pub fn require_client_auth(mut self) -> Self {
+        self.anon_client = false;
+        self
+    }
 }
 
 impl IntoIterator for MultiTest {

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -519,7 +519,7 @@ impl KeyType {
 pub struct MultiTest {
     providers: Vec<(ProtocolVersion, Arc<CryptoProvider>)>,
     anon_client: bool,
-    client_auth: bool,
+    client_auth: ClientAuth,
     key_types: Vec<KeyType>,
 }
 
@@ -545,13 +545,21 @@ impl MultiTest {
         Self {
             providers,
             anon_client: true,
-            client_auth: true,
+            client_auth: ClientAuth::Yes,
             key_types,
         }
     }
 
     pub fn require_client_auth(mut self) -> Self {
         self.anon_client = false;
+        self
+    }
+
+    pub fn with_client_verifier(
+        mut self,
+        builder: Box<dyn Fn(KeyType, Arc<CryptoProvider>) -> Arc<dyn ClientVerifier>>,
+    ) -> Self {
+        self.client_auth = ClientAuth::CustomClientVerifier(builder);
         self
     }
 }
@@ -576,17 +584,34 @@ impl IntoIterator for MultiTest {
                     ));
                 }
 
-                if self.client_auth {
-                    options.push((
-                        Arc::new(make_client_config_with_auth(*kt, &provider)),
-                        Arc::new(make_server_config_with_mandatory_client_auth(
-                            *kt, &provider,
-                        )),
-                        Expectation {
-                            key_type: *kt,
-                            client_auth: true,
-                        },
-                    ));
+                match &self.client_auth {
+                    ClientAuth::Yes => {
+                        options.push((
+                            Arc::new(make_client_config_with_auth(*kt, &provider)),
+                            Arc::new(make_server_config_with_mandatory_client_auth(
+                                *kt, &provider,
+                            )),
+                            Expectation {
+                                key_type: *kt,
+                                client_auth: true,
+                            },
+                        ));
+                    }
+                    ClientAuth::CustomClientVerifier(make_verifier) => {
+                        options.push((
+                            Arc::new(make_client_config_with_auth(*kt, &provider)),
+                            Arc::new(
+                                ServerConfig::builder(provider.clone())
+                                    .with_client_cert_verifier(make_verifier(*kt, provider.clone()))
+                                    .with_single_cert(kt.identity(), kt.key())
+                                    .unwrap(),
+                            ),
+                            Expectation {
+                                key_type: *kt,
+                                client_auth: true,
+                            },
+                        ));
+                    }
                 }
             }
         }
@@ -598,6 +623,11 @@ impl IntoIterator for MultiTest {
 pub struct Expectation {
     pub key_type: KeyType,
     pub client_auth: bool,
+}
+
+pub enum ClientAuth {
+    Yes,
+    CustomClientVerifier(Box<dyn Fn(KeyType, Arc<CryptoProvider>) -> Arc<dyn ClientVerifier>>),
 }
 
 pub trait ServerConfigExt {

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -520,6 +520,9 @@ pub struct MultiTest {
     providers: Vec<(ProtocolVersion, Arc<CryptoProvider>)>,
     anon_client: bool,
     client_auth: ClientAuth,
+    #[expect(clippy::type_complexity)]
+    custom_server_verifier:
+        Option<Box<dyn Fn(KeyType, Arc<CryptoProvider>) -> Arc<dyn ServerVerifier>>>,
     key_types: Vec<KeyType>,
 }
 
@@ -546,6 +549,7 @@ impl MultiTest {
             providers,
             anon_client: true,
             client_auth: ClientAuth::Yes,
+            custom_server_verifier: None,
             key_types,
         }
     }
@@ -562,6 +566,14 @@ impl MultiTest {
         self.client_auth = ClientAuth::CustomClientVerifier(builder);
         self
     }
+
+    pub fn with_server_verifier(
+        mut self,
+        builder: Box<dyn Fn(KeyType, Arc<CryptoProvider>) -> Arc<dyn ServerVerifier>>,
+    ) -> Self {
+        self.custom_server_verifier = Some(builder);
+        self
+    }
 }
 
 impl IntoIterator for MultiTest {
@@ -573,9 +585,24 @@ impl IntoIterator for MultiTest {
 
         for (version, provider) in self.providers {
             for kt in &self.key_types {
+                let verifier = match &self.custom_server_verifier {
+                    Some(make_verifier) => make_verifier(*kt, provider.clone()),
+                    None => Arc::new(
+                        WebPkiServerVerifier::builder(kt.client_root_store(), &provider)
+                            .build()
+                            .unwrap(),
+                    ),
+                };
+
                 if self.anon_client {
                     options.push((
-                        Arc::new(make_client_config(*kt, &provider)),
+                        Arc::new(
+                            ClientConfig::builder(provider.clone())
+                                .dangerous()
+                                .with_custom_certificate_verifier(verifier.clone())
+                                .with_no_client_auth()
+                                .unwrap(),
+                        ),
                         Arc::new(make_server_config(*kt, &provider)),
                         Expectation {
                             key_type: *kt,
@@ -585,10 +612,18 @@ impl IntoIterator for MultiTest {
                     ));
                 }
 
+                let client_auth_config = Arc::new(
+                    ClientConfig::builder(provider.clone())
+                        .dangerous()
+                        .with_custom_certificate_verifier(verifier)
+                        .with_client_auth_cert(kt.client_identity(), kt.client_key())
+                        .unwrap(),
+                );
+
                 match &self.client_auth {
                     ClientAuth::Yes => {
                         options.push((
-                            Arc::new(make_client_config_with_auth(*kt, &provider)),
+                            client_auth_config.clone(),
                             Arc::new(make_server_config_with_mandatory_client_auth(
                                 *kt, &provider,
                             )),
@@ -601,7 +636,7 @@ impl IntoIterator for MultiTest {
                     }
                     ClientAuth::CustomClientVerifier(make_verifier) => {
                         options.push((
-                            Arc::new(make_client_config_with_auth(*kt, &provider)),
+                            client_auth_config.clone(),
                             Arc::new(
                                 ServerConfig::builder(provider.clone())
                                     .with_client_cert_verifier(make_verifier(*kt, provider.clone()))
@@ -788,17 +823,6 @@ pub fn make_client_config_with_kx_groups(
 
 pub fn make_client_config_with_auth(kt: KeyType, provider: &CryptoProvider) -> ClientConfig {
     ClientConfig::builder(provider.clone().into()).finish_with_creds(kt)
-}
-
-pub fn make_client_config_with_verifier(
-    verifier_builder: ServerVerifierBuilder,
-    provider: &CryptoProvider,
-) -> ClientConfig {
-    ClientConfig::builder(provider.clone().into())
-        .dangerous()
-        .with_custom_certificate_verifier(Arc::new(verifier_builder.build().unwrap()))
-        .with_no_client_auth()
-        .unwrap()
 }
 
 pub fn webpki_client_verifier_builder(
@@ -2144,11 +2168,6 @@ pub mod macros {
             const fn provider_is_fips() -> bool {
                 false
             }
-            #[allow(dead_code)]
-            const ALL_VERSIONS: [rustls::crypto::CryptoProvider; 2] = [
-                provider::DEFAULT_TLS12_PROVIDER,
-                provider::DEFAULT_TLS13_PROVIDER,
-            ];
         };
     }
 
@@ -2169,11 +2188,6 @@ pub mod macros {
             const fn provider_is_fips() -> bool {
                 cfg!(feature = "fips")
             }
-            #[allow(dead_code)]
-            const ALL_VERSIONS: [rustls::crypto::CryptoProvider; 2] = [
-                provider::DEFAULT_TLS12_PROVIDER,
-                provider::DEFAULT_TLS13_PROVIDER,
-            ];
         };
     }
 }

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -537,18 +537,6 @@ pub fn make_server_config_with_kx_groups(
     .finish(kt)
 }
 
-pub fn make_server_config_with_mandatory_client_auth_crls(
-    kt: KeyType,
-    crls: Vec<CertificateRevocationListDer<'static>>,
-    provider: &CryptoProvider,
-) -> ServerConfig {
-    make_server_config_with_client_verifier(
-        kt,
-        webpki_client_verifier_builder(kt.client_root_store(), provider).with_crls(crls),
-        provider,
-    )
-}
-
 pub fn make_server_config_with_mandatory_client_auth(
     kt: KeyType,
     provider: &CryptoProvider,
@@ -793,31 +781,6 @@ pub fn do_handshake_until_error(
         transfer(server, client_input);
         client
             .process_new_packets(client_input)
-            .map_err(ErrorFromPeer::Client)?;
-    }
-
-    Ok(())
-}
-
-pub fn do_handshake_altered(
-    mut client: ClientConnection,
-    alter_server_message: impl Fn(&mut EncodedMessage<Vec<u8>>) -> Altered,
-    alter_client_message: impl Fn(&mut EncodedMessage<Vec<u8>>) -> Altered,
-    mut server: ServerConnection,
-) -> Result<(), ErrorFromPeer> {
-    let mut client_input = VecInput::default();
-    let mut server_input = VecInput::default();
-    while server.is_handshaking() || client.is_handshaking() {
-        transfer_altered(&mut client, &alter_client_message, &mut server_input);
-
-        server
-            .process_new_packets(&mut server_input)
-            .map_err(ErrorFromPeer::Server)?;
-
-        transfer_altered(&mut server, &alter_server_message, &mut client_input);
-
-        client
-            .process_new_packets(&mut client_input)
             .map_err(ErrorFromPeer::Client)?;
     }
 

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -306,11 +306,12 @@ where
     total
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum KeyType {
     Rsa2048,
     Rsa3072,
     Rsa4096,
+    #[default]
     EcdsaP256,
     EcdsaP384,
     EcdsaP521,
@@ -2168,7 +2169,8 @@ pub mod encoding {
                 typ: Self::SIGNATURE_ALGORITHMS,
                 body: len_u16(vector_of(
                     [
-                        SignatureScheme::RSA_PKCS1_SHA256,
+                        SignatureScheme::ED25519,
+                        SignatureScheme::RSA_PSS_SHA256,
                         SignatureScheme::ECDSA_NISTP256_SHA256,
                     ]
                     .map(|s| s.to_array()),

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -507,6 +507,94 @@ impl KeyType {
     }
 }
 
+/// An iterator for testing several combinations of config
+///
+/// By default the iterator goes over compatible pairs of client/server configs
+/// alongside the expected `KeyType`:
+///
+/// - for the provider as-is
+/// - for the provider reduced to only support TLS1.2 and 1.3 alone
+/// - for each key type supported by the provider
+/// - for server authentication and mutual authentication
+pub struct MultiTest {
+    providers: Vec<(ProtocolVersion, Arc<CryptoProvider>)>,
+    anon_client: bool,
+    client_auth: bool,
+    key_types: Vec<KeyType>,
+}
+
+impl MultiTest {
+    pub fn new(provider: CryptoProvider) -> Self {
+        let key_types = KeyType::all_for_provider(&provider).to_vec();
+        let mut providers = vec![(ProtocolVersion::TLSv1_3, Arc::new(provider.clone()))];
+        providers.push((
+            ProtocolVersion::TLSv1_3,
+            Arc::new(CryptoProvider {
+                tls12_cipher_suites: Cow::Borrowed(&[]),
+                ..provider.clone()
+            }),
+        ));
+        providers.push((
+            ProtocolVersion::TLSv1_2,
+            Arc::new(CryptoProvider {
+                tls13_cipher_suites: Cow::Borrowed(&[]),
+                ..provider
+            }),
+        ));
+
+        Self {
+            providers,
+            anon_client: true,
+            client_auth: true,
+            key_types,
+        }
+    }
+}
+
+impl IntoIterator for MultiTest {
+    type Item = (Arc<ClientConfig>, Arc<ServerConfig>, Expectation);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let mut options = vec![];
+
+        for (_, provider) in self.providers {
+            for kt in &self.key_types {
+                if self.anon_client {
+                    options.push((
+                        Arc::new(make_client_config(*kt, &provider)),
+                        Arc::new(make_server_config(*kt, &provider)),
+                        Expectation {
+                            key_type: *kt,
+                            client_auth: false,
+                        },
+                    ));
+                }
+
+                if self.client_auth {
+                    options.push((
+                        Arc::new(make_client_config_with_auth(*kt, &provider)),
+                        Arc::new(make_server_config_with_mandatory_client_auth(
+                            *kt, &provider,
+                        )),
+                        Expectation {
+                            key_type: *kt,
+                            client_auth: true,
+                        },
+                    ));
+                }
+            }
+        }
+
+        options.into_iter()
+    }
+}
+
+pub struct Expectation {
+    pub key_type: KeyType,
+    pub client_auth: bool,
+}
+
 pub trait ServerConfigExt {
     fn finish(self, kt: KeyType) -> ServerConfig;
 }

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -571,7 +571,7 @@ impl IntoIterator for MultiTest {
     fn into_iter(self) -> Self::IntoIter {
         let mut options = vec![];
 
-        for (_, provider) in self.providers {
+        for (version, provider) in self.providers {
             for kt in &self.key_types {
                 if self.anon_client {
                     options.push((
@@ -580,6 +580,7 @@ impl IntoIterator for MultiTest {
                         Expectation {
                             key_type: *kt,
                             client_auth: false,
+                            version,
                         },
                     ));
                 }
@@ -594,6 +595,7 @@ impl IntoIterator for MultiTest {
                             Expectation {
                                 key_type: *kt,
                                 client_auth: true,
+                                version,
                             },
                         ));
                     }
@@ -609,6 +611,7 @@ impl IntoIterator for MultiTest {
                             Expectation {
                                 key_type: *kt,
                                 client_auth: true,
+                                version,
                             },
                         ));
                     }
@@ -620,9 +623,11 @@ impl IntoIterator for MultiTest {
     }
 }
 
+#[derive(Debug)]
 pub struct Expectation {
     pub key_type: KeyType,
     pub client_auth: bool,
+    pub version: ProtocolVersion,
 }
 
 pub enum ClientAuth {

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -52,13 +52,13 @@ fn alpn_test_error(
     agreed: Option<ApplicationProtocol<'static>>,
     expected_error: Option<ErrorFromPeer>,
 ) {
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut server_config = make_server_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
     server_config.alpn_protocols = server_protos;
 
     let server_config = Arc::new(server_config);
 
     for version_provider in ALL_VERSIONS {
-        let mut client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let mut client_config = make_client_config(KeyType::default(), &version_provider);
         client_config
             .alpn_protocols
             .clone_from(&client_protos);
@@ -128,12 +128,12 @@ fn alpn() {
 #[test]
 fn connection_level_alpn_protocols() {
     let provider = provider::DEFAULT_PROVIDER;
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.alpn_protocols = vec![b"h2".into(), b"http/1.1".into()];
     let server_config = Arc::new(server_config);
 
     // Config specifies `h2`
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.alpn_protocols = vec![b"h2".into()];
     let client_config = Arc::new(client_config);
 
@@ -192,7 +192,7 @@ fn server_selects_unoffered_alpn_unchecked() {
 }
 
 fn unoffered_alpn_test(check_selected_alpn: bool) -> Result<rustls::IoState, Error> {
-    let mut config = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut config = make_client_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
     config.check_selected_alpn = check_selected_alpn;
     let mut client = Arc::new(config)
         .connect(server_name("localhost"))
@@ -233,8 +233,8 @@ fn version_test(
     let client_provider = apply_versions(provider.clone(), client_versions);
     let server_provider = apply_versions(provider, server_versions);
 
-    let client_config = make_client_config(KeyType::Rsa2048, &client_provider);
-    let server_config = make_server_config(KeyType::Rsa2048, &server_provider);
+    let client_config = make_client_config(KeyType::default(), &client_provider);
+    let server_config = make_server_config(KeyType::default(), &server_provider);
 
     println!("version {client_versions:?} {server_versions:?} -> {result:?}");
 
@@ -339,7 +339,7 @@ fn config_builder_for_client_rejects_empty_kx_groups() {
             }
             .into()
         )
-        .with_root_certificates(KeyType::EcdsaP256.client_root_store())
+        .with_root_certificates(KeyType::default().client_root_store())
         .with_no_client_auth()
         .err(),
         Some(ApiMisuse::NoKeyExchangeGroupsConfigured.into())
@@ -357,7 +357,7 @@ fn config_builder_for_client_rejects_empty_cipher_suites() {
             }
             .into()
         )
-        .with_root_certificates(KeyType::EcdsaP256.client_root_store())
+        .with_root_certificates(KeyType::default().client_root_store())
         .with_no_client_auth()
         .err(),
         Some(ApiMisuse::NoCipherSuitesConfigured.into())
@@ -375,7 +375,7 @@ fn config_builder_for_server_rejects_empty_kx_groups() {
             .into()
         )
         .with_no_client_auth()
-        .with_single_cert(KeyType::EcdsaP256.identity(), KeyType::EcdsaP256.key())
+        .with_single_cert(KeyType::default().identity(), KeyType::default().key())
         .err(),
         Some(ApiMisuse::NoKeyExchangeGroupsConfigured.into())
     );
@@ -393,7 +393,7 @@ fn config_builder_for_server_rejects_empty_cipher_suites() {
             .into()
         )
         .with_no_client_auth()
-        .with_single_cert(KeyType::EcdsaP256.identity(), KeyType::EcdsaP256.key())
+        .with_single_cert(KeyType::default().identity(), KeyType::default().key())
         .err(),
         Some(ApiMisuse::NoCipherSuitesConfigured.into())
     );
@@ -575,7 +575,7 @@ fn test_config_builders_debug() {
 
 #[test]
 fn test_tls13_valid_early_plaintext_alert() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut server_input = VecInput::default();
 
     // Perform the start of a TLS 1.3 handshake, sending a client hello to the server.
@@ -601,7 +601,7 @@ fn test_tls13_valid_early_plaintext_alert() {
 
 #[test]
 fn test_tls13_too_short_early_plaintext_alert() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut server_input = VecInput::default();
 
     // Perform the start of a TLS 1.3 handshake, sending a client hello to the server.
@@ -624,7 +624,7 @@ fn test_tls13_too_short_early_plaintext_alert() {
 
 #[test]
 fn test_tls13_late_plaintext_alert() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -650,9 +650,9 @@ fn test_tls13_late_plaintext_alert() {
 #[test]
 fn server_rejects_empty_post_handshake_alert_fragment() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.enable_secret_extraction = true;
-    let server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let server_config = make_server_config(KeyType::default(), &provider);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
@@ -688,7 +688,7 @@ fn server_rejects_empty_post_handshake_alert_fragment() {
 
 #[test]
 fn client_error_is_sticky() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     client_input
         .read(&mut b"\x16\x03\x03\x00\x08\x0f\x00\x00\x04junk".as_ref())
@@ -703,7 +703,7 @@ fn client_error_is_sticky() {
 
 #[test]
 fn server_error_is_sticky() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut server_input = VecInput::default();
     server_input
         .read(&mut b"\x16\x03\x03\x00\x08\x0f\x00\x00\x04junk".as_ref())
@@ -719,7 +719,7 @@ fn server_error_is_sticky() {
 #[allow(clippy::unnecessary_operation)]
 #[test]
 fn server_is_send_and_sync() {
-    let (_, server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     &server as &dyn Send;
     &server as &dyn Sync;
 }
@@ -727,36 +727,36 @@ fn server_is_send_and_sync() {
 #[allow(clippy::unnecessary_operation)]
 #[test]
 fn client_is_send_and_sync() {
-    let (client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     &client as &dyn Send;
     &client as &dyn Sync;
 }
 
 #[test]
 fn server_config_is_clone() {
-    let _ = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let _ = make_server_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
 }
 
 #[test]
 fn client_config_is_clone() {
-    let _ = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let _ = make_client_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
 }
 
 #[test]
 fn client_connection_is_debug() {
-    let (client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     println!("{client:?}");
 }
 
 #[test]
 fn server_connection_is_debug() {
-    let (_, server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     println!("{server:?}");
 }
 
 #[test]
 fn server_exposes_offered_sni() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_PROVIDER;
     for version_provider in ALL_VERSIONS {
         let client_config = Arc::new(make_client_config(kt, &version_provider));
@@ -787,7 +787,7 @@ fn server_exposes_offered_sni() {
 #[test]
 fn server_exposes_offered_sni_smashed_to_lowercase() {
     // webpki actually does this for us in its DnsName type
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_PROVIDER;
     for version_provider in ALL_VERSIONS {
         let client_config = Arc::new(make_client_config(kt, &version_provider));
@@ -975,8 +975,8 @@ fn test_extended_master_secret_reporting() {
     // rustls<->rustls 1.2 handshake negotiates it and reports `Some(true)` on
     // both ends.
     let provider = provider::DEFAULT_TLS12_PROVIDER;
-    let client_config = make_client_config(KeyType::Rsa2048, &provider);
-    let server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let client_config = make_client_config(KeyType::default(), &provider);
+    let server_config = make_server_config(KeyType::default(), &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     assert_eq!(client.extended_master_secret(), None);
     assert_eq!(server.extended_master_secret(), None);
@@ -994,8 +994,8 @@ fn test_extended_master_secret_reporting() {
     // TLS 1.3 has no Extended Master Secret extension (the property is intrinsic
     // to its key schedule), so it is reported as `None`.
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let client_config = make_client_config(KeyType::Rsa2048, &provider);
-    let server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let client_config = make_client_config(KeyType::default(), &provider);
+    let server_config = make_server_config(KeyType::default(), &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
     do_handshake(
@@ -1011,8 +1011,8 @@ fn test_extended_master_secret_reporting() {
 #[test]
 fn test_tls13_exporter_maximum_output_length() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let client_config = make_client_config(KeyType::EcdsaP256, &provider);
-    let server_config = make_server_config(KeyType::EcdsaP256, &provider);
+    let client_config = make_client_config(KeyType::default(), &provider);
+    let server_config = make_server_config(KeyType::default(), &provider);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     let mut client_input = VecInput::default();
@@ -1274,7 +1274,7 @@ fn test_client_rejects_illegal_tls13_ccs() {
         Altered::InPlace
     }
 
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     transfer(&mut client, &mut server_input);
@@ -1338,10 +1338,10 @@ fn test_no_warning_logging_during_successful_sessions() {
 #[test]
 fn test_explicit_provider_selection() {
     let client_config =
-        ClientConfig::builder(rustls_ring::DEFAULT_PROVIDER.into()).finish(KeyType::Rsa2048);
+        ClientConfig::builder(rustls_ring::DEFAULT_PROVIDER.into()).finish(KeyType::default());
 
     let server_config =
-        ServerConfig::builder(rustls_aws_lc_rs::DEFAULT_PROVIDER.into()).finish(KeyType::Rsa2048);
+        ServerConfig::builder(rustls_aws_lc_rs::DEFAULT_PROVIDER.into()).finish(KeyType::default());
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     let mut client_input = VecInput::default();
@@ -1394,7 +1394,7 @@ fn test_client_construction_fails_if_random_source_fails_in_first_request() {
         }
         .into(),
     )
-    .finish(KeyType::Rsa2048);
+    .finish(KeyType::default());
 
     assert_eq!(
         Arc::new(client_config)
@@ -1418,7 +1418,7 @@ fn test_client_construction_fails_if_random_source_fails_in_second_request() {
         }
         .into(),
     )
-    .finish(KeyType::Rsa2048);
+    .finish(KeyType::default());
 
     assert_eq!(
         Arc::new(client_config)
@@ -1445,7 +1445,7 @@ fn test_client_construction_requires_66_bytes_of_random_material() {
         }
         .into(),
     )
-    .finish(KeyType::Rsa2048);
+    .finish(KeyType::default());
 
     Arc::new(client_config)
         .connect(server_name("localhost"))
@@ -1480,11 +1480,11 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
     }
 
     let provider = provider::DEFAULT_TLS12_PROVIDER;
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     let storage = Arc::new(ClientStorage::new());
     client_config.resumption = Resumption::store(storage.clone());
     let client_config = Arc::new(client_config);
-    let server_config = Arc::new(make_server_config(KeyType::Rsa2048, &provider));
+    let server_config = Arc::new(make_server_config(KeyType::default(), &provider));
 
     // successful handshake to allow resumption
     let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
@@ -1531,7 +1531,7 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
 
 #[test]
 fn test_client_fips_service_indicator() {
-    match make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).fips() {
+    match make_client_config(KeyType::default(), &provider::DEFAULT_PROVIDER).fips() {
         FipsStatus::Pending | FipsStatus::Certified { .. } if provider_is_fips() => {}
         FipsStatus::Unvalidated if !provider_is_fips() => {}
         other => panic!(
@@ -1543,7 +1543,7 @@ fn test_client_fips_service_indicator() {
 
 #[test]
 fn test_server_fips_service_indicator() {
-    match make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER).fips() {
+    match make_server_config(KeyType::default(), &provider::DEFAULT_PROVIDER).fips() {
         FipsStatus::Pending | FipsStatus::Certified { .. } if provider_is_fips() => {}
         FipsStatus::Unvalidated if !provider_is_fips() => {}
         other => panic!(
@@ -1556,8 +1556,8 @@ fn test_server_fips_service_indicator() {
 #[test]
 fn test_connection_fips_service_indicator() {
     let provider = provider::DEFAULT_PROVIDER;
-    let client_config = Arc::new(make_client_config(KeyType::Rsa2048, &provider));
-    let server_config = Arc::new(make_server_config(KeyType::Rsa2048, &provider));
+    let client_config = Arc::new(make_client_config(KeyType::default(), &provider));
+    let server_config = Arc::new(make_server_config(KeyType::default(), &provider));
     let conn_pair = make_pair_for_arc_configs(&client_config, &server_config);
     // Each connection's FIPS status should reflect the FIPS status of the config it was created
     // from.
@@ -1571,7 +1571,7 @@ fn test_client_fips_service_indicator_includes_require_ems() {
         return;
     }
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut client_config = make_client_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert!(matches!(
         client_config.fips(),
         FipsStatus::Pending | FipsStatus::Certified { .. }
@@ -1586,7 +1586,7 @@ fn test_server_fips_service_indicator_includes_require_ems() {
         return;
     }
 
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut server_config = make_server_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert!(matches!(
         server_config.fips(),
         FipsStatus::Pending | FipsStatus::Certified { .. }
@@ -1619,14 +1619,14 @@ fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
         // ECH HPKE suite is itself FIPS approved.
         let config = ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into())
             .with_ech(EchMode::Enable(ech_config));
-        let config = config.finish(KeyType::Rsa2048);
+        let config = config.finish(KeyType::default());
         assert_eq!(config.fips(), suite.fips());
 
         // The same applies if an ECH GREASE client configuration is used.
         let (public_key, _) = suite.generate_key_pair().unwrap();
         let config = ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into())
             .with_ech(EchMode::Grease(EchGreaseConfig::new(*suite, public_key)));
-        let config = Arc::new(config.finish(KeyType::Rsa2048));
+        let config = Arc::new(config.finish(KeyType::default()));
         assert_eq!(config.fips(), suite.fips());
 
         // And a connection made from a client config should retain the fips status of the
@@ -1642,8 +1642,8 @@ fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
 #[test]
 fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let client_config = make_client_config(KeyType::Rsa2048, &provider);
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let client_config = make_client_config(KeyType::default(), &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.enable_secret_extraction = true;
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -1682,8 +1682,8 @@ fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
 #[test]
 fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
     let provider = provider::DEFAULT_TLS12_PROVIDER;
-    let client_config = make_client_config(KeyType::Rsa2048, &provider);
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let client_config = make_client_config(KeyType::default(), &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.enable_secret_extraction = true;
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -1731,9 +1731,9 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
 #[test]
 fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.enable_secret_extraction = true;
-    let server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let server_config = make_server_config(KeyType::default(), &provider);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     let mut client_input = VecInput::default();
@@ -1765,8 +1765,8 @@ fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
 #[test]
 fn test_illegal_client_renegotiation_attempt_during_tls12_handshake() {
     let provider = provider::DEFAULT_TLS12_PROVIDER;
-    let server_config = make_server_config(KeyType::Rsa2048, &provider);
-    let client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let server_config = make_server_config(KeyType::default(), &provider);
+    let client_config = make_client_config(KeyType::default(), &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
     let mut client_hello = vec![];
@@ -1832,7 +1832,7 @@ fn tls13_packed_handshake() {
 
 #[test]
 fn large_client_hello() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut server_input = VecInput::default();
     let hello = include_bytes!("../data/bug2227-clienthello.bin");
     let mut cursor = io::Cursor::new(hello);
@@ -1871,7 +1871,7 @@ fn large_client_hello_acceptor() {
 
 #[test]
 fn acceptor_with_illegal_max_fragment_size() {
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let mut server_config = make_server_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
     server_config.max_fragment_size = Some(31);
 
     let receive = ServerHandshake::start();
@@ -1980,8 +1980,8 @@ fn server_invalid_sni_policy() {
 
     for (policy, sni, expected_result) in test_cases {
         let provider = provider::DEFAULT_PROVIDER;
-        let client_config = make_client_config(KeyType::EcdsaP256, &provider);
-        let mut server_config = make_server_config(KeyType::EcdsaP256, &provider);
+        let client_config = make_client_config(KeyType::default(), &provider);
+        let mut server_config = make_server_config(KeyType::default(), &provider);
 
         server_config.cert_resolver = Arc::new(ServerCheckSni {
             expect_sni: matches!(expected_result, Accept),

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -34,16 +34,14 @@ use rustls::{
 use rustls_aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
 use rustls_test::{
     Altered, ClientConfigExt, ClientStorage, ClientStorageOp, ErrorFromPeer, KeyType,
-    MockServerVerifier, RawTls, ServerConfigExt, do_handshake, do_handshake_until_error,
-    do_suite_and_kx_test, encoding, make_client_config, make_client_config_with_auth, make_pair,
-    make_pair_for_arc_configs, make_pair_for_configs, make_server_config,
-    make_server_config_with_mandatory_client_auth, provider_with_one_suite, provider_with_suites,
+    MockServerVerifier, MultiTest, RawTls, ServerConfigExt, do_handshake, do_handshake_until_error,
+    do_suite_and_kx_test, encoding, make_client_config, make_pair, make_pair_for_arc_configs,
+    make_pair_for_configs, make_server_config, provider_with_one_suite, provider_with_suites,
     server_name, transfer, transfer_altered, unsafe_plaintext_crypto_provider,
 };
 
 use super::{
-    ALL_VERSIONS, COUNTS, CountingLogger, provider, provider_is_aws_lc_rs, provider_is_fips,
-    provider_is_ring,
+    COUNTS, CountingLogger, provider, provider_is_aws_lc_rs, provider_is_fips, provider_is_ring,
 };
 
 fn alpn_test_error(
@@ -52,19 +50,16 @@ fn alpn_test_error(
     agreed: Option<ApplicationProtocol<'static>>,
     expected_error: Option<ErrorFromPeer>,
 ) {
-    let mut server_config = make_server_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
-    server_config.alpn_protocols = server_protos;
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let mut server_config = Arc::unwrap_or_clone(server_config);
+        server_config.alpn_protocols = server_protos.clone();
 
-    let server_config = Arc::new(server_config);
-
-    for version_provider in ALL_VERSIONS {
-        let mut client_config = make_client_config(KeyType::default(), &version_provider);
+        let mut client_config = Arc::unwrap_or_clone(client_config);
         client_config
             .alpn_protocols
             .clone_from(&client_protos);
 
-        let (mut client, mut server) =
-            make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+        let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
 
@@ -417,126 +412,104 @@ fn config_builder_for_server_with_time() {
 
 #[test]
 fn client_can_get_server_cert() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config(*kt, &version_provider);
-            let (mut client, mut server) =
-                make_pair_for_configs(client_config, make_server_config(*kt, &provider));
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(client.peer_identity().unwrap(), &*kt.identity());
-        }
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            client.peer_identity().unwrap(),
+            &*expect.key_type.identity()
+        );
     }
 }
 
 #[test]
 fn client_can_get_server_cert_after_resumption() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = make_server_config(*kt, &provider);
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config(*kt, &version_provider);
-            let (mut client, mut server) =
-                make_pair_for_configs(client_config.clone(), server_config.clone());
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
 
-            let original_certs = client.peer_identity();
+        let original_certs = client.peer_identity();
 
-            let (mut client, mut server) =
-                make_pair_for_configs(client_config.clone(), server_config.clone());
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
 
-            let resumed_certs = client.peer_identity();
+        let resumed_certs = client.peer_identity();
 
-            assert_eq!(original_certs, resumed_certs);
-        }
+        assert_eq!(original_certs, resumed_certs);
     }
 }
 
 #[test]
 fn server_can_get_client_cert() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = Arc::new(make_server_config_with_mandatory_client_auth(
-            *kt, &provider,
-        ));
-
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config_with_auth(*kt, &version_provider);
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(server.peer_identity().unwrap(), &*kt.client_identity());
-        }
+    for (client_config, server_config, expect) in
+        MultiTest::new(provider::DEFAULT_PROVIDER).require_client_auth()
+    {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            server.peer_identity().unwrap(),
+            &*expect.key_type.client_identity()
+        );
     }
 }
 
 #[test]
 fn server_can_get_client_cert_after_resumption() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = Arc::new(make_server_config_with_mandatory_client_auth(
-            *kt, &provider,
-        ));
+    for (client_config, server_config, _) in
+        MultiTest::new(provider::DEFAULT_PROVIDER).require_client_auth()
+    {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        let original_certs = server.peer_identity();
 
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config_with_auth(*kt, &version_provider);
-            let client_config = Arc::new(client_config);
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&client_config, &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            let original_certs = server.peer_identity();
-
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&client_config, &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            let resumed_certs = server.peer_identity();
-            assert_eq!(original_certs, resumed_certs);
-        }
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        let resumed_certs = server.peer_identity();
+        assert_eq!(original_certs, resumed_certs);
     }
 }
 
@@ -756,19 +729,15 @@ fn server_connection_is_debug() {
 
 #[test]
 fn server_exposes_offered_sni() {
-    let kt = KeyType::default();
-    let provider = provider::DEFAULT_PROVIDER;
-    for version_provider in ALL_VERSIONS {
-        let client_config = Arc::new(make_client_config(kt, &version_provider));
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
         let mut client = client_config
             .connect(server_name("second.testserver.com"))
             .build()
             .unwrap();
 
-        let mut server =
-            ServerConnection::new(Arc::new(make_server_config(kt, &provider))).unwrap();
-
+        let mut server = ServerConnection::new(server_config).unwrap();
         assert_eq!(None, server.server_name());
+
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
         do_handshake(
@@ -787,17 +756,13 @@ fn server_exposes_offered_sni() {
 #[test]
 fn server_exposes_offered_sni_smashed_to_lowercase() {
     // webpki actually does this for us in its DnsName type
-    let kt = KeyType::default();
-    let provider = provider::DEFAULT_PROVIDER;
-    for version_provider in ALL_VERSIONS {
-        let client_config = Arc::new(make_client_config(kt, &version_provider));
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
         let mut client = client_config
             .connect(server_name("SECOND.TESTServer.com"))
             .build()
             .unwrap();
 
-        let mut server =
-            ServerConnection::new(Arc::new(make_server_config(kt, &provider))).unwrap();
+        let mut server = ServerConnection::new(server_config).unwrap();
 
         assert_eq!(None, server.server_name());
         let mut client_input = VecInput::default();
@@ -1295,22 +1260,16 @@ fn test_client_rejects_illegal_tls13_ccs() {
 fn test_no_warning_logging_during_successful_sessions() {
     CountingLogger::install();
     CountingLogger::reset();
-
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config(*kt, &version_provider);
-            let (mut client, mut server) =
-                make_pair_for_configs(client_config, make_server_config(*kt, &provider));
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-        }
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
     }
 
     if cfg!(feature = "log") {

--- a/rustls-test/tests/api/client_cert_verifier.rs
+++ b/rustls-test/tests/api/client_cert_verifier.rs
@@ -6,16 +6,14 @@ use std::sync::Arc;
 
 use rustls::error::{AlertDescription, CertificateError, Error, InvalidMessage, PeerMisbehaved};
 use rustls::server::danger::PeerVerified;
-use rustls::{ServerConfig, ServerConnection, VecInput};
+use rustls::{ClientConfig, ServerConnection, VecInput};
 use rustls_test::{
-    ErrorFromPeer, KeyType, MockClientVerifier, do_handshake, do_handshake_until_both_error,
-    do_handshake_until_error, make_client_config, make_client_config_with_auth,
-    make_pair_for_arc_configs, make_server_config_with_client_verifier,
-    make_server_config_with_mandatory_client_auth, make_server_config_with_optional_client_auth,
-    server_name, webpki_client_verifier_builder,
+    ErrorFromPeer, MockClientVerifier, MultiTest, do_handshake, do_handshake_until_both_error,
+    do_handshake_until_error, make_pair_for_arc_configs, make_server_config_with_client_verifier,
+    make_server_config_with_optional_client_auth, server_name, webpki_client_verifier_builder,
 };
 
-use super::{ALL_VERSIONS, provider};
+use super::provider;
 
 // Client is authorized!
 fn ver_ok() -> Result<PeerVerified, Error> {
@@ -32,144 +30,124 @@ fn ver_err() -> Result<PeerVerified, Error> {
     Err(Error::General("test err".to_string()))
 }
 
-fn server_config_with_verifier(
-    kt: KeyType,
-    client_cert_verifier: MockClientVerifier,
-) -> ServerConfig {
-    ServerConfig::builder(provider::DEFAULT_PROVIDER.into())
-        .with_client_cert_verifier(Arc::new(client_cert_verifier))
-        .with_single_cert(kt.identity(), kt.key())
-        .unwrap()
-}
-
-#[test]
 // Happy path, we resolve to a root, it is verified OK, should be able to connect
+#[test]
 fn client_verifier_works() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider).iter() {
-        let client_verifier = MockClientVerifier::new(ver_ok, *kt, &provider);
-        let server_config = server_config_with_verifier(*kt, client_verifier);
-        let server_config = Arc::new(server_config);
-
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config_with_auth(*kt, &version_provider);
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config.clone()), &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(err, Ok(()));
-        }
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .require_client_auth()
+        .with_client_verifier(Box::new(|kt, provider| {
+            Arc::new(MockClientVerifier::new(ver_ok, kt, &provider))
+        }))
+    {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(err, Ok(()));
     }
 }
 
 // Server offers no verification schemes
 #[test]
 fn client_verifier_no_schemes() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider).iter() {
-        let mut client_verifier = MockClientVerifier::new(ver_ok, *kt, &provider);
-        client_verifier.offered_schemes = Some(vec![]);
-        let server_config = server_config_with_verifier(*kt, client_verifier);
-        let server_config = Arc::new(server_config);
-
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config_with_auth(*kt, &version_provider);
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config.clone()), &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Client(Error::InvalidMessage(
-                    InvalidMessage::NoSignatureSchemes,
-                ))),
-            );
-        }
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .require_client_auth()
+        .with_client_verifier(Box::new(|kt, provider| {
+            let mut verifier = MockClientVerifier::new(ver_ok, kt, &provider);
+            verifier.offered_schemes = Some(vec![]);
+            Arc::new(verifier)
+        }))
+    {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            err,
+            Err(ErrorFromPeer::Client(Error::InvalidMessage(
+                InvalidMessage::NoSignatureSchemes,
+            ))),
+        );
     }
 }
 
-// If we do have a root, we must do auth
+// server demands client auth, but client config has no credentials.
 #[test]
 fn client_verifier_no_auth_yes_root() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider).iter() {
-        let client_verifier = MockClientVerifier::new(ver_unreachable, *kt, &provider);
+    for (_, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .require_client_auth()
+        .with_client_verifier(Box::new(|kt, provider| {
+            Arc::new(MockClientVerifier::new(ver_unreachable, kt, &provider))
+        }))
+    {
+        let mut server = ServerConnection::new(server_config).unwrap();
 
-        let server_config = server_config_with_verifier(*kt, client_verifier);
-        let server_config = Arc::new(server_config);
+        let mut client = Arc::new(
+            ClientConfig::builder(Arc::new(provider::DEFAULT_PROVIDER))
+                .with_root_certificates(expect.key_type.client_root_store())
+                .with_no_client_auth()
+                .unwrap(),
+        )
+        .connect(server_name("localhost"))
+        .build()
+        .unwrap();
 
-        for version_provider in ALL_VERSIONS {
-            let client_config = Arc::new(make_client_config(*kt, &version_provider));
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-            let mut client = client_config
-                .connect(server_name("localhost"))
-                .build()
-                .unwrap();
-
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let errs = do_handshake_until_both_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                errs,
-                Err(vec![
-                    ErrorFromPeer::Server(Error::PeerMisbehaved(
-                        PeerMisbehaved::NoCertificatesPresented
-                    )),
-                    ErrorFromPeer::Client(Error::AlertReceived(
-                        AlertDescription::CertificateRequired
-                    ))
-                ])
-            );
-        }
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let errs = do_handshake_until_both_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            errs,
+            Err(vec![
+                ErrorFromPeer::Server(Error::PeerMisbehaved(
+                    PeerMisbehaved::NoCertificatesPresented
+                )),
+                ErrorFromPeer::Client(Error::AlertReceived(AlertDescription::CertificateRequired))
+            ])
+        );
     }
 }
 
-#[test]
 // Triple checks we propagate the rustls::Error through
+#[test]
 fn client_verifier_fails_properly() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider).iter() {
-        let client_verifier = MockClientVerifier::new(ver_err, *kt, &provider);
-        let server_config = server_config_with_verifier(*kt, client_verifier);
-        let server_config = Arc::new(server_config);
-
-        for version_provider in ALL_VERSIONS {
-            let client_config = Arc::new(make_client_config_with_auth(*kt, &version_provider));
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-            let mut client = client_config
-                .connect(server_name("localhost"))
-                .build()
-                .unwrap();
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Server(Error::General("test err".into())))
-            );
-        }
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .require_client_auth()
+        .with_client_verifier(Box::new(|kt, provider| {
+            Arc::new(MockClientVerifier::new(ver_err, kt, &provider))
+        }))
+    {
+        let mut server = ServerConnection::new(server_config).unwrap();
+        let mut client = client_config
+            .connect(server_name("localhost"))
+            .build()
+            .unwrap();
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            err,
+            Err(ErrorFromPeer::Server(Error::General("test err".into())))
+        );
     }
 }
 
@@ -179,176 +157,165 @@ fn client_verifier_fails_properly() {
 /// certificate and not being given one.
 #[test]
 fn server_allow_any_anonymous_or_authenticated_client() {
-    let provider = Arc::new(provider::DEFAULT_PROVIDER);
-    let kt = KeyType::default();
-    for client_cert_chain in [None, Some(kt.client_identity())] {
-        let client_auth = Arc::new(
-            webpki_client_verifier_builder(kt.client_root_store(), &provider)
-                .allow_unauthenticated()
-                .build()
-                .unwrap(),
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .with_client_verifier(Box::new(|kt, provider| {
+            Arc::new(
+                webpki_client_verifier_builder(kt.client_root_store(), &provider)
+                    .allow_unauthenticated()
+                    .build()
+                    .unwrap(),
+            )
+        }))
+    {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
         );
-
-        let server_config = ServerConfig::builder(provider.clone())
-            .with_client_cert_verifier(client_auth)
-            .with_single_cert(kt.identity(), kt.key())
-            .unwrap();
-        let server_config = Arc::new(server_config);
-
-        for version_provider in ALL_VERSIONS {
-            let client_config = if client_cert_chain.is_some() {
-                make_client_config_with_auth(kt, &version_provider)
-            } else {
-                make_client_config(kt, &version_provider)
-            };
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(server.peer_identity(), client_cert_chain.as_deref());
-        }
+        assert_eq!(
+            server.peer_identity(),
+            match expect.client_auth {
+                true => Some(expect.key_type.client_identity()),
+                false => None,
+            }
+            .as_deref()
+        );
     }
 }
 
 #[test]
 fn client_auth_works() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = Arc::new(make_server_config_with_mandatory_client_auth(
-            *kt, &provider,
-        ));
-
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config_with_auth(*kt, &version_provider);
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-        }
+    for (client_config, server_config, _) in
+        MultiTest::new(provider::DEFAULT_PROVIDER).require_client_auth()
+    {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
     }
 }
 
 #[test]
 fn client_mandatory_auth_client_revocation_works() {
     let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
+    for (client_config, _, expect) in MultiTest::new(provider.clone()).require_client_auth() {
         // Create a server configuration that includes a CRL that specifies the client certificate
         // is revoked.
-        let relevant_crls = vec![kt.client_crl()];
+        let relevant_crls = vec![expect.key_type.client_crl()];
         // Only check the EE certificate status. See client_mandatory_auth_intermediate_revocation_works
         // for testing revocation status of the whole chain.
-        let ee_verifier_builder = webpki_client_verifier_builder(kt.client_root_store(), &provider)
-            .with_crls(relevant_crls)
-            .only_check_end_entity_revocation();
+        let ee_verifier_builder =
+            webpki_client_verifier_builder(expect.key_type.client_root_store(), &provider)
+                .with_crls(relevant_crls)
+                .only_check_end_entity_revocation();
         let revoked_server_config = Arc::new(make_server_config_with_client_verifier(
-            *kt,
+            expect.key_type,
             ee_verifier_builder,
             &provider,
         ));
 
         // Create a server configuration that includes a CRL that doesn't cover the client certificate,
         // and uses the default behaviour of treating unknown revocation status as an error.
-        let unrelated_crls = vec![kt.intermediate_crl()];
-        let ee_verifier_builder = webpki_client_verifier_builder(kt.client_root_store(), &provider)
-            .with_crls(unrelated_crls.clone())
-            .only_check_end_entity_revocation();
+        let unrelated_crls = vec![expect.key_type.intermediate_crl()];
+        let ee_verifier_builder =
+            webpki_client_verifier_builder(expect.key_type.client_root_store(), &provider)
+                .with_crls(unrelated_crls.clone())
+                .only_check_end_entity_revocation();
         let missing_client_crl_server_config = Arc::new(make_server_config_with_client_verifier(
-            *kt,
+            expect.key_type,
             ee_verifier_builder,
             &provider,
         ));
 
         // Create a server configuration that includes a CRL that doesn't cover the client certificate,
         // but change the builder to allow unknown revocation status.
-        let ee_verifier_builder = webpki_client_verifier_builder(kt.client_root_store(), &provider)
-            .with_crls(unrelated_crls.clone())
-            .only_check_end_entity_revocation()
-            .allow_unknown_revocation_status();
-        let allow_missing_client_crl_server_config = Arc::new(
-            make_server_config_with_client_verifier(*kt, ee_verifier_builder, &provider),
-        );
+        let ee_verifier_builder =
+            webpki_client_verifier_builder(expect.key_type.client_root_store(), &provider)
+                .with_crls(unrelated_crls.clone())
+                .only_check_end_entity_revocation()
+                .allow_unknown_revocation_status();
+        let allow_missing_client_crl_server_config =
+            Arc::new(make_server_config_with_client_verifier(
+                expect.key_type,
+                ee_verifier_builder,
+                &provider,
+            ));
 
-        for version_provider in ALL_VERSIONS {
-            // Connecting to the server with a CRL that indicates the client certificate is revoked
-            // should fail with the expected error.
-            let client_config = Arc::new(make_client_config_with_auth(*kt, &version_provider));
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&client_config, &revoked_server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Server(Error::InvalidCertificate(
-                    CertificateError::Revoked
-                )))
-            );
-            // Connecting to the server missing CRL information for the client certificate should
-            // fail with the expected unknown revocation status error.
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&client_config, &missing_client_crl_server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let res = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                res,
-                Err(ErrorFromPeer::Server(Error::InvalidCertificate(
-                    CertificateError::UnknownRevocationStatus
-                )))
-            );
-            // Connecting to the server missing CRL information for the client should not error
-            // if the server's verifier allows unknown revocation status.
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&client_config, &allow_missing_client_crl_server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            )
-            .unwrap();
-        }
+        // Connecting to the server with a CRL that indicates the client certificate is revoked
+        // should fail with the expected error.
+        let (mut client, mut server) =
+            make_pair_for_arc_configs(&client_config, &revoked_server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            err,
+            Err(ErrorFromPeer::Server(Error::InvalidCertificate(
+                CertificateError::Revoked
+            )))
+        );
+        // Connecting to the server missing CRL information for the client certificate should
+        // fail with the expected unknown revocation status error.
+        let (mut client, mut server) =
+            make_pair_for_arc_configs(&client_config, &missing_client_crl_server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let res = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            res,
+            Err(ErrorFromPeer::Server(Error::InvalidCertificate(
+                CertificateError::UnknownRevocationStatus
+            )))
+        );
+        // Connecting to the server missing CRL information for the client should not error
+        // if the server's verifier allows unknown revocation status.
+        let (mut client, mut server) =
+            make_pair_for_arc_configs(&client_config, &allow_missing_client_crl_server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        )
+        .unwrap();
     }
 }
 
 #[test]
 fn client_mandatory_auth_intermediate_revocation_works() {
     let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
+    for (client_config, _, expect) in MultiTest::new(provider.clone()).require_client_auth() {
         // Create a server configuration that includes a CRL that specifies the intermediate certificate
         // is revoked. We check the full chain for revocation status (default), and allow unknown
         // revocation status so the EE's unknown revocation status isn't an error.
-        let crls = vec![kt.intermediate_crl()];
+        let crls = vec![expect.key_type.intermediate_crl()];
         let full_chain_verifier_builder =
-            webpki_client_verifier_builder(kt.client_root_store(), &provider)
+            webpki_client_verifier_builder(expect.key_type.client_root_store(), &provider)
                 .with_crls(crls.clone())
                 .allow_unknown_revocation_status();
         let full_chain_server_config = Arc::new(make_server_config_with_client_verifier(
-            *kt,
+            expect.key_type,
             full_chain_verifier_builder,
             &provider,
         ));
@@ -356,82 +323,76 @@ fn client_mandatory_auth_intermediate_revocation_works() {
         // Also create a server configuration that uses the same CRL, but that only checks the EE
         // cert revocation status.
         let ee_only_verifier_builder =
-            webpki_client_verifier_builder(kt.client_root_store(), &provider)
+            webpki_client_verifier_builder(expect.key_type.client_root_store(), &provider)
                 .with_crls(crls)
                 .only_check_end_entity_revocation()
                 .allow_unknown_revocation_status();
         let ee_server_config = Arc::new(make_server_config_with_client_verifier(
-            *kt,
+            expect.key_type,
             ee_only_verifier_builder,
             &provider,
         ));
 
-        for version_provider in ALL_VERSIONS {
-            // When checking the full chain, we expect an error - the intermediate is revoked.
-            let client_config = Arc::new(make_client_config_with_auth(*kt, &version_provider));
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&client_config, &full_chain_server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Server(Error::InvalidCertificate(
-                    CertificateError::Revoked
-                )))
-            );
-            // However, when checking just the EE cert we expect no error - the intermediate's
-            // revocation status should not be checked.
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&client_config, &ee_server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            )
-            .unwrap();
-        }
+        // When checking the full chain, we expect an error - the intermediate is revoked.
+        let (mut client, mut server) =
+            make_pair_for_arc_configs(&client_config, &full_chain_server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            err,
+            Err(ErrorFromPeer::Server(Error::InvalidCertificate(
+                CertificateError::Revoked
+            )))
+        );
+        // However, when checking just the EE cert we expect no error - the intermediate's
+        // revocation status should not be checked.
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &ee_server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        )
+        .unwrap();
     }
 }
 
 #[test]
 fn client_optional_auth_client_revocation_works() {
     let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
+    for (client_config, _, expect) in MultiTest::new(provider.clone()).require_client_auth() {
         // Create a server configuration that includes a CRL that specifies the client certificate
         // is revoked.
-        let crls = vec![kt.client_crl()];
+        let crls = vec![expect.key_type.client_crl()];
         let server_config = Arc::new(make_server_config_with_optional_client_auth(
-            *kt, crls, &provider,
+            expect.key_type,
+            crls,
+            &provider,
         ));
 
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config_with_auth(*kt, &version_provider);
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            // Because the client certificate is revoked, the handshake should fail.
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Server(Error::InvalidCertificate(
-                    CertificateError::Revoked
-                )))
-            );
-        }
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        // Because the client certificate is revoked, the handshake should fail.
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            err,
+            Err(ErrorFromPeer::Server(Error::InvalidCertificate(
+                CertificateError::Revoked
+            )))
+        );
     }
 }

--- a/rustls-test/tests/api/client_cert_verifier.rs
+++ b/rustls-test/tests/api/client_cert_verifier.rs
@@ -180,7 +180,7 @@ fn client_verifier_fails_properly() {
 #[test]
 fn server_allow_any_anonymous_or_authenticated_client() {
     let provider = Arc::new(provider::DEFAULT_PROVIDER);
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     for client_cert_chain in [None, Some(kt.client_identity())] {
         let client_auth = Arc::new(
             webpki_client_verifier_builder(kt.client_root_store(), &provider)

--- a/rustls-test/tests/api/compress.rs
+++ b/rustls-test/tests/api/compress.rs
@@ -32,9 +32,9 @@ fn test_server_uses_cached_compressed_certificates() {
     static COMPRESS_COUNT: AtomicUsize = AtomicUsize::new(0);
 
     let provider = provider::DEFAULT_PROVIDER;
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.cert_compressors = vec![&CountingCompressor];
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.resumption = Resumption::disabled();
 
     let server_config = Arc::new(server_config);
@@ -78,9 +78,9 @@ fn test_server_uses_cached_compressed_certificates() {
 #[test]
 fn test_server_uses_uncompressed_certificate_if_compression_fails() {
     let provider = provider::DEFAULT_PROVIDER;
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.cert_compressors = vec![&FailingCompressor];
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.cert_decompressors = vec![&NeverDecompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -98,9 +98,9 @@ fn test_server_uses_uncompressed_certificate_if_compression_fails() {
 fn test_client_uses_uncompressed_certificate_if_compression_fails() {
     let provider = provider::DEFAULT_PROVIDER;
     let mut server_config =
-        make_server_config_with_mandatory_client_auth(KeyType::Rsa2048, &provider);
+        make_server_config_with_mandatory_client_auth(KeyType::default(), &provider);
     server_config.cert_decompressors = vec![&NeverDecompressor];
-    let mut client_config = make_client_config_with_auth(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config_with_auth(KeyType::default(), &provider);
     client_config.cert_compressors = vec![&FailingCompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -155,10 +155,10 @@ fn test_server_can_opt_out_of_compression_cache() {
     static COMPRESS_COUNT: AtomicUsize = AtomicUsize::new(0);
 
     let provider = provider::DEFAULT_PROVIDER;
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.cert_compressors = vec![&AlwaysInteractiveCompressor];
     server_config.cert_compression_cache = Arc::new(rustls::compress::CompressionCache::Disabled);
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.resumption = Resumption::disabled();
 
     let server_config = Arc::new(server_config);
@@ -203,9 +203,9 @@ fn test_server_can_opt_out_of_compression_cache() {
 #[test]
 fn test_cert_decompression_by_client_produces_invalid_cert_payload() {
     let provider = provider::DEFAULT_PROVIDER;
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.cert_compressors = vec![&IdentityCompressor];
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.cert_decompressors = vec![&GarbageDecompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -233,9 +233,9 @@ fn test_cert_decompression_by_client_produces_invalid_cert_payload() {
 fn test_cert_decompression_by_server_produces_invalid_cert_payload() {
     let provider = provider::DEFAULT_PROVIDER;
     let mut server_config =
-        make_server_config_with_mandatory_client_auth(KeyType::Rsa2048, &provider);
+        make_server_config_with_mandatory_client_auth(KeyType::default(), &provider);
     server_config.cert_decompressors = vec![&GarbageDecompressor];
-    let mut client_config = make_client_config_with_auth(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config_with_auth(KeyType::default(), &provider);
     client_config.cert_compressors = vec![&IdentityCompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -322,9 +322,9 @@ fn test_cert_decompression_by_server_rejects_trailing_data() {
 fn test_cert_decompression_by_server_fails() {
     let provider = provider::DEFAULT_PROVIDER;
     let mut server_config =
-        make_server_config_with_mandatory_client_auth(KeyType::Rsa2048, &provider);
+        make_server_config_with_mandatory_client_auth(KeyType::default(), &provider);
     server_config.cert_decompressors = vec![&FailingDecompressor];
-    let mut client_config = make_client_config_with_auth(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config_with_auth(KeyType::default(), &provider);
     client_config.cert_compressors = vec![&IdentityCompressor];
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -352,19 +352,20 @@ fn test_cert_decompression_by_server_fails() {
 #[test]
 fn test_cert_decompression_by_server_would_result_in_excessively_large_cert() {
     let provider = provider::DEFAULT_PROVIDER;
-    let server_config = make_server_config_with_mandatory_client_auth(KeyType::Rsa2048, &provider);
+    let server_config =
+        make_server_config_with_mandatory_client_auth(KeyType::default(), &provider);
 
     let big_cert = CertificateDer::from(vec![0u8; 0xffff]);
     let key = provider::DEFAULT_PROVIDER
         .key_provider
-        .load_private_key(KeyType::Rsa2048.client_key())
+        .load_private_key(KeyType::default().client_key())
         .unwrap();
     let big_cert_and_key = Credentials::new_unchecked(
         Arc::new(Identity::from_cert_chain(vec![big_cert]).unwrap()),
         key,
     );
     let client_config = ClientConfig::builder(Arc::new(provider))
-        .add_root_certs(KeyType::Rsa2048)
+        .add_root_certs(KeyType::default())
         .with_client_credential_resolver(Arc::new(SingleCredential::from(big_cert_and_key)))
         .unwrap();
 

--- a/rustls-test/tests/api/crypto.rs
+++ b/rustls-test/tests/api/crypto.rs
@@ -26,7 +26,7 @@ fn key_log_for_tls12() {
     let server_key_log = Arc::new(KeyLogToVec::new("server"));
 
     let provider = provider::DEFAULT_TLS12_PROVIDER;
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let mut client_config = make_client_config(kt, &provider);
     client_config.key_log = client_key_log.clone();
     let client_config = Arc::new(client_config);
@@ -76,7 +76,7 @@ fn key_log_for_tls13() {
     let server_key_log = Arc::new(KeyLogToVec::new("server"));
 
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let mut client_config = make_client_config(kt, &provider);
     client_config.key_log = client_key_log.clone();
     let client_config = Arc::new(client_config);
@@ -355,7 +355,7 @@ fn test_secret_extract_produces_correct_variant() {
 /// the handshake is done.
 #[test]
 fn test_secret_extraction_disabled_or_too_early() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     let provider = Arc::new(CryptoProvider {
@@ -415,7 +415,7 @@ fn test_secret_extraction_disabled_or_too_early() {
 
 #[test]
 fn test_refresh_traffic_keys_during_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert_eq!(
         client
             .refresh_traffic_keys()
@@ -432,7 +432,7 @@ fn test_refresh_traffic_keys_during_handshake() {
 
 #[test]
 fn test_refresh_traffic_keys() {
-    let (mut client, mut server) = make_pair(KeyType::Ed25519, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -508,8 +508,8 @@ fn test_automatic_refresh_traffic_keys() {
     const KEY_UPDATE_SIZE: usize = encrypted_size(5);
     let provider = aes_128_gcm_with_1024_confidentiality_limit(provider::DEFAULT_PROVIDER);
 
-    let client_config = ClientConfig::builder(provider.clone()).finish(KeyType::Ed25519);
-    let server_config = ServerConfig::builder(provider).finish(KeyType::Ed25519);
+    let client_config = ClientConfig::builder(provider.clone()).finish(KeyType::default());
+    let server_config = ServerConfig::builder(provider).finish(KeyType::default());
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     let mut client_input = VecInput::default();
@@ -578,8 +578,9 @@ fn tls12_connection_fails_after_key_reaches_confidentiality_limit() {
         )))
     });
 
-    let client_config = ClientConfig::builder(provider.clone()).finish(KeyType::Ed25519);
-    let server_config = ServerConfig::builder(provider).finish(KeyType::Ed25519);
+    let kt = KeyType::EcdsaP256;
+    let client_config = ClientConfig::builder(provider.clone()).finish(kt);
+    let server_config = ServerConfig::builder(provider).finish(kt);
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     let mut client_input = VecInput::default();

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -32,12 +32,12 @@ use super::{ALL_VERSIONS, provider};
 #[test]
 fn buffered_client_data_sent() {
     let server_config = Arc::new(make_server_config(
-        KeyType::Rsa2048,
+        KeyType::default(),
         &provider::DEFAULT_PROVIDER,
     ));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(KeyType::default(), &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
         let mut client_input = VecInput::default();
@@ -64,12 +64,12 @@ fn buffered_client_data_sent() {
 #[test]
 fn buffered_server_data_sent() {
     let server_config = Arc::new(make_server_config(
-        KeyType::Rsa2048,
+        KeyType::default(),
         &provider::DEFAULT_PROVIDER,
     ));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(KeyType::default(), &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
         let mut client_input = VecInput::default();
@@ -96,12 +96,12 @@ fn buffered_server_data_sent() {
 #[test]
 fn buffered_both_data_sent() {
     let server_config = Arc::new(make_server_config(
-        KeyType::Rsa2048,
+        KeyType::default(),
         &provider::DEFAULT_PROVIDER,
     ));
 
     for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+        let client_config = make_client_config(KeyType::default(), &version_provider);
         let (mut client, mut server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
         let mut client_input = VecInput::default();
@@ -145,7 +145,7 @@ fn buffered_both_data_sent() {
 
 #[test]
 fn server_respects_buffer_limit_pre_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -182,7 +182,7 @@ fn server_respects_buffer_limit_pre_handshake() {
 
 #[test]
 fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -215,7 +215,7 @@ fn server_respects_buffer_limit_pre_handshake_with_vectored_write() {
 
 #[test]
 fn server_respects_buffer_limit_post_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -253,7 +253,7 @@ fn server_respects_buffer_limit_post_handshake() {
 
 #[test]
 fn client_respects_buffer_limit_pre_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -290,7 +290,7 @@ fn client_respects_buffer_limit_pre_handshake() {
 
 #[test]
 fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -323,7 +323,7 @@ fn client_respects_buffer_limit_pre_handshake_with_vectored_write() {
 
 #[test]
 fn client_respects_buffer_limit_post_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -361,7 +361,7 @@ fn client_respects_buffer_limit_post_handshake() {
 #[test]
 fn client_detects_broken_write_vectored_impl() {
     // see https://github.com/rustls/rustls/issues/2316
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let err = client
         .write_tls(&mut BrokenWriteVectored)
         .unwrap_err();
@@ -389,7 +389,7 @@ fn client_detects_broken_write_vectored_impl() {
 
 #[test]
 fn buf_read() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -431,35 +431,35 @@ fn buf_read() {
 
 #[test]
 fn server_read_returns_wouldblock_when_no_data() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert!(matches!(server.reader().read(&mut [0u8; 1]),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn client_read_returns_wouldblock_when_no_data() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert!(matches!(client.reader().read(&mut [0u8; 1]),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn server_fill_buf_returns_wouldblock_when_no_data() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert!(matches!(server.reader().fill_buf(),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn client_fill_buf_returns_wouldblock_when_no_data() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert!(matches!(client.reader().fill_buf(),
                      Err(err) if err.kind() == io::ErrorKind::WouldBlock));
 }
 
 #[test]
 fn new_server_returns_initial_io_state() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut server_input = VecInput::default();
     let io_state = server
         .process_new_packets(&mut server_input)
@@ -472,7 +472,7 @@ fn new_server_returns_initial_io_state() {
 
 #[test]
 fn new_client_returns_initial_io_state() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let io_state = client
         .process_new_packets(&mut client_input)
@@ -485,7 +485,7 @@ fn new_client_returns_initial_io_state() {
 
 #[test]
 fn client_complete_io_for_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -503,7 +503,7 @@ fn client_complete_io_for_handshake() {
 
 #[test]
 fn buffered_client_complete_io_for_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -521,7 +521,7 @@ fn buffered_client_complete_io_for_handshake() {
 
 #[test]
 fn client_complete_io_for_handshake_eof() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut input = io::Cursor::new(Vec::new());
 
@@ -569,7 +569,7 @@ fn client_complete_io_for_write() {
 
 #[test]
 fn client_complete_io_with_nonblocking_io() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
 
     // absolutely no progress writing ClientHello
@@ -585,7 +585,7 @@ fn client_complete_io_with_nonblocking_io() {
     );
 
     // a little progress writing ClientHello
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     assert_eq!(
         complete_io(
@@ -601,7 +601,7 @@ fn client_complete_io_with_nonblocking_io() {
     );
 
     // complete writing ClientHello
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     assert_eq!(
         complete_io(
@@ -618,7 +618,7 @@ fn client_complete_io_with_nonblocking_io() {
     );
 
     // complete writing ClientHello, partial read of ServerHello
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let (rd, wr) = dbg!(complete_io(
         &mut TestNonBlockIo {
@@ -633,7 +633,7 @@ fn client_complete_io_with_nonblocking_io() {
     assert!(wr > 1);
 
     // data phase:
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -782,7 +782,7 @@ fn server_complete_io_for_handshake() {
 
 #[test]
 fn server_complete_io_for_handshake_eof() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut server_input = VecInput::default();
     let mut input = io::Cursor::new(Vec::new());
 
@@ -1077,7 +1077,7 @@ fn test_server_stream_read(stream_kind: StreamKind, read_kind: ReadKind) {
 
 #[test]
 fn test_client_write_and_vectored_write_equivalence() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -1111,7 +1111,7 @@ fn test_client_write_and_vectored_write_equivalence() {
 
 #[test]
 fn test_write_vectored_degenerate_cases() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -1186,7 +1186,7 @@ impl Write for FailsWrites {
 
 #[test]
 fn stream_write_reports_underlying_io_error_before_plaintext_processed() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -1213,7 +1213,7 @@ fn stream_write_reports_underlying_io_error_before_plaintext_processed() {
 
 #[test]
 fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -1334,7 +1334,7 @@ fn server_streamowned_handshake_error() {
 
 #[test]
 fn vectored_write_for_server_appdata() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -1366,7 +1366,7 @@ fn vectored_write_for_server_appdata() {
 
 #[test]
 fn vectored_write_for_client_appdata() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -1523,7 +1523,7 @@ fn vectored_write_for_server_handshake_no_half_rtt_by_default() {
 
 #[test]
 fn vectored_write_for_client_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -1564,7 +1564,7 @@ fn vectored_write_for_client_handshake() {
 
 #[test]
 fn vectored_write_with_slow_client() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
 
@@ -1607,7 +1607,7 @@ fn test_client_mtu_reduction() {
         client_config.max_fragment_size = Some(64);
         let (mut client, mut server) = make_pair_for_configs(
             client_config,
-            make_server_config(KeyType::Rsa2048, &provider),
+            make_server_config(KeyType::default(), &provider),
         );
 
         {
@@ -1627,11 +1627,11 @@ fn test_client_mtu_reduction() {
 #[test]
 fn test_server_mtu_reduction() {
     let provider = provider::DEFAULT_PROVIDER;
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.max_fragment_size = Some(64);
     server_config.send_half_rtt_data = true;
     let (mut client, mut server) = make_pair_for_configs(
-        make_client_config(KeyType::Rsa2048, &provider),
+        make_client_config(KeyType::default(), &provider),
         server_config,
     );
     let mut client_input = VecInput::default();
@@ -1686,7 +1686,7 @@ fn test_server_mtu_reduction() {
 
 fn check_client_max_fragment_size(size: usize) -> Option<Error> {
     let provider = provider::DEFAULT_PROVIDER;
-    let mut client_config = make_client_config(KeyType::Ed25519, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.max_fragment_size = Some(size);
     Arc::new(client_config)
         .connect(server_name("localhost"))
@@ -1763,7 +1763,7 @@ fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
 #[test]
 fn test_full_server_handshake() {
     let provider = provider::DEFAULT_PROVIDER;
-    let client_config = Arc::new(make_client_config(KeyType::Ed25519, &provider));
+    let client_config = Arc::new(make_client_config(KeyType::default(), &provider));
     let mut client = client_config
         .connect(server_name("localhost"))
         .build()
@@ -1788,7 +1788,7 @@ fn test_full_server_handshake() {
     };
     let mut server = accepted
         .choose_config(
-            Arc::new(make_server_config(KeyType::Ed25519, &provider)),
+            Arc::new(make_server_config(KeyType::default(), &provider)),
             &mut server_output,
         )
         .unwrap();
@@ -1825,7 +1825,7 @@ fn test_full_server_handshake() {
 #[test]
 fn test_server_handshake() {
     let provider = provider::DEFAULT_PROVIDER;
-    let client_config = Arc::new(make_client_config(KeyType::Ed25519, &provider));
+    let client_config = Arc::new(make_client_config(KeyType::default(), &provider));
     let mut client = client_config
         .connect(server_name("localhost"))
         .build()
@@ -1833,7 +1833,7 @@ fn test_server_handshake() {
     let mut buf = Vec::new();
     client.write_tls(&mut buf).unwrap();
 
-    let server_config = Arc::new(make_server_config(KeyType::Ed25519, &provider));
+    let server_config = Arc::new(make_server_config(KeyType::default(), &provider));
     let receive = ServerHandshake::start();
     let mut acceptor_input = VecInput::default();
     acceptor_input
@@ -1957,7 +1957,7 @@ fn test_server_handshake() {
 fn test_acceptor_continues_tls13_hrr_with_compatibility_ccs() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let client_config = Arc::new(make_client_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::SECP384R1, provider::kx_group::X25519],
         &provider,
     ));
@@ -1972,7 +1972,7 @@ fn test_acceptor_continues_tls13_hrr_with_compatibility_ccs() {
         .unwrap();
 
     let server_config = Arc::new(make_server_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::X25519],
         &provider,
     ));
@@ -2024,7 +2024,7 @@ fn test_acceptor_continues_tls13_hrr_with_compatibility_ccs() {
 #[test]
 fn test_acceptor_rejected_handshake() {
     let client_config =
-        ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into()).finish(KeyType::Ed25519);
+        ClientConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into()).finish(KeyType::default());
     let mut client = Arc::new(client_config)
         .connect(server_name("localhost"))
         .build()
@@ -2033,7 +2033,7 @@ fn test_acceptor_rejected_handshake() {
     client.write_tls(&mut buf).unwrap();
 
     let server_config =
-        ServerConfig::builder(provider::DEFAULT_TLS12_PROVIDER.into()).finish(KeyType::Ed25519);
+        ServerConfig::builder(provider::DEFAULT_TLS12_PROVIDER.into()).finish(KeyType::default());
     let receive = ServerHandshake::start();
     let mut acceptor_input = VecInput::default();
     acceptor_input
@@ -2075,7 +2075,7 @@ fn test_received_plaintext_backpressure() {
 
 fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
     dbg!(plaintext_limit);
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_PROVIDER;
 
     let server_config = Arc::new(
@@ -2182,20 +2182,20 @@ fn test_plaintext_buffer_limit(limit: Option<usize>, plaintext_limit: usize) {
 
 #[test]
 fn server_flush_does_nothing() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert!(matches!(server.writer().flush(), Ok(())));
 }
 
 #[test]
 fn client_flush_does_nothing() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert!(matches!(client.writer().flush(), Ok(())));
 }
 
 #[test]
 fn server_close_notify() {
     let provider = provider::DEFAULT_PROVIDER;
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
 
     for version_provider in ALL_VERSIONS {
@@ -2246,7 +2246,7 @@ fn server_close_notify() {
 #[test]
 fn client_close_notify() {
     let provider = provider::DEFAULT_PROVIDER;
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
 
     for version_provider in ALL_VERSIONS {
@@ -2297,7 +2297,7 @@ fn client_close_notify() {
 #[test]
 fn server_closes_uncleanly() {
     let provider = provider::DEFAULT_PROVIDER;
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let server_config = Arc::new(make_server_config(kt, &provider));
 
     for version_provider in ALL_VERSIONS {
@@ -2354,7 +2354,7 @@ fn server_closes_uncleanly() {
 #[test]
 fn client_closes_uncleanly() {
     let provider = provider::DEFAULT_PROVIDER;
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let server_config = Arc::new(make_server_config(kt, &provider));
 
     for version_provider in ALL_VERSIONS {
@@ -2443,7 +2443,7 @@ fn test_complete_io_errors_if_close_notify_received_too_early() {
 
 #[test]
 fn test_complete_io_with_no_io_needed() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -2488,7 +2488,7 @@ fn test_complete_io_with_no_io_needed() {
 
 #[test]
 fn test_junk_after_close_notify_received() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -2540,7 +2540,7 @@ fn test_junk_after_close_notify_received() {
 
 #[test]
 fn test_data_after_close_notify_is_ignored() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -2582,7 +2582,7 @@ fn test_data_after_close_notify_is_ignored() {
 #[test]
 fn test_close_notify_sent_prior_to_handshake_complete() {
     let mut server = ServerConnection::new(Arc::new(make_server_config(
-        KeyType::EcdsaP256,
+        KeyType::default(),
         &provider::DEFAULT_PROVIDER,
     )))
     .unwrap();
@@ -2612,7 +2612,7 @@ fn test_close_notify_sent_prior_to_handshake_complete() {
 
 #[test]
 fn test_subsequent_close_notify_ignored() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut server_input = VecInput::default();
     client.send_close_notify();
     assert!(transfer(&mut client, &mut server_input) > 0);
@@ -2624,7 +2624,7 @@ fn test_subsequent_close_notify_ignored() {
 
 #[test]
 fn test_second_close_notify_after_handshake() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(
@@ -2646,7 +2646,7 @@ fn test_second_close_notify_after_handshake() {
 
 #[test]
 fn test_read_tls_artificial_eof_after_close_notify() {
-    let (mut client, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
     do_handshake(

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -27,19 +27,12 @@ use rustls_test::{
 };
 use rustls_util::{Stream, StreamOwned, complete_io};
 
-use super::{ALL_VERSIONS, provider};
+use super::provider;
 
 #[test]
 fn buffered_client_data_sent() {
-    let server_config = Arc::new(make_server_config(
-        KeyType::default(),
-        &provider::DEFAULT_PROVIDER,
-    ));
-
-    for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(KeyType::default(), &version_provider);
-        let (mut client, mut server) =
-            make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
 
@@ -63,15 +56,8 @@ fn buffered_client_data_sent() {
 
 #[test]
 fn buffered_server_data_sent() {
-    let server_config = Arc::new(make_server_config(
-        KeyType::default(),
-        &provider::DEFAULT_PROVIDER,
-    ));
-
-    for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(KeyType::default(), &version_provider);
-        let (mut client, mut server) =
-            make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
 
@@ -95,15 +81,8 @@ fn buffered_server_data_sent() {
 
 #[test]
 fn buffered_both_data_sent() {
-    let server_config = Arc::new(make_server_config(
-        KeyType::default(),
-        &provider::DEFAULT_PROVIDER,
-    ));
-
-    for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(KeyType::default(), &version_provider);
-        let (mut client, mut server) =
-            make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
 
@@ -1718,44 +1697,43 @@ fn bad_client_max_fragment_sizes() {
 #[test]
 fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
     // general exercising of msgs::fragmenter and msgs::deframer
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        for version_provider in ALL_VERSIONS {
-            // no hidden significance to these numbers
-            for frag_size in [37, 61, 101, 257] {
-                println!("test kt={kt:?} version={version_provider:?} frag={frag_size:?}");
-                let mut client_config = make_client_config(*kt, &version_provider);
-                client_config.max_fragment_size = Some(frag_size);
-                let mut server_config = make_server_config(*kt, &provider);
-                server_config.max_fragment_size = Some(frag_size);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let mut client_config = Arc::unwrap_or_clone(client_config);
+        let mut server_config = Arc::unwrap_or_clone(server_config);
 
-                let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
-                let mut client_input = VecInput::default();
-                let mut server_input = VecInput::default();
-                do_handshake(
-                    &mut client_input,
-                    &mut client,
-                    &mut server_input,
-                    &mut server,
-                );
+        // no hidden significance to these numbers
+        for frag_size in [37, 61, 101, 257] {
+            println!("test configs={client_config:?}/{server_config:?} frag={frag_size:?}");
+            client_config.max_fragment_size = Some(frag_size);
+            server_config.max_fragment_size = Some(frag_size);
 
-                // check server -> client data flow
-                let pattern = (0x00..=0xffu8).collect::<Vec<u8>>();
-                assert_eq!(pattern.len(), server.writer().write(&pattern).unwrap());
-                transfer(&mut server, &mut client_input);
-                client
-                    .process_new_packets(&mut client_input)
-                    .unwrap();
-                check_read(&mut client.reader(), &pattern);
+            let (mut client, mut server) =
+                make_pair_for_configs(client_config.clone(), server_config.clone());
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client,
+                &mut server_input,
+                &mut server,
+            );
 
-                // and client -> server
-                assert_eq!(pattern.len(), client.writer().write(&pattern).unwrap());
-                transfer(&mut client, &mut server_input);
-                server
-                    .process_new_packets(&mut server_input)
-                    .unwrap();
-                check_read(&mut server.reader(), &pattern);
-            }
+            // check server -> client data flow
+            let pattern = (0x00..=0xffu8).collect::<Vec<u8>>();
+            assert_eq!(pattern.len(), server.writer().write(&pattern).unwrap());
+            transfer(&mut server, &mut client_input);
+            client
+                .process_new_packets(&mut client_input)
+                .unwrap();
+            check_read(&mut client.reader(), &pattern);
+
+            // and client -> server
+            assert_eq!(pattern.len(), client.writer().write(&pattern).unwrap());
+            transfer(&mut client, &mut server_input);
+            server
+                .process_new_packets(&mut server_input)
+                .unwrap();
+            check_read(&mut server.reader(), &pattern);
         }
     }
 }
@@ -2186,14 +2164,8 @@ fn client_flush_does_nothing() {
 
 #[test]
 fn server_close_notify() {
-    let provider = provider::DEFAULT_PROVIDER;
-    let kt = KeyType::default();
-    let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
-
-    for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config_with_auth(kt, &version_provider);
-        let (mut client, mut server) =
-            make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
         do_handshake(
@@ -2237,14 +2209,8 @@ fn server_close_notify() {
 
 #[test]
 fn client_close_notify() {
-    let provider = provider::DEFAULT_PROVIDER;
-    let kt = KeyType::default();
-    let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt, &provider));
-
-    for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config_with_auth(kt, &version_provider);
-        let (mut client, mut server) =
-            make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
         do_handshake(
@@ -2288,14 +2254,8 @@ fn client_close_notify() {
 
 #[test]
 fn server_closes_uncleanly() {
-    let provider = provider::DEFAULT_PROVIDER;
-    let kt = KeyType::default();
-    let server_config = Arc::new(make_server_config(kt, &provider));
-
-    for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(kt, &version_provider);
-        let (mut client, mut server) =
-            make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
         do_handshake(
@@ -2345,14 +2305,8 @@ fn server_closes_uncleanly() {
 
 #[test]
 fn client_closes_uncleanly() {
-    let provider = provider::DEFAULT_PROVIDER;
-    let kt = KeyType::default();
-    let server_config = Arc::new(make_server_config(kt, &provider));
-
-    for version_provider in ALL_VERSIONS {
-        let client_config = make_client_config(kt, &version_provider);
-        let (mut client, mut server) =
-            make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
         do_handshake(

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 
 use pki_types::DnsName;
 use rustls::crypto::CryptoProvider;
-use rustls::crypto::kx::NamedGroup;
 use rustls::enums::{ContentType, HandshakeType, ProtocolVersion};
 use rustls::error::{AlertDescription, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use rustls::server::ServerHandshake;
@@ -18,12 +17,13 @@ use rustls::{
     ClientConfig, Connection, HandshakeKind, ServerConfig, ServerConnection, SliceInput, VecInput,
 };
 use rustls_test::{
-    ClientConfigExt, KeyType, OtherSession, ServerConfigExt, TestNonBlockIo, check_fill_buf,
-    check_fill_buf_err, check_read, check_read_and_close, check_read_err, do_handshake, encoding,
-    make_client_config, make_client_config_with_auth, make_client_config_with_kx_groups,
-    make_disjoint_suite_configs, make_pair, make_pair_for_arc_configs, make_pair_for_configs,
-    make_server_config, make_server_config_with_kx_groups,
-    make_server_config_with_mandatory_client_auth, server_name, transfer, transfer_eof,
+    ClientConfigExt, KeyType, MultiTest, OtherSession, ServerConfigExt, TestNonBlockIo,
+    check_fill_buf, check_fill_buf_err, check_read, check_read_and_close, check_read_err,
+    do_handshake, encoding, make_client_config, make_client_config_with_auth,
+    make_client_config_with_kx_groups, make_disjoint_suite_configs, make_pair,
+    make_pair_for_arc_configs, make_pair_for_configs, make_server_config,
+    make_server_config_with_kx_groups, make_server_config_with_mandatory_client_auth, server_name,
+    transfer, transfer_eof,
 };
 use rustls_util::{Stream, StreamOwned, complete_io};
 
@@ -1824,133 +1824,125 @@ fn test_full_server_handshake() {
 
 #[test]
 fn test_server_handshake() {
-    let provider = provider::DEFAULT_PROVIDER;
-    let client_config = Arc::new(make_client_config(KeyType::default(), &provider));
-    let mut client = client_config
-        .connect(server_name("localhost"))
-        .build()
-        .unwrap();
-    let mut buf = Vec::new();
-    client.write_tls(&mut buf).unwrap();
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let mut client = client_config
+            .connect(server_name("localhost"))
+            .build()
+            .unwrap();
+        let mut buf = Vec::new();
+        client.write_tls(&mut buf).unwrap();
 
-    let server_config = Arc::new(make_server_config(KeyType::default(), &provider));
-    let receive = ServerHandshake::start();
-    let mut acceptor_input = VecInput::default();
-    acceptor_input
-        .read(&mut buf.as_slice())
-        .unwrap();
-    let mut output = vec![];
-    let ServerHandshake::Accepted(accepted) = receive
-        .process(&mut acceptor_input, &mut output)
-        .unwrap()
-    else {
-        panic!("unexpected state");
-    };
-    let ch = accepted.client_hello();
-    assert_eq!(
-        ch.server_name(),
-        Some(&DnsName::try_from("localhost").unwrap())
-    );
-    assert_eq!(
-        ch.named_groups().unwrap(),
-        provider::DEFAULT_PROVIDER
-            .kx_groups
-            .iter()
-            .map(|kx| kx.name())
-            .collect::<Vec<NamedGroup>>()
-    );
+        let receive = ServerHandshake::start();
+        let mut acceptor_input = VecInput::default();
+        acceptor_input
+            .read(&mut buf.as_slice())
+            .unwrap();
+        let mut output = vec![];
+        let ServerHandshake::Accepted(accepted) = receive
+            .process(&mut acceptor_input, &mut output)
+            .unwrap()
+        else {
+            panic!("unexpected state");
+        };
+        let ch = accepted.client_hello();
+        assert_eq!(
+            ch.server_name(),
+            Some(&DnsName::try_from("localhost").unwrap())
+        );
+        assert!(!ch.named_groups().unwrap().is_empty());
 
-    let _server = accepted
-        .choose_config(server_config, &mut output)
-        .unwrap();
-    assert!(!output.is_empty());
+        let _server = accepted
+            .choose_config(server_config, &mut output)
+            .unwrap();
+        assert!(!output.is_empty());
 
-    // (Reusing `accepted` is not possible)
+        // (Reusing `accepted` is not possible)
 
-    let receive = ServerHandshake::start();
-    let mut acceptor_input = VecInput::default();
-    let mut output = vec![];
-    let ServerHandshake::NeedsInput(receive) = receive
-        .process(&mut acceptor_input, &mut output)
-        .unwrap()
-    else {
-        panic!("unexpected state");
-    };
-    assert!(output.is_empty());
+        let receive = ServerHandshake::start();
+        let mut acceptor_input = VecInput::default();
+        let mut output = vec![];
+        let ServerHandshake::NeedsInput(receive) = receive
+            .process(&mut acceptor_input, &mut output)
+            .unwrap()
+        else {
+            panic!("unexpected state");
+        };
+        assert!(output.is_empty());
 
-    acceptor_input
-        .read(&mut &buf[..3])
-        .unwrap(); // incomplete message
-    let ServerHandshake::NeedsInput(receive) = receive
-        .process(&mut acceptor_input, &mut output)
-        .unwrap()
-    else {
-        panic!("unexpected state");
-    };
-    assert!(output.is_empty());
+        acceptor_input
+            .read(&mut &buf[..3])
+            .unwrap(); // incomplete message
+        let ServerHandshake::NeedsInput(receive) = receive
+            .process(&mut acceptor_input, &mut output)
+            .unwrap()
+        else {
+            panic!("unexpected state");
+        };
+        assert!(output.is_empty());
 
-    acceptor_input
-        .read(&mut [0x80, 0x00].as_ref())
-        .unwrap(); // invalid message (len = 32k bytes)
-    let error = receive
-        .process(&mut acceptor_input, &mut output)
-        .unwrap_err();
-    assert_eq!(
-        error,
-        Error::InvalidMessage(InvalidMessage::MessageTooLarge)
-    );
-    let alert_content = output
-        .pop()
-        .expect("should've sent an alert");
-    let expected = encoding::alert(AlertDescription::DecodeError, &[]);
-    assert_eq!(alert_content, expected);
+        acceptor_input
+            .read(&mut [0x80, 0x00].as_ref())
+            .unwrap(); // invalid message (len = 32k bytes)
+        let error = receive
+            .process(&mut acceptor_input, &mut output)
+            .unwrap_err();
+        assert_eq!(
+            error,
+            Error::InvalidMessage(InvalidMessage::MessageTooLarge)
+        );
+        let alert_content = output
+            .pop()
+            .expect("should've sent an alert");
+        let expected = encoding::alert(AlertDescription::DecodeError, &[]);
+        assert_eq!(alert_content, expected);
 
-    let receive = ServerHandshake::start();
-    let mut acceptor_input = VecInput::default();
-    // Minimal valid 1-byte application data message is not a handshake message
-    acceptor_input
-        .read(
-            &mut encoding::message_framing(
-                ContentType::ApplicationData,
-                ProtocolVersion::TLSv1_2,
-                vec![0x00],
+        let receive = ServerHandshake::start();
+        let mut acceptor_input = VecInput::default();
+        // Minimal valid 1-byte application data message is not a handshake message
+        acceptor_input
+            .read(
+                &mut encoding::message_framing(
+                    ContentType::ApplicationData,
+                    ProtocolVersion::TLSv1_2,
+                    vec![0x00],
+                )
+                .as_slice(),
             )
-            .as_slice(),
-        )
-        .unwrap();
-    let error = receive
-        .process(&mut acceptor_input, &mut output)
-        .unwrap_err();
-    assert!(matches!(error, Error::InappropriateMessage { .. }));
-    let alert_content = output
-        .pop()
-        .expect("should've sent an alert");
-    let expected = encoding::alert(AlertDescription::UnexpectedMessage, &[]);
-    assert_eq!(alert_content, expected);
+            .unwrap();
+        let error = receive
+            .process(&mut acceptor_input, &mut output)
+            .unwrap_err();
+        assert!(matches!(error, Error::InappropriateMessage { .. }));
+        let alert_content = output
+            .pop()
+            .expect("should've sent an alert");
+        let expected = encoding::alert(AlertDescription::UnexpectedMessage, &[]);
+        assert_eq!(alert_content, expected);
 
-    let receive = ServerHandshake::start();
-    let mut acceptor_input = VecInput::default();
-    // Minimal 1-byte ClientHello message is not a legal handshake message
-    acceptor_input
-        .read(
-            &mut encoding::message_framing(
-                ContentType::Handshake,
-                ProtocolVersion::TLSv1_2,
-                encoding::handshake_framing(HandshakeType::ClientHello, vec![0x00]),
+        let receive = ServerHandshake::start();
+        let mut acceptor_input = VecInput::default();
+        // Minimal 1-byte ClientHello message is not a legal handshake message
+        acceptor_input
+            .read(
+                &mut encoding::message_framing(
+                    ContentType::Handshake,
+                    ProtocolVersion::TLSv1_2,
+                    encoding::handshake_framing(HandshakeType::ClientHello, vec![0x00]),
+                )
+                .as_slice(),
             )
-            .as_slice(),
-        )
-        .unwrap();
-    let error = receive
-        .process(&mut acceptor_input, &mut output)
-        .unwrap_err();
-    assert!(matches!(
-        error,
-        Error::InvalidMessage(InvalidMessage::MissingData(_))
-    ));
-    let alert_content = output.pop().unwrap();
-    let expected = encoding::alert(AlertDescription::DecodeError, &[]);
-    assert_eq!(alert_content, expected);
+            .unwrap();
+        let error = receive
+            .process(&mut acceptor_input, &mut output)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            Error::InvalidMessage(InvalidMessage::MissingData(_))
+        ));
+        let alert_content = output.pop().unwrap();
+        let expected = encoding::alert(AlertDescription::DecodeError, &[]);
+        assert_eq!(alert_content, expected);
+    }
 }
 
 #[test]

--- a/rustls-test/tests/api/kx.rs
+++ b/rustls-test/tests/api/kx.rs
@@ -28,8 +28,8 @@ fn test_client_config_keyshare() {
     let provider = provider::DEFAULT_PROVIDER;
     let kx_groups = vec![provider::kx_group::SECP384R1];
     let client_config =
-        make_client_config_with_kx_groups(KeyType::Rsa2048, kx_groups.clone(), &provider);
-    let server_config = make_server_config_with_kx_groups(KeyType::Rsa2048, kx_groups, &provider);
+        make_client_config_with_kx_groups(KeyType::default(), kx_groups.clone(), &provider);
+    let server_config = make_server_config_with_kx_groups(KeyType::default(), kx_groups, &provider);
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
@@ -46,12 +46,12 @@ fn test_client_config_keyshare() {
 fn test_client_config_keyshare_mismatch() {
     let provider = provider::DEFAULT_PROVIDER;
     let client_config = make_client_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::SECP384R1],
         &provider,
     );
     let server_config = make_server_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::X25519],
         &provider,
     );
@@ -89,12 +89,12 @@ fn exercise_all_key_exchange_methods() {
             }
 
             let client_config = make_client_config_with_kx_groups(
-                KeyType::Rsa2048,
+                KeyType::default(),
                 vec![*kx_group],
                 &version_provider,
             );
             let server_config = make_server_config_with_kx_groups(
-                KeyType::Rsa2048,
+                KeyType::default(),
                 vec![*kx_group],
                 &version_provider,
             );
@@ -116,7 +116,7 @@ fn test_client_sends_helloretryrequest() {
     let provider = provider::DEFAULT_PROVIDER;
     // client sends a secp384r1 key share
     let mut client_config = make_client_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::SECP384R1, provider::kx_group::X25519],
         &provider,
     );
@@ -126,7 +126,7 @@ fn test_client_sends_helloretryrequest() {
 
     // but server only accepts x25519, so a HRR is required
     let server_config = make_server_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::X25519],
         &provider,
     );
@@ -242,7 +242,7 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     // first, client sends a secp-256 share and server agrees. secp-256 is inserted
     //   into kx group cache.
     let mut client_config_1 = make_client_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::SECP256R1],
         &provider,
     );
@@ -251,13 +251,13 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     // second, client only supports secp-384 and so kx group cache
     //   contains an unusable value.
     let mut client_config_2 = make_client_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::SECP384R1],
         &provider,
     );
     client_config_2.resumption = Resumption::store(shared_storage.clone());
 
-    let server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let server_config = make_server_config(KeyType::default(), &provider);
 
     // first handshake
     let (mut client_1, mut server) = make_pair_for_configs(client_config_1, server_config.clone());
@@ -315,7 +315,7 @@ fn test_client_sends_share_for_less_preferred_group() {
     // first, client sends a secp384r1 share and server agrees. secp384r1 is inserted
     //   into kx group cache.
     let mut client_config_1 = make_client_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::SECP384R1],
         &provider,
     );
@@ -324,14 +324,14 @@ fn test_client_sends_share_for_less_preferred_group() {
     // second, client supports (x25519, secp384r1) and so kx group cache
     //   contains a supported but less-preferred group.
     let mut client_config_2 = make_client_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::X25519, provider::kx_group::SECP384R1],
         &provider,
     );
     client_config_2.resumption = Resumption::store(shared_storage.clone());
 
     let server_config = make_server_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         provider::ALL_KX_GROUPS.to_vec(),
         &provider,
     );
@@ -384,7 +384,7 @@ fn test_client_sends_share_for_less_preferred_group() {
 
 #[test]
 fn test_server_rejects_clients_without_any_kx_groups() {
-    let (_, mut server) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (_, mut server) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     let mut server_input = VecInput::default();
     server_input
         .read(
@@ -419,7 +419,7 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
     for version_provider in ALL_VERSIONS {
         let (mut client, mut server) = make_pair_for_configs(
             make_client_config_with_kx_groups(
-                KeyType::Rsa2048,
+                KeyType::default(),
                 vec![provider::kx_group::X25519],
                 &version_provider,
             ),
@@ -430,7 +430,7 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
                 }
                 .into(),
             )
-            .finish(KeyType::Rsa2048),
+            .finish(KeyType::default()),
         );
 
         let mut client_input = VecInput::default();
@@ -453,7 +453,7 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
 
 #[test]
 fn hybrid_kx_component_share_offered_but_server_chooses_something_else() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let client_config = ClientConfig::builder(
         CryptoProvider {
             kx_groups: Cow::Owned(vec![&FakeHybrid, provider::kx_group::SECP384R1]),

--- a/rustls-test/tests/api/kx.rs
+++ b/rustls-test/tests/api/kx.rs
@@ -15,13 +15,13 @@ use rustls::enums::{ContentType, ProtocolVersion};
 use rustls::error::{AlertDescription, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved};
 use rustls::{ClientConfig, Connection, HandshakeKind, ServerConfig, VecInput};
 use rustls_test::{
-    ClientConfigExt, ClientStorage, ClientStorageOp, ErrorFromPeer, KeyType, OtherSession,
-    ServerConfigExt, do_handshake, do_handshake_until_error, encoding,
+    ClientConfigExt, ClientStorage, ClientStorageOp, ErrorFromPeer, KeyType, MultiTest,
+    OtherSession, ServerConfigExt, do_handshake, do_handshake_until_error, encoding,
     make_client_config_with_kx_groups, make_pair, make_pair_for_configs, make_server_config,
     make_server_config_with_kx_groups, transfer,
 };
 
-use super::{ALL_VERSIONS, provider};
+use super::provider;
 
 #[test]
 fn test_client_config_keyshare() {
@@ -76,27 +76,25 @@ fn test_client_config_keyshare_mismatch() {
 fn exercise_all_key_exchange_methods() {
     let mut client_input = VecInput::default();
     let mut server_input = VecInput::default();
-    for (version, version_provider) in [
-        (ProtocolVersion::TLSv1_3, provider::DEFAULT_TLS13_PROVIDER),
-        (ProtocolVersion::TLSv1_2, provider::DEFAULT_TLS12_PROVIDER),
-    ] {
+
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
         for kx_group in provider::ALL_KX_GROUPS {
             if !kx_group
                 .name()
-                .usable_for_version(version)
+                .usable_for_version(expect.version)
             {
                 continue;
             }
 
             let client_config = make_client_config_with_kx_groups(
-                KeyType::default(),
+                expect.key_type,
                 vec![*kx_group],
-                &version_provider,
+                client_config.provider(),
             );
             let server_config = make_server_config_with_kx_groups(
-                KeyType::default(),
+                expect.key_type,
                 vec![*kx_group],
-                &version_provider,
+                server_config.provider(),
             );
             let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
             do_handshake_until_error(
@@ -416,17 +414,18 @@ fn test_server_rejects_clients_without_any_kx_groups() {
 
 #[test]
 fn test_server_rejects_clients_without_any_kx_group_overlap() {
-    for version_provider in ALL_VERSIONS {
+    for (client_config, _, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let base_provider = client_config.provider();
         let (mut client, mut server) = make_pair_for_configs(
             make_client_config_with_kx_groups(
-                KeyType::default(),
+                expect.key_type,
                 vec![provider::kx_group::X25519],
-                &version_provider,
+                base_provider,
             ),
             ServerConfig::builder(
                 CryptoProvider {
                     kx_groups: Cow::Owned(vec![provider::kx_group::SECP384R1]),
-                    ..version_provider
+                    ..CryptoProvider::clone(base_provider)
                 }
                 .into(),
             )

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -49,7 +49,7 @@ fn test_quic_handshake() {
             && equal_packet_keys(x.remote.packet.as_ref(), y.local.packet.as_ref())
     }
 
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let mut client_config = make_client_config(kt, &provider);
     client_config.enable_early_data = true;
@@ -209,7 +209,7 @@ fn test_quic_handshake() {
 
 #[test]
 fn test_quic_acceptor() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let mut client_config = make_client_config(kt, &provider);
     client_config.alpn_protocols = vec![b"h3".into()];
@@ -299,7 +299,7 @@ fn test_quic_acceptor() {
 
 #[test]
 fn test_quic_acceptor_continues_with_server_config_chosen_from_client_hello() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let mut client_config = make_client_config(kt, &provider);
     client_config.alpn_protocols = vec![b"h3".into()];
@@ -391,7 +391,7 @@ fn test_quic_acceptor_continues_with_server_config_chosen_from_client_hello() {
 
 #[test]
 fn test_quic_acceptor_invalid_early_data_size() {
-    let kt = KeyType::Ed25519;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let client_config = Arc::new(make_client_config(kt, &provider));
     let mut server_config = make_server_config(kt, &provider);
@@ -487,7 +487,7 @@ fn test_quic_rejects_missing_alpn() {
 #[test]
 fn test_quic_no_tls13_error() {
     let provider = provider::DEFAULT_TLS12_PROVIDER;
-    let mut client_config = make_client_config(KeyType::Ed25519, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.alpn_protocols = vec![b"foo".into()];
     let client_config = Arc::new(client_config);
 
@@ -502,7 +502,7 @@ fn test_quic_no_tls13_error() {
         Some(ApiMisuse::QuicRequiresTls13Support.into())
     );
 
-    let mut server_config = make_server_config(KeyType::Ed25519, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.alpn_protocols = vec![b"foo".into()];
     let server_config = Arc::new(server_config);
 
@@ -516,7 +516,7 @@ fn test_quic_no_tls13_error() {
 #[test]
 fn test_quic_invalid_early_data_size() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let mut server_config = make_server_config(KeyType::Ed25519, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.alpn_protocols = vec![b"foo".into()];
 
     let cases = [
@@ -544,7 +544,7 @@ fn test_quic_invalid_early_data_size() {
 #[test]
 fn test_quic_read_deframer_failure() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let server_config = make_server_config(KeyType::EcdsaP256, &provider);
+    let server_config = make_server_config(KeyType::default(), &provider);
     let server_config = Arc::new(server_config);
 
     let mut server =
@@ -568,7 +568,7 @@ fn test_quic_read_deframer_failure() {
 #[test]
 fn test_quic_server_no_params_received() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let server_config = make_server_config(KeyType::EcdsaP256, &provider);
+    let server_config = make_server_config(KeyType::default(), &provider);
     let server_config = Arc::new(server_config);
 
     let mut server =
@@ -593,7 +593,7 @@ fn test_quic_server_no_params_received() {
 #[test]
 fn test_quic_server_no_tls12() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let mut server_config = make_server_config(KeyType::Ed25519, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.alpn_protocols = vec![b"foo".into()];
     let server_config = Arc::new(server_config);
 
@@ -682,7 +682,7 @@ fn flatten_events(send: &mut impl Connection) -> Vec<u8> {
 #[test]
 fn test_quic_resumption_data_basic() {
     let server_params = b"server params";
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_TLS13_PROVIDER;
 
     let mut server_config = make_server_config(kt, &provider);
@@ -729,7 +729,7 @@ fn test_quic_resumption_data_basic() {
 fn test_quic_resumption_data_0rtt() {
     let client_params = b"client params";
     let server_params = b"server params";
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_TLS13_PROVIDER;
 
     let mut client_config = make_client_config(kt, &provider);
@@ -1060,7 +1060,7 @@ fn test_quic_exporter() {
 #[test]
 fn test_fragmented_append() {
     // Create a QUIC client connection.
-    let client_config = make_client_config(KeyType::Rsa2048, &provider::DEFAULT_TLS13_PROVIDER);
+    let client_config = make_client_config(KeyType::default(), &provider::DEFAULT_TLS13_PROVIDER);
     let client_config = Arc::new(client_config);
     let mut client = quic::ClientConnection::new(
         client_config,
@@ -1098,7 +1098,7 @@ fn test_fragmented_append() {
 fn server_rejects_client_hello_with_trailing_fragment() {
     let mut server = quic::ServerConnection::new(
         Arc::new(make_server_config(
-            KeyType::EcdsaP256,
+            KeyType::default(),
             &provider::DEFAULT_TLS13_PROVIDER,
         )),
         quic::Version::V2,

--- a/rustls-test/tests/api/resolve.rs
+++ b/rustls-test/tests/api/resolve.rs
@@ -480,7 +480,7 @@ fn client_cert_resolve_server_added_hint() {
 
 #[test]
 fn server_exposes_offered_sni_even_if_resolver_fails() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_PROVIDER;
     let resolver = ServerNameResolver::new();
 
@@ -512,7 +512,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
 
 #[test]
 fn sni_resolver_works() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_PROVIDER;
     let mut resolver = ServerNameResolver::new();
     let signing_key = kt.load_key(&provider);
@@ -563,7 +563,7 @@ fn sni_resolver_works() {
 
 #[test]
 fn sni_resolver_rejects_wrong_names() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let mut resolver = ServerNameResolver::new();
 
     assert_eq!(
@@ -588,7 +588,7 @@ fn sni_resolver_rejects_wrong_names() {
 
 #[test]
 fn sni_resolver_lower_cases_configured_names() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_PROVIDER;
     let mut resolver = ServerNameResolver::new();
     let signing_key = kt.load_key(&provider);
@@ -624,7 +624,7 @@ fn sni_resolver_lower_cases_configured_names() {
 #[test]
 fn sni_resolver_lower_cases_queried_names() {
     // actually, the handshake parser does this, but the effect is the same.
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_PROVIDER;
     let mut resolver = ServerNameResolver::new();
     let signing_key = kt.load_key(&provider);
@@ -659,7 +659,7 @@ fn sni_resolver_lower_cases_queried_names() {
 
 #[test]
 fn sni_resolver_rejects_bad_certs() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let mut resolver = ServerNameResolver::new();
 
     let bad_chain =

--- a/rustls-test/tests/api/resolve.rs
+++ b/rustls-test/tests/api/resolve.rs
@@ -17,14 +17,14 @@ use rustls::{
     SupportedCipherSuite, VecInput,
 };
 use rustls_test::{
-    ClientConfigExt, ErrorFromPeer, KeyType, ServerCheckCertResolve,
+    ClientConfigExt, ErrorFromPeer, KeyType, MultiTest, ServerCheckCertResolve,
     certificate_error_expecting_name, do_handshake_until_error, make_client_config,
     make_pair_for_arc_configs, make_pair_for_configs, make_server_config,
     make_server_config_with_client_verifier, make_server_config_with_mandatory_client_auth,
     provider_with_one_suite, server_name, transfer, webpki_client_verifier_builder,
 };
 
-use super::{ALL_VERSIONS, provider, provider_is_aws_lc_rs};
+use super::{provider, provider_is_aws_lc_rs};
 
 #[test]
 fn server_cert_resolve_with_sni() {
@@ -259,36 +259,33 @@ fn server_cert_resolve_reduces_sigalgs_for_ecdsa_ciphersuite() {
 
 #[test]
 fn client_with_sni_disabled_does_not_send_sni() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let mut server_config = make_server_config(*kt, &provider);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let mut server_config = Arc::unwrap_or_clone(server_config);
         server_config.cert_resolver = Arc::new(ServerCheckNoSni {});
         let server_config = Arc::new(server_config);
 
-        for version_provider in ALL_VERSIONS {
-            let mut client_config = make_client_config(*kt, &version_provider);
-            client_config.enable_sni = false;
+        let mut client_config = Arc::unwrap_or_clone(client_config);
+        client_config.enable_sni = false;
 
-            let mut client = Arc::new(client_config)
-                .connect(server_name("value-not-sent"))
-                .build()
-                .unwrap();
+        let mut client = Arc::new(client_config)
+            .connect(server_name("value-not-sent"))
+            .build()
+            .unwrap();
 
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            dbg!(&err);
-            assert_eq!(
-                err.err(),
-                Some(ErrorFromPeer::Server(Error::NoSuitableCertificate))
-            );
-        }
+        let mut server = ServerConnection::new(server_config.clone()).unwrap();
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        dbg!(&err);
+        assert_eq!(
+            err.err(),
+            Some(ErrorFromPeer::Server(Error::NoSuitableCertificate))
+        );
     }
 }
 
@@ -480,16 +477,13 @@ fn client_cert_resolve_server_added_hint() {
 
 #[test]
 fn server_exposes_offered_sni_even_if_resolver_fails() {
-    let kt = KeyType::default();
-    let provider = provider::DEFAULT_PROVIDER;
-    let resolver = ServerNameResolver::new();
+    let resolver = Arc::new(ServerNameResolver::new());
 
-    let mut server_config = make_server_config(kt, &provider);
-    server_config.cert_resolver = Arc::new(resolver);
-    let server_config = Arc::new(server_config);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let mut server_config = Arc::unwrap_or_clone(server_config);
+        server_config.cert_resolver = resolver.clone();
+        let server_config = Arc::new(server_config);
 
-    for version_provider in ALL_VERSIONS {
-        let client_config = Arc::new(make_client_config(kt, &version_provider));
         let mut server = ServerConnection::new(server_config.clone()).unwrap();
         let mut client = client_config
             .connect(server_name("thisdoesNOTexist.com"))

--- a/rustls-test/tests/api/resume.rs
+++ b/rustls-test/tests/api/resume.rs
@@ -15,27 +15,22 @@ use rustls::error::{ApiMisuse, Error, PeerMisbehaved};
 use rustls::server::{ServerSessionKey, Tls13Tickets};
 use rustls::{ClientConfig, Connection, HandshakeKind, ServerConfig, ServerConnection, VecInput};
 use rustls_test::{
-    ClientConfigExt, ClientStorage, ClientStorageOp, ErrorFromPeer, KeyType, ServerConfigExt,
-    do_handshake, do_handshake_until_error, make_client_config, make_client_config_with_auth,
-    make_client_config_with_kx_groups, make_pair, make_pair_for_arc_configs, make_pair_for_configs,
-    make_server_config, make_server_config_with_kx_groups, transfer,
-    webpki_server_verifier_builder,
+    ClientConfigExt, ClientStorage, ClientStorageOp, ErrorFromPeer, KeyType, MultiTest,
+    ServerConfigExt, do_handshake, do_handshake_until_error, make_client_config,
+    make_client_config_with_auth, make_client_config_with_kx_groups, make_pair,
+    make_pair_for_arc_configs, make_pair_for_configs, make_server_config,
+    make_server_config_with_kx_groups, transfer, webpki_server_verifier_builder,
 };
 
-use super::{ALL_VERSIONS, provider};
+use super::provider;
 
 #[test]
 fn client_only_attempts_resumption_with_compatible_security() {
-    let provider = provider::DEFAULT_PROVIDER;
-    let kt = KeyType::Rsa2048;
-
-    let server_config = make_server_config(kt, &provider);
-    for version_provider in ALL_VERSIONS {
+    for (base_client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
-        let base_client_config = make_client_config(kt, &version_provider);
         let (mut client, mut server) =
-            make_pair_for_configs(base_client_config.clone(), server_config.clone());
+            make_pair_for_arc_configs(&base_client_config, &server_config);
         do_handshake(
             &mut client_input,
             &mut client,
@@ -46,7 +41,7 @@ fn client_only_attempts_resumption_with_compatible_security() {
 
         // base case
         let (mut client, mut server) =
-            make_pair_for_configs(base_client_config.clone(), server_config.clone());
+            make_pair_for_arc_configs(&base_client_config, &server_config);
         do_handshake(
             &mut client_input,
             &mut client,
@@ -58,7 +53,7 @@ fn client_only_attempts_resumption_with_compatible_security() {
         // allowed case, using `clone`
         let client_config = ClientConfig::clone(&base_client_config);
         let (mut client, mut server) =
-            make_pair_for_configs(client_config.clone(), server_config.clone());
+            make_pair_for_configs(client_config.clone(), ServerConfig::clone(&server_config));
         do_handshake(
             &mut client_input,
             &mut client,
@@ -68,17 +63,17 @@ fn client_only_attempts_resumption_with_compatible_security() {
         assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
 
         // disallowed case: unmatching `client_auth_cert_resolver`
-        let client_config = ClientConfig::builder(Arc::new(version_provider.clone()))
-            .add_root_certs(kt)
+        let client_config = ClientConfig::builder(base_client_config.provider().clone())
+            .add_root_certs(expect.key_type)
             .with_client_credential_resolver(
-                make_client_config_with_auth(KeyType::EcdsaP256, &version_provider)
+                make_client_config_with_auth(expect.key_type, base_client_config.provider())
                     .resolver()
                     .clone(),
             )
             .unwrap();
 
         let (mut client, mut server) =
-            make_pair_for_configs(client_config.clone(), server_config.clone());
+            make_pair_for_configs(client_config.clone(), ServerConfig::clone(&server_config));
         do_handshake(
             &mut client_input,
             &mut client,
@@ -88,59 +83,97 @@ fn client_only_attempts_resumption_with_compatible_security() {
         assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
 
         // disallowed case: unmatching `verifier`
-        let mut client_config = ClientConfig::builder(Arc::new(version_provider.clone()))
-            .dangerous()
-            .with_custom_certificate_verifier(Arc::new(
-                webpki_server_verifier_builder(kt.client_root_store(), &version_provider)
+        if !expect.client_auth {
+            let mut client_config = ClientConfig::builder(base_client_config.provider().clone())
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(
+                    webpki_server_verifier_builder(
+                        expect.key_type.client_root_store(),
+                        base_client_config.provider(),
+                    )
                     .allow_unknown_revocation_status()
                     .build()
                     .unwrap(),
-            ))
-            .with_client_credential_resolver(client_config.resolver().clone())
-            .unwrap();
-        client_config.resumption = base_client_config.resumption.clone();
-
-        let (mut client, mut server) =
-            make_pair_for_configs(client_config.clone(), server_config.clone());
-        do_handshake(
-            &mut client_input,
-            &mut client,
-            &mut server_input,
-            &mut server,
-        );
-        assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
-    }
-}
-
-#[test]
-fn resumption_combinations() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = make_server_config(*kt, &provider);
-        for (version, version_provider) in [
-            (ProtocolVersion::TLSv1_2, provider::DEFAULT_TLS12_PROVIDER),
-            (ProtocolVersion::TLSv1_3, provider::DEFAULT_TLS13_PROVIDER),
-        ] {
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let resumption_data = format!("resumption data {kt:?} {version:?}");
-            let client_config = make_client_config(*kt, &version_provider);
-            let (mut client, mut server) =
-                make_pair_for_configs(client_config.clone(), server_config.clone());
-            server
-                .set_resumption_data(resumption_data.as_bytes())
+                ))
+                .with_client_credential_resolver(client_config.resolver().clone())
                 .unwrap();
+            client_config.resumption = base_client_config.resumption.clone();
+
+            let (mut client, mut server) =
+                make_pair_for_configs(client_config, ServerConfig::clone(&server_config));
             do_handshake(
                 &mut client_input,
                 &mut client,
                 &mut server_input,
                 &mut server,
             );
-
-            let expected_kx = expected_kx_for_version(version);
-
             assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
-            assert_eq!(server.handshake_kind(), Some(HandshakeKind::Full));
+        }
+    }
+}
+
+#[test]
+fn resumption_combinations() {
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let resumption_data = format!("resumption data {expect:?}");
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        server
+            .set_resumption_data(resumption_data.as_bytes())
+            .unwrap();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+
+        let expected_kx = expected_kx_for_version(expect.version);
+
+        assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
+        assert_eq!(server.handshake_kind(), Some(HandshakeKind::Full));
+        assert_eq!(
+            client
+                .negotiated_key_exchange_group()
+                .unwrap()
+                .name(),
+            expected_kx
+        );
+        assert_eq!(
+            server
+                .negotiated_key_exchange_group()
+                .unwrap()
+                .name(),
+            expected_kx
+        );
+
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+
+        assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
+        assert_eq!(server.handshake_kind(), Some(HandshakeKind::Resumed));
+        assert_eq!(
+            server.received_resumption_data(),
+            Some(resumption_data.as_bytes())
+        );
+        if expect.version == ProtocolVersion::TLSv1_2 {
+            assert!(
+                client
+                    .negotiated_key_exchange_group()
+                    .is_none()
+            );
+            assert!(
+                server
+                    .negotiated_key_exchange_group()
+                    .is_none()
+            );
+        } else {
             assert_eq!(
                 client
                     .negotiated_key_exchange_group()
@@ -155,49 +188,6 @@ fn resumption_combinations() {
                     .name(),
                 expected_kx
             );
-
-            let (mut client, mut server) =
-                make_pair_for_configs(client_config.clone(), server_config.clone());
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-
-            assert_eq!(client.handshake_kind(), Some(HandshakeKind::Resumed));
-            assert_eq!(server.handshake_kind(), Some(HandshakeKind::Resumed));
-            assert_eq!(
-                server.received_resumption_data(),
-                Some(resumption_data.as_bytes())
-            );
-            if version == ProtocolVersion::TLSv1_2 {
-                assert!(
-                    client
-                        .negotiated_key_exchange_group()
-                        .is_none()
-                );
-                assert!(
-                    server
-                        .negotiated_key_exchange_group()
-                        .is_none()
-                );
-            } else {
-                assert_eq!(
-                    client
-                        .negotiated_key_exchange_group()
-                        .unwrap()
-                        .name(),
-                    expected_kx
-                );
-                assert_eq!(
-                    server
-                        .negotiated_key_exchange_group()
-                        .unwrap()
-                        .name(),
-                    expected_kx
-                );
-            }
         }
     }
 }

--- a/rustls-test/tests/api/resume.rs
+++ b/rustls-test/tests/api/resume.rs
@@ -218,17 +218,17 @@ fn expected_kx_for_version(version: ProtocolVersion) -> NamedGroup {
 #[test]
 fn test_client_tls12_no_resume_after_server_downgrade() {
     let provider = provider::DEFAULT_PROVIDER;
-    let mut client_config = make_client_config(KeyType::Ed25519, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     let client_storage = Arc::new(ClientStorage::new());
     client_config.resumption = Resumption::store(client_storage.clone());
     let client_config = Arc::new(client_config);
 
     let server_config_1 = Arc::new(
-        ServerConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into()).finish(KeyType::Ed25519),
+        ServerConfig::builder(provider::DEFAULT_TLS13_PROVIDER.into()).finish(KeyType::default()),
     );
 
     let mut server_config_2 =
-        ServerConfig::builder(provider::DEFAULT_TLS12_PROVIDER.into()).finish(KeyType::Ed25519);
+        ServerConfig::builder(provider::DEFAULT_TLS12_PROVIDER.into()).finish(KeyType::default());
     server_config_2.session_storage = Arc::new(rustls::server::NoServerSessionStorage {});
 
     let mut client_input = VecInput::default();
@@ -292,11 +292,11 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     let shared_storage = Arc::new(ClientStorage::new());
     let provider = provider::DEFAULT_PROVIDER;
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.resumption = Resumption::store(shared_storage.clone());
     let client_config = Arc::new(client_config);
 
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.send_tls13_tickets = Tls13Tickets { default: 5, max: 5 };
     let server_config = Arc::new(server_config);
 
@@ -355,7 +355,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
 
 #[test]
 fn tls13_stateful_resumption() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let client_config = make_client_config(kt, &provider);
     let client_config = Arc::new(client_config);
@@ -445,7 +445,7 @@ fn tls13_stateful_resumption() {
 
 #[test]
 fn tls13_stateless_resumption() {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let client_config = make_client_config(kt, &provider);
     let client_config = Arc::new(client_config);
@@ -540,12 +540,12 @@ fn tls13_stateless_resumption() {
 
 #[test]
 fn early_data_not_available() {
-    let (mut client, _) = make_pair(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+    let (mut client, _) = make_pair(KeyType::default(), &provider::DEFAULT_PROVIDER);
     assert!(client.early_data().is_none());
 }
 
 fn early_data_configs() -> (Arc<ClientConfig>, Arc<ServerConfig>) {
-    let kt = KeyType::Rsa2048;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_PROVIDER;
     let mut client_config = make_client_config(kt, &provider);
     client_config.enable_early_data = true;
@@ -657,7 +657,7 @@ fn early_data_is_available_on_resumption() {
 #[test]
 fn early_data_not_available_on_server_before_client_hello() {
     let mut server = ServerConnection::new(Arc::new(make_server_config(
-        KeyType::Rsa2048,
+        KeyType::default(),
         &provider::DEFAULT_PROVIDER,
     )))
     .unwrap();
@@ -913,7 +913,7 @@ fn tls13_ticket_request_new_vs_resumed() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let shared_storage = Arc::new(ClientStorage::new());
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.resumption = Resumption::store(shared_storage.clone());
     client_config.send_ticket_request = Some(TicketRequest {
         new_session_count: 3,
@@ -921,7 +921,7 @@ fn tls13_ticket_request_new_vs_resumed() {
     });
     let client_config = Arc::new(client_config);
 
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     // default is 2, but the client may request up to 5
     server_config.send_tls13_tickets = Tls13Tickets { default: 2, max: 5 };
     let server_config = Arc::new(server_config);
@@ -970,7 +970,7 @@ fn tls13_ticket_request_zero_means_no_tickets() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let shared_storage = Arc::new(ClientStorage::new());
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.resumption = Resumption::store(shared_storage.clone());
     client_config.send_ticket_request = Some(TicketRequest {
         new_session_count: 0,
@@ -978,7 +978,7 @@ fn tls13_ticket_request_zero_means_no_tickets() {
     });
     let client_config = Arc::new(client_config);
 
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     // server would send 5 by default, but the client requests 0
     server_config.send_tls13_tickets = Tls13Tickets { default: 5, max: 5 };
     let server_config = Arc::new(server_config);
@@ -1007,7 +1007,7 @@ fn tls13_ticket_request_capped_by_server() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let shared_storage = Arc::new(ClientStorage::new());
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.resumption = Resumption::store(shared_storage.clone());
     client_config.send_ticket_request = Some(TicketRequest {
         new_session_count: 10,
@@ -1015,7 +1015,7 @@ fn tls13_ticket_request_capped_by_server() {
     });
     let client_config = Arc::new(client_config);
 
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     // client requests 10, but the server's max is 3
     server_config.send_tls13_tickets = Tls13Tickets { default: 2, max: 3 };
     let server_config = Arc::new(server_config);
@@ -1044,12 +1044,12 @@ fn tls13_ticket_request_not_sent_when_none() {
     let provider = provider::DEFAULT_TLS13_PROVIDER;
     let shared_storage = Arc::new(ClientStorage::new());
 
-    let mut client_config = make_client_config(KeyType::Rsa2048, &provider);
+    let mut client_config = make_client_config(KeyType::default(), &provider);
     client_config.resumption = Resumption::store(shared_storage.clone());
     client_config.send_ticket_request = None;
     let client_config = Arc::new(client_config);
 
-    let mut server_config = make_server_config(KeyType::Rsa2048, &provider);
+    let mut server_config = make_server_config(KeyType::default(), &provider);
     server_config.send_tls13_tickets = Tls13Tickets { default: 4, max: 8 };
     let server_config = Arc::new(server_config);
 
@@ -1080,7 +1080,7 @@ fn tls13_ticket_request_survives_hello_retry_request() {
 
     // client offers secp384r1 first, server only accepts x25519 -> triggers HRR
     let mut client_config = make_client_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::SECP384R1, provider::kx_group::X25519],
         &provider,
     );
@@ -1092,7 +1092,7 @@ fn tls13_ticket_request_survives_hello_retry_request() {
     let client_config = Arc::new(client_config);
 
     let server_config = Arc::new(make_server_config_with_kx_groups(
-        KeyType::Rsa2048,
+        KeyType::default(),
         vec![provider::kx_group::X25519],
         &provider,
     ));

--- a/rustls-test/tests/api/server_cert_verifier.rs
+++ b/rustls-test/tests/api/server_cert_verifier.rs
@@ -207,7 +207,7 @@ fn client_can_override_certificate_verification_and_offer_no_signature_schemes()
 #[test]
 fn test_pinned_ocsp_response_given_to_custom_server_cert_verifier() {
     let ocsp_response = b"hello-ocsp-world!";
-    let kt = KeyType::EcdsaP256;
+    let kt = KeyType::default();
     let provider = provider::DEFAULT_PROVIDER;
 
     for version_provider in ALL_VERSIONS {
@@ -719,7 +719,7 @@ fn client_check_server_certificate_helper_api() {
 
 #[test]
 fn client_check_server_valid_purpose() {
-    let Identity::X509(identity) = &*KeyType::EcdsaP256.client_identity() else {
+    let Identity::X509(identity) = &*KeyType::default().client_identity() else {
         panic!("expected X509 identity");
     };
 

--- a/rustls-test/tests/api/server_cert_verifier.rs
+++ b/rustls-test/tests/api/server_cert_verifier.rs
@@ -21,79 +21,60 @@ use rustls::{
     ClientConfig, DistinguishedName, RootCertStore, ServerConfig, ServerConnection, VecInput,
 };
 use rustls_test::{
-    ErrorFromPeer, KeyType, MockServerVerifier, certificate_error_expecting_name, do_handshake,
-    do_handshake_until_both_error, do_handshake_until_error, make_client_config,
-    make_client_config_with_verifier, make_pair_for_arc_configs, make_pair_for_configs,
-    make_server_config, server_name, webpki_server_verifier_builder,
+    ErrorFromPeer, KeyType, MockServerVerifier, MultiTest, certificate_error_expecting_name,
+    do_handshake, do_handshake_until_both_error, do_handshake_until_error, make_client_config,
+    make_pair_for_arc_configs, make_server_config, server_name, webpki_server_verifier_builder,
 };
 use webpki::anchor_from_trusted_cert;
 use x509_parser::prelude::FromDer;
 use x509_parser::x509::X509Name;
 
-use super::{ALL_VERSIONS, provider};
+use super::provider;
 
 #[test]
 fn client_can_override_certificate_verification() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider).iter() {
-        let verifier = Arc::new(MockServerVerifier::accepts_anything());
-
-        let server_config = Arc::new(make_server_config(*kt, &provider));
-
-        for version_provider in ALL_VERSIONS {
-            let mut client_config = make_client_config(*kt, &version_provider);
-            client_config
-                .dangerous()
-                .set_certificate_verifier(verifier.clone());
-
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-        }
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .with_server_verifier(Box::new(|_, _| {
+            Arc::new(MockServerVerifier::accepts_anything())
+        }))
+    {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
     }
 }
 
 #[test]
 fn client_can_override_certificate_verification_and_reject_certificate() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider).iter() {
-        let verifier = Arc::new(MockServerVerifier::rejects_certificate(
-            CertificateError::ApplicationVerificationFailure.into(),
-        ));
-
-        let server_config = Arc::new(make_server_config(*kt, &provider));
-
-        for version_provider in ALL_VERSIONS {
-            let mut client_config = make_client_config(*kt, &version_provider);
-            client_config
-                .dangerous()
-                .set_certificate_verifier(verifier.clone());
-
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let errs = do_handshake_until_both_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                errs,
-                Err(vec![
-                    ErrorFromPeer::Client(CertificateError::ApplicationVerificationFailure.into()),
-                    ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::AccessDenied)),
-                ]),
-            );
-        }
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .with_server_verifier(Box::new(|_, _| {
+            Arc::new(MockServerVerifier::rejects_certificate(
+                CertificateError::ApplicationVerificationFailure.into(),
+            ))
+        }))
+    {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let errs = do_handshake_until_both_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            errs,
+            Err(vec![
+                ErrorFromPeer::Client(CertificateError::ApplicationVerificationFailure.into()),
+                ErrorFromPeer::Server(Error::AlertReceived(AlertDescription::AccessDenied)),
+            ]),
+        );
     }
 }
 
@@ -169,62 +150,52 @@ fn client_can_override_certificate_verification_and_reject_tls13_signatures() {
 
 #[test]
 fn client_can_override_certificate_verification_and_offer_no_signature_schemes() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider).iter() {
-        let verifier = Arc::new(MockServerVerifier::offers_no_signature_schemes());
-
-        let server_config = Arc::new(make_server_config(*kt, &provider));
-
-        for version_provider in ALL_VERSIONS {
-            let mut client_config = make_client_config(*kt, &version_provider);
-            client_config
-                .dangerous()
-                .set_certificate_verifier(verifier.clone());
-
-            let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let errs = do_handshake_until_both_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                errs,
-                Err(vec![
-                    ErrorFromPeer::Server(Error::InvalidMessage(
-                        InvalidMessage::NoSignatureSchemes
-                    )),
-                    ErrorFromPeer::Client(Error::AlertReceived(AlertDescription::DecodeError)),
-                ])
-            );
-        }
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .with_server_verifier(Box::new(|_, _| {
+            Arc::new(MockServerVerifier::offers_no_signature_schemes())
+        }))
+    {
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let errs = do_handshake_until_both_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            errs,
+            Err(vec![
+                ErrorFromPeer::Server(Error::InvalidMessage(InvalidMessage::NoSignatureSchemes)),
+                ErrorFromPeer::Client(Error::AlertReceived(AlertDescription::DecodeError)),
+            ])
+        );
     }
 }
 
 #[test]
 fn test_pinned_ocsp_response_given_to_custom_server_cert_verifier() {
     let ocsp_response = b"hello-ocsp-world!";
-    let kt = KeyType::default();
-    let provider = provider::DEFAULT_PROVIDER;
 
-    for version_provider in ALL_VERSIONS {
-        let server_config = ServerConfig::builder(provider.clone().into())
-            .with_no_client_auth()
-            .with_single_cert_with_ocsp(kt.identity(), kt.key(), Arc::from(&ocsp_response[..]))
-            .unwrap();
+    for (client_config, _, expect) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .with_server_verifier(Box::new(|_, _| {
+            Arc::new(MockServerVerifier::expects_ocsp_response(ocsp_response))
+        }))
+    {
+        let provider = client_config.provider();
+        let server_config = Arc::new(
+            ServerConfig::builder(provider.clone())
+                .with_no_client_auth()
+                .with_single_cert_with_ocsp(
+                    expect.key_type.identity(),
+                    expect.key_type.key(),
+                    Arc::from(&ocsp_response[..]),
+                )
+                .unwrap(),
+        );
 
-        let client_config = ClientConfig::builder(version_provider.into())
-            .dangerous()
-            .with_custom_certificate_verifier(Arc::new(MockServerVerifier::expects_ocsp_response(
-                ocsp_response,
-            )))
-            .with_no_client_auth()
-            .unwrap();
-
-        let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+        let (mut client, mut server) = make_pair_for_arc_configs(&client_config, &server_config);
         let mut client_input = VecInput::default();
         let mut server_input = VecInput::default();
         do_handshake(
@@ -352,328 +323,334 @@ fn client_checks_server_certificate_with_given_ip_address() {
         )
     }
 
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = Arc::new(make_server_config(*kt, &provider));
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        // positive ipv4 case
+        assert_eq!(
+            check_server_name(client_config.clone(), server_config.clone(), "198.51.100.1"),
+            Ok(()),
+        );
 
-        for version_provider in ALL_VERSIONS {
-            let client_config = Arc::new(make_client_config(*kt, &version_provider));
+        // negative ipv4 case
+        assert_eq!(
+            check_server_name(client_config.clone(), server_config.clone(), "198.51.100.2"),
+            Err(ErrorFromPeer::Client(Error::InvalidCertificate(
+                certificate_error_expecting_name("198.51.100.2")
+            )))
+        );
 
-            // positive ipv4 case
-            assert_eq!(
-                check_server_name(client_config.clone(), server_config.clone(), "198.51.100.1"),
-                Ok(()),
-            );
+        // positive ipv6 case
+        assert_eq!(
+            check_server_name(client_config.clone(), server_config.clone(), "2001:db8::1"),
+            Ok(()),
+        );
 
-            // negative ipv4 case
-            assert_eq!(
-                check_server_name(client_config.clone(), server_config.clone(), "198.51.100.2"),
-                Err(ErrorFromPeer::Client(Error::InvalidCertificate(
-                    certificate_error_expecting_name("198.51.100.2")
-                )))
-            );
-
-            // positive ipv6 case
-            assert_eq!(
-                check_server_name(client_config.clone(), server_config.clone(), "2001:db8::1"),
-                Ok(()),
-            );
-
-            // negative ipv6 case
-            assert_eq!(
-                check_server_name(client_config.clone(), server_config.clone(), "2001:db8::2"),
-                Err(ErrorFromPeer::Client(Error::InvalidCertificate(
-                    certificate_error_expecting_name("2001:db8::2")
-                )))
-            );
-        }
+        // negative ipv6 case
+        assert_eq!(
+            check_server_name(client_config.clone(), server_config.clone(), "2001:db8::2"),
+            Err(ErrorFromPeer::Client(Error::InvalidCertificate(
+                certificate_error_expecting_name("2001:db8::2")
+            )))
+        );
     }
 }
 
 #[test]
 fn client_checks_server_certificate_with_given_name() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = Arc::new(make_server_config(*kt, &provider));
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let mut client = client_config
+            .connect(server_name("not-the-right-hostname.com"))
+            .build()
+            .unwrap();
+        let mut server = ServerConnection::new(server_config.clone()).unwrap();
 
-        for version_provider in ALL_VERSIONS {
-            let client_config = Arc::new(make_client_config(*kt, &version_provider));
-            let mut client = client_config
-                .connect(server_name("not-the-right-hostname.com"))
-                .build()
-                .unwrap();
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Client(Error::InvalidCertificate(
-                    certificate_error_expecting_name("not-the-right-hostname.com")
-                )))
-            );
-        }
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            err,
+            Err(ErrorFromPeer::Client(Error::InvalidCertificate(
+                certificate_error_expecting_name("not-the-right-hostname.com")
+            )))
+        );
     }
 }
 
 #[test]
 fn client_check_server_certificate_ee_revoked() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = Arc::new(make_server_config(*kt, &provider));
-
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
         // Setup a server verifier that will check the EE certificate's revocation status.
-        let crls = vec![kt.end_entity_crl()];
-        let builder = webpki_server_verifier_builder(kt.client_root_store(), &provider)
-            .with_crls(crls)
-            .only_check_end_entity_revocation();
+        let crls = vec![expect.key_type.end_entity_crl()];
+        let builder = webpki_server_verifier_builder(
+            expect.key_type.client_root_store(),
+            client_config.provider(),
+        )
+        .with_crls(crls)
+        .only_check_end_entity_revocation();
 
-        for version_provider in ALL_VERSIONS {
-            let client_config =
-                make_client_config_with_verifier(builder.clone(), &version_provider);
-            let mut client = Arc::new(client_config)
-                .connect(server_name("localhost"))
-                .build()
-                .unwrap();
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
+        let mut client_config = Arc::unwrap_or_clone(client_config);
+        client_config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(builder.build().unwrap()));
 
-            // We expect the handshake to fail since the server's EE certificate is revoked.
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Client(Error::InvalidCertificate(
-                    CertificateError::Revoked
-                )))
-            );
-        }
+        let mut client = Arc::new(client_config)
+            .connect(server_name("localhost"))
+            .build()
+            .unwrap();
+        let mut server = ServerConnection::new(server_config.clone()).unwrap();
+
+        // We expect the handshake to fail since the server's EE certificate is revoked.
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            err,
+            Err(ErrorFromPeer::Client(Error::InvalidCertificate(
+                CertificateError::Revoked
+            )))
+        );
     }
 }
 
 #[test]
 fn client_check_server_certificate_ee_unknown_revocation() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = Arc::new(make_server_config(*kt, &provider));
-
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
         // Setup a server verifier builder that will check the EE certificate's revocation status, but not
         // allow unknown revocation status (the default). We'll provide CRLs that are not relevant
         // to the EE cert to ensure its status is unknown.
-        let unrelated_crls = vec![kt.intermediate_crl()];
-        let forbid_unknown_verifier =
-            webpki_server_verifier_builder(kt.client_root_store(), &provider)
-                .with_crls(unrelated_crls.clone())
-                .only_check_end_entity_revocation();
+        let unrelated_crls = vec![expect.key_type.intermediate_crl()];
+        let forbid_unknown_verifier = webpki_server_verifier_builder(
+            expect.key_type.client_root_store(),
+            client_config.provider(),
+        )
+        .with_crls(unrelated_crls.clone())
+        .only_check_end_entity_revocation();
 
         // Also set up a verifier builder that will allow unknown revocation status.
-        let allow_unknown_verifier =
-            webpki_server_verifier_builder(kt.client_root_store(), &provider)
-                .with_crls(unrelated_crls)
-                .only_check_end_entity_revocation()
-                .allow_unknown_revocation_status();
+        let allow_unknown_verifier = webpki_server_verifier_builder(
+            expect.key_type.client_root_store(),
+            client_config.provider(),
+        )
+        .with_crls(unrelated_crls)
+        .only_check_end_entity_revocation()
+        .allow_unknown_revocation_status();
 
-        for version_provider in ALL_VERSIONS {
-            let client_config = Arc::new(make_client_config_with_verifier(
-                forbid_unknown_verifier.clone(),
-                &version_provider,
-            ));
-            let mut client = client_config
-                .connect(server_name("localhost"))
-                .build()
-                .unwrap();
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
+        let mut client_config = Arc::unwrap_or_clone(client_config);
+        client_config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(forbid_unknown_verifier.build().unwrap()));
 
-            // We expect if we use the forbid_unknown_verifier that the handshake will fail since the
-            // server's EE certificate's revocation status is unknown given the CRLs we've provided.
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Client(Error::InvalidCertificate(
-                    CertificateError::UnknownRevocationStatus
-                )))
-            );
-
-            // We expect if we use the allow_unknown_verifier that the handshake will not fail.
-            let client_config =
-                make_client_config_with_verifier(allow_unknown_verifier.clone(), &version_provider);
-            let mut client = Arc::new(client_config)
-                .connect(server_name("localhost"))
-                .build()
-                .unwrap();
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            )
+        let mut client = Arc::new(client_config.clone())
+            .connect(server_name("localhost"))
+            .build()
             .unwrap();
-        }
+        let mut server = ServerConnection::new(server_config.clone()).unwrap();
+
+        // We expect if we use the forbid_unknown_verifier that the handshake will fail since the
+        // server's EE certificate's revocation status is unknown given the CRLs we've provided.
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            err,
+            Err(ErrorFromPeer::Client(Error::InvalidCertificate(
+                CertificateError::UnknownRevocationStatus
+            )))
+        );
+
+        // We expect if we use the allow_unknown_verifier that the handshake will not fail.
+
+        client_config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(allow_unknown_verifier.build().unwrap()));
+
+        let mut client = Arc::new(client_config)
+            .connect(server_name("localhost"))
+            .build()
+            .unwrap();
+        let mut server = ServerConnection::new(server_config.clone()).unwrap();
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        )
+        .unwrap();
     }
 }
 
 #[test]
 fn client_check_server_certificate_intermediate_revoked() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = Arc::new(make_server_config(*kt, &provider));
-
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
         // Setup a server verifier builder that will check the full chain revocation status against a CRL
         // that marks the intermediate certificate as revoked. We allow unknown revocation status
         // so the EE cert's unknown status doesn't cause an error.
-        let crls = vec![kt.intermediate_crl()];
-        let full_chain_verifier_builder =
-            webpki_server_verifier_builder(kt.client_root_store(), &provider)
-                .with_crls(crls.clone())
-                .allow_unknown_revocation_status();
+        let crls = vec![expect.key_type.intermediate_crl()];
+        let full_chain_verifier_builder = webpki_server_verifier_builder(
+            expect.key_type.client_root_store(),
+            client_config.provider(),
+        )
+        .with_crls(crls.clone())
+        .allow_unknown_revocation_status();
 
         // Also set up a verifier builder that will use the same CRL, but only check the EE certificate
         // revocation status.
-        let ee_verifier_builder = webpki_server_verifier_builder(kt.client_root_store(), &provider)
-            .with_crls(crls.clone())
-            .only_check_end_entity_revocation()
-            .allow_unknown_revocation_status();
+        let ee_verifier_builder = webpki_server_verifier_builder(
+            expect.key_type.client_root_store(),
+            client_config.provider(),
+        )
+        .with_crls(crls.clone())
+        .only_check_end_entity_revocation()
+        .allow_unknown_revocation_status();
 
-        for version_provider in ALL_VERSIONS {
-            let client_config = Arc::new(make_client_config_with_verifier(
-                full_chain_verifier_builder.clone(),
-                &version_provider,
+        let mut client_config = Arc::unwrap_or_clone(client_config);
+        client_config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(
+                full_chain_verifier_builder
+                    .build()
+                    .unwrap(),
             ));
-            let mut client = client_config
-                .connect(server_name("localhost"))
-                .build()
-                .unwrap();
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
 
-            // We expect the handshake to fail when using the full chain verifier since the intermediate's
-            // EE certificate is revoked.
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert_eq!(
-                err,
-                Err(ErrorFromPeer::Client(Error::InvalidCertificate(
-                    CertificateError::Revoked
-                )))
-            );
-
-            let client_config =
-                make_client_config_with_verifier(ee_verifier_builder.clone(), &version_provider);
-            let mut client = Arc::new(client_config)
-                .connect(server_name("localhost"))
-                .build()
-                .unwrap();
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-            // We expect the handshake to succeed when we use the verifier that only checks the EE certificate
-            // revocation status. The revoked intermediate status should not be checked.
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            )
+        let mut client = Arc::new(client_config.clone())
+            .connect(server_name("localhost"))
+            .build()
             .unwrap();
-        }
+        let mut server = ServerConnection::new(server_config.clone()).unwrap();
+
+        // We expect the handshake to fail when using the full chain verifier since the intermediate's
+        // EE certificate is revoked.
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert_eq!(
+            err,
+            Err(ErrorFromPeer::Client(Error::InvalidCertificate(
+                CertificateError::Revoked
+            )))
+        );
+
+        client_config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(ee_verifier_builder.build().unwrap()));
+
+        let mut client = Arc::new(client_config)
+            .connect(server_name("localhost"))
+            .build()
+            .unwrap();
+        let mut server = ServerConnection::new(server_config.clone()).unwrap();
+        // We expect the handshake to succeed when we use the verifier that only checks the EE certificate
+        // revocation status. The revoked intermediate status should not be checked.
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        )
+        .unwrap();
     }
 }
 
 #[test]
 fn client_check_server_certificate_ee_crl_expired() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let server_config = Arc::new(make_server_config(*kt, &provider));
-
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
         // Setup a server verifier that will check the EE certificate's revocation status, with CRL expiration enforced.
-        let crls = vec![kt.end_entity_crl_expired()];
-        let enforce_expiration_builder =
-            webpki_server_verifier_builder(kt.client_root_store(), &provider)
-                .with_crls(crls)
-                .only_check_end_entity_revocation()
-                .enforce_revocation_expiration();
+        let crls = vec![expect.key_type.end_entity_crl_expired()];
+        let enforce_expiration_builder = webpki_server_verifier_builder(
+            expect.key_type.client_root_store(),
+            client_config.provider(),
+        )
+        .with_crls(crls)
+        .only_check_end_entity_revocation()
+        .enforce_revocation_expiration();
 
         // Also setup a server verifier without CRL expiration enforced.
-        let crls = vec![kt.end_entity_crl_expired()];
-        let ignore_expiration_builder =
-            webpki_server_verifier_builder(kt.client_root_store(), &provider)
-                .with_crls(crls)
-                .only_check_end_entity_revocation();
+        let crls = vec![expect.key_type.end_entity_crl_expired()];
+        let ignore_expiration_builder = webpki_server_verifier_builder(
+            expect.key_type.client_root_store(),
+            client_config.provider(),
+        )
+        .with_crls(crls)
+        .only_check_end_entity_revocation();
 
-        for version_provider in ALL_VERSIONS {
-            let client_config = Arc::new(make_client_config_with_verifier(
-                enforce_expiration_builder.clone(),
-                &version_provider,
-            ));
-            let mut client = client_config
-                .connect(server_name("localhost"))
-                .build()
-                .unwrap();
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-
-            // We expect the handshake to fail since the CRL is expired.
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            let err = do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            );
-            assert!(matches!(
-                err,
-                Err(ErrorFromPeer::Client(Error::InvalidCertificate(
-                    CertificateError::ExpiredRevocationListContext { .. }
-                )))
+        let mut client_config = Arc::unwrap_or_clone(client_config);
+        client_config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(
+                enforce_expiration_builder
+                    .build()
+                    .unwrap(),
             ));
 
-            let client_config = Arc::new(make_client_config_with_verifier(
-                ignore_expiration_builder.clone(),
-                &version_provider,
-            ));
-            let mut client = client_config
-                .connect(server_name("localhost"))
-                .build()
-                .unwrap();
-            let mut server = ServerConnection::new(server_config.clone()).unwrap();
-
-            // We expect the handshake to succeed when CRL expiration is ignored.
-            let mut client_input = VecInput::default();
-            let mut server_input = VecInput::default();
-            do_handshake_until_error(
-                &mut client_input,
-                &mut client,
-                &mut server_input,
-                &mut server,
-            )
+        let mut client = Arc::new(client_config.clone())
+            .connect(server_name("localhost"))
+            .build()
             .unwrap();
-        }
+        let mut server = ServerConnection::new(server_config.clone()).unwrap();
+
+        // We expect the handshake to fail since the CRL is expired.
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        let err = do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        );
+        assert!(matches!(
+            err,
+            Err(ErrorFromPeer::Client(Error::InvalidCertificate(
+                CertificateError::ExpiredRevocationListContext { .. }
+            )))
+        ));
+
+        client_config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(
+                ignore_expiration_builder
+                    .build()
+                    .unwrap(),
+            ));
+
+        let mut client = Arc::new(client_config)
+            .connect(server_name("localhost"))
+            .build()
+            .unwrap();
+        let mut server = ServerConnection::new(server_config.clone()).unwrap();
+
+        // We expect the handshake to succeed when CRL expiration is ignored.
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake_until_error(
+            &mut client_input,
+            &mut client,
+            &mut server_input,
+            &mut server,
+        )
+        .unwrap();
     }
 }
 

--- a/rustls-test/tests/api/split.rs
+++ b/rustls-test/tests/api/split.rs
@@ -14,7 +14,7 @@ use rustls_test::{KeyType, do_handshake, make_pair};
 #[test]
 fn split_pairwise() {
     let (mut client, mut server) =
-        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+        make_pair(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
     let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
     do_handshake(
         &mut client_input,
@@ -91,7 +91,7 @@ fn split_pairwise() {
 #[test]
 fn split_incremental() {
     let (mut client, mut server) =
-        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+        make_pair(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
     let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
     do_handshake(
         &mut client_input,
@@ -239,7 +239,7 @@ fn split_write_tls_into_limited_space() {
 #[test]
 fn split_client_tickets_received() {
     let (mut client, mut server) =
-        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+        make_pair(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
     let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
     do_handshake(
         &mut client_input,
@@ -260,7 +260,7 @@ fn split_client_tickets_received() {
 
 #[test]
 fn split_fails_during_handshake() {
-    let (client, server) = make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+    let (client, server) = make_pair(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
     assert_eq!(
         client.split().err(),
         Some(Error::ApiMisuse(ApiMisuse::SplitDuringHandshake))
@@ -274,7 +274,7 @@ fn split_fails_during_handshake() {
 #[test]
 fn split_fails_with_pending_plaintext() {
     let (mut client, mut server) =
-        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+        make_pair(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
     assert_eq!(client.writer().write(b"huh").unwrap(), 3);
     assert_eq!(server.writer().write(b"hmm").unwrap(), 3);
 
@@ -299,7 +299,7 @@ fn split_fails_with_pending_plaintext() {
 #[test]
 fn key_update() {
     let (mut client, mut server) =
-        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+        make_pair(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
     let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
     do_handshake(
         &mut client_input,
@@ -355,7 +355,7 @@ fn key_update() {
 #[test]
 fn key_update_alongside_data() {
     let (mut client, mut server) =
-        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+        make_pair(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
     let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
     do_handshake(
         &mut client_input,
@@ -394,7 +394,7 @@ fn key_update_alongside_data() {
 #[test]
 fn close_alongside_data() {
     let (mut client, mut server) =
-        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+        make_pair(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
     let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
     do_handshake(
         &mut client_input,
@@ -433,7 +433,7 @@ fn close_alongside_data() {
 #[test]
 fn read_invalid_data_and_send_alert() {
     let (mut client, mut server) =
-        make_pair(KeyType::EcdsaP256, &super::provider::DEFAULT_PROVIDER);
+        make_pair(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
     let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
     do_handshake(
         &mut client_input,

--- a/rustls-test/tests/key_log_file_env/tests.rs
+++ b/rustls-test/tests/key_log_file_env/tests.rs
@@ -28,27 +28,23 @@ use std::io::Write;
 use std::sync::Arc;
 
 use rustls::{Connection, VecInput};
-use rustls_test::{
-    KeyType, do_handshake, make_client_config, make_pair_for_arc_configs, make_server_config,
-    transfer,
-};
+use rustls_test::{MultiTest, do_handshake, make_pair_for_arc_configs, transfer};
 use rustls_util::KeyLogFile;
 
-use super::{ALL_VERSIONS, provider, serialized};
+use super::{provider, serialized};
 
 #[test]
 fn exercise_key_log_file_for_client() {
     serialized(|| {
-        let provider = provider::DEFAULT_PROVIDER;
-        let server_config = Arc::new(make_server_config(KeyType::default(), &provider));
         unsafe { env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt") };
 
-        for version_provider in ALL_VERSIONS {
-            let mut client_config = make_client_config(KeyType::default(), &version_provider);
+        for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+            let mut client_config = Arc::unwrap_or_clone(client_config);
             client_config.key_log = Arc::new(KeyLogFile::new());
+            let client_config = Arc::new(client_config);
 
             let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+                make_pair_for_arc_configs(&client_config, &server_config);
             let mut client_input = VecInput::default();
             let mut server_input = VecInput::default();
 
@@ -71,17 +67,15 @@ fn exercise_key_log_file_for_client() {
 #[test]
 fn exercise_key_log_file_for_server() {
     serialized(|| {
-        let mut server_config = make_server_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
-
         unsafe { env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt") };
-        server_config.key_log = Arc::new(KeyLogFile::new());
 
-        let server_config = Arc::new(server_config);
+        for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+            let mut server_config = Arc::unwrap_or_clone(server_config);
+            server_config.key_log = Arc::new(KeyLogFile::new());
+            let server_config = Arc::new(server_config);
 
-        for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config(KeyType::default(), &version_provider);
             let (mut client, mut server) =
-                make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
+                make_pair_for_arc_configs(&client_config, &server_config);
             let mut client_input = VecInput::default();
             let mut server_input = VecInput::default();
 

--- a/rustls-test/tests/key_log_file_env/tests.rs
+++ b/rustls-test/tests/key_log_file_env/tests.rs
@@ -40,11 +40,11 @@ use super::{ALL_VERSIONS, provider, serialized};
 fn exercise_key_log_file_for_client() {
     serialized(|| {
         let provider = provider::DEFAULT_PROVIDER;
-        let server_config = Arc::new(make_server_config(KeyType::Rsa2048, &provider));
+        let server_config = Arc::new(make_server_config(KeyType::default(), &provider));
         unsafe { env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt") };
 
         for version_provider in ALL_VERSIONS {
-            let mut client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+            let mut client_config = make_client_config(KeyType::default(), &version_provider);
             client_config.key_log = Arc::new(KeyLogFile::new());
 
             let (mut client, mut server) =
@@ -71,7 +71,7 @@ fn exercise_key_log_file_for_client() {
 #[test]
 fn exercise_key_log_file_for_server() {
     serialized(|| {
-        let mut server_config = make_server_config(KeyType::Rsa2048, &provider::DEFAULT_PROVIDER);
+        let mut server_config = make_server_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
 
         unsafe { env::set_var("SSLKEYLOGFILE", "./sslkeylogfile.txt") };
         server_config.key_log = Arc::new(KeyLogFile::new());
@@ -79,7 +79,7 @@ fn exercise_key_log_file_for_server() {
         let server_config = Arc::new(server_config);
 
         for version_provider in ALL_VERSIONS {
-            let client_config = make_client_config(KeyType::Rsa2048, &version_provider);
+            let client_config = make_client_config(KeyType::default(), &version_provider);
             let (mut client, mut server) =
                 make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
             let mut client_input = VecInput::default();

--- a/rustls-test/tests/process_provider.rs
+++ b/rustls-test/tests/process_provider.rs
@@ -28,5 +28,5 @@ fn test_explicit_choice_required() {
     let provider = CryptoProvider::get_default().expect("provider missing");
 
     // does not panic
-    ClientConfig::builder(provider.clone()).finish(KeyType::Rsa2048);
+    ClientConfig::builder(provider.clone()).finish(KeyType::default());
 }


### PR DESCRIPTION
The impetus for this change is that I found the Accepter-type API had no testing in cases where client auth is enabled, and broke that in some other work. That is quite silly because it is trivial to test.

Elsewhere we have a hodge-podge of things, like nested loops over protocol versions.

This makes the tests a little slower and more wasteful, but 2.5s for --release still seems acceptable to me.

