### PR TITLE
Expose `ServerHandshake` state for client cert verification

### DIFF
--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -88,8 +88,13 @@ fn main() {
             handshake = match handshake {
                 // Read TLS packets until we've completed the handshake.
                 ServerHandshake::NeedsInput(receive) => {
-                    input.read(&mut stream).unwrap();
                     match receive.process(&mut input, &mut output) {
+                        Ok(next @ ServerHandshake::NeedsInput(_)) => {
+                            stream.write_all(&output).unwrap();
+                            output.clear();
+                            input.read(&mut stream).unwrap();
+                            next
+                        }
                         Ok(next) => next,
                         Err(error) => panic!("error completing handshake: {error}"),
                     }
@@ -103,6 +108,10 @@ fn main() {
                         .choose_config(config, &mut output)
                         .expect("error choosing configuration for connection")
                 }
+
+                ServerHandshake::VerifyClientIdentity(verify) => verify
+                    .use_verifier_trait(&mut output)
+                    .expect("error verifying client certificate for connection"),
 
                 ServerHandshake::Complete(connection) => break connection,
 

--- a/rustls-test/tests/api/client_cert_verifier.rs
+++ b/rustls-test/tests/api/client_cert_verifier.rs
@@ -4,13 +4,17 @@
 
 use std::sync::Arc;
 
+use rustls::client::ClientConnection;
 use rustls::crypto::VerifiedIdentity;
+use rustls::enums::ProtocolVersion;
 use rustls::error::{AlertDescription, CertificateError, Error, InvalidMessage, PeerMisbehaved};
-use rustls::{ClientConfig, ServerConnection, VecInput};
+use rustls::server::{ServerHandshake, VerifyClientIdentity};
+use rustls::{ClientConfig, Connection, ServerConfig, ServerConnection, SliceInput, VecInput};
 use rustls_test::{
     ErrorFromPeer, MockClientVerifier, MultiTest, do_handshake, do_handshake_until_both_error,
-    do_handshake_until_error, make_pair_for_arc_configs, make_server_config_with_client_verifier,
-    make_server_config_with_optional_client_auth, server_name, webpki_client_verifier_builder,
+    do_handshake_until_error, encoding, make_pair_for_arc_configs,
+    make_server_config_with_client_verifier, make_server_config_with_optional_client_auth,
+    server_name, webpki_client_verifier_builder,
 };
 
 use super::provider;
@@ -167,6 +171,134 @@ fn client_verifier_fails_properly() {
             Err(ErrorFromPeer::Server(Error::General("test err".into())))
         );
     }
+}
+
+#[test]
+fn server_external_verifier_does_not_call_trait() {
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER)
+        .require_client_auth()
+        .with_client_verifier(Box::new(|kt, provider| {
+            Arc::new(MockClientVerifier::new(ver_unreachable, kt, &provider))
+        }))
+    {
+        let (verify, mut server_output, mut client, mut client_output) =
+            server_external_verifier_test_setup(client_config, server_config);
+
+        let identity = verify.presented_identity().unwrap();
+        assert_eq!(
+            identity.identity,
+            expect
+                .key_type
+                .client_identity()
+                .as_ref()
+        );
+        let verified = VerifiedIdentity::assertion(identity.identity.to_owned());
+        let ServerHandshake::NeedsInput(server) = verify
+            .continue_with(Ok(verified), &mut server_output)
+            .unwrap()
+        else {
+            panic!("unexpected state");
+        };
+
+        let mut server_input = SliceInput::new(&mut client_output);
+        let ServerHandshake::Complete(server) = server
+            .process(&mut server_input, &mut server_output)
+            .unwrap()
+        else {
+            panic!("unexpected state");
+        };
+
+        client
+            .process_new_packets(&mut SliceInput::new(&mut server_output), &mut client_output)
+            .handle_all(&mut Vec::new())
+            .unwrap();
+        server_output.clear();
+
+        assert!(!client.is_handshaking());
+        assert!(server.outputs.peer_identity().is_some());
+    }
+}
+
+#[test]
+fn server_external_verifier_error_sends_alert() {
+    for (client_config, server_config, expect) in
+        MultiTest::new(provider::DEFAULT_PROVIDER).require_client_auth()
+    {
+        let (verify, mut server_output, mut client, mut client_output) =
+            server_external_verifier_test_setup(client_config, server_config);
+
+        let mut alert_output = Vec::new();
+        let err = verify
+            .continue_with(Err(CertificateError::Expired.into()), &mut alert_output)
+            .unwrap_err();
+
+        assert_eq!(err, CertificateError::Expired.into());
+        if expect.version == ProtocolVersion::TLSv1_2 {
+            assert_eq!(
+                alert_output,
+                encoding::alert(AlertDescription::CertificateExpired, &[])
+            );
+        }
+
+        server_output.extend(alert_output);
+
+        let client_err = client
+            .process_new_packets(&mut SliceInput::new(&mut server_output), &mut client_output)
+            .handle_all(&mut Vec::new())
+            .unwrap_err();
+        assert_eq!(
+            client_err,
+            Error::AlertReceived(AlertDescription::CertificateExpired)
+        );
+    }
+}
+
+fn server_external_verifier_test_setup(
+    client_config: Arc<ClientConfig>,
+    server_config: Arc<ServerConfig>,
+) -> (VerifyClientIdentity, Vec<u8>, ClientConnection, Vec<u8>) {
+    let mut client_output = Vec::new();
+    let mut client = client_config
+        .connect(server_name("localhost"))
+        .build(&mut client_output)
+        .unwrap();
+
+    let mut server_input = SliceInput::new(&mut client_output);
+    let mut server_output = Vec::new();
+    let ServerHandshake::Accepted(accepted) = ServerHandshake::start()
+        .process(&mut server_input, &mut server_output)
+        .unwrap()
+    else {
+        panic!("unexpected state");
+    };
+    client_output.clear();
+
+    let ServerHandshake::NeedsInput(server) = accepted
+        .choose_config(server_config, &mut server_output)
+        .unwrap()
+    else {
+        panic!("unexpected state");
+    };
+
+    client
+        .process_new_packets(&mut SliceInput::new(&mut server_output), &mut client_output)
+        .handle_all(&mut Vec::new())
+        .unwrap();
+    server_output.clear();
+
+    let mut server_input = SliceInput::new(&mut client_output);
+    let ServerHandshake::VerifyClientIdentity(verify) = server
+        .process(&mut server_input, &mut server_output)
+        .unwrap()
+    else {
+        panic!("unexpected state");
+    };
+    let used = server_input.into_used();
+    client_output.drain(..used);
+
+    println!("{verify:?}");
+
+    (verify, server_output, client, client_output)
 }
 
 /// Test that the server handles combination of `offer_client_auth()` returning true

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1963,60 +1963,81 @@ fn handshakes_complete_and_data_flows_with_gratuitous_max_fragment_sizes() {
 
 #[test]
 fn test_full_server_handshake() {
-    let provider = provider::DEFAULT_PROVIDER;
-    let client_config = Arc::new(make_client_config(KeyType::default(), &provider));
-    let mut buf = Vec::new();
-    let mut client = client_config
-        .connect(server_name("localhost"))
-        .build(&mut buf)
-        .unwrap();
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        println!("expect: {expect:?}");
+        let mut buf = Vec::new();
+        let mut client = client_config
+            .connect(server_name("localhost"))
+            .build(&mut buf)
+            .unwrap();
 
-    // client first flight
-    let receive = ServerHandshake::start();
-    let mut acceptor_input = VecInput::default();
-    acceptor_input
-        .read(&mut buf.as_slice())
-        .unwrap();
+        // client first flight
+        let receive = ServerHandshake::start();
+        let mut acceptor_input = VecInput::default();
+        acceptor_input
+            .read(&mut buf.as_slice())
+            .unwrap();
 
-    // server first flight and config choice
-    let mut server_output = vec![];
-    let ServerHandshake::Accepted(accepted) = receive
-        .process(&mut acceptor_input, &mut server_output)
-        .unwrap()
-    else {
-        panic!("unexpected state");
-    };
-    let mut server = accepted
-        .choose_config(
-            Arc::new(make_server_config(KeyType::default(), &provider)),
-            &mut server_output,
-        )
-        .unwrap();
-    assert!(!server_output.is_empty());
-
-    // client receives server flight, producing its second flight
-    let mut client_output = vec![];
-    client
-        .process_new_packets(&mut SliceInput::new(&mut server_output), &mut client_output)
-        .handle_all(&mut Vec::new())
-        .unwrap();
-
-    // client second flight
-    let mut server_output = vec![];
-    server = if let ServerHandshake::NeedsInput(receive) = server {
-        receive
-            .process(&mut SliceInput::new(&mut client_output), &mut server_output)
+        // server first flight and config choice
+        let mut server_output = vec![];
+        let ServerHandshake::Accepted(accepted) = receive
+            .process(&mut acceptor_input, &mut server_output)
             .unwrap()
-    } else {
-        panic!("unexpected state");
-    };
-    client
-        .process_new_packets(&mut SliceInput::new(&mut server_output), &mut client_output)
-        .handle_all(&mut Vec::new())
-        .unwrap();
+        else {
+            panic!("unexpected state");
+        };
+        let mut server = accepted
+            .choose_config(server_config, &mut server_output)
+            .unwrap();
+        assert!(!server_output.is_empty());
 
-    assert!(matches!(server, ServerHandshake::Complete(_)));
-    assert!(!client.is_handshaking());
+        // client receives server flight, producing its second flight
+        let mut client_output = vec![];
+        client
+            .process_new_packets(&mut SliceInput::new(&mut server_output), &mut client_output)
+            .handle_all(&mut Vec::new())
+            .unwrap();
+
+        // client second flight
+        let mut server_output = vec![];
+        let mut client_input = SliceInput::new(&mut client_output);
+        server = if let ServerHandshake::NeedsInput(receive) = server {
+            receive
+                .process(&mut client_input, &mut server_output)
+                .unwrap()
+        } else {
+            panic!("unexpected state");
+        };
+
+        // client certificate verification, if client auth was in use
+        server = match server {
+            ServerHandshake::VerifyClientIdentity(vci) => {
+                assert!(expect.client_auth);
+                println!("client identity {:?}", vci.presented_identity());
+                let ServerHandshake::NeedsInput(receive) = vci
+                    .use_verifier_trait(&mut server_output)
+                    .unwrap()
+                else {
+                    panic!("unexpected state");
+                };
+                receive
+                    .process(&mut client_input, &mut server_output)
+                    .unwrap()
+            }
+            server => {
+                assert!(!expect.client_auth);
+                server
+            }
+        };
+
+        client
+            .process_new_packets(&mut SliceInput::new(&mut server_output), &mut client_output)
+            .handle_all(&mut Vec::new())
+            .unwrap();
+
+        assert!(matches!(server, ServerHandshake::Complete(_)));
+        assert!(!client.is_handshaking());
+    }
 }
 
 #[test]

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -15,8 +15,8 @@ use rustls::quic::{self, Connection, QuicEvent, ServerHandshake, Side};
 use rustls::server::Tls13Tickets;
 use rustls::{CipherSuiteCommon, HandshakeKind, SliceInput, Tls13CipherSuite, VecInput};
 use rustls_test::{
-    ClientStorage, KeyType, do_handshake, encoding, make_client_config, make_pair_for_arc_configs,
-    make_server_config, server_name,
+    ClientStorage, KeyType, MultiTest, do_handshake, encoding, make_client_config,
+    make_pair_for_arc_configs, make_server_config, server_name,
 };
 
 use super::provider;
