### PR TITLE
Reinstate tests that used x25519_provider

### DIFF
--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -13,11 +13,11 @@ use super::{Tls12Session, Tls13ClientSessionInput, Tls13Session};
 use crate::client::{ClientConfig, Resumption, Tls12Resumption};
 use crate::crypto::cipher::{EncodedMessage, MessageEncrypter, Payload, encode_record_header};
 use crate::crypto::kx::{self, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup};
-use crate::crypto::test_provider::FakeKeyExchangeGroup;
+use crate::crypto::test_provider::{FakeKeyExchangeGroup, KEY_EXCHANGE_GROUP, TLS_TEST_SUITE};
 use crate::crypto::tls13::OkmBlock;
 use crate::crypto::{
     CipherSuite, Credentials, CryptoProvider, Identity, SignatureScheme, SingleCredential,
-    TEST_PROVIDER, tls12_only, tls13_only, tls13_suite,
+    TEST_PROVIDER, TLS13_TEST_SUITE, tls12_only, tls13_only, tls13_suite,
 };
 use crate::enums::{CertificateType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
@@ -32,6 +32,7 @@ use crate::msgs::{
 };
 use crate::pki_types::PrivateKeyDer;
 use crate::pki_types::pem::PemObject;
+use crate::suites::Suite;
 use crate::sync::Arc;
 use crate::tls13::key_schedule::{derive_traffic_iv, derive_traffic_key};
 use crate::verify::{
@@ -288,12 +289,8 @@ fn cas_extension_in_client_hello_if_server_verifier_requests_it() {
 /// Regression test for <https://github.com/seanmonstar/reqwest/issues/2191>
 #[test]
 fn test_client_with_custom_verifier_can_accept_ecdsa_sha1_signatures() {
-    let Some(provider) = x25519_provider(TEST_PROVIDER.clone()) else {
-        return;
-    };
-
     let verifier = Arc::new(ExpectSha1EcdsaVerifier::default());
-    let config = ClientConfig::builder(Arc::new(provider))
+    let config = ClientConfig::builder(Arc::new(TEST_PROVIDER))
         .dangerous()
         .with_custom_certificate_verifier(verifier.clone())
         .with_no_client_auth()
@@ -312,7 +309,7 @@ fn test_client_with_custom_verifier_can_accept_ecdsa_sha1_signatures() {
             ServerHelloPayload {
                 random: Random([0u8; 32]),
                 compression_method: Compression::Null,
-                cipher_suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                cipher_suite: TLS_TEST_SUITE.suite(),
                 legacy_version: ProtocolVersion::TLSv1_2,
                 session_id: SessionId::empty(),
                 extensions: Box::new(ServerExtensions {
@@ -353,9 +350,14 @@ fn test_client_with_custom_verifier_can_accept_ecdsa_sha1_signatures() {
                     params: ServerKeyExchangeParams::Ecdh(ServerEcdhParams {
                         curve_params: EcParameters {
                             curve_type: ECCurveType::NamedCurve,
-                            named_group: NamedGroup::X25519,
+                            named_group: KEY_EXCHANGE_GROUP.name(),
                         },
-                        public: SizedPayload::from(vec![0xab; 32]),
+                        public: KEY_EXCHANGE_GROUP
+                            .start()
+                            .unwrap()
+                            .pub_key()
+                            .to_vec()
+                            .into(),
                     }),
                 },
             )),
@@ -490,13 +492,9 @@ fn client_requiring_rpk_receives_server_ee(
     encrypted_extensions: EncryptedExtensions<'_>,
     provider: &CryptoProvider,
 ) {
-    let Some(provider) = x25519_provider(provider.clone()) else {
-        return;
-    };
-
     let provider = Arc::new(CryptoProvider {
         tls12_cipher_suites: Cow::default(),
-        ..provider
+        ..provider.clone()
     });
 
     let fake_server_crypto = Arc::new(FakeServerCrypto::new(provider.clone()));
@@ -521,13 +519,18 @@ fn client_requiring_rpk_receives_server_ee(
             ServerHelloPayload {
                 random: Random([0; 32]),
                 compression_method: Compression::Null,
-                cipher_suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
+                cipher_suite: TLS13_TEST_SUITE.suite(),
                 legacy_version: ProtocolVersion::TLSv1_3,
                 session_id: SessionId::empty(),
                 extensions: Box::new(ServerExtensions {
                     key_share: Some(KeyShareEntry {
-                        group: NamedGroup::X25519,
-                        payload: SizedPayload::from(vec![0xaa; 32]),
+                        group: KEY_EXCHANGE_GROUP.name(),
+                        payload: KEY_EXCHANGE_GROUP
+                            .start()
+                            .unwrap()
+                            .pub_key()
+                            .to_vec()
+                            .into(),
                     }),
                     ..ServerExtensions::default()
                 }),
@@ -669,16 +672,6 @@ fn client_key() -> PrivateKeyDer<'static> {
     .unwrap()
 }
 
-fn x25519_provider(provider: CryptoProvider) -> Option<CryptoProvider> {
-    // ensures X25519 is offered irrespective of cfg(feature = "fips"), which eases
-    // creation of fake server messages.
-    let x25519 = provider.find_kx_group(NamedGroup::X25519, ProtocolVersion::TLSv1_3)?;
-    Some(CryptoProvider {
-        kx_groups: Cow::Owned(vec![x25519]),
-        ..provider
-    })
-}
-
 #[derive(Clone, Debug)]
 struct ServerVerifierWithAuthorityNames(Arc<[DistinguishedName]>);
 
@@ -779,7 +772,7 @@ impl FakeServerCrypto {
             .get()
             .unwrap();
 
-        let cipher_suite = tls13_suite(CipherSuite::TLS13_AES_128_GCM_SHA256, &self.provider);
+        let cipher_suite = tls13_suite(TLS13_TEST_SUITE.suite(), &self.provider);
         let expander = cipher_suite
             .hkdf_provider
             .expander_for_okm(&OkmBlock::new(secret));

--- a/rustls/src/crypto/test_provider.rs
+++ b/rustls/src/crypto/test_provider.rs
@@ -81,7 +81,7 @@ pub(crate) const TLS13_TEST_SUITE: &Tls13CipherSuite = &Tls13CipherSuite {
     quic: None,
 };
 
-const TLS_TEST_SUITE: &Tls12CipherSuite = &Tls12CipherSuite {
+pub(crate) const TLS_TEST_SUITE: &Tls12CipherSuite = &Tls12CipherSuite {
     common: CipherSuiteCommon {
         suite: CipherSuite(0xff12),
         hash_provider: FAKE_HASH,
@@ -292,7 +292,8 @@ impl crypto::kx::ActiveKeyExchange for ActiveKeyExchange {
     }
 }
 
-const KEY_EXCHANGE_GROUP: &dyn SupportedKxGroup = &FakeKeyExchangeGroup(NamedGroup(0xfe00));
+pub(crate) const KEY_EXCHANGE_GROUP: &dyn SupportedKxGroup =
+    &FakeKeyExchangeGroup(NamedGroup(0xfe00));
 
 #[derive(Debug)]
 pub(crate) struct FakeKeyExchangeGroup(pub(crate) NamedGroup);

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -16,21 +16,21 @@ use crate::crypto::kx::{
     ActiveKeyExchange, KeyExchangeAlgorithm, NamedGroup, SharedSecret, StartedKeyExchange,
     SupportedKxGroup,
 };
-use crate::crypto::test_provider::{FAKE_HASH, FAKE_HMAC};
+use crate::crypto::test_provider::{FAKE_HASH, FAKE_HMAC, KEY_EXCHANGE_GROUP, TLS_TEST_SUITE};
 use crate::crypto::{
     CertificateIdentity, CipherSuite, Credentials, CryptoProvider, Identity, SignatureScheme,
-    SingleCredential, TEST_PROVIDER, tls12, tls12_only,
+    SingleCredential, TEST_PROVIDER, TLS13_TEST_SUITE, tls12, tls12_only,
 };
 use crate::enums::{CertificateType, ProtocolVersion};
 use crate::error::{Error, PeerIncompatible};
 use crate::msgs::{
     ClientExtensions, ClientHelloPayload, Codec, Compression, HEADER_SIZE, HandshakeMessagePayload,
     HandshakePayload, KeyShareEntry, Message, MessagePayload, Random, Reader, SessionId,
-    SizedPayload, SupportedProtocolVersions,
+    SupportedProtocolVersions,
 };
 use crate::pki_types::pem::PemObject;
 use crate::pki_types::{CertificateDer, FipsStatus, PrivateKeyDer};
-use crate::suites::CipherSuiteCommon;
+use crate::suites::{CipherSuiteCommon, Suite};
 use crate::sync::Arc;
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
@@ -327,9 +327,7 @@ fn server_chooses_ffdhe_group_for_client_hello(
 
 #[test]
 fn test_server_requiring_rpk_client_rejects_x509_client() {
-    let Some(server_config) = server_config_for_rpk(TEST_PROVIDER.clone()) else {
-        return;
-    };
+    let server_config = server_config_for_rpk(TEST_PROVIDER.clone());
 
     let mut ch = minimal_client_hello();
     ch.extensions.client_certificate_types = Some(vec![CertificateType::X509]);
@@ -354,9 +352,7 @@ fn test_server_requiring_rpk_client_rejects_x509_client() {
 
 #[test]
 fn test_rpk_only_server_rejects_x509_only_client() {
-    let Some(server_config) = server_config_for_rpk(TEST_PROVIDER.clone()) else {
-        return;
-    };
+    let server_config = server_config_for_rpk(TEST_PROVIDER.clone());
 
     let mut ch = minimal_client_hello();
     ch.extensions.server_certificate_types = Some(vec![CertificateType::X509]);
@@ -380,21 +376,12 @@ fn test_rpk_only_server_rejects_x509_only_client() {
     );
 }
 
-fn server_config_for_rpk(provider: CryptoProvider) -> Option<ServerConfig> {
-    let provider = CryptoProvider {
-        kx_groups: Cow::Owned(vec![
-            provider.find_kx_group(NamedGroup::X25519, ProtocolVersion::TLSv1_2)?,
-        ]),
-        ..provider
-    };
-
+fn server_config_for_rpk(provider: CryptoProvider) -> ServerConfig {
     let credentials = SingleCredential::from(server_credentials(&provider));
-    Some(
-        ServerConfig::builder(Arc::new(provider))
-            .with_no_client_auth()
-            .with_server_credential_resolver(Arc::new(credentials))
-            .unwrap(),
-    )
+    ServerConfig::builder(Arc::new(provider))
+        .with_no_client_auth()
+        .with_server_credential_resolver(Arc::new(credentials))
+        .unwrap()
 }
 
 fn server_credentials(provider: &CryptoProvider) -> Credentials {
@@ -505,7 +492,7 @@ fn minimal_client_hello() -> ClientHelloPayload {
         client_version: ProtocolVersion::TLSv1_3,
         random: Random::from([0u8; 32]),
         session_id: SessionId::empty(),
-        cipher_suites: vec![CipherSuite(0xff13), CipherSuite(0xff12)],
+        cipher_suites: vec![TLS13_TEST_SUITE.suite(), TLS_TEST_SUITE.suite()],
         compression_methods: vec![Compression::Null],
         extensions: Box::new(ClientExtensions {
             signature_schemes: Some(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
@@ -515,8 +502,13 @@ fn minimal_client_hello() -> ClientHelloPayload {
                 tls13: true,
             }),
             key_shares: Some(vec![KeyShareEntry {
-                group: NamedGroup::from(0xfe00),
-                payload: SizedPayload::from(vec![0xab; 32]),
+                group: KEY_EXCHANGE_GROUP.name(),
+                payload: KEY_EXCHANGE_GROUP
+                    .start()
+                    .unwrap()
+                    .pub_key()
+                    .to_vec()
+                    .into(),
             }]),
             extended_master_secret_request: Some(()),
             ..ClientExtensions::default()

--- a/rustls/src/tls12.rs
+++ b/rustls/src/tls12.rs
@@ -417,19 +417,12 @@ pub(crate) const DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::TEST_PROVIDER;
-    use crate::crypto::kx::NamedGroup;
+    use crate::crypto::test_provider::KEY_EXCHANGE_GROUP;
     use crate::msgs::{ServerEcdhParams, ServerKeyExchangeParams};
 
     #[test]
     fn server_ecdhe_remaining_bytes() {
-        let Some(kx_group) =
-            TEST_PROVIDER.find_kx_group(NamedGroup::X25519, ProtocolVersion::TLSv1_3)
-        else {
-            return;
-        };
-
-        let key = kx_group.start().unwrap();
+        let key = KEY_EXCHANGE_GROUP.start().unwrap();
         let server_params = ServerEcdhParams::new(&*key);
         let mut server_buf = Vec::new();
         server_params.encode(&mut server_buf);

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -177,30 +177,55 @@ const MAX_VERIFY_MSG: usize = 64 + CLIENT_CONSTANT.len() + hash::Output::MAX_LEN
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::{CipherSuite, TEST_PROVIDER, tls13_suite};
+    use std::boxed::Box;
+
+    use crate::crypto::test_provider::FAKE_HASH;
+    use crate::crypto::{HashAlgorithm, TLS13_TEST_SUITE, hash};
+    use crate::{CipherSuiteCommon, Tls13CipherSuite};
 
     #[test]
     fn test_can_resume_to() {
-        let Some(cha_poly) = TEST_PROVIDER
-            .tls13_cipher_suites
-            .iter()
-            .find(|cs| cs.common.suite == CipherSuite::TLS13_CHACHA20_POLY1305_SHA256)
-        else {
-            return;
+        let other_tls13_suite = Tls13CipherSuite {
+            common: CipherSuiteCommon {
+                hash_provider: &OtherHash,
+                ..TLS13_TEST_SUITE.common
+            },
+            ..*TLS13_TEST_SUITE
         };
 
-        let aes_128_gcm = tls13_suite(CipherSuite::TLS13_AES_128_GCM_SHA256, &TEST_PROVIDER);
         assert!(
-            aes_128_gcm
-                .can_resume_from(cha_poly)
+            TLS13_TEST_SUITE
+                .can_resume_from(TLS13_TEST_SUITE)
                 .is_some()
         );
 
-        let aes_256_gcm = tls13_suite(CipherSuite::TLS13_AES_256_GCM_SHA384, &TEST_PROVIDER);
         assert!(
-            aes_256_gcm
-                .can_resume_from(cha_poly)
+            other_tls13_suite
+                .can_resume_from(TLS13_TEST_SUITE)
                 .is_none()
         );
+    }
+
+    struct OtherHash;
+
+    impl hash::Hash for OtherHash {
+        #[cfg_attr(coverage_nightly, coverage(off))]
+        fn start(&self) -> Box<dyn hash::Context> {
+            FAKE_HASH.start()
+        }
+
+        #[cfg_attr(coverage_nightly, coverage(off))]
+        fn hash(&self, data: &[u8]) -> hash::Output {
+            FAKE_HASH.hash(data)
+        }
+
+        #[cfg_attr(coverage_nightly, coverage(off))]
+        fn output_len(&self) -> usize {
+            FAKE_HASH.output_len()
+        }
+
+        fn algorithm(&self) -> HashAlgorithm {
+            HashAlgorithm(123)
+        }
     }
 }


### PR DESCRIPTION
Just port these tests to fix the values used by TEST_PROVIDER.

fixes #3183 