### PR TITLE
Prepare dev.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
  "base64",
  "env_logger",
  "nix",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-aws-lc-rs",
  "rustls-ring",
  "rustls-webpki 0.104.0-alpha.7",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.24.0-dev.0"
+version = "0.24.0-dev.1"
 dependencies = [
  "bencher",
  "brotli",
@@ -1861,12 +1861,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-aws-lc-rs"
-version = "0.1.0-dev.0"
+version = "0.1.0-dev.1"
 dependencies = [
  "aws-lc-rs",
  "bencher",
  "hex",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-pki-types",
  "rustls-test",
  "serde",
@@ -1880,7 +1880,7 @@ name = "rustls-bench"
 version = "0.1.0"
 dependencies = [
  "clap",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-aws-lc-rs",
  "rustls-graviola",
  "rustls-ring",
@@ -1900,7 +1900,7 @@ dependencies = [
  "itertools 0.15.0",
  "rayon",
  "rustc-hash",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-aws-lc-rs",
  "rustls-fuzzing-provider",
  "rustls-ring",
@@ -1913,7 +1913,7 @@ version = "0.0.1"
 dependencies = [
  "regex",
  "ring",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "tokio",
 ]
 
@@ -1927,7 +1927,7 @@ dependencies = [
  "log",
  "mio",
  "rcgen",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-aws-lc-rs",
  "rustls-util",
  "serde",
@@ -1940,7 +1940,7 @@ name = "rustls-fuzzing-provider"
 version = "0.1.0"
 dependencies = [
  "env_logger",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
 ]
 
 [[package]]
@@ -1962,7 +1962,7 @@ dependencies = [
  "num-bigint 0.5.1",
  "once_cell",
  "openssl",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-aws-lc-rs",
  "rustls-util",
 ]
@@ -1978,13 +1978,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-post-quantum"
-version = "0.3.0-alpha.0"
+version = "0.3.0-dev.1"
 dependencies = [
  "aws-lc-rs",
  "criterion",
  "env_logger",
  "rcgen",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-aws-lc-rs",
  "rustls-test",
  "rustls-util",
@@ -1997,7 +1997,7 @@ name = "rustls-provider-test"
 version = "0.1.0"
 dependencies = [
  "hex",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-aws-lc-rs",
  "serde",
  "serde_json",
@@ -2005,11 +2005,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-ring"
-version = "0.1.0-dev.0"
+version = "0.1.0-dev.1"
 dependencies = [
  "bencher",
  "ring",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-pki-types",
  "rustls-test",
  "subtle",
@@ -2023,7 +2023,7 @@ dependencies = [
  "log",
  "macro_rules_attribute",
  "num-bigint 0.5.1",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
  "rustls-aws-lc-rs",
  "rustls-pki-types",
  "rustls-ring",
@@ -2035,11 +2035,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-util"
-version = "0.1.0"
+version = "0.1.0-dev.1"
 dependencies = [
  "env_logger",
  "log",
- "rustls 0.24.0-dev.0",
+ "rustls 0.24.0-dev.1",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustls"
-version = "0.24.0-dev.0"
+version = "0.24.0-dev.1"
 dependencies = [
  "log",
  "once_cell",

--- a/rustls-aws-lc-rs/Cargo.toml
+++ b/rustls-aws-lc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-aws-lc-rs"
-version = "0.1.0-dev.0"
+version = "0.1.0-dev.1"
 edition.workspace = true
 rust-version = "1.85"
 license = "Apache-2.0 OR ISC OR MIT"
@@ -19,7 +19,7 @@ std = []
 [dependencies]
 aws-lc-rs = { workspace = true, features = ["prebuilt-nasm"] }
 pki-types = { workspace = true }
-rustls = { path = "../rustls", version = "0.24.0-dev.0", default-features = false }
+rustls = { path = "../rustls", version = "0.24.0-dev.1", default-features = false }
 subtle = { workspace = true }
 zeroize = { workspace = true }
 

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-post-quantum"
-version = "0.3.0-alpha.0"
+version = "0.3.0-dev.1"
 edition.workspace = true
 rust-version = "1.85"
 license = "Apache-2.0 OR ISC OR MIT"
@@ -13,7 +13,7 @@ autobenches = false
 
 [dependencies]
 aws-lc-rs = { workspace = true, features = ["unstable"] }
-rustls-aws-lc-rs = { path = "../rustls-aws-lc-rs" }
+rustls-aws-lc-rs = { version = "0.1.0-dev.1", path = "../rustls-aws-lc-rs" }
 rustls = { path = "../rustls", version = "0.24.0-dev.0", default-features = false }
 webpki = { workspace = true }
 

--- a/rustls-provider-test/Cargo.toml
+++ b/rustls-provider-test/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 hex = "0.4"
-rustls = { version = "0.24.0-dev.0", features = ["log"], path = "../rustls" }
+rustls = { version = "0.24.0-dev.1", features = ["log"], path = "../rustls" }
 rustls-aws-lc-rs = { path = "../rustls-aws-lc-rs" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rustls-ring/Cargo.toml
+++ b/rustls-ring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-ring"
-version = "0.1.0-dev.0"
+version = "0.1.0-dev.1"
 edition.workspace = true
 rust-version = "1.85"
 license = "Apache-2.0 OR ISC OR MIT"
@@ -16,7 +16,7 @@ std = []
 
 [dependencies]
 pki-types = { workspace = true }
-rustls = { path = "../rustls", version = "0.24.0-dev.0", default-features = false }
+rustls = { path = "../rustls", version = "0.24.0-dev.1", default-features = false }
 ring = { workspace = true }
 subtle = { workspace = true }
 

--- a/rustls-util/Cargo.toml
+++ b/rustls-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-util"
-version = "0.1.0"
+version = "0.1.0-dev.1"
 edition.workspace = true
 license = "Apache-2.0 OR ISC OR MIT"
 description = "Utilities for use with rustls"
@@ -13,7 +13,7 @@ log = ["dep:log", "rustls/log"]
 
 [dependencies]
 log = { workspace = true, optional = true }
-rustls = { path = "../rustls", version = "0.24.0-dev.0", default-features = false }
+rustls = { path = "../rustls", version = "0.24.0-dev.1", default-features = false }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.24.0-dev.0"
+version = "0.24.0-dev.1"
 edition.workspace = true
 rust-version = "1.85"
 license = "Apache-2.0 OR ISC OR MIT"


### PR DESCRIPTION
This is merely a checkpoint to publish something off main against rustls-util as required by crates.io policies.

I will publish:

- rustls v0.24.0-dev.1
- rustls-aws-lc-rs v0.1.0-dev.1
- rustls-ring v0.1.0-dev.1
- rustls-util v0.1.0-dev.1
- rustls-post-quantum v0.3.0-dev.1

No release notes or github releases for these.
