### PR TITLE
use checked_sub for the mac tag offset in Rfc5077Ticketer::decrypt

### DIFF
--- a/rustls-aws-lc-rs/src/ticketer.rs
+++ b/rustls-aws-lc-rs/src/ticketer.rs
@@ -139,7 +139,8 @@ impl TicketProducer for Rfc5077Ticketer {
             .algorithm()
             .digest_algorithm()
             .output_len();
-        let (enc_state, mac) = ciphertext.split_at_checked(ciphertext.len() - tag_len)?;
+        let (enc_state, mac) =
+            ciphertext.split_at_checked(ciphertext.len().checked_sub(tag_len)?)?;
 
         // Reconstitute the HMAC data to verify the tag.
         let mut hmac_data =
@@ -214,6 +215,20 @@ mod tests {
         // first branch in `decrypt()`
         cipher.push(0);
         assert_eq!(t.decrypt(&cipher), None);
+    }
+
+    #[test]
+    fn refuses_decrypt_truncated_ciphertext() {
+        let t = AwsLcRs.ticketer().unwrap();
+        let cipher = t.encrypt(b"hello world").unwrap();
+        assert_eq!(t.decrypt(&cipher), Some(b"hello world".to_vec()));
+
+        // a truncation is rejected at any length; lengths that leave fewer
+        // bytes than the trailing tag after the key_name and iv prefix
+        // exercise the final split.
+        for len in 0..cipher.len() {
+            assert_eq!(t.decrypt(&cipher[..len]), None);
+        }
     }
 
     #[test]


### PR DESCRIPTION
`Rfc5077Ticketer::decrypt` splits an incoming ticket into `key_name`, IV, encrypted state and HMAC tag. The first two splits use `split_at_checked`, but the final offset is computed as `ciphertext.len() - tag_len` over the remainder left after the 16-byte `key_name` and 16-byte IV are stripped, and the only length guard in the function is the `maximum_ciphertext_len` upper bound. That bound is `fetch_max`'d on every `encrypt`, so once the server has issued one ticket a peer can send a 32 to 63 byte TLS 1.3 `pre_shared_key` identity or TLS 1.2 `session_ticket`, which `TicketRotator::decrypt_at` forwards verbatim, and leave fewer than `tag_len` bytes at the final split; the `usize` subtraction then underflows, panicking with `overflow-checks` on and wrapping silently without.

`checked_sub` makes the short-ticket case return `None`, the same way every other length mismatch in this function is already handled. The bound belongs here rather than in `TicketRotator` or the handshake code because `tag_len` comes from this producer's HMAC algorithm, and `TicketProducer::decrypt` takes arbitrary peer bytes by contract. The added test walks every truncation of a real ticket and asserts each one is refused.
