### PR TITLE
Remove stale `std` feature references

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -51,7 +51,7 @@ path = "examples/internal/test_ca.rs"
 
 [package.metadata.docs.rs]
 # all non-default features except fips (cannot build on docs.rs environment)
-features = ["brotli", "hashbrown", "log", "std", "zlib"]
+features = ["brotli", "hashbrown", "log", "zlib"]
 rustdoc-args = ["--cfg", "rustls_docsrs"]
 
 [package.metadata.cargo_check_external_types]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -271,9 +271,6 @@
 //! Here's a list of what features are exposed by the rustls crate and what
 //! they mean.
 //!
-//! - `std` (enabled by default): enable the high-level (buffered) Connection API and other functionality
-//!   which relies on the `std` library.
-//!
 //! - `log` (enabled by default): make the rustls crate depend on the `log` crate.
 //!   rustls outputs interesting protocol-level messages at `trace!` and `debug!` level,
 //!   and protocol-level errors at `warn!` and `error!` level.  The log messages do not


### PR DESCRIPTION
Rustls no longer has the std but its still refrenced in package.metadata.docs.rs this  breaks the docks.rs-style build 
To fix this I removed the stale references from both places.   
Closes #3134