### PR TITLE
rustls-post-quantum: drop unused webpki dependency, prepare 0.3.0-dev.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-post-quantum"
-version = "0.3.0-dev.1"
+version = "0.3.0-dev.2"
 dependencies = [
  "aws-lc-rs",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,7 +1994,6 @@ dependencies = [
  "rustls-aws-lc-rs",
  "rustls-test",
  "rustls-util",
- "rustls-webpki 0.104.0-alpha.7",
  "webpki-roots",
 ]
 

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-post-quantum"
-version = "0.3.0-dev.1"
+version = "0.3.0-dev.2"
 edition.workspace = true
 rust-version = "1.85"
 license = "Apache-2.0 OR ISC OR MIT"

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -15,7 +15,6 @@ autobenches = false
 aws-lc-rs = { workspace = true, features = ["unstable"] }
 rustls-aws-lc-rs = { version = "0.1.0-dev.1", path = "../rustls-aws-lc-rs" }
 rustls = { path = "../rustls", version = "0.24.0-dev.0", default-features = false }
-webpki = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
Nothing in the crate's sources, examples, or benches directly ref's webpki at this point.

I don't think it needs proposed release notes. I'm only bumping the version so I can take this crate as a dev-dep in `webpki` for the ML-DSA sig. algs for `x509-limbo` purposes.