### PR TITLE
Correct interactions between TLS1.2 and QUIC

### DIFF
--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -2336,20 +2336,32 @@ pub mod encoding {
             }
         }
 
-        pub fn new_dummy_key_share() -> Self {
-            const SOME_POINT_ON_P256: &[u8] = &[
-                4, 41, 39, 177, 5, 18, 186, 227, 237, 220, 254, 70, 120, 40, 18, 139, 173, 41, 3,
-                38, 153, 25, 247, 8, 96, 105, 200, 196, 223, 108, 115, 40, 56, 199, 120, 121, 100,
-                234, 172, 0, 229, 146, 31, 177, 73, 138, 96, 244, 96, 103, 102, 179, 217, 104, 80,
-                1, 85, 141, 26, 151, 78, 115, 65, 81, 62,
-            ];
+        pub fn new_versions_server_tls13() -> Self {
+            Self {
+                typ: Self::SUPPORTED_VERSIONS,
+                body: ProtocolVersion::TLSv1_3
+                    .to_array()
+                    .to_vec(),
+            }
+        }
 
-            let mut share = len_u16(SOME_POINT_ON_P256.to_vec());
+        pub fn new_dummy_key_share() -> Self {
+            let mut share = len_u16(Self::SOME_POINT_ON_P256.to_vec());
             share.splice(0..0, NamedGroup::secp256r1.to_array());
 
             Self {
                 typ: Self::KEY_SHARE,
                 body: len_u16(share),
+            }
+        }
+
+        pub fn new_dummy_key_share_server() -> Self {
+            let mut share = len_u16(Self::SOME_POINT_ON_P256.to_vec());
+            share.splice(0..0, NamedGroup::secp256r1.to_array());
+
+            Self {
+                typ: Self::KEY_SHARE,
+                body: share,
             }
         }
 
@@ -2373,6 +2385,13 @@ pub mod encoding {
         pub const KEY_SHARE: u16 = 0x0033;
         pub const TRANSPORT_PARAMETERS: u16 = 0x0039;
         pub const ALPN: u16 = 0x0010;
+
+        const SOME_POINT_ON_P256: &[u8] = &[
+            4, 41, 39, 177, 5, 18, 186, 227, 237, 220, 254, 70, 120, 40, 18, 139, 173, 41, 3, 38,
+            153, 25, 247, 8, 96, 105, 200, 196, 223, 108, 115, 40, 56, 199, 120, 121, 100, 234,
+            172, 0, 229, 146, 31, 177, 73, 138, 96, 244, 96, 103, 102, 179, 217, 104, 80, 1, 85,
+            141, 26, 151, 78, 115, 65, 81, 62,
+        ];
     }
 
     /// Return a full TLS message containing a fatal alert.

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -2,17 +2,18 @@
 
 #![allow(clippy::disallowed_types, clippy::duplicate_mod)]
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use rustls::client::Resumption;
-use rustls::crypto::CipherSuite;
+use rustls::crypto::{CipherSuite, CryptoProvider};
 use rustls::enums::ProtocolVersion;
 use rustls::error::{
     AlertDescription, ApiMisuse, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved,
 };
 use rustls::quic::{self, Connection, QuicEvent, ServerHandshake, Side};
 use rustls::server::Tls13Tickets;
-use rustls::{HandshakeKind, SliceInput};
+use rustls::{CipherSuiteCommon, HandshakeKind, SliceInput, Tls13CipherSuite};
 use rustls_test::{
     ClientStorage, KeyType, encoding, make_client_config, make_server_config, server_name,
 };
@@ -1174,3 +1175,62 @@ fn server_rejects_client_hello_with_trailing_fragment() {
         PeerMisbehaved::KeyEpochWithPendingFragment.into()
     );
 }
+
+#[test]
+fn client_rejects_server_choosing_non_quic_suite() {
+    // we support [TLS13_AES_128_GCM_SHA256_WITHOUT_QUIC, TLS13_AES_256_GCM_SHA384].  our
+    // offer is [TLS13_AES_256_GCM_SHA384].  The server chooses TLS13_AES_128_GCM_SHA256_WITHOUT_QUIC
+    // which we should reject.
+    let provider = CryptoProvider {
+        tls13_cipher_suites: Cow::Owned(vec![
+            TLS13_AES_128_GCM_SHA256_WITHOUT_QUIC,
+            provider::cipher_suite::TLS13_AES_256_GCM_SHA384,
+        ]),
+        kx_groups: Cow::Owned(vec![provider::kx_group::SECP256R1]),
+        ..provider::DEFAULT_PROVIDER
+    };
+    let mut client = quic::ClientConnection::new(
+        Arc::new(make_client_config(KeyType::EcdsaP256, &provider)),
+        quic::Version::V2,
+        "hello.com".try_into().unwrap(),
+        vec![],
+    )
+    .unwrap();
+    let _ = client.events();
+    assert_eq!(
+        client
+            .read_hs(&mut SliceInput::new(&mut encoding::server_hello(
+                ProtocolVersion::TLSv1_2,
+                &[0x12; 32],
+                &[0],
+                CipherSuite::TLS13_AES_128_GCM_SHA256,
+                vec![
+                    encoding::Extension::new_versions_server_tls13(),
+                    encoding::Extension::new_dummy_key_share_server()
+                ]
+            )))
+            .err(),
+        Some(PeerMisbehaved::SelectedUnofferedCipherSuite.into()),
+    );
+}
+
+/// TLS13_AES_128_GCM_SHA256 which doesn't support QUIC.
+///
+/// Once `clone` is const this can be more directly written.
+const TLS13_AES_128_GCM_SHA256_WITHOUT_QUIC: &Tls13CipherSuite = &Tls13CipherSuite {
+    common: CipherSuiteCommon {
+        suite: provider::cipher_suite::TLS13_AES_128_GCM_SHA256
+            .common
+            .suite,
+        hash_provider: provider::cipher_suite::TLS13_AES_128_GCM_SHA256
+            .common
+            .hash_provider,
+        confidentiality_limit: provider::cipher_suite::TLS13_AES_128_GCM_SHA256
+            .common
+            .confidentiality_limit,
+    },
+    protocol_version: provider::cipher_suite::TLS13_AES_128_GCM_SHA256.protocol_version,
+    hkdf_provider: provider::cipher_suite::TLS13_AES_128_GCM_SHA256.hkdf_provider,
+    aead_alg: provider::cipher_suite::TLS13_AES_128_GCM_SHA256.aead_alg,
+    quic: None,
+};

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -5,6 +5,8 @@
 use std::sync::Arc;
 
 use rustls::client::Resumption;