@@ -213,92 +213,95 @@ fn test_quic_handshake() {
 
 #[test]
 fn test_quic_acceptor() {
-    let kt = KeyType::default();
-    let provider = provider::DEFAULT_TLS13_PROVIDER;
-    let mut client_config = make_client_config(kt, &provider);
-    client_config.alpn_protocols = vec![b"h3".into()];
-    let client_config = Arc::new(client_config);
-    let mut server_config = make_server_config(kt, &provider);
-    server_config.alpn_protocols = vec![b"h3".into()];
-    let server_config = Arc::new(server_config);
-    let client_fips = client_config.fips();
-    let server_fips = server_config.fips();
-    let client_params = &b"client params"[..];
-    let server_params = &b"server params"[..];
+    for (client_config, server_config, _expect) in MultiTest::new(provider::DEFAULT_TLS13_PROVIDER)
+    {
+        let mut client_config = Arc::unwrap_or_clone(client_config);
+        client_config.alpn_protocols = vec![b"h3".into()];
+        let client_config = Arc::new(client_config);
 
-    let mut client = quic::ClientConnection::new(
-        client_config,
-        quic::Version::V1,
-        server_name("localhost"),
-        client_params.into(),
-    )
-    .unwrap();
-    assert_eq!(client.fips(), client_fips);
+        let mut server_config = Arc::unwrap_or_clone(server_config);
+        server_config.alpn_protocols = vec![b"h3".into()];
+        let server_config = Arc::new(server_config);
 
-    let needs_input = ServerHandshake::start(quic::Version::V1);
+        let client_fips = client_config.fips();
+        let server_fips = server_config.fips();
+        let client_params = &b"client params"[..];
+        let server_params = &b"server params"[..];
 
-    let mut client_initial = flatten_events(&mut client);
-    assert!(client_initial.len() > 8);
-    println!("client_initial: {client_initial:x?}");
-
-    let ServerHandshake::NeedsInput(needs_input) = needs_input
-        .process(&mut SliceInput::new(&mut client_initial[..8]), &mut vec![])
-        .unwrap()
-    else {
-        panic!("unexpected state after partial hello");
-    };
-
-    let ServerHandshake::Accepted(accepted) = needs_input
-        .process(&mut SliceInput::new(&mut client_initial), &mut vec![])
-        .unwrap()
-    else {
-        panic!("unexpected state after full hello");
-    };
-
-    let client_hello = accepted.client_hello();
-    assert_eq!(
-        client_hello
-            .server_name()
-            .unwrap()
-            .as_ref(),
-        "localhost"
-    );
-    assert_eq!(
-        client_hello
-            .alpn()
-            .unwrap()
-            .collect::<Vec<_>>(),
-        vec![b"h3".as_slice()]
-    );
-
-    let mut server_flight = vec![];
-    let Ok(ServerHandshake::NeedsInput(server)) =
-        accepted.choose_config(server_config, server_params.into(), &mut server_flight)
-    else {
-        panic!("unexpected state");
-    };
-    quic_insert(server_flight, &mut client).unwrap();
-
-    let mut server_flight = vec![];
-    let ServerHandshake::Complete(mut server) = server
-        .process(
-            &mut SliceInput::new(&mut flatten_events(&mut client)),
-            &mut server_flight,
+        let mut client = quic::ClientConnection::new(
+            client_config,
+            quic::Version::V1,
+            server_name("localhost"),
+            client_params.into(),
         )
-        .unwrap()
-    else {
-        panic!("unexpected state");
-    };
+        .unwrap();
+        assert_eq!(client.fips(), client_fips);
 
-    assert_eq!(server.fips(), server_fips);
-    assert_eq!(server.quic_transport_parameters(), Some(client_params));
+        let needs_input = ServerHandshake::start(quic::Version::V1);
 
-    quic_transfer(&mut server, &mut client).unwrap();
-    quic_transfer(&mut client, &mut server).unwrap();
+        let mut client_initial = flatten_events(&mut client);
+        assert!(client_initial.len() > 8);
+        println!("client_initial: {client_initial:x?}");
 
-    assert!(!client.is_handshaking());
-    assert!(!server.is_handshaking());
-    assert_eq!(client.quic_transport_parameters(), Some(server_params));
+        let ServerHandshake::NeedsInput(needs_input) = needs_input
+            .process(&mut SliceInput::new(&mut client_initial[..8]), &mut vec![])
+            .unwrap()
+        else {
+            panic!("unexpected state after partial hello");
+        };
+
+        let ServerHandshake::Accepted(accepted) = needs_input
+            .process(&mut SliceInput::new(&mut client_initial), &mut vec![])
+            .unwrap()
+        else {
+            panic!("unexpected state after full hello");
+        };
+
+        let client_hello = accepted.client_hello();
+        assert_eq!(
+            client_hello
+                .server_name()
+                .unwrap()
+                .as_ref(),
+            "localhost"
+        );
+        assert_eq!(
+            client_hello
+                .alpn()
+                .unwrap()
+                .collect::<Vec<_>>(),
+            vec![b"h3".as_slice()]
+        );
+
+        let mut server_flight = vec![];
+        let Ok(ServerHandshake::NeedsInput(server)) =
+            accepted.choose_config(server_config, server_params.into(), &mut server_flight)
+        else {
+            panic!("unexpected state");
+        };
+        quic_insert(server_flight, &mut client).unwrap();
+
+        let mut server_flight = vec![];
+        let ServerHandshake::Complete(mut server) = server
+            .process(
+                &mut SliceInput::new(&mut flatten_events(&mut client)),
+                &mut server_flight,
+            )
+            .unwrap()
+        else {
+            panic!("unexpected state");
+        };
+
+        assert_eq!(server.fips(), server_fips);
+        assert_eq!(server.quic_transport_parameters(), Some(client_params));
+
+        quic_transfer(&mut server, &mut client).unwrap();
+        quic_transfer(&mut client, &mut server).unwrap();
+
+        assert!(!client.is_handshaking());
+        assert!(!server.is_handshaking());
+        assert_eq!(client.quic_transport_parameters(), Some(server_params));
+    }
 }
 
 #[test]

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -9,7 +9,8 @@ use rustls::client::Resumption;
 use rustls::crypto::{CipherSuite, CryptoProvider};
 use rustls::enums::ProtocolVersion;
 use rustls::error::{
-    AlertDescription, ApiMisuse, Error, InvalidMessage, PeerIncompatible, PeerMisbehaved,
+    AlertDescription, ApiMisuse, CertificateError, Error, InvalidMessage, PeerIncompatible,
+    PeerMisbehaved,
 };
 use rustls::quic::{self, Connection, QuicEvent, ServerHandshake, Side};
 use rustls::server::Tls13Tickets;
@@ -213,8 +214,7 @@ fn test_quic_handshake() {
 
 #[test]
 fn test_quic_acceptor() {
-    for (client_config, server_config, _expect) in MultiTest::new(provider::DEFAULT_TLS13_PROVIDER)
-    {
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_TLS13_PROVIDER) {
         let mut client_config = Arc::unwrap_or_clone(client_config);
         client_config.alpn_protocols = vec![b"h3".into()];
         let client_config = Arc::new(client_config);
@@ -282,14 +282,36 @@ fn test_quic_acceptor() {
         quic_insert(server_flight, &mut client).unwrap();
 
         let mut server_flight = vec![];
-        let ServerHandshake::Complete(mut server) = server
-            .process(
-                &mut SliceInput::new(&mut flatten_events(&mut client)),
-                &mut server_flight,
-            )
-            .unwrap()
-        else {
-            panic!("unexpected state");
+        let mut data = flatten_events(&mut client);
+        let mut server_input = SliceInput::new(&mut data);
+        let server = server
+            .process(&mut server_input, &mut server_flight)
+            .unwrap();
+
+        let mut server = match server {
+            ServerHandshake::Complete(server) => {
+                assert!(!expect.client_auth);
+                server
+            }
+
+            ServerHandshake::VerifyClientIdentity(verify) => {
+                assert!(expect.client_auth);
+                println!("{verify:?}");
+                println!("identity: {:?}", verify.presented_identity());
+                let ServerHandshake::NeedsInput(server) = verify.use_verifier_trait().unwrap()
+                else {
+                    panic!("unexpected state");
+                };
+                let ServerHandshake::Complete(server) = server
+                    .process(&mut server_input, &mut server_flight)
+                    .unwrap()
+                else {
+                    panic!("unexpected state");
+                };
+                server
+            }
+
+            _ => panic!("unexpected state"),
         };
 
         assert_eq!(server.fips(), server_fips);
@@ -301,6 +323,59 @@ fn test_quic_acceptor() {
         assert!(!client.is_handshaking());
         assert!(!server.is_handshaking());
         assert_eq!(client.quic_transport_parameters(), Some(server_params));
+    }
+}
+
+#[test]
+fn test_quic_acceptor_external_verifier_rejects_client_cert() {
+    for (client_config, server_config, _) in
+        MultiTest::new(provider::DEFAULT_TLS13_PROVIDER).require_client_auth()
+    {
+        let mut client = quic::ClientConnection::new(
+            client_config,
+            quic::Version::V1,
+            server_name("localhost"),
+            b"client params".into(),
+        )
+        .unwrap();
+
+        let needs_input = ServerHandshake::start(quic::Version::V1);
+
+        let mut client_initial = flatten_events(&mut client);
+
+        let ServerHandshake::Accepted(accepted) = needs_input
+            .process(&mut SliceInput::new(&mut client_initial), &mut vec![])
+            .unwrap()
+        else {
+            panic!("unexpected state after full hello");
+        };
+
+        let mut server_flight = vec![];
+        let Ok(ServerHandshake::NeedsInput(server)) =
+            accepted.choose_config(server_config, b"server params".into(), &mut server_flight)
+        else {
+            panic!("unexpected state");
+        };
+        quic_insert(server_flight, &mut client).unwrap();
+
+        let mut server_flight = vec![];
+        let mut data = flatten_events(&mut client);
+        let mut server_input = SliceInput::new(&mut data);
+        let ServerHandshake::VerifyClientIdentity(verify_client) = server
+            .process(&mut server_input, &mut server_flight)
+            .unwrap()
+        else {
+            panic!("unexpected state");
+        };
+
+        let err = verify_client
+            .continue_with(Err(CertificateError::UnknownIssuer.into()))
+            .unwrap_err();
+        assert_eq!(err, CertificateError::UnknownIssuer.into());
+        assert_eq!(
+            AlertDescription::try_from(&err),
+            Ok(AlertDescription::UnknownCa)
+        );
     }
 }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -62,6 +62,10 @@ impl StateMachine for ClientState {
         true
     }
 
+    fn handle_without_input(self) -> Result<Self, Error> {
+        Ok(self)
+    }
+
     fn is_traffic(&self) -> bool {
         matches!(
             self,

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -316,7 +316,7 @@ impl<'a, 'm, Side: SideData> MessageHandler<'a, 'm, Side> {
         core: &'a mut ConnectionCommon<Side>,
     ) -> Self {
         Self {
-            iter: MessageIter::new(input, tls, None, core),
+            iter: MessageIter::new(input, tls, None, core, true),
             done: false,
         }
     }
@@ -573,8 +573,17 @@ pub(crate) mod private {
 use private::SideOutput;
 
 pub(crate) trait StateMachine: Sized {
+    /// Advance the state machine using `input` and emitting data to `output`.
     fn handle<'m>(self, input: Input<'m>, output: &mut dyn Output<'m>) -> Result<Self, Error>;
+
+    /// Return true if the current state requires input to be provided via `handle()`.
     fn wants_input(&self) -> bool;
+
+    /// Advance the state machine using no input if possible.
+    ///
+    /// This should return `Ok(self)` otherwise.
+    fn handle_without_input(self) -> Result<Self, Error>;
+
     fn is_traffic(&self) -> bool;
     fn handle_decrypt_error(&mut self);
     fn into_external_state(

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -30,6 +30,7 @@ pub(crate) struct MessageIter<'a, 'm, Side: SideData, Send: SendOutput + 'a> {
     pub(super) recv: &'a mut ReceivePath,
     pub(super) state: &'a mut Result<Side::State, Error>,
     pub(super) output: JoinOutput<'a, Send>,
+    pub(super) advance: bool,
 }
 
 impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side, SendPath> {
@@ -38,6 +39,7 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side, SendPath> {
         tls: &'a mut Vec<u8>,
         quic: Option<&'a mut dyn QuicOutput>,
         conn: &'a mut ConnectionCommon<Side>,
+        advance: bool,
     ) -> Self {
         Self {
             input,
@@ -50,6 +52,7 @@ impl<'a, 'm, Side: SideData> MessageIter<'a, 'm, Side, SendPath> {
                 send: &mut conn.common.send,
                 side: &mut conn.side,
             },
+            advance,
         }
     }
 }
@@ -61,6 +64,7 @@ impl<'a, 'm, 's, Side: SideData> MessageIter<'a, 'm, Side, SendAdapter<'s>> {
         state: &'a mut Result<Side::State, Error>,
         recv: &'a mut ReceivePath,
         output: JoinOutput<'a, SendAdapter<'s>>,
+        advance: bool,
     ) -> Self {
         Self {
             input,
@@ -68,6 +72,7 @@ impl<'a, 'm, 's, Side: SideData> MessageIter<'a, 'm, Side, SendAdapter<'s>> {
             recv,
             state,
             output,
+            advance,
         }
     }
 }
@@ -156,6 +161,17 @@ impl<'a, 'm, Side: SideData, Send: SendOutput + 'a> MessageIter<'a, 'm, Side, Se
                     *self.state = Err(e.clone());
                     return Some(Err(e));
                 }
+            }
+
+            if self.advance && !st.wants_input() {
+                st = match st.handle_without_input() {
+                    Ok(st) => st,
+                    Err(err) => {
+                        maybe_send_fatal_alert(self.output.send, &err, self.tls);
+                        *self.state = Err(err.clone());
+                        return Some(Err(err));
+                    }
+                };
             }
 
             if self.recv.has_received_close_notify {

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -208,7 +208,8 @@ impl<Side: SideData> ReceiveTraffic<Side> {
             side: &mut Discard,
         };
 
-        let mut iter = MessageIter::<Side, _>::receive(input, tls, &mut state, &mut recv, output);
+        let mut iter =
+            MessageIter::<Side, _>::receive(input, tls, &mut state, &mut recv, output, true);
         let received_plain = match iter.next() {
             Some(Ok(payload)) => Some(payload),
             Some(Err(error)) => {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -596,7 +596,13 @@ impl<Side: SideData> QuicCommon<Side> {
             .input_quic(input.slice_mut())?;
 
         let mut tls = Vec::new();
-        let mut iter = MessageIter::new(input, &mut tls, Some(&mut self.quic), &mut self.common);
+        let mut iter = MessageIter::new(
+            input,
+            &mut tls,
+            Some(&mut self.quic),
+            &mut self.common,
+            true,
+        );
         let result = match iter.next() {
             Some(Ok(_)) | None => Ok(()),
             Some(Err(e)) => Err(e),

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -10,6 +10,7 @@ use crate::client::{ClientConfig, ClientSide};
 pub use crate::common_state::Side;
 use crate::common_state::{CommonState, ConnectionOutputs, Protocol};
 use crate::conn::{ConnectionCommon, KeyingMaterialExporter, MessageIter, SideData, StateMachine};
+use crate::crypto::VerifiedIdentity;
 use crate::crypto::cipher::{AeadKey, Iv, Payload};
 use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock};
 use crate::enums::ApplicationProtocol;
@@ -17,13 +18,16 @@ use crate::error::{ApiMisuse, Error};
 use crate::msgs::{
     ClientExtensionsInput, Message, MessagePayload, ServerExtensionsInput, TransportParameters,
 };
-use crate::server::{ChooseConfig, ClientHello, ServerConfig, ServerSide, ServerState};
+use crate::server::{
+    ChooseConfig, ClientHello, HandshakeVerifyClientIdentity, ServerConfig, ServerSide, ServerState,
+};
 use crate::suites::SupportedCipherSuite;
 use crate::sync::Arc;
 use crate::tls13::Tls13CipherSuite;
 use crate::tls13::key_schedule::{
     hkdf_expand_label, hkdf_expand_label_aead_key, hkdf_expand_label_block,
 };
+use crate::verify::ClientIdentity;
 
 /// A QUIC client or server connection.
 pub trait Connection: fmt::Debug + Deref<Target = ConnectionOutputs> {
@@ -179,7 +183,7 @@ impl Connection for ClientConnection {
     }
 
     fn read_hs(&mut self, input: &mut dyn TlsInputBuffer) -> Result<(), Error> {
-        self.inner.read_hs(input)
+        self.inner.read_hs(input, true)
     }
 
     fn events(&mut self) -> impl Iterator<Item = QuicEvent> {
@@ -317,7 +321,7 @@ impl Connection for ServerConnection {
     }
 
     fn read_hs(&mut self, input: &mut dyn TlsInputBuffer) -> Result<(), Error> {
-        self.inner.read_hs(input)
+        self.inner.read_hs(input, true)
     }
 
     fn events(&mut self) -> impl Iterator<Item = QuicEvent> {
@@ -356,6 +360,11 @@ pub enum ServerHandshake {
     /// The handshake can be progressed by choosing a [`ServerConfig`] based on
     /// [`Accepted::client_hello()`] and providing it to [`Accepted::choose_config()`].
     Accepted(Accepted),
+
+    /// The client's presented identity must be verified.
+    ///
+    /// See [`VerifyClientIdentity`] for how to proceed.
+    VerifyClientIdentity(VerifyClientIdentity),
 
     /// The handshake is complete.
     Complete(ServerConnection),
@@ -396,6 +405,10 @@ impl TryFrom<QuicCommon<ServerSide>> for ServerHandshake {
                 choose_config,
             }),
 
+            ServerState::VerifyClientIdentity(verify) => {
+                Self::VerifyClientIdentity(VerifyClientIdentity { inner, verify })
+            }
+
             state if state.is_traffic() => {
                 inner.common.state = Ok(state);
                 Self::Complete(ServerConnection { inner })
@@ -409,7 +422,7 @@ impl TryFrom<QuicCommon<ServerSide>> for ServerHandshake {
     }
 }
 
-/// More data needs to be received to make progress.
+/// More data needs to be processed to make progress.
 ///
 /// Provide the data to [`Self::process()`].
 pub struct NeedsInput {
@@ -442,7 +455,7 @@ impl NeedsInput {
         input: &mut dyn TlsInputBuffer,
         output: &mut Vec<QuicEvent>,
     ) -> Result<ServerHandshake, Error> {
-        self.inner.read_hs(input)?;
+        self.inner.read_hs(input, false)?;
         output.extend(self.inner.events());
         ServerHandshake::try_from(self.inner)
     }
@@ -536,6 +549,72 @@ fn check_server_config(config: &ServerConfig) -> Result<(), Error> {
     Ok(())
 }
 
+/// The client's presented identity must be verified.
+///
+/// The caller has three choices:
+///
+/// - Call [`Self::use_verifier_trait()`].  This calls [`ClientVerifier::verify_identity()`][]
+///   synchronously.
+///
+/// - Call [`Self::presented_identity()`] to obtain the peer's presented identity,
+///   verify that outside the library (perhaps asynchronously), and then continue the handshake with
+///   [`Self::continue_with()`].
+///
+///   If the verification fails, the error can be passed into [`Self::continue_with()`] to follow
+///   a uniform error handling path.
+///
+/// - Abandon the handshake by discarding this object.
+///
+/// The returned object is a further [`ServerHandshake`].  Commonly this will be a
+/// [`ServerHandshake::NeedsInput`] which will accept and process further data.
+///
+/// [`ClientVerifier::verify_identity()`]: crate::verify::ClientVerifier::verify_identity
+pub struct VerifyClientIdentity {
+    // invariant: `inner.state` is `Err(_)` and requires restoring
+    inner: QuicCommon<ServerSide>,
+    verify: HandshakeVerifyClientIdentity,
+}
+
+impl VerifyClientIdentity {
+    /// Progress the handshake by calling the pre-configured certificate verification trait.
+    pub fn use_verifier_trait(self) -> Result<ServerHandshake, Error> {
+        Self::next(self.inner, self.verify.use_verifier_trait())
+    }
+
+    /// Progress the handshake by incorporating the result of an external verification.
+    ///
+    /// If `verification_result` is an error, this error is returned and the handshake terminates.
+    pub fn continue_with(
+        self,
+        verification_result: Result<VerifiedIdentity<'static>, Error>,
+    ) -> Result<ServerHandshake, Error> {
+        Self::next(
+            self.inner,
+            verification_result.and_then(|verified| self.verify.continue_with(verified)),
+        )
+    }
+
+    /// Inspect the identity that the client has provided.
+    pub fn presented_identity(&self) -> Result<ClientIdentity<'static, '_>, Error> {
+        self.verify.presented_identity()
+    }
+
+    fn next(
+        mut inner: QuicCommon<ServerSide>,
+        result: Result<ServerState, Error>,
+    ) -> Result<ServerHandshake, Error> {
+        inner.common.state = result;
+        ServerHandshake::try_from(inner)
+    }
+}
+
+impl fmt::Debug for VerifyClientIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VerifyClientIdentity")
+            .finish_non_exhaustive()
+    }
+}
+
 /// QUIC events that should be handled by the caller.
 #[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
@@ -588,7 +667,7 @@ impl<Side: SideData> QuicCommon<Side> {
         ))
     }
 
-    fn read_hs(&mut self, input: &mut dyn TlsInputBuffer) -> Result<(), Error> {
+    fn read_hs(&mut self, input: &mut dyn TlsInputBuffer, advance: bool) -> Result<(), Error> {
         self.common
             .common
             .recv
@@ -601,7 +680,7 @@ impl<Side: SideData> QuicCommon<Side> {
             &mut tls,
             Some(&mut self.quic),
             &mut self.common,
-            true,
+            advance,
         );
         let result = match iter.next() {
             Some(Ok(_)) | None => Ok(()),

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -21,11 +21,12 @@ use crate::crypto;
 use crate::crypto::cipher::{OutboundPlain, Payload};
 use crate::error::Error;
 use crate::msgs::ServerExtensionsInput;
-use crate::server::hs::{ChooseConfig, ExpectClientHello, ReadClientHello, ServerState};
+use crate::server::hs::{self, ChooseConfig, ExpectClientHello, ReadClientHello, ServerState};
 use crate::suites::ExtractedSecrets;
 use crate::sync::Arc;
 use crate::tracing::trace;
 use crate::vecbuf::ChunkVecBuffer;
+use crate::verify::{ClientIdentity, VerifiedIdentity};
 
 /// This represents a single TLS server connection.
 ///
@@ -209,6 +210,11 @@ pub enum ServerHandshake {
     /// [`Accepted::client_hello()`] and providing it to [`Accepted::choose_config()`].
     Accepted(Accepted),
 
+    /// The client's presented identity must be verified.
+    ///
+    /// See [`VerifyClientIdentity`] for how to proceed.
+    VerifyClientIdentity(VerifyClientIdentity),
+
     /// The handshake is complete.
     ///
     /// Now see [`SplitConnection`] to continue the connection.
@@ -244,6 +250,13 @@ impl TryFrom<ConnectionCommon<ServerSide>> for ServerHandshake {
                 choose_config,
             }),
 
+            ServerState::VerifyClientIdentity(verify_identity) => {
+                Self::VerifyClientIdentity(VerifyClientIdentity {
+                    inner,
+                    verify_identity,
+                })
+            }
+
             state if state.is_traffic() => {
                 inner.state = Ok(state);
                 Self::Complete(SplitConnection::try_from(inner)?)
@@ -257,7 +270,7 @@ impl TryFrom<ConnectionCommon<ServerSide>> for ServerHandshake {
     }
 }
 
-/// More data needs to be received to make progress.
+/// More data needs to be supplied to make progress.
 ///
 /// Provide the data to [`Self::process()`].
 pub struct NeedsInput {
@@ -274,18 +287,15 @@ impl NeedsInput {
     /// An error from this function is otherwise fatal to the connection, as it consumes
     /// the [`NeedsInput`] object.
     ///
-    /// On success, this returns:
-    ///
-    /// - a [`ServerHandshake::NeedsInput`] if more data is required.
-    /// - a [`ServerHandshake::Accepted`] if a whole `ClientHello` has been received, requiring
-    ///   and a choice of [`ServerConfig`] is required to continue.
-    /// - a [`ServerHandshake::Complete`] if the handshake is complete.
+    /// On success, this returns a [`ServerHandshake`] specifying what to do to progress
+    /// the connection.  If this is a [`ServerHandshake::NeedsInput`] then obtaining more
+    /// input (eg, from a socket or other source) is certainly necessary.
     pub fn process(
         mut self,
         input: &mut dyn TlsInputBuffer,
         tls: &mut Vec<u8>,
     ) -> Result<ServerHandshake, Error> {
-        let mut iter = MessageIter::new(input, tls, None, &mut self.inner);
+        let mut iter = MessageIter::new(input, tls, None, &mut self.inner, false);
         let r = loop {
             match iter.next() {
                 Some(Ok(_)) => {}
@@ -384,6 +394,89 @@ impl Accepted {
 impl fmt::Debug for Accepted {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Accepted")
+            .finish_non_exhaustive()
+    }
+}
+
+/// The client's presented identity must be verified.
+///
+/// The caller has three choices:
+///
+/// - Call [`Self::use_verifier_trait()`].  This calls [`ClientVerifier::verify_identity()`][]
+///   synchronously.
+///
+/// - Call [`Self::presented_identity()`] to obtain the peer's presented identity,
+///   verify that outside the library (perhaps asynchronously), and then continue the handshake with
+///   [`Self::continue_with()`].
+///
+///   If the verification fails, the error can be passed into [`Self::continue_with()`] to follow
+///   a uniform error handling path.
+///
+/// - Abandon the handshake by discarding this object.
+///
+/// The returned object is a further [`ServerHandshake`].  Commonly this will be a
+/// [`ServerHandshake::NeedsInput`] which will accept and process further data.
+///
+/// [`ClientVerifier::verify_identity()`]: crate::verify::ClientVerifier::verify_identity
+pub struct VerifyClientIdentity {
+    // invariant: `inner.state` is `Err(_)` and requires restoring
+    inner: ConnectionCommon<ServerSide>,
+    verify_identity: hs::VerifyClientIdentity,
+}
+
+impl VerifyClientIdentity {
+    /// Progress the handshake by calling the pre-configured certificate verification trait.
+    pub fn use_verifier_trait(self, tls: &mut Vec<u8>) -> Result<ServerHandshake, Error> {
+        Self::next(
+            self.inner,
+            self.verify_identity
+                .use_verifier_trait(),
+            tls,
+        )
+    }
+
+    /// Progress the handshake by incorporating the result of an external verification.
+    ///
+    /// If `verification_result` is an error, this error is returned and the handshake terminates.
+    /// An alert may be appended to `tls` for sending to the peer.
+    pub fn continue_with(
+        self,
+        verification_result: Result<VerifiedIdentity<'static>, Error>,
+        tls: &mut Vec<u8>,
+    ) -> Result<ServerHandshake, Error> {
+        Self::next(
+            self.inner,
+            verification_result.and_then(|verified| {
+                self.verify_identity
+                    .continue_with(verified)
+            }),
+            tls,
+        )
+    }
+
+    /// Inspect the identity that the client has provided.
+    pub fn presented_identity(&self) -> Result<ClientIdentity<'static, '_>, Error> {
+        self.verify_identity
+            .presented_identity()
+    }
+
+    fn next(
+        mut inner: ConnectionCommon<ServerSide>,
+        result: Result<ServerState, Error>,
+        tls: &mut Vec<u8>,
+    ) -> Result<ServerHandshake, Error> {
+        if let Err(err) = &result {
+            maybe_send_fatal_alert(&mut inner.common.send, err, tls);
+        }
+
+        inner.state = result;
+        ServerHandshake::try_from(inner)
+    }
+}
+
+impl fmt::Debug for VerifyClientIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VerifyClientIdentity")
             .finish_non_exhaustive()
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -31,6 +31,7 @@ use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
 use crate::tls13::key_schedule::KeyScheduleTrafficSend;
 use crate::tracing::{debug, trace};
+use crate::verify::{ClientIdentity, VerifiedIdentity};
 
 pub(crate) enum ServerState {
     /// Reading an entire ClientHello
@@ -44,6 +45,10 @@ pub(crate) enum ServerState {
 
     /// Processing the received ClientHello.
     ClientHello(Box<ExpectClientHello>),
+
+    /// Verifying the client's present certificate chain.
+    VerifyClientIdentity(VerifyClientIdentity),
+
     Tls12(tls12::Tls12State),
     Tls13(tls13::Tls13State),
 }
@@ -63,8 +68,8 @@ impl crate::conn::StateMachine for ServerState {
     fn handle<'m>(self, input: Input<'m>, output: &mut dyn Output<'m>) -> Result<Self, Error> {
         match self {
             Self::ReadClientHello(r) => r.handle(input, output),
-            Self::ChooseConfig(_) => {
-                Err(Error::Unreachable("ChooseConfig cannot process a message"))
+            Self::ChooseConfig(_) | Self::VerifyClientIdentity(_) => {
+                Err(Error::Unreachable("state cannot process a message"))
             }
             Self::ClientHello(e) => e.handle(input, output),
             Self::Tls12(sm) => sm.handle(input, output),
@@ -73,7 +78,14 @@ impl crate::conn::StateMachine for ServerState {
     }
 
     fn wants_input(&self) -> bool {
-        !matches!(self, Self::ChooseConfig(_))
+        !matches!(self, Self::ChooseConfig(_) | Self::VerifyClientIdentity(_))
+    }
+
+    fn handle_without_input(self) -> Result<Self, Error> {
+        match self {
+            Self::VerifyClientIdentity(vci) => vci.use_verifier_trait(),
+            _ => Ok(self),
+        }
     }
 
     fn is_traffic(&self) -> bool {
@@ -773,6 +785,46 @@ impl From<Box<ExpectClientHello>> for ServerState {
     fn from(value: Box<ExpectClientHello>) -> Self {
         Self::ClientHello(value)
     }
+}
+
+pub(crate) struct VerifyClientIdentity {
+    inner: Box<dyn VerifyClientIdentityInternal>,
+}
+
+impl VerifyClientIdentity {
+    /// Obtain the peer's asserted identity for external verification.
+    pub(crate) fn presented_identity(&self) -> Result<ClientIdentity<'static, '_>, Error> {
+        self.inner.presented_identity()
+    }
+
+    /// Progress the handshake by calling the verifier trait synchronously.
+    pub(crate) fn use_verifier_trait(self) -> Result<ServerState, Error> {
+        self.inner.with_config()
+    }
+
+    /// Progress the handshake by incorporating an external verification.
+    pub(crate) fn continue_with(
+        self,
+        verified: VerifiedIdentity<'static>,
+    ) -> Result<ServerState, Error> {
+        self.inner.continue_with(verified)
+    }
+}
+
+impl From<Box<dyn VerifyClientIdentityInternal>> for VerifyClientIdentity {
+    fn from(inner: Box<dyn VerifyClientIdentityInternal>) -> Self {
+        Self { inner }
+    }
+}
+
+/// Trait to maintain static unreachablity of per-protocol-version code.
+pub(crate) trait VerifyClientIdentityInternal: Send + Sync {
+    fn presented_identity(&self) -> Result<ClientIdentity<'static, '_>, Error>;
+    fn with_config(self: Box<Self>) -> Result<ServerState, Error>;
+    fn continue_with(
+        self: Box<Self>,
+        verified: VerifiedIdentity<'static>,
+    ) -> Result<ServerState, Error>;
 }
 
 pub(crate) trait ServerHandler<T>: fmt::Debug + Sealed + Send + Sync {

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -23,6 +23,7 @@ pub use config::{
 mod connection;
 pub use connection::{
     Accepted, NeedsInput, ReadEarlyData, ServerConnection, ServerHandshake, ServerSide,
+    VerifyClientIdentity,
 };
 
 pub(crate) mod handy;

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -32,7 +32,9 @@ pub use handy::ServerNameResolver;
 pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
 
 mod hs;
-pub(crate) use hs::{ChooseConfig, ServerHandler, ServerState};
+pub(crate) use hs::{
+    ChooseConfig, ServerHandler, ServerState, VerifyClientIdentity as HandshakeVerifyClientIdentity,
+};
 
 mod tls12;
 pub(crate) use tls12::TLS12_HANDLER;

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -551,42 +551,67 @@ impl ExpectCertificate {
 
         trace!("certs {cert_chain:?}");
 
-        let peer_identity = match Identity::from_peer(cert_chain.0, CertificateType::X509)? {
-            None if mandatory => {
-                return Err(PeerMisbehaved::NoCertificatesPresented.into());
-            }
+        match Identity::from_peer(cert_chain.0, CertificateType::X509)? {
+            None if mandatory => Err(PeerMisbehaved::NoCertificatesPresented.into()),
             None => {
                 debug!("client auth requested but no certificate supplied");
                 self.hs.transcript.abandon_client_auth();
-                None
-            }
-            Some(identity) => {
-                let identity = self
-                    .hs
-                    .config
-                    .verifier
-                    .verify_identity(&ClientIdentity {
-                        identity: &identity,
-                        now: self.hs.config.current_time()?,
-                    })?;
-                Some(identity.into_owned())
-            }
-        };
 
-        Ok(Box::new(ExpectClientKx {
-            hs: self.hs,
-            randoms: self.randoms,
-            suite: self.suite,
-            server_kx: self.server_kx,
-            peer_identity,
-        })
-        .into())
+                Ok(Box::new(ExpectClientKx {
+                    hs: self.hs,
+                    randoms: self.randoms,
+                    suite: self.suite,
+                    server_kx: self.server_kx,
+                    peer_identity: None,
+                })
+                .into())
+            }
+            Some(identity) => AwaitClientIdentityVerification {
+                hs: self.hs,
+                randoms: self.randoms,
+                suite: self.suite,
+                server_kx: self.server_kx,
+                peer_identity: identity.into_owned(),
+            }
+            .with_config(),
+        }
     }
 }
 
 impl From<Box<ExpectCertificate>> for ServerState {
     fn from(value: Box<ExpectCertificate>) -> Self {
         Self::Tls12(Tls12State::Certificate(value))
+    }
+}
+
+// --- Verify the client's identity
+struct AwaitClientIdentityVerification {
+    hs: HandshakeState,
+    randoms: ConnectionRandoms,
+    suite: &'static Tls12CipherSuite,
+    server_kx: GroupAndKeyExchange,
+    peer_identity: Identity<'static>,
+}
+
+impl AwaitClientIdentityVerification {
+    fn with_config(self) -> Result<ServerState, Error> {
+        let peer_identity = self
+            .hs
+            .config
+            .verifier
+            .verify_identity(&ClientIdentity {
+                identity: &self.peer_identity,
+                now: self.hs.config.current_time()?,
+            })?;
+
+        Ok(Box::new(ExpectClientKx {
+            hs: self.hs,
+            randoms: self.randoms,
+            suite: self.suite,
+            server_kx: self.server_kx,
+            peer_identity: Some(peer_identity),
+        })
+        .into())
     }
 }
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -28,6 +28,7 @@ use crate::msgs::{
     HandshakeAlignedProof, HandshakeMessagePayload, HandshakePayload, Message, MessagePayload,
     NewSessionTicketPayload, NewSessionTicketPayloadTls13, Reader, SessionId,
 };
+use crate::server::hs::{VerifyClientIdentity, VerifyClientIdentityInternal};
 use crate::suites::PartiallyExtractedSecrets;
 use crate::sync::Arc;
 use crate::tls12::{self, ConnectionSecrets, Tls12CipherSuite};
@@ -566,14 +567,14 @@ impl ExpectCertificate {
                 })
                 .into())
             }
-            Some(identity) => AwaitClientIdentityVerification {
+            Some(identity) => Ok(Box::new(AwaitClientIdentityVerification {
                 hs: self.hs,
                 randoms: self.randoms,
                 suite: self.suite,
                 server_kx: self.server_kx,
                 peer_identity: identity.into_owned(),
-            }
-            .with_config(),
+            })
+            .into()),
         }
     }
 }
@@ -593,17 +594,28 @@ struct AwaitClientIdentityVerification {
     peer_identity: Identity<'static>,
 }
 
-impl AwaitClientIdentityVerification {
-    fn with_config(self) -> Result<ServerState, Error> {
+impl VerifyClientIdentityInternal for AwaitClientIdentityVerification {
+    fn presented_identity(&self) -> Result<ClientIdentity<'static, '_>, Error> {
+        Ok(ClientIdentity {
+            identity: &self.peer_identity,
+            now: self.hs.config.current_time()?,
+        })
+    }
+
+    fn with_config(self: Box<Self>) -> Result<ServerState, Error> {
         let peer_identity = self
             .hs
             .config
             .verifier
-            .verify_identity(&ClientIdentity {
-                identity: &self.peer_identity,
-                now: self.hs.config.current_time()?,
-            })?;
+            .verify_identity(&self.presented_identity()?)?;
 
+        self.continue_with(peer_identity)
+    }
+
+    fn continue_with(
+        self: Box<Self>,
+        peer_identity: VerifiedIdentity<'static>,
+    ) -> Result<ServerState, Error> {
         Ok(Box::new(ExpectClientKx {
             hs: self.hs,
             randoms: self.randoms,
@@ -612,6 +624,14 @@ impl AwaitClientIdentityVerification {
             peer_identity: Some(peer_identity),
         })
         .into())
+    }
+}
+
+impl From<Box<AwaitClientIdentityVerification>> for ServerState {
+    fn from(value: Box<AwaitClientIdentityVerification>) -> Self {
+        Self::VerifyClientIdentity(VerifyClientIdentity::from(
+            value as Box<dyn VerifyClientIdentityInternal>,
+        ))
     }
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1071,21 +1071,12 @@ impl ExpectCertificate {
             return Err(PeerMisbehaved::NoCertificatesPresented.into());
         };
 
-        let peer_identity = self
-            .hs
-            .config
-            .verifier
-            .verify_identity(&ClientIdentity {
-                identity: &peer_identity,
-                now: self.hs.config.current_time()?,
-            })?;
-
-        Ok(Box::new(ExpectCertificateVerify {
+        AwaitClientIdentityVerification {
             hs: self.hs,
             key_schedule: self.key_schedule,
             peer_identity: peer_identity.into_owned(),
-        })
-        .into())
+        }
+        .with_config()
     }
 }
 
@@ -1102,6 +1093,33 @@ impl ExpectCertificate {
 impl From<Box<ExpectCertificate>> for ServerState {
     fn from(value: Box<ExpectCertificate>) -> Self {
         Self::Tls13(Tls13State::Certificate(value))
+    }
+}
+
+// --- Verify the client's identity
+struct AwaitClientIdentityVerification {
+    hs: HandshakeState,
+    key_schedule: KeyScheduleTrafficWithClientFinishedPending,
+    peer_identity: Identity<'static>,
+}
+
+impl AwaitClientIdentityVerification {
+    fn with_config(self) -> Result<ServerState, Error> {
+        let peer_identity = self
+            .hs
+            .config
+            .verifier
+            .verify_identity(&ClientIdentity {
+                identity: &self.peer_identity,
+                now: self.hs.config.current_time()?,
+            })?;
+
+        Ok(Box::new(ExpectCertificateVerify {
+            hs: self.hs,
+            key_schedule: self.key_schedule,
+            peer_identity,
+        })
+        .into())
     }
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -28,7 +28,7 @@ use crate::msgs::{
     HandshakePayload, KeyUpdateRequest, Message, MessagePayload, NewSessionTicketPayloadTls13,
     PresharedKeyIdentity, Reader, ServerTicketRequestHint, SizedPayload,
 };
-use crate::server::hs::ExpectClientHello;
+use crate::server::hs::{ExpectClientHello, VerifyClientIdentity, VerifyClientIdentityInternal};
 use crate::suites::PartiallyExtractedSecrets;
 use crate::sync::Arc;
 use crate::tls13::key_schedule::{
@@ -1071,12 +1071,12 @@ impl ExpectCertificate {
             return Err(PeerMisbehaved::NoCertificatesPresented.into());
         };
 
-        AwaitClientIdentityVerification {
+        Ok(Box::new(AwaitClientIdentityVerification {
             hs: self.hs,
             key_schedule: self.key_schedule,
             peer_identity: peer_identity.into_owned(),
-        }
-        .with_config()
+        })
+        .into())
     }
 }
 
@@ -1103,23 +1103,42 @@ struct AwaitClientIdentityVerification {
     peer_identity: Identity<'static>,
 }
 
-impl AwaitClientIdentityVerification {
-    fn with_config(self) -> Result<ServerState, Error> {
+impl VerifyClientIdentityInternal for AwaitClientIdentityVerification {
+    fn presented_identity(&self) -> Result<ClientIdentity<'static, '_>, Error> {
+        Ok(ClientIdentity {
+            identity: &self.peer_identity,
+            now: self.hs.config.current_time()?,
+        })
+    }
+
+    fn with_config(self: Box<Self>) -> Result<ServerState, Error> {
         let peer_identity = self
             .hs
             .config
             .verifier
-            .verify_identity(&ClientIdentity {
-                identity: &self.peer_identity,
-                now: self.hs.config.current_time()?,
-            })?;
+            .verify_identity(&self.presented_identity()?)?;
 
+        self.continue_with(peer_identity)
+    }
+
+    fn continue_with(
+        self: Box<Self>,
+        peer_identity: VerifiedIdentity<'static>,
+    ) -> Result<ServerState, Error> {
         Ok(Box::new(ExpectCertificateVerify {
             hs: self.hs,
             key_schedule: self.key_schedule,
             peer_identity,
         })
         .into())
+    }
+}
+
+impl From<Box<AwaitClientIdentityVerification>> for ServerState {
+    fn from(value: Box<AwaitClientIdentityVerification>) -> Self {
+        Self::VerifyClientIdentity(VerifyClientIdentity::from(
+            value as Box<dyn VerifyClientIdentityInternal>,
+        ))
     }
 }
 


### PR DESCRIPTION
This works towards #850 along the style of #2713.

Future plans for this path:

- [ ] follow the same for client handshakes & server cert verification
- [ ] implement the internals of `ServerConnection` using `ServerHandshake` and `SplitConnection`?

Draft: docs and testing gaps.