+use rustls::crypto::CipherSuite;
+use rustls::enums::ProtocolVersion;
 use rustls::error::{
     AlertDescription, ApiMisuse, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved,
 };
@@ -617,6 +619,31 @@ fn test_quic_server_no_tls12() {
     assert_eq!(
         AlertDescription::try_from(&err).ok(),
         Some(AlertDescription::ProtocolVersion)
+    );
+}
+
+#[test]
+fn test_quic_server_rejects_tls12_hello() {
+    let mut server = quic::ServerConnection::new(
+        Arc::new(make_server_config(
+            KeyType::EcdsaP256,
+            &provider::DEFAULT_PROVIDER,
+        )),
+        quic::Version::V2,
+        vec![],
+    )
+    .unwrap();
+    assert_eq!(
+        server
+            .read_hs(&mut SliceInput::new(&mut encoding::client_hello(
+                ProtocolVersion::TLSv1_2,
+                &[0x12; 32],
+                &[0x00],
+                vec![CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256],
+                vec![encoding::Extension::new_sig_algs()],
+            )))
+            .err(),
+        Some(PeerIncompatible::Tls13RequiredForQuic.into())
     );
 }
 

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -647,6 +647,33 @@ fn test_quic_server_rejects_tls12_hello() {
     );
 }
 
+#[test]
+fn test_quic_client_rejects_tls12_server() {
+    let mut client = quic::ClientConnection::new(
+        Arc::new(make_client_config(
+            KeyType::EcdsaP256,
+            &provider::DEFAULT_PROVIDER,
+        )),
+        quic::Version::V2,
+        "hello.com".try_into().unwrap(),
+        vec![],
+    )
+    .unwrap();
+    let _ = client.events();
+    assert_eq!(
+        client
+            .read_hs(&mut SliceInput::new(&mut encoding::server_hello(
+                ProtocolVersion::TLSv1_2,
+                &[0x12; 32],
+                &[0],
+                CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                vec![]
+            )))
+            .err(),
+        Some(PeerIncompatible::ServerTlsVersionIsDisabledByOurConfig.into()),
+    );
+}
+
 fn do_quic_handshake(client: &mut impl Connection, server: &mut impl Connection) {
     while client.is_handshaking() || server.is_handshaking() {
         quic_transfer(client, server).unwrap();

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -1214,6 +1214,42 @@ fn client_rejects_server_choosing_non_quic_suite() {
     );
 }
 
+#[test]
+fn server_rejects_client_choosing_non_quic_suite() {
+    let provider = CryptoProvider {
+        tls13_cipher_suites: Cow::Owned(vec![
+            TLS13_AES_128_GCM_SHA256_WITHOUT_QUIC,
+            provider::cipher_suite::TLS13_AES_256_GCM_SHA384,
+        ]),
+        kx_groups: Cow::Owned(vec![provider::kx_group::SECP256R1]),
+        ..provider::DEFAULT_PROVIDER
+    };
+    let mut server = quic::ServerConnection::new(
+        Arc::new(make_server_config(KeyType::EcdsaP256, &provider)),
+        quic::Version::V2,
+        vec![],
+    )
+    .unwrap();
+    assert_eq!(
+        server
+            .read_hs(&mut SliceInput::new(&mut encoding::client_hello(
+                ProtocolVersion::TLSv1_2,
+                &[0x12; 32],
+                &[0x00],
+                vec![CipherSuite::TLS13_AES_128_GCM_SHA256],
+                vec![
+                    encoding::Extension::new_sig_algs(),
+                    encoding::Extension::new_versions(),
+                    encoding::Extension::new_dummy_key_share(),
+                    encoding::Extension::new_kx_groups(),
+                    encoding::Extension::new_quic_transport_params(b"blurgh")
+                ],
+            )))
+            .err(),
+        Some(PeerIncompatible::NoCipherSuitesInCommon.into())
+    );
+}
+
 /// TLS13_AES_128_GCM_SHA256 which doesn't support QUIC.
 ///
 /// Once `clone` is const this can be more directly written.

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -13,9 +13,10 @@ use rustls::error::{
 };
 use rustls::quic::{self, Connection, QuicEvent, ServerHandshake, Side};
 use rustls::server::Tls13Tickets;
-use rustls::{CipherSuiteCommon, HandshakeKind, SliceInput, Tls13CipherSuite};
+use rustls::{CipherSuiteCommon, HandshakeKind, SliceInput, Tls13CipherSuite, VecInput};
 use rustls_test::{
-    ClientStorage, KeyType, encoding, make_client_config, make_server_config, server_name,
+    ClientStorage, KeyType, do_handshake, encoding, make_client_config, make_pair_for_arc_configs,
+    make_server_config, server_name,
 };
 
 use super::provider;
@@ -1248,6 +1249,71 @@ fn server_rejects_client_choosing_non_quic_suite() {
             .err(),
         Some(PeerIncompatible::NoCipherSuitesInCommon.into())
     );
+}
+
+// A session stored from a TCP connection may name a cipher suite that cannot be
+// used for QUIC.  Such a session is simply not resumable on a QUIC connection:
+// it must not prevent the connection being made at all.
+#[test]
+fn quic_client_ignores_stored_session_with_non_quic_suite() {
+    let tcp_provider = CryptoProvider {
+        tls13_cipher_suites: Cow::Owned(vec![TLS13_AES_128_GCM_SHA256_WITHOUT_QUIC]),
+        ..provider::DEFAULT_TLS13_PROVIDER
+    };
+
+    // Fill the session store over TCP, using the suite which does not support QUIC.
+    let storage = Arc::new(ClientStorage::new());
+    let mut client_config = make_client_config(KeyType::default(), &tcp_provider);
+    client_config.resumption = Resumption::store(storage.clone());
+    let (mut client, mut server) = make_pair_for_arc_configs(
+        &Arc::new(client_config),
+        &Arc::new(make_server_config(KeyType::default(), &tcp_provider)),
+    );
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client,
+        &mut server_input,
+        &mut server,
+    );
+    assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
+    assert!(
+        storage
+            .ops()
+            .iter()
+            .any(|op| matches!(op, rustls_test::ClientStorageOp::InsertTls13Ticket(_)))
+    );
+
+    // Now connect over QUIC, sharing the session store.  This provider _does_ offer a
+    // QUIC-capable suite, so the connection is perfectly viable -- the stored session
+    // just cannot be used for it.
+    let quic_provider = CryptoProvider {
+        tls13_cipher_suites: Cow::Owned(vec![
+            TLS13_AES_128_GCM_SHA256_WITHOUT_QUIC,
+            provider::cipher_suite::TLS13_AES_256_GCM_SHA384,
+        ]),
+        ..provider::DEFAULT_TLS13_PROVIDER
+    };
+    let mut client_config = make_client_config(KeyType::default(), &quic_provider);
+    client_config.resumption = Resumption::store(storage);
+    let mut client = quic::ClientConnection::new(
+        Arc::new(client_config),
+        quic::Version::V2,
+        "localhost".try_into().unwrap(),
+        vec![],
+    )
+    .unwrap();
+    let mut server = quic::ServerConnection::new(
+        Arc::new(make_server_config(KeyType::EcdsaP256, &quic_provider)),
+        quic::Version::V2,
+        vec![],
+    )
+    .unwrap();
+
+    do_quic_handshake(&mut client, &mut server);
+    assert_eq!(client.handshake_kind(), Some(HandshakeKind::Full));
+    assert_eq!(server.handshake_kind(), Some(HandshakeKind::Full));
 }
 
 /// TLS13_AES_128_GCM_SHA256 which doesn't support QUIC.

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -614,7 +614,7 @@ fn test_quic_server_no_tls12() {
         .unwrap();
     assert_eq!(
         err,
-        Error::PeerIncompatible(PeerIncompatible::SupportedVersionsExtensionRequired),
+        Error::PeerIncompatible(PeerIncompatible::Tls13RequiredForQuic),
     );
     assert_eq!(
         AlertDescription::try_from(&err).ok(),

--- a/rustls/src/client/config.rs
+++ b/rustls/src/client/config.rs
@@ -13,6 +13,7 @@ use super::handy::{ClientSessionMemoryCache, FailResolveClientCert, NoClientSess
 use super::{Tls12Session, Tls13Session};
 use crate::builder::{ConfigBuilder, WantsVerifier};
 use crate::client::connection::ClientConnectionBuilder;
+use crate::common_state::Protocol;
 #[cfg(doc)]
 use crate::crypto;
 use crate::crypto::kx::NamedGroup;
@@ -270,8 +271,8 @@ impl ClientConfig {
         &self.domain.verifier
     }
 
-    pub(crate) fn supports_version(&self, v: ProtocolVersion) -> bool {
-        self.domain.provider.supports_version(v)
+    pub(crate) fn supports_version(&self, v: ProtocolVersion, protocol: Protocol) -> bool {
+        self.domain.provider.supports_version(v) && protocol.supports_version(v)
     }
 
     pub(super) fn find_cipher_suite(&self, suite: CipherSuite) -> Option<SupportedCipherSuite> {

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -270,7 +270,7 @@ impl EchGreaseConfig {
 
         // Construct an inner hello using the outer hello - this allows us to know the size of
         // dummy payload we should use for the GREASE extension.
-        let encoded_inner_hello = grease_state.encode_inner_hello(outer_hello, None, None);
+        let encoded_inner_hello = grease_state.encode_inner_hello(outer_hello, None, None)?;
 
         // Generate a payload of random data equivalent in length to a real inner hello.
         let payload_len = encoded_inner_hello.len()
@@ -416,7 +416,7 @@ impl EchState {
         );
 
         // Construct the encoded inner hello and update the transcript.
-        let encoded_inner_hello = self.encode_inner_hello(&outer_hello, retry_req, resuming);
+        let encoded_inner_hello = self.encode_inner_hello(&outer_hello, retry_req, resuming)?;
 
         // Complete the ClientHelloOuterAAD with an ech extension, the payload should be a placeholder
         // of size L, all zeroes. L == length of encrypting encoded client hello inner w/ the selected
@@ -587,7 +587,7 @@ impl EchState {
         outer_hello: &ClientHelloPayload,
         retryreq: Option<&HelloRetryRequest>,
         resuming: Option<&Retrieved<&Tls13Session>>,
-    ) -> Vec<u8> {
+    ) -> Result<Vec<u8>, Error> {
         // Start building an inner hello using the outer_hello as a template.
         let mut inner_hello = ClientHelloPayload {
             // Some information is copied over as-is.
@@ -678,8 +678,11 @@ impl EchState {
         if let Some(resuming) = resuming.as_ref() {
             let mut chp = HandshakeMessagePayload(HandshakePayload::ClientHello(inner_hello));
 
-            let key_schedule =
-                KeyScheduleEarlyClient::new(self.protocol, resuming.suite, resuming.secret.bytes());
+            let key_schedule = KeyScheduleEarlyClient::new(
+                self.protocol,
+                resuming.suite,
+                resuming.secret.bytes(),
+            )?;
             tls13::fill_in_psk_binder(&key_schedule, &self.inner_hello_transcript, &mut chp);
             self.early_data_key_schedule = Some(key_schedule);
 
@@ -744,7 +747,7 @@ impl EchState {
         self.inner_hello_transcript
             .add_message(&inner_hello_msg);
 
-        encoded_hello
+        Ok(encoded_hello)
     }
 
     // See https://datatracker.ietf.org/doc/html/rfc9849#name-grease-psk
@@ -910,7 +913,9 @@ mod tests {
 
     #[test]
     fn inner_client_hello_length_conceals_inner_name_length() {
-        let base_inner_len = inner_hello_encoding_for_name(dns_name_of_len(1), true).len();
+        let base_inner_len = inner_hello_encoding_for_name(dns_name_of_len(1), true)
+            .unwrap()
+            .len();
         assert!(
             base_inner_len % 32 == 0,
             "inner hello length must be 32-byte padded"
@@ -922,7 +927,9 @@ mod tests {
 
         for inner_name_len in 1..251 {
             assert_eq!(
-                inner_hello_encoding_for_name(dns_name_of_len(inner_name_len), true).len(),
+                inner_hello_encoding_for_name(dns_name_of_len(inner_name_len), true)
+                    .unwrap()
+                    .len(),
                 base_inner_len,
                 "all inner hello lengths must be invariant wrt inner name length"
             );
@@ -931,7 +938,9 @@ mod tests {
 
     #[test]
     fn inner_client_hello_length_does_not_leak_length_of_omitted_inner_name() {
-        let base_inner_len = inner_hello_encoding_for_name(dns_name_of_len(1), false).len();
+        let base_inner_len = inner_hello_encoding_for_name(dns_name_of_len(1), false)
+            .unwrap()
+            .len();
         assert!(
             base_inner_len % 32 == 0,
             "inner hello length must be 32-byte padded"
@@ -943,14 +952,19 @@ mod tests {
 
         for inner_name_len in 1..251 {
             assert_eq!(
-                inner_hello_encoding_for_name(dns_name_of_len(inner_name_len), false).len(),
+                inner_hello_encoding_for_name(dns_name_of_len(inner_name_len), false)
+                    .unwrap()
+                    .len(),
                 base_inner_len,
                 "all inner hello lengths must be invariant wrt inner name length"
             );
         }
     }
 
-    fn inner_hello_encoding_for_name(name: DnsName<'static>, enable_sni: bool) -> Vec<u8> {
+    fn inner_hello_encoding_for_name(
+        name: DnsName<'static>,
+        enable_sni: bool,
+    ) -> Result<Vec<u8>, Error> {
         let config = EchConfig {
             config: EchConfigPayload::V18(EchConfigContents {
                 key_config: HpkeKeyConfig {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -156,7 +156,10 @@ impl ExpectServerHello {
 
         let suite = <CryptoProvider as Borrow<[&'static T]>>::borrow(self.input.config.provider())
             .iter()
-            .find(|cs| cs.common().suite == server_hello.cipher_suite)
+            .find(|cs| {
+                cs.common().suite == server_hello.cipher_suite
+                    && cs.usable_for_protocol(self.input.protocol)
+            })
             .ok_or(PeerMisbehaved::SelectedUnofferedCipherSuite)?;
 
         match self.suite {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -1006,6 +1006,14 @@ fn prepare_resumption<'a>(
         suite.can_resume_from(tls13.suite)?;
     }
 
+    // Similarly, if the suite is not usable for the protocol.
+    if !tls13
+        .suite
+        .usable_for_protocol(protocol)
+    {
+        return None;
+    }
+
     let early_data_enabled =
         tls13::prepare_resumption(config, output, &tls13, exts, suite.is_some());
     Some((tls13, early_data_enabled))

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -840,7 +840,7 @@ fn emit_client_hello_for_retry(
                 input.protocol,
                 tls13_session.suite,
                 tls13_session.secret.bytes(),
-            );
+            )?;
             tls13::fill_in_psk_binder(&key_schedule, &transcript_buffer, &mut chp);
             Some((tls13_session.suite, key_schedule))
         }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -154,13 +154,19 @@ impl ExpectServerHello {
             }
         }
 
-        let suite = <CryptoProvider as Borrow<[&'static T]>>::borrow(self.input.config.provider())
-            .iter()
-            .find(|cs| {
-                cs.common().suite == server_hello.cipher_suite
-                    && cs.usable_for_protocol(self.input.protocol)
+        let Some(Some(suite)) = self
+            .input
+            .hello
+            .offered_cipher_suites
+            .contains(&server_hello.cipher_suite)
+            .then(|| {
+                <CryptoProvider as Borrow<[&'static T]>>::borrow(self.input.config.provider())
+                    .iter()
+                    .find(|cs| cs.common().suite == server_hello.cipher_suite)
             })
-            .ok_or(PeerMisbehaved::SelectedUnofferedCipherSuite)?;
+        else {
+            return Err(PeerMisbehaved::SelectedUnofferedCipherSuite.into());
+        };
 
         match self.suite {
             Some(prev_suite) if prev_suite.suite() != suite.common().suite => {
@@ -815,6 +821,7 @@ fn emit_client_hello_for_retry(
 
     // Note what extensions we sent.
     input.hello.sent_extensions = chp_payload.collect_used();
+    input.hello.offered_cipher_suites = chp_payload.cipher_suites.clone();
 
     let mut chp = HandshakeMessagePayload(HandshakePayload::ClientHello(chp_payload));
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -192,7 +192,6 @@ impl ExpectServerHello {
         trace!("We got ServerHello {server_hello:#?}");
 
         let config = &self.input.config;
-        let tls13_supported = config.supports_version(ProtocolVersion::TLSv1_3);
 
         let server_version = if server_hello.legacy_version == ProtocolVersion::TLSv1_2 {
             server_hello
@@ -203,10 +202,14 @@ impl ExpectServerHello {
         };
 
         match server_version {
-            ProtocolVersion::TLSv1_3 if tls13_supported => {
+            ProtocolVersion::TLSv1_3
+                if config.supports_version(ProtocolVersion::TLSv1_3, self.input.protocol) =>
+            {
                 self.with_version::<Tls13CipherSuite>(server_hello, &input, output)
             }
-            ProtocolVersion::TLSv1_2 if config.supports_version(ProtocolVersion::TLSv1_2) => {
+            ProtocolVersion::TLSv1_2
+                if config.supports_version(ProtocolVersion::TLSv1_2, self.input.protocol) =>
+            {
                 if let Some((_, true)) = &self.early_data_key_schedule {
                     // The client must fail with a dedicated error code if the server
                     // responds with TLS 1.2 when offering 0-RTT.
@@ -461,7 +464,9 @@ impl ClientHelloInput {
         let session_id = match session_id {
             Some(session_id) => session_id,
             None if output.quic().is_some() => SessionId::empty(),
-            None if !config.supports_version(ProtocolVersion::TLSv1_3) => SessionId::empty(),
+            None if !config.supports_version(ProtocolVersion::TLSv1_3, protocol) => {
+                SessionId::empty()
+            }
             None => SessionId::random(config.provider().secure_random)?,
         };
 
@@ -504,7 +509,7 @@ impl ClientHelloInput {
 
         let key_share = if self
             .config
-            .supports_version(ProtocolVersion::TLSv1_3)
+            .supports_version(ProtocolVersion::TLSv1_3, self.protocol)
         {
             Some(tls13::initial_key_share(&self.config, &self.session_key)?)
         } else {
@@ -556,8 +561,8 @@ fn emit_client_hello_for_retry(
     let forbids_tls12 = input.protocol.is_quic() || ech_state.is_some();
 
     let supported_versions = SupportedProtocolVersions {
-        tls13: config.supports_version(ProtocolVersion::TLSv1_3),
-        tls12: config.supports_version(ProtocolVersion::TLSv1_2) && !forbids_tls12,
+        tls13: config.supports_version(ProtocolVersion::TLSv1_3, input.protocol),
+        tls12: config.supports_version(ProtocolVersion::TLSv1_2, input.protocol) && !forbids_tls12,
     };
 
     // should be unreachable thanks to config builder
@@ -722,7 +727,14 @@ fn emit_client_hello_for_retry(
     }
 
     // Do we have a SessionID or ticket cached for this host?
-    let tls13_session = prepare_resumption(&input.resuming, &mut exts, suite, output, config);
+    let tls13_session = prepare_resumption(
+        &input.resuming,
+        &mut exts,
+        suite,
+        input.protocol,
+        output,
+        config,
+    );
     let (tls13_session, early_data_enabled) = match tls13_session {
         Some((tls13_session, early_data_enabled)) => (Some(tls13_session), early_data_enabled),
         _ => (None, false),
@@ -940,6 +952,7 @@ fn prepare_resumption<'a>(
     resuming: &'a Option<Retrieved<ClientSessionValue>>,
     exts: &mut ClientExtensions<'_>,
     suite: Option<SupportedCipherSuite>,
+    protocol: Protocol,
     output: &mut dyn Output<'_>,
     config: &ClientConfig,
 ) -> Option<(Retrieved<&'a Tls13Session>, bool)> {
@@ -947,7 +960,7 @@ fn prepare_resumption<'a>(
     let resuming = match resuming {
         Some(resuming) if !resuming.ticket().is_empty() => resuming,
         _ => {
-            if config.supports_version(ProtocolVersion::TLSv1_2)
+            if config.supports_version(ProtocolVersion::TLSv1_2, protocol)
                 && config.resumption.tls12_resumption == Tls12Resumption::SessionIdOrTickets
             {
                 // If we don't have a ticket, request one.
@@ -959,7 +972,7 @@ fn prepare_resumption<'a>(
 
     let Some(tls13) = resuming.map(|csv| csv.tls13()) else {
         // TLS 1.2; send the ticket if we have support this protocol version
-        if config.supports_version(ProtocolVersion::TLSv1_2)
+        if config.supports_version(ProtocolVersion::TLSv1_2, protocol)
             && config.resumption.tls12_resumption == Tls12Resumption::SessionIdOrTickets
         {
             exts.session_ticket = Some(ClientSessionTicket::Offer(Payload::new(resuming.ticket())));
@@ -967,7 +980,7 @@ fn prepare_resumption<'a>(
         return None; // TLS 1.2, so nothing to return here
     };
 
-    if !config.supports_version(ProtocolVersion::TLSv1_3) {
+    if !config.supports_version(ProtocolVersion::TLSv1_3, protocol) {
         return None;
     }
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -362,6 +362,7 @@ struct ClientHelloDetails {
     sent_extensions: Vec<ExtensionType>,
     extension_order_seed: u16,
     offered_cert_compression: bool,
+    offered_cipher_suites: Vec<CipherSuite>,
 }
 
 impl ClientHelloDetails {
@@ -371,6 +372,7 @@ impl ClientHelloDetails {
             sent_extensions: Vec::new(),
             extension_order_seed,
             offered_cert_compression: false,
+            offered_cipher_suites: Vec::new(),
         }
     }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -72,6 +72,7 @@ mod server_hello {
     use crate::client::hs::{
         ClientHandler, ClientHelloInput, ClientSessionValue, ClientState, ExpectServerHello,
     };
+    use crate::common_state::Protocol;
     use crate::msgs::ServerHelloPayload;
     use crate::sealed::Sealed;
 
@@ -107,7 +108,7 @@ mod server_hello {
             if st
                 .input
                 .config
-                .supports_version(ProtocolVersion::TLSv1_3)
+                .supports_version(ProtocolVersion::TLSv1_3, Protocol::Tcp)
                 && has_downgrade_marker
             {
                 return Err(PeerMisbehaved::AttemptedDowngradeToTls12WhenTls13IsSupported.into());

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -183,7 +183,7 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
                     output.emit(Event::EarlyData(EarlyDataEvent::Rejected));
                     resuming_session.take();
                     (
-                        KeySchedulePreHandshake::new(Side::Client, protocol, suite),
+                        KeySchedulePreHandshake::new(Side::Client, protocol, suite)?,
                         false,
                     )
                 }

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -397,6 +397,13 @@ impl Protocol {
     pub(crate) fn is_quic(&self) -> bool {
         matches!(self, Self::Quic(_))
     }
+
+    pub(crate) fn supports_version(&self, version: ProtocolVersion) -> bool {
+        match self {
+            Self::Quic(_) => version == ProtocolVersion::TLSv1_3,
+            Self::Tcp => true,
+        }
+    }
 }
 
 pub(crate) struct HandshakeFlight<'a, const TLS13: bool> {

--- a/rustls/src/server/config.rs
+++ b/rustls/src/server/config.rs
@@ -9,6 +9,7 @@ use pki_types::{DnsName, FipsStatus, UnixTime};
 
 use super::{ServerSessionKey, handy};
 use crate::builder::{ConfigBuilder, WantsVerifier};
+use crate::common_state::Protocol;
 #[cfg(doc)]
 use crate::crypto;
 use crate::crypto::kx::NamedGroup;
@@ -286,8 +287,8 @@ impl ServerConfig {
         &self.provider
     }
 
-    pub(crate) fn supports_version(&self, v: ProtocolVersion) -> bool {
-        self.provider.supports_version(v)
+    pub(crate) fn supports_version(&self, v: ProtocolVersion, protocol: Protocol) -> bool {
+        self.provider.supports_version(v) && protocol.supports_version(v)
     }
 
     pub(super) fn current_time(&self) -> Result<UnixTime, Error> {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -681,6 +681,8 @@ impl ExpectClientHello {
 
                 // Reduce our supported ciphersuites by the certified key's algorithm.
                 (suite.usable_for_signature_scheme(sig_scheme)
+                // And usable by the current protocol
+                && suite.usable_for_protocol(self.protocol)
                 // And support for one of the key exchange groups
                 && (ecdhe_possible && suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::ECDHE)
                 || ffdhe_possible && suite.usable_for_kx_algorithm(KeyExchangeAlgorithm::DHE)))

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -492,10 +492,10 @@ impl ExpectClientHello {
     ) -> Result<ServerState, Error> {
         let tls13_enabled = self
             .config
-            .supports_version(ProtocolVersion::TLSv1_3);
+            .supports_version(ProtocolVersion::TLSv1_3, self.protocol);
         let tls12_enabled = self
             .config
-            .supports_version(ProtocolVersion::TLSv1_2);
+            .supports_version(ProtocolVersion::TLSv1_2, self.protocol);
 
         // Are we doing TLS1.3?
         if let Some(versions) = &input.client_hello.supported_versions {
@@ -511,10 +511,10 @@ impl ExpectClientHello {
         } else if u16::from(input.client_hello.client_version) < u16::from(ProtocolVersion::TLSv1_2)
         {
             Err(PeerIncompatible::Tls12NotOffered.into())
-        } else if !tls12_enabled && tls13_enabled {
-            Err(PeerIncompatible::SupportedVersionsExtensionRequired.into())
         } else if self.protocol.is_quic() {
             Err(PeerIncompatible::Tls13RequiredForQuic.into())
+        } else if !tls12_enabled && tls13_enabled {
+            Err(PeerIncompatible::SupportedVersionsExtensionRequired.into())
         } else {
             self.with_version::<Tls12CipherSuite>(input, output)
         }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -488,7 +488,7 @@ mod client_hello {
 
             if !check_binder(
                 transcript,
-                &KeyScheduleEarlyServer::new(protocol, suite, session.secret.bytes()),
+                &KeyScheduleEarlyServer::new(protocol, suite, session.secret.bytes())?,
                 input.message,
                 psk_offer.binders[i].as_ref(),
             ) {
@@ -570,7 +570,7 @@ mod client_hello {
         // Start key schedule
         let key_schedule_pre_handshake = if let Some((_, psk)) = resuming {
             let early_key_schedule =
-                KeyScheduleEarlyServer::new(protocol, suite, psk.secret.bytes());
+                KeyScheduleEarlyServer::new(protocol, suite, psk.secret.bytes())?;
             early_key_schedule.client_early_traffic_secret(
                 &client_hello_hash,
                 &*config.key_log,
@@ -591,7 +591,7 @@ mod client_hello {
 
             KeySchedulePreHandshake::from(early_key_schedule)
         } else {
-            KeySchedulePreHandshake::new(Side::Server, protocol, suite)
+            KeySchedulePreHandshake::new(Side::Server, protocol, suite)?
         };
 
         // Do key exchange

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -11,7 +11,7 @@ use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError, expa
 use crate::crypto::{hash, hmac};
 use crate::error::{ApiMisuse, Error};
 use crate::msgs::{HandshakeAlignedProof, Message};
-use crate::{ConnectionTrafficSecrets, KeyLog, Tls13CipherSuite};
+use crate::{ConnectionTrafficSecrets, KeyLog, Tls13CipherSuite, quic};
 
 // We express the state of a contained KeySchedule using these
 // typestates.  This means we can write code that cannot accidentally
@@ -22,8 +22,17 @@ use crate::{ConnectionTrafficSecrets, KeyLog, Tls13CipherSuite};
 pub(crate) struct KeyScheduleEarlyClient(KeyScheduleEarly);
 
 impl KeyScheduleEarlyClient {
-    pub(crate) fn new(protocol: Protocol, suite: &'static Tls13CipherSuite, secret: &[u8]) -> Self {
-        Self(KeyScheduleEarly::new(Side::Client, protocol, suite, secret))
+    pub(crate) fn new(
+        protocol: Protocol,
+        suite: &'static Tls13CipherSuite,
+        secret: &[u8],
+    ) -> Result<Self, Error> {
+        Ok(Self(KeyScheduleEarly::new(
+            Side::Client,
+            protocol,
+            suite,
+            secret,
+        )?))
     }
 
     /// Computes the `client_early_traffic_secret` and installs it as encrypter.
@@ -58,8 +67,17 @@ impl Deref for KeyScheduleEarlyClient {
 pub(crate) struct KeyScheduleEarlyServer(KeyScheduleEarly);
 
 impl KeyScheduleEarlyServer {
-    pub(crate) fn new(protocol: Protocol, suite: &'static Tls13CipherSuite, secret: &[u8]) -> Self {
-        Self(KeyScheduleEarly::new(Side::Server, protocol, suite, secret))
+    pub(crate) fn new(
+        protocol: Protocol,
+        suite: &'static Tls13CipherSuite,
+        secret: &[u8],
+    ) -> Result<Self, Error> {
+        Ok(Self(KeyScheduleEarly::new(
+            Side::Server,
+            protocol,
+            suite,
+            secret,
+        )?))
     }
 
     /// Computes the `client_early_traffic_secret` and installs it as decrypter.
@@ -106,10 +124,10 @@ impl KeyScheduleEarly {
         protocol: Protocol,
         suite: &'static Tls13CipherSuite,
         secret: &[u8],
-    ) -> Self {
-        Self {
-            ks: KeySchedule::new(local, protocol, suite, secret),
-        }
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            ks: KeySchedule::new(local, protocol, suite, secret)?,
+        })
     }
 
     /// Computes the `client_early_traffic_secret` and returns it.
@@ -206,10 +224,14 @@ pub(crate) struct KeySchedulePreHandshake {
 
 impl KeySchedulePreHandshake {
     /// Creates a key schedule without a PSK.
-    pub(crate) fn new(local: Side, protocol: Protocol, suite: &'static Tls13CipherSuite) -> Self {
-        Self {
-            ks: KeySchedule::new_with_empty_secret(local, protocol, suite),
-        }
+    pub(crate) fn new(
+        local: Side,
+        protocol: Protocol,
+        suite: &'static Tls13CipherSuite,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            ks: KeySchedule::new_with_empty_secret(local, protocol, suite)?,
+        })
     }
 
     /// `shared_secret` is the "(EC)DHE" secret input to
@@ -351,7 +373,7 @@ impl KeyScheduleHandshakeStart {
                 client_secret.clone(),
                 server_secret.clone(),
                 self.ks.suite,
-                self.ks.suite.quic.unwrap(),
+                self.ks.quic.unwrap(),
                 self.ks.side,
             );
         }
@@ -434,7 +456,7 @@ impl KeyScheduleHandshake {
                 client_secret.clone(),
                 server_secret.clone(),
                 before_finished.ks.suite,
-                before_finished.ks.suite.quic.unwrap(),
+                before_finished.ks.quic.unwrap(),
                 before_finished.ks.side,
             );
         }
@@ -583,7 +605,7 @@ impl KeyScheduleClientBeforeFinished {
                 client_secret.clone(),
                 server_secret.clone(),
                 next.ks.suite,
-                next.ks.suite.quic.unwrap(),
+                next.ks.quic.unwrap(),
                 next.ks.side,
             );
         }
@@ -807,8 +829,14 @@ impl KeySchedule {
         protocol: Protocol,
         suite: &'static Tls13CipherSuite,
         secret: &[u8],
-    ) -> Self {
-        Self {
+    ) -> Result<Self, Error> {
+        let quic = match protocol {
+            Protocol::Quic(_) => Some(suite.quic.ok_or(Error::Unreachable(
+                "QUIC connection negotiated a cipher suite without QUIC support",
+            ))?),
+            Protocol::Tcp => None,
+        };
+        Ok(Self {
             current: suite
                 .hkdf_provider
                 .extract_from_secret(None, secret),
@@ -816,8 +844,9 @@ impl KeySchedule {
                 side,
                 protocol,
                 suite,
+                quic,
             },
-        }
+        })
     }
 
     /// Creates a key schedule without a PSK.
@@ -825,8 +854,14 @@ impl KeySchedule {
         side: Side,
         protocol: Protocol,
         suite: &'static Tls13CipherSuite,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, Error> {
+        let quic = match protocol {
+            Protocol::Quic(_) => Some(suite.quic.ok_or(Error::Unreachable(
+                "QUIC connection negotiated a cipher suite without QUIC support",
+            ))?),
+            Protocol::Tcp => None,
+        };
+        Ok(Self {
             current: suite
                 .hkdf_provider
                 .extract_from_zero_ikm(None),
@@ -834,8 +869,9 @@ impl KeySchedule {
                 side,
                 protocol,
                 suite,
+                quic,
             },
-        }
+        })
     }
 
     /// Input the empty secret.
@@ -927,6 +963,8 @@ struct KeyScheduleSuite {
     side: Side,
     protocol: Protocol,
     suite: &'static Tls13CipherSuite,
+    // invariant: Some(suite.quic) if protocol is QUIC
+    quic: Option<&'static dyn quic::Algorithm>,
 }
 
 impl KeyScheduleSuite {
@@ -1323,7 +1361,8 @@ mod tests {
         ];
 
         let suite = TLS13_TEST_SUITE;
-        let mut ks = KeySchedule::new_with_empty_secret(Side::Server, Protocol::Tcp, suite);
+        let mut ks =
+            KeySchedule::new_with_empty_secret(Side::Server, Protocol::Tcp, suite).unwrap();
         ks.input_secret(&ecdhe_secret);
 
         assert_traffic_secret(
@@ -1440,7 +1479,8 @@ mod benchmarks {
 
         b.iter(|| {
             let mut ks =
-                KeySchedule::new_with_empty_secret(Side::Client, Protocol::Tcp, TLS13_TEST_SUITE);
+                KeySchedule::new_with_empty_secret(Side::Client, Protocol::Tcp, TLS13_TEST_SUITE)
+                    .unwrap();
             ks.input_secret(&[0u8; 32]);
 
             extract_traffic_secret(&ks, SecretKind::ClientHandshakeTrafficSecret);


### PR DESCRIPTION
This PR addresses two disclosed private reports that I have opted to treat as normal bugs.

Found and verified with rust-in-peace (https://github.com/scadastrangelove/rust-in-peace) by @scadastrangelove

These are summarised as:

- A `CryptoProvider` mixing QUIC-capable and -incapable TLS1.3 suites can panic if the peer chooses the QUIC-incapable one. This affects clients but not servers in 0.23, but both in 0.24 (current main) due to 207f809627d4b02b238b49e29d80bd5e39783234. This PR effectively backs that out and tests it.
- A QUIC client would incorrectly accept a TLS1.2 server hello. A full handshake would require a trusted server that talks TLS1.2 in QUIC.

Probably will drop the final commit, as responding to internal inconsistency with misbehaviour is never preferable to an assertion failure.