### PR TITLE
Track QUIC suite state in the type system

### DIFF
--- a/rustls-aws-lc-rs/src/quic.rs
+++ b/rustls-aws-lc-rs/src/quic.rs
@@ -223,7 +223,7 @@ mod tests {
     use std::dbg;
 
     use rustls::crypto::tls13::OkmBlock;
-    use rustls::quic::*;
+    use rustls::quic::{KeyBuilder, Keys, Side, Suite, Version};
 
     use crate::tls13::{TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256};
 
@@ -309,8 +309,7 @@ mod tests {
         let icid = [0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08];
         let server = Keys::initial(
             Version::V2,
-            TLS13_AES_128_GCM_SHA256,
-            TLS13_AES_128_GCM_SHA256.quic.unwrap(),
+            Suite::try_from(TLS13_AES_128_GCM_SHA256).unwrap(),
             &icid,
             Side::Server,
         );

--- a/rustls-ring/src/quic.rs
+++ b/rustls-ring/src/quic.rs
@@ -223,7 +223,7 @@ mod tests {
     use std::dbg;
 
     use rustls::crypto::tls13::OkmBlock;
-    use rustls::quic::{KeyBuilder, Keys, Side, Version};
+    use rustls::quic::{KeyBuilder, Keys, Side, Suite, Version};
 
     use crate::tls13::{TLS13_AES_128_GCM_SHA256, TLS13_CHACHA20_POLY1305_SHA256};
 
@@ -309,8 +309,7 @@ mod tests {
         let icid = [0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08];
         let server = Keys::initial(
             Version::V2,
-            TLS13_AES_128_GCM_SHA256,
-            TLS13_AES_128_GCM_SHA256.quic.unwrap(),
+            Suite::try_from(TLS13_AES_128_GCM_SHA256).unwrap(),
             &icid,
             Side::Server,
         );

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -925,8 +925,7 @@ fn packet_key_api() {
 
     let client_keys = Keys::initial(
         Version::V1,
-        TLS13_AES_128_GCM_SHA256,
-        TLS13_AES_128_GCM_SHA256.quic.unwrap(),
+        quic::Suite::try_from(TLS13_AES_128_GCM_SHA256).unwrap(),
         CONNECTION_ID,
         Side::Client,
     );
@@ -1047,8 +1046,7 @@ fn packet_key_api() {
 
     let server_keys = Keys::initial(
         Version::V1,
-        TLS13_AES_128_GCM_SHA256,
-        TLS13_AES_128_GCM_SHA256.quic.unwrap(),
+        quic::Suite::try_from(TLS13_AES_128_GCM_SHA256).unwrap(),
         CONNECTION_ID,
         Side::Server,
     );

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -8,7 +8,6 @@ use subtle::ConstantTimeEq;
 
 use super::config::ClientConfig;
 use super::{Retrieved, Tls13Session, tls13};
-use crate::common_state::Protocol;
 use crate::crypto::cipher::Payload;
 use crate::crypto::hash::Hash;
 use crate::crypto::hpke::{
@@ -126,13 +125,11 @@ impl EchConfig {
     pub(super) fn state(
         &self,
         server_name: ServerName<'static>,
-        protocol: Protocol,
         config: &ClientConfig,
     ) -> Result<EchState, Error> {
         EchState::new(
             self,
             server_name,
-            protocol,
             !config
                 .resolver()
                 .supported_certificate_types()
@@ -232,7 +229,6 @@ impl EchGreaseConfig {
     pub(crate) fn grease_ext(
         &self,
         secure_random: &'static dyn SecureRandom,
-        protocol: Protocol,
         inner_name: ServerName<'static>,
         outer_hello: &ClientHelloPayload,
     ) -> Result<EncryptedClientHello, Error> {
@@ -262,7 +258,6 @@ impl EchGreaseConfig {
                 suite: self.suite,
             },
             inner_name,
-            protocol,
             false,
             secure_random,
             false, // Does not matter if we enable/disable SNI here. Inner hello is not used.
@@ -326,8 +321,6 @@ pub(crate) struct EchState {
     pub(crate) inner_hello_transcript: HandshakeHashBuffer,
     // A source of secure random data.
     secure_random: &'static dyn SecureRandom,
-    // The top level protocol
-    protocol: Protocol,
     // An HPKE sealer context that can be used for encrypting ECH data.
     sender: Box<dyn HpkeSealer>,
     // The ID of the ECH configuration we've chosen - this is included in the outer ECH extension.
@@ -353,7 +346,6 @@ impl EchState {
     pub(crate) fn new(
         config: &EchConfig,
         inner_name: ServerName<'static>,
-        protocol: Protocol,
         client_auth_enabled: bool,
         secure_random: &'static dyn SecureRandom,
         enable_sni: bool,
@@ -389,7 +381,6 @@ impl EchState {
             inner_name,
             maximum_name_length: config_contents.maximum_name_length,
             cipher_suite: config.suite.suite().sym,
-            protocol,
             enc,
             enable_sni,
             sent_extensions: Vec::new(),
@@ -678,11 +669,8 @@ impl EchState {
         if let Some(resuming) = resuming.as_ref() {
             let mut chp = HandshakeMessagePayload(HandshakePayload::ClientHello(inner_hello));
 
-            let key_schedule = KeyScheduleEarlyClient::new(
-                self.protocol,
-                resuming.suite,
-                resuming.secret.bytes(),
-            )?;
+            let key_schedule =
+                KeyScheduleEarlyClient::new(resuming.suite, resuming.secret.bytes())?;
             tls13::fill_in_psk_binder(&key_schedule, &self.inner_hello_transcript, &mut chp);
             self.early_data_key_schedule = Some(key_schedule);
 
@@ -983,7 +971,6 @@ mod tests {
         EchState::new(
             &config,
             ServerName::from(name.clone()),
-            Protocol::Tcp,
             false,
             TEST_PROVIDER.secure_random,
             enable_sni,

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -189,6 +189,7 @@ mod tests {
         NewSessionTicketExtensions, NewSessionTicketPayloadTls13, SessionId, SizedPayload,
     };
     use crate::sync::Arc;
+    use crate::tls13::Tls13ProtocolSuite;
 
     #[test]
     fn test_noclientsessionstorage_does_nothing() {
@@ -237,7 +238,10 @@ mod tests {
                     },
                 },
                 Tls13ClientSessionInput {
-                    suite: tls13_suite(CipherSuite(0xff13), &TEST_PROVIDER),
+                    suite: Tls13ProtocolSuite::Tcp(tls13_suite(
+                        CipherSuite(0xff13),
+                        &TEST_PROVIDER,
+                    )),
                     peer_identity: Identity::X509(CertificateIdentity {
                         end_entity: CertificateDer::from(&[][..]),
                         intermediates: Vec::new(),

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -526,11 +526,9 @@ impl ClientHelloInput {
         };
 
         let ech_state = match self.config.ech_mode.as_ref() {
-            Some(EchMode::Enable(ech_config)) => Some(ech_config.state(
-                self.session_key.server_name.clone(),
-                self.protocol,
-                &self.config,
-            )?),
+            Some(EchMode::Enable(ech_config)) => {
+                Some(ech_config.state(self.session_key.server_name.clone(), &self.config)?)
+            }
             _ => None,
         };
 
@@ -782,7 +780,6 @@ fn emit_client_hello_for_retry(
         .and_then(|mode| match mode {
             EchMode::Grease(cfg) => Some(cfg.grease_ext(
                 config.provider().secure_random,
-                input.protocol,
                 input.session_key.server_name.clone(),
                 &chp_payload,
             )),
@@ -836,11 +833,8 @@ fn emit_client_hello_for_retry(
         // When we're not doing ECH and resuming, then the PSK binder need to be filled in as
         // normal.
         (_, Some(tls13_session)) => {
-            let key_schedule = KeyScheduleEarlyClient::new(
-                input.protocol,
-                tls13_session.suite,
-                tls13_session.secret.bytes(),
-            )?;
+            let key_schedule =
+                KeyScheduleEarlyClient::new(tls13_session.suite, tls13_session.secret.bytes())?;
             tls13::fill_in_psk_binder(&key_schedule, &transcript_buffer, &mut chp);
             Some((tls13_session.suite, key_schedule))
         }
@@ -898,7 +892,10 @@ fn emit_client_hello_for_retry(
             tls13::derive_early_traffic_secret(
                 &*config.key_log,
                 output,
-                resuming_suite.common.hash_provider,
+                resuming_suite
+                    .suite()
+                    .common
+                    .hash_provider,
                 &schedule,
                 &mut input.sent_tls13_fake_ccs,
                 transcript_buffer,
@@ -1003,12 +1000,13 @@ fn prepare_resumption<'a>(
 
     // If the selected cipher suite can't select from the session's, we can't resume.
     if let Some(suite) = suite {
-        suite.can_resume_from(tls13.suite)?;
+        suite.can_resume_from(tls13.suite.suite())?;
     }
 
     // Similarly, if the suite is not usable for the protocol.
     if !tls13
         .suite
+        .suite()
         .usable_for_protocol(protocol)
     {
         return None;

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -15,13 +15,14 @@ use crate::msgs::{
     SessionId, SizedPayload,
 };
 use crate::sync::Arc;
+use crate::tls13::Tls13ProtocolSuite;
 use crate::verify::DistinguishedName;
 #[cfg(feature = "webpki")]
 pub use crate::webpki::{
     ServerVerifierBuilder, VerifierBuilderError, WebPkiServerVerifier,
     verify_identity_signed_by_trust_anchor, verify_server_name,
 };
-use crate::{Tls12CipherSuite, Tls13CipherSuite, compress};
+use crate::{Tls12CipherSuite, compress};
 
 mod config;
 pub use config::{
@@ -116,7 +117,7 @@ impl<T> Deref for Retrieved<T> {
 /// A stored TLS 1.3 client session value.
 #[derive(Debug)]
 pub struct Tls13Session {
-    suite: &'static Tls13CipherSuite,
+    suite: Tls13ProtocolSuite,
     secret: Zeroizing<SizedPayload<'static, u8>>,
     pub(crate) age_add: u32,
     max_early_data_size: u32,
@@ -126,6 +127,7 @@ pub struct Tls13Session {
 
 impl Tls13Session {
     /// Decode a ticket from the given bytes.
+    #[cfg(test)]
     pub fn from_slice(bytes: &[u8], provider: &CryptoProvider) -> Result<Self, Error> {
         Reader::new(bytes).all("Tls13Session", |reader| {
             let suite = CipherSuite::read(reader)?;
@@ -136,7 +138,7 @@ impl Tls13Session {
                 .ok_or(ApiMisuse::ResumingFromUnknownCipherSuite(suite))?;
 
             Ok(Self {
-                suite: *suite,
+                suite: Tls13ProtocolSuite::Tcp(suite),
                 secret: Zeroizing::new(SizedPayload::<u8>::read(reader)?.into_owned()),
                 age_add: u32::read(reader)?,
                 max_early_data_size: u32::read(reader)?,
@@ -174,7 +176,11 @@ impl Tls13Session {
 
     /// Encode this ticket into `buf` for persistence.
     pub fn encode(&self, buf: &mut Vec<u8>) {
-        self.suite.common.suite.encode(buf);
+        self.suite
+            .suite()
+            .common
+            .suite
+            .encode(buf);
         self.secret.encode(buf);
         buf.extend_from_slice(&self.age_add.to_be_bytes());
         buf.extend_from_slice(&self.max_early_data_size.to_be_bytes());
@@ -210,7 +216,7 @@ impl Deref for Tls13Session {
 /// A "template" for future TLS1.3 client session values.
 #[derive(Clone)]
 pub(crate) struct Tls13ClientSessionInput {
-    pub(crate) suite: &'static Tls13CipherSuite,
+    pub(crate) suite: Tls13ProtocolSuite,
     pub(crate) peer_identity: Identity<'static>,
     pub(crate) quic_params: Option<SizedPayload<'static, u16, MaybeEmpty>>,
 }

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -33,6 +33,7 @@ use crate::msgs::{
 use crate::pki_types::PrivateKeyDer;
 use crate::pki_types::pem::PemObject;
 use crate::sync::Arc;
+use crate::tls13::Tls13ProtocolSuite;
 use crate::tls13::key_schedule::{derive_traffic_iv, derive_traffic_key};
 use crate::verify::{
     HandshakeSignatureValid, PeerVerified, ServerIdentity, ServerVerifier,
@@ -98,7 +99,7 @@ fn tls13_client_session_value_roundtrip() {
             },
         },
         Tls13ClientSessionInput {
-            suite: TEST_PROVIDER.tls13_cipher_suites[0],
+            suite: Tls13ProtocolSuite::Tcp(TEST_PROVIDER.tls13_cipher_suites[0]),
             peer_identity: peer_identity.clone(),
             quic_params: Some(SizedPayload::<u16, MaybeEmpty>::from(vec![
                 0xaa, 0xbb, 0xcc, 0xdd,
@@ -112,7 +113,10 @@ fn tls13_client_session_value_roundtrip() {
     session.encode(&mut encoded);
     let decoded = Tls13Session::from_slice(&encoded, &TEST_PROVIDER).unwrap();
 
-    assert_eq!(decoded.suite.common.suite, session.suite.common.suite);
+    assert_eq!(
+        decoded.suite.suite().common.suite,
+        session.suite.suite().common.suite
+    );
     assert_eq!(decoded.secret.bytes(), session.secret.bytes());
     assert_eq!(decoded.age_add, age_add);
     assert_eq!(decoded.max_early_data_size, session.max_early_data_size);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::check::inappropriate_handshake_message;
 use crate::common_state::{
-    EarlyDataEvent, Event, HandshakeFlightTls13, HandshakeKind, Output, OutputEvent, Side,
+    EarlyDataEvent, Event, HandshakeFlightTls13, HandshakeKind, Output, OutputEvent, Protocol, Side,
 };
 use crate::conn::kernel::KernelState;
 use crate::conn::{ConnectionRandoms, Input, TrafficTemperCounters};
@@ -45,10 +45,11 @@ use crate::tls13::key_schedule::{
     KeyScheduleTrafficReceive, KeyScheduleTrafficSend,
 };
 use crate::tls13::{
-    Tls13CipherSuite, construct_client_verify_message, construct_server_verify_message,
+    Tls13CipherSuite, Tls13ProtocolSuite, construct_client_verify_message,
+    construct_server_verify_message,
 };
 use crate::verify::{self, DigitallySignedStruct, ServerIdentity, SignatureVerificationInput};
-use crate::{ConnectionTrafficSecrets, KeyLog, compress, crypto};
+use crate::{ConnectionTrafficSecrets, KeyLog, compress, crypto, quic};
 
 #[expect(private_interfaces)]
 pub(crate) enum Tls13State {
@@ -147,12 +148,20 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
         let our_key_share = KeyExchangeChoice::new(&config, output, our_key_share, their_key_share)
             .map_err(|_| PeerMisbehaved::WrongGroupForKeyShare)?;
 
+        let suite = match protocol {
+            Protocol::Tcp => Tls13ProtocolSuite::Tcp(suite),
+            Protocol::Quic(_) => Tls13ProtocolSuite::Quic(quic::Suite::try_from(suite)?),
+        };
+
         let (key_schedule_pre_handshake, in_early_traffic) =
             match (server_hello.preshared_key, st.early_data_key_schedule) {
                 (Some(selected_psk), Some((early_key_schedule, in_early_traffic))) => {
                     match &resuming_session {
                         Some(resuming) => {
-                            let Some(resuming_suite) = suite.can_resume_from(resuming.suite) else {
+                            let Some(resuming_suite) = suite
+                                .suite()
+                                .can_resume_from(resuming.suite.suite())
+                            else {
                                 return Err(
                                     PeerMisbehaved::ResumptionOfferedWithIncompatibleCipherSuite
                                         .into(),
@@ -161,7 +170,7 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
 
                             // If the server varies the suite here, we will have encrypted early data with
                             // the wrong suite.
-                            if in_early_traffic && resuming_suite != suite {
+                            if in_early_traffic && resuming_suite != suite.suite() {
                                 return Err(
                                     PeerMisbehaved::EarlyDataOfferedWithVariedCipherSuite.into()
                                 );
@@ -188,10 +197,7 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
                     // Discard the early data key schedule.
                     output.emit(Event::EarlyData(EarlyDataEvent::Rejected));
                     resuming_session.take();
-                    (
-                        KeySchedulePreHandshake::new(Side::Client, protocol, suite)?,
-                        false,
-                    )
+                    (KeySchedulePreHandshake::new(Side::Client, suite)?, false)
                 }
             };
 
@@ -215,7 +221,7 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
                 &key_schedule,
                 server_hello,
                 server_hello_encoded,
-                suite.common.hash_provider,
+                suite.suite().common.hash_provider,
             )? {
                 // The server accepted our ECH offer, so complete the inner transcript with the
                 // server hello message, and switch the relevant state to the copies for the
@@ -403,7 +409,7 @@ pub(super) fn prepare_resumption(
     doing_retry: bool,
 ) -> bool {
     let resuming_suite = resuming_session.suite;
-    output.output(OutputEvent::CipherSuite(resuming_suite.into()));
+    output.output(OutputEvent::CipherSuite(resuming_suite.suite().into()));
     // The EarlyData extension MUST be supplied together with the
     // PreSharedKey extension.
     let max_early_data_size = resuming_session.max_early_data_size;
@@ -426,6 +432,7 @@ pub(super) fn prepare_resumption(
     let obfuscated_ticket_age = resuming_session.obfuscated_ticket_age();
 
     let binder_len = resuming_suite
+        .suite()
         .common
         .hash_provider
         .output_len();
@@ -499,7 +506,7 @@ fn validate_encrypted_extensions(
 struct ExpectEncryptedExtensions {
     hs: HandshakeState,
     resuming_session: Option<Tls13Session>,
-    suite: &'static Tls13CipherSuite,
+    suite: Tls13ProtocolSuite,
     hello: ClientHelloDetails,
     ech_status: EchStatus,
     in_early_traffic: bool,
@@ -689,7 +696,7 @@ fn check_cert_type(
 
 struct ExpectCertificateOrCompressedCertificateOrCertReq {
     hs: HandshakeState,
-    suite: &'static Tls13CipherSuite,
+    suite: Tls13ProtocolSuite,
     quic_params: Option<SizedPayload<'static, u16, MaybeEmpty>>,
     ech: Ech,
     expected_certificate_type: CertificateType,
@@ -766,7 +773,7 @@ impl From<Box<ExpectCertificateOrCompressedCertificateOrCertReq>> for ClientStat
 
 struct ExpectCertificateOrCompressedCertificate {
     hs: HandshakeState,
-    suite: &'static Tls13CipherSuite,
+    suite: Tls13ProtocolSuite,
     quic_params: Option<SizedPayload<'static, u16, MaybeEmpty>>,
     client_auth: Option<ClientAuthDetails>,
     ech: Ech,
@@ -826,7 +833,7 @@ impl From<Box<ExpectCertificateOrCompressedCertificate>> for ClientState {
 
 struct ExpectCertificateOrCertReq {
     hs: HandshakeState,
-    suite: &'static Tls13CipherSuite,
+    suite: Tls13ProtocolSuite,
     quic_params: Option<SizedPayload<'static, u16, MaybeEmpty>>,
     ech: Ech,
     expected_certificate_type: CertificateType,
@@ -890,7 +897,7 @@ impl From<Box<ExpectCertificateOrCertReq>> for ClientState {
 // in TLS1.3.
 struct ExpectCertificateRequest {
     hs: HandshakeState,
-    suite: &'static Tls13CipherSuite,
+    suite: Tls13ProtocolSuite,
     quic_params: Option<SizedPayload<'static, u16, MaybeEmpty>>,
     offered_cert_compression: bool,
     ech: Ech,
@@ -983,7 +990,7 @@ impl ExpectCertificateRequest {
 
 struct ExpectCompressedCertificate {
     hs: HandshakeState,
-    suite: &'static Tls13CipherSuite,
+    suite: Tls13ProtocolSuite,
     quic_params: Option<SizedPayload<'static, u16, MaybeEmpty>>,
     client_auth: Option<ClientAuthDetails>,
     ech: Ech,
@@ -1043,7 +1050,7 @@ impl ExpectCompressedCertificate {
 
 struct ExpectCertificate {
     hs: HandshakeState,
-    suite: &'static Tls13CipherSuite,
+    suite: Tls13ProtocolSuite,
     quic_params: Option<SizedPayload<'static, u16, MaybeEmpty>>,
     client_auth: Option<ClientAuthDetails>,
     ech: Ech,
@@ -1110,7 +1117,7 @@ impl From<Box<ExpectCertificate>> for ClientState {
 // --- TLS1.3 CertificateVerify ---
 struct ExpectCertificateVerify {
     hs: HandshakeState,
-    suite: &'static Tls13CipherSuite,
+    suite: Tls13ProtocolSuite,
     quic_params: Option<SizedPayload<'static, u16, MaybeEmpty>>,
     server_cert: ServerCertDetails,
     client_auth: Option<ClientAuthDetails>,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -256,7 +256,7 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
             &proof,
         );
 
-        if !key_schedule.protocol().is_quic() {
+        if !key_schedule.is_quic() {
             emit_fake_ccs(&mut sent_tls13_fake_ccs, output);
         }
 
@@ -447,7 +447,7 @@ pub(super) fn derive_early_traffic_secret(
     transcript_buffer: &HandshakeHashBuffer,
     client_random: &[u8; 32],
 ) {
-    if !early_key_schedule.protocol().is_quic() {
+    if !early_key_schedule.is_quic() {
         // For middlebox compatibility
         emit_fake_ccs(sent_tls13_fake_ccs, output);
     }
@@ -538,11 +538,7 @@ impl ExpectEncryptedExtensions {
         // mechanism) if and only if any ALPN protocols were configured. This defends against badly-behaved
         // servers which accept a connection that requires an application-layer protocol they do not
         // understand.
-        if self
-            .hs
-            .key_schedule
-            .protocol()
-            .is_quic()
+        if self.hs.key_schedule.is_quic()
             && selected_alpn.is_none()
             && !self.hello.alpn_protocols.is_empty()
         {
@@ -1320,7 +1316,7 @@ impl ExpectFinished {
         /* The EndOfEarlyData message to server is still encrypted with early data keys,
          * but appears in the transcript after the server Finished. */
         if st.in_early_traffic {
-            if !st.hs.key_schedule.protocol().is_quic() {
+            if !st.hs.key_schedule.is_quic() {
                 emit_end_of_early_data_tls13(&mut st.hs.transcript, output);
             }
             output.emit(Event::EarlyData(EarlyDataEvent::Finished));
@@ -1414,7 +1410,7 @@ impl ExpectFinished {
             .into());
         }
 
-        let protocol = key_schedule_recv.protocol();
+        let is_quic = key_schedule_recv.is_quic();
 
         let st = ExpectTraffic {
             config: st.hs.config.clone(),
@@ -1429,7 +1425,7 @@ impl ExpectFinished {
             _fin_verified: fin,
         };
 
-        Ok(match protocol.is_quic() {
+        Ok(match is_quic {
             true => Box::new(ExpectQuicTraffic(st)).into(),
             false => Box::new(st).into(),
         })
@@ -1474,11 +1470,7 @@ impl ExpectTraffic {
 
         let now = self.config.current_time()?;
         let value = Tls13Session::new(nst, self.session_input.clone(), secret.as_ref(), now);
-        if self
-            .key_schedule_recv
-            .protocol()
-            .is_quic()
-        {
+        if self.key_schedule_recv.is_quic() {
             if let Some(sz) = nst.extensions.max_early_data_size {
                 if sz != 0 && sz != 0xffff_ffff {
                     return Err(PeerMisbehaved::InvalidMaxEarlyDataSize.into());
@@ -1507,11 +1499,7 @@ impl ExpectTraffic {
         output: &mut dyn Output<'_>,
         key_update_request: &KeyUpdateRequest,
     ) -> Result<(), Error> {
-        if self
-            .key_schedule_recv
-            .protocol()
-            .is_quic()
-        {
+        if self.key_schedule_recv.is_quic() {
             return Err(PeerMisbehaved::KeyUpdateReceivedInQuicConnection.into());
         }
 

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -566,9 +566,13 @@ impl<Side: SideData> ConnectionCommon<Side> {
                 _ => None,
             })?;
 
+        let suite = Suite {
+            inner: suite,
+            quic: suite.quic?,
+        };
+
         Some(DirectionalKeys::new(
             suite,
-            suite.quic?,
             self.quic.early_secret.as_ref()?,
             self.quic.version,
         ))
@@ -664,8 +668,7 @@ impl QuicOutput for Quic {
         &mut self,
         client_secret: OkmBlock,
         server_secret: OkmBlock,
-        suite: &'static Tls13CipherSuite,
-        quic: &'static dyn Algorithm,
+        suite: Suite,
         side: Side,
     ) {
         self.events
@@ -674,7 +677,6 @@ impl QuicOutput for Quic {
                     client_secret,
                     server_secret,
                     suite,
-                    quic,
                     side,
                     self.version,
                 )),
@@ -685,18 +687,10 @@ impl QuicOutput for Quic {
         &mut self,
         client_secret: OkmBlock,
         server_secret: OkmBlock,
-        suite: &'static Tls13CipherSuite,
-        quic: &'static dyn Algorithm,
+        suite: Suite,
         side: Side,
     ) {
-        let mut secrets = Secrets::new(
-            client_secret,
-            server_secret,
-            suite,
-            quic,
-            side,
-            self.version,
-        );
+        let mut secrets = Secrets::new(client_secret, server_secret, suite, side, self.version);
         let keys = Keys::new(&secrets);
         secrets.update();
         self.events
@@ -720,8 +714,7 @@ pub(crate) trait QuicOutput {
         &mut self,
         client_secret: OkmBlock,
         server_secret: OkmBlock,
-        suite: &'static Tls13CipherSuite,
-        quic: &'static dyn Algorithm,
+        suite: Suite,
         side: Side,
     );
 
@@ -729,8 +722,7 @@ pub(crate) trait QuicOutput {
         &mut self,
         client_secret: OkmBlock,
         server_secret: OkmBlock,
-        suite: &'static Tls13CipherSuite,
-        quic: &'static dyn Algorithm,
+        suite: Suite,
         side: Side,
     );
 
@@ -745,8 +737,7 @@ pub struct Secrets {
     /// Secret used to encrypt packets transmitted by the server
     pub(crate) server: OkmBlock,
     /// Cipher suite used with these secrets
-    suite: &'static Tls13CipherSuite,
-    quic: &'static dyn Algorithm,
+    suite: Suite,
     side: Side,
     version: Version,
 }
@@ -755,8 +746,7 @@ impl Secrets {
     pub(crate) fn new(
         client: OkmBlock,
         server: OkmBlock,
-        suite: &'static Tls13CipherSuite,
-        quic: &'static dyn Algorithm,
+        suite: Suite,
         side: Side,
         version: Version,
     ) -> Self {
@@ -764,7 +754,6 @@ impl Secrets {
             client,
             server,
             suite,
-            quic,
             side,
             version,
         }
@@ -780,6 +769,7 @@ impl Secrets {
     pub(crate) fn update(&mut self) {
         self.client = hkdf_expand_label_block(
             self.suite
+                .inner
                 .hkdf_provider
                 .expander_for_okm(&self.client)
                 .as_ref(),
@@ -788,6 +778,7 @@ impl Secrets {
         );
         self.server = hkdf_expand_label_block(
             self.suite
+                .inner
                 .hkdf_provider
                 .expander_for_okm(&self.server)
                 .as_ref(),
@@ -814,13 +805,8 @@ pub struct DirectionalKeys {
 }
 
 impl DirectionalKeys {
-    pub(crate) fn new(
-        suite: &'static Tls13CipherSuite,
-        quic: &'static dyn Algorithm,
-        secret: &OkmBlock,
-        version: Version,
-    ) -> Self {
-        let builder = KeyBuilder::new(secret, version, quic, suite.hkdf_provider);
+    pub(crate) fn new(suite: Suite, secret: &OkmBlock, version: Version) -> Self {
+        let builder = KeyBuilder::new(secret, version, suite.quic, suite.inner.hkdf_provider);
         Self {
             header: builder.header_protection_key(),
             packet: builder.packet_key(),
@@ -1009,7 +995,12 @@ pub struct PacketKeySet {
 impl PacketKeySet {
     fn new(secrets: &Secrets) -> Self {
         let (local, remote) = secrets.local_remote();
-        let (version, alg, hkdf) = (secrets.version, secrets.quic, secrets.suite.hkdf_provider);
+        let (version, alg, hkdf) = (
+            secrets.version,
+            secrets.suite.quic,
+            secrets.suite.inner.hkdf_provider,
+        );
+
         Self {
             local: KeyBuilder::new(local, version, alg, hkdf).packet_key(),
             remote: KeyBuilder::new(remote, version, alg, hkdf).packet_key(),
@@ -1081,13 +1072,7 @@ pub struct Suite {
 impl Suite {
     /// Produce a set of initial keys given the connection ID, side and version
     pub fn keys(&self, client_dst_connection_id: &[u8], side: Side, version: Version) -> Keys {
-        Keys::initial(
-            version,
-            self.inner,
-            self.quic,
-            client_dst_connection_id,
-            side,
-        )
+        Keys::initial(version, *self, client_dst_connection_id, side)
     }
 }
 
@@ -1117,8 +1102,7 @@ impl Keys {
     /// Construct keys for use with initial packets
     pub fn initial(
         version: Version,
-        suite: &'static Tls13CipherSuite,
-        quic: &'static dyn Algorithm,
+        suite: Suite,
         client_dst_connection_id: &[u8],
         side: Side,
     ) -> Self {
@@ -1126,6 +1110,7 @@ impl Keys {
         const SERVER_LABEL: &[u8] = b"server in";
         let salt = version.initial_salt();
         let hs_secret = suite
+            .inner
             .hkdf_provider
             .extract_from_secret(Some(salt), client_dst_connection_id);
 
@@ -1133,18 +1118,18 @@ impl Keys {
             client: hkdf_expand_label_block(hs_secret.as_ref(), CLIENT_LABEL, &[]),
             server: hkdf_expand_label_block(hs_secret.as_ref(), SERVER_LABEL, &[]),
             suite,
-            quic,
             side,
             version,
         };
+
         Self::new(&secrets)
     }
 
     fn new(secrets: &Secrets) -> Self {
         let (local, remote) = secrets.local_remote();
         Self {
-            local: DirectionalKeys::new(secrets.suite, secrets.quic, local, secrets.version),
-            remote: DirectionalKeys::new(secrets.suite, secrets.quic, remote, secrets.version),
+            local: DirectionalKeys::new(secrets.suite, local, secrets.version),
+            remote: DirectionalKeys::new(secrets.suite, remote, secrets.version),
         }
     }
 }
@@ -1281,8 +1266,10 @@ mod tests {
                     0x4e, 0xb1, 0xe4, 0x38, 0xd8, 0x55,
                 ][..],
             ),
-            suite: TLS13_TEST_SUITE,
-            quic: &FakeAlgorithm,
+            suite: Suite {
+                inner: TLS13_TEST_SUITE,
+                quic: &FakeAlgorithm,
+            },
             side: Side::Client,
             version: Version::V1,
         };

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -1089,6 +1089,14 @@ impl TryFrom<&'static Tls13CipherSuite> for Suite {
     }
 }
 
+impl fmt::Debug for Suite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Suite")
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Complete set of keys used to communicate with the peer
 #[expect(clippy::exhaustive_structs)]
 pub struct Keys {

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -1073,7 +1073,7 @@ impl<'a> KeyBuilder<'a> {
 #[derive(Clone, Copy)]
 pub struct Suite {
     /// The TLS 1.3 ciphersuite used to derive keys.
-    pub suite: &'static Tls13CipherSuite,
+    pub inner: &'static Tls13CipherSuite,
     /// The QUIC key generation algorithm used to derive keys.
     pub quic: &'static dyn Algorithm,
 }
@@ -1083,7 +1083,7 @@ impl Suite {
     pub fn keys(&self, client_dst_connection_id: &[u8], side: Side, version: Version) -> Keys {
         Keys::initial(
             version,
-            self.suite,
+            self.inner,
             self.quic,
             client_dst_connection_id,
             side,

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -1091,6 +1091,19 @@ impl Suite {
     }
 }
 
+impl TryFrom<&'static Tls13CipherSuite> for Suite {
+    type Error = ApiMisuse;
+
+    fn try_from(suite: &'static Tls13CipherSuite) -> Result<Self, Self::Error> {
+        Ok(Self {
+            inner: suite,
+            quic: suite
+                .quic
+                .ok_or(ApiMisuse::NoQuicCompatibleCipherSuites)?,
+        })
+    }
+}
+
 /// Complete set of keys used to communicate with the peer
 #[expect(clippy::exhaustive_structs)]
 pub struct Keys {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -87,9 +87,11 @@ mod client_hello {
         HelloRetryRequest, HelloRetryRequestExtensions, KeyShareEntry, Random, ServerExtensions,
         ServerExtensionsInput, ServerHelloPayload, SessionId, SizedPayload,
     };
+    use crate::quic;
     use crate::sealed::Sealed;
     use crate::server::Tls13ServerSessionValue;
     use crate::server::hs::{ClientHelloInput, ExpectClientHello, ServerHandler, Tls13Extensions};
+    use crate::tls13::Tls13ProtocolSuite;
     use crate::tls13::key_schedule::{
         KeyScheduleEarlyServer, KeyScheduleHandshake, KeySchedulePreHandshake,
     };
@@ -212,14 +214,18 @@ mod client_hello {
                 };
             };
 
-            let mut resuming = handle_psk_offer(
-                &input,
-                &transcript,
-                st.sni.as_ref(),
-                suite,
-                st.protocol,
-                &st.config,
-            )?;
+            let suite = match st.protocol {
+                Protocol::Tcp => Tls13ProtocolSuite::Tcp(suite),
+                Protocol::Quic(_) => Tls13ProtocolSuite::Quic(quic::Suite {
+                    inner: suite,
+                    quic: suite
+                        .quic
+                        .ok_or_else(|| Error::from(ApiMisuse::NoQuicCompatibleCipherSuites))?,
+                }),
+            };
+
+            let mut resuming =
+                handle_psk_offer(&input, &transcript, st.sni.as_ref(), suite, &st.config)?;
 
             if !input
                 .client_hello
@@ -257,7 +263,6 @@ mod client_hello {
                 &mut transcript,
                 &randoms,
                 suite,
-                st.protocol,
                 output,
                 &input.client_hello.session_id,
                 chosen_share_and_kxg,
@@ -288,7 +293,7 @@ mod client_hello {
                 doing_early_data,
             ) = emit_encrypted_extensions(
                 &mut flight,
-                suite,
+                suite.suite(),
                 output,
                 &mut ocsp_response,
                 input.client_hello,
@@ -366,7 +371,7 @@ mod client_hello {
             let hs = HandshakeState {
                 config: st.config,
                 transcript,
-                suite,
+                suite: suite.suite(),
                 alpn_protocol,
                 sni: st.sni,
                 resumption_data: st.resumption_data,
@@ -444,8 +449,7 @@ mod client_hello {
         input: &ClientHelloInput<'_>,
         transcript: &HandshakeHash,
         sni: Option<&DnsName<'_>>,
-        suite: &'static Tls13CipherSuite,
-        protocol: Protocol,
+        suite: Tls13ProtocolSuite,
         config: &ServerConfig,
     ) -> Result<Option<(usize, Tls13ServerSessionValue<'static>)>, Error> {
         let Some(psk_offer) = &input.client_hello.preshared_key_offer else {
@@ -481,14 +485,14 @@ mod client_hello {
             session.set_freshness(psk_id.obfuscated_ticket_age, now);
             if !session
                 .common
-                .can_resume(suite.common.suite, sni)
+                .can_resume(suite.suite().common.suite, sni)
             {
                 continue;
             }
 
             if !check_binder(
                 transcript,
-                &KeyScheduleEarlyServer::new(protocol, suite, session.secret.bytes())?,
+                &KeyScheduleEarlyServer::new(suite, session.secret.bytes())?,
                 input.message,
                 psk_offer.binders[i].as_ref(),
             ) {
@@ -526,8 +530,7 @@ mod client_hello {
     fn emit_server_hello(
         transcript: &mut HandshakeHash,
         randoms: &ConnectionRandoms,
-        suite: &'static Tls13CipherSuite,
-        protocol: Protocol,
+        suite: Tls13ProtocolSuite,
         output: &mut dyn Output<'_>,
         session_id: &SessionId,
         share_and_kxgroup: (&KeyShareEntry, &'static dyn SupportedKxGroup),
@@ -555,7 +558,7 @@ mod client_hello {
                     legacy_version: ProtocolVersion::TLSv1_2,
                     random: Random::from(randoms.server),
                     session_id: *session_id,
-                    cipher_suite: suite.common.suite,
+                    cipher_suite: suite.suite().common.suite,
                     compression_method: Compression::Null,
                     extensions,
                 }),
@@ -570,8 +573,7 @@ mod client_hello {
 
         // Start key schedule
         let key_schedule_pre_handshake = if let Some((_, psk)) = resuming {
-            let early_key_schedule =
-                KeyScheduleEarlyServer::new(protocol, suite, psk.secret.bytes())?;
+            let early_key_schedule = KeyScheduleEarlyServer::new(suite, psk.secret.bytes())?;
             early_key_schedule.client_early_traffic_secret(
                 &client_hello_hash,
                 &*config.key_log,
@@ -592,7 +594,7 @@ mod client_hello {
 
             KeySchedulePreHandshake::from(early_key_schedule)
         } else {
-            KeySchedulePreHandshake::new(Side::Server, protocol, suite)?
+            KeySchedulePreHandshake::new(Side::Server, suite)?
         };
 
         // Do key exchange

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1472,7 +1472,7 @@ impl ExpectFinished {
             .update_key_schedule(Box::new(key_schedule_send));
         output.start_traffic();
 
-        Ok(match key_schedule_recv.protocol().is_quic() {
+        Ok(match key_schedule_recv.is_quic() {
             true => Box::new(ExpectQuicTraffic { _fin_verified: fin }).into(),
             false => Box::new(ExpectTraffic {
                 config: self.hs.config,
@@ -1516,11 +1516,7 @@ impl ExpectTraffic {
         output: &mut dyn Output<'_>,
         key_update_request: &KeyUpdateRequest,
     ) -> Result<(), Error> {
-        if self
-            .key_schedule_recv
-            .protocol()
-            .is_quic()
-        {
+        if self.key_schedule_recv.is_quic() {
             return Err(PeerMisbehaved::KeyUpdateReceivedInQuicConnection.into());
         }
 

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -3,7 +3,7 @@
 use alloc::boxed::Box;
 use core::ops::Deref;
 
-use crate::common_state::{Output, Protocol, Side};
+use crate::common_state::{Output, Side};
 use crate::conn::{Exporter, ReceivePath, SendOutput};
 use crate::crypto::cipher::{AeadKey, Iv, MessageDecrypter, Tls13AeadAlgorithm};
 use crate::crypto::kx::SharedSecret;
@@ -11,7 +11,8 @@ use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError, expa
 use crate::crypto::{hash, hmac};
 use crate::error::{ApiMisuse, Error};
 use crate::msgs::{HandshakeAlignedProof, Message};
-use crate::{ConnectionTrafficSecrets, KeyLog, Tls13CipherSuite, quic};
+use crate::tls13::Tls13ProtocolSuite;
+use crate::{ConnectionTrafficSecrets, KeyLog};
 
 // We express the state of a contained KeySchedule using these
 // typestates.  This means we can write code that cannot accidentally
@@ -22,17 +23,8 @@ use crate::{ConnectionTrafficSecrets, KeyLog, Tls13CipherSuite, quic};
 pub(crate) struct KeyScheduleEarlyClient(KeyScheduleEarly);
 
 impl KeyScheduleEarlyClient {
-    pub(crate) fn new(
-        protocol: Protocol,
-        suite: &'static Tls13CipherSuite,
-        secret: &[u8],
-    ) -> Result<Self, Error> {
-        Ok(Self(KeyScheduleEarly::new(
-            Side::Client,
-            protocol,
-            suite,
-            secret,
-        )?))
+    pub(crate) fn new(suite: Tls13ProtocolSuite, secret: &[u8]) -> Result<Self, Error> {
+        Ok(Self(KeyScheduleEarly::new(Side::Client, suite, secret)?))
     }
 
     /// Computes the `client_early_traffic_secret` and installs it as encrypter.
@@ -52,7 +44,7 @@ impl KeyScheduleEarlyClient {
     }
 
     pub(crate) fn is_quic(&self) -> bool {
-        self.0.ks.protocol.is_quic()
+        self.0.ks.state.is_quic()
     }
 }
 
@@ -67,17 +59,8 @@ impl Deref for KeyScheduleEarlyClient {
 pub(crate) struct KeyScheduleEarlyServer(KeyScheduleEarly);
 
 impl KeyScheduleEarlyServer {
-    pub(crate) fn new(
-        protocol: Protocol,
-        suite: &'static Tls13CipherSuite,
-        secret: &[u8],
-    ) -> Result<Self, Error> {
-        Ok(Self(KeyScheduleEarly::new(
-            Side::Server,
-            protocol,
-            suite,
-            secret,
-        )?))
+    pub(crate) fn new(suite: Tls13ProtocolSuite, secret: &[u8]) -> Result<Self, Error> {
+        Ok(Self(KeyScheduleEarly::new(Side::Server, suite, secret)?))
     }
 
     /// Computes the `client_early_traffic_secret` and installs it as decrypter.
@@ -119,14 +102,9 @@ pub(crate) struct KeyScheduleEarly {
 }
 
 impl KeyScheduleEarly {
-    fn new(
-        local: Side,
-        protocol: Protocol,
-        suite: &'static Tls13CipherSuite,
-        secret: &[u8],
-    ) -> Result<Self, Error> {
+    fn new(local: Side, suite: Tls13ProtocolSuite, secret: &[u8]) -> Result<Self, Error> {
         Ok(Self {
-            ks: KeySchedule::new(local, protocol, suite, secret)?,
+            ks: KeySchedule::new(local, suite, secret)?,
         })
     }
 
@@ -191,7 +169,12 @@ impl KeyScheduleEarly {
     }
 
     pub(crate) fn hash(&self) -> &'static dyn hash::Hash {
-        self.ks.inner.suite.common.hash_provider
+        self.ks
+            .inner
+            .state
+            .suite()
+            .common
+            .hash_provider
     }
 }
 
@@ -224,13 +207,9 @@ pub(crate) struct KeySchedulePreHandshake {
 
 impl KeySchedulePreHandshake {
     /// Creates a key schedule without a PSK.
-    pub(crate) fn new(
-        local: Side,
-        protocol: Protocol,
-        suite: &'static Tls13CipherSuite,
-    ) -> Result<Self, Error> {
+    pub(crate) fn new(local: Side, suite: Tls13ProtocolSuite) -> Result<Self, Error> {
         Ok(Self {
-            ks: KeySchedule::new_with_empty_secret(local, protocol, suite)?,
+            ks: KeySchedule::new_with_empty_secret(local, suite)?,
         })
     }
 
@@ -276,7 +255,7 @@ impl KeyScheduleHandshakeStart {
         mut self,
         early_data_enabled: bool,
         hs_hash: hash::Output,
-        suite: &'static Tls13CipherSuite,
+        state: Tls13ProtocolSuite,
         key_log: &dyn KeyLog,
         client_random: &[u8; 32],
         output: &mut dyn Output<'_>,
@@ -284,7 +263,7 @@ impl KeyScheduleHandshakeStart {
     ) -> KeyScheduleHandshake {
         debug_assert_eq!(self.ks.side, Side::Client);
         // Suite might have changed due to resumption
-        self.ks.inner.suite = suite;
+        self.ks.inner.state = state;
         let new = self.into_handshake(hs_hash, key_log, client_random, output);
 
         // Decrypt with the peer's key, encrypt with our own key
@@ -336,7 +315,8 @@ impl KeyScheduleHandshakeStart {
          */
         hkdf_expand_label(
             self.ks
-                .suite
+                .state
+                .suite()
                 .hkdf_provider
                 .extract_from_secret(None, client_hello_inner_random)
                 .as_ref(),
@@ -369,15 +349,14 @@ impl KeyScheduleHandshakeStart {
         );
 
         if let Some(quic) = output.quic() {
-            quic.handshake_secrets(
-                client_secret.clone(),
-                server_secret.clone(),
-                quic::Suite {
-                    inner: self.ks.suite,
-                    quic: self.ks.quic.unwrap(),
-                },
-                self.ks.side,
-            );
+            if let Tls13ProtocolSuite::Quic(suite) = self.ks.state {
+                quic.handshake_secrets(
+                    client_secret.clone(),
+                    server_secret.clone(),
+                    suite,
+                    self.ks.side,
+                );
+            }
         }
 
         KeyScheduleHandshake {
@@ -454,15 +433,14 @@ impl KeyScheduleHandshake {
             .set_encrypter(server_secret, output.send());
 
         if let Some(quic) = output.quic() {
-            quic.traffic_secrets(
-                client_secret.clone(),
-                server_secret.clone(),
-                quic::Suite {
-                    inner: before_finished.ks.suite,
-                    quic: before_finished.ks.quic.unwrap(),
-                },
-                before_finished.ks.side,
-            );
+            if let Tls13ProtocolSuite::Quic(suite) = before_finished.ks.state {
+                quic.traffic_secrets(
+                    client_secret.clone(),
+                    server_secret.clone(),
+                    suite,
+                    before_finished.ks.side,
+                );
+            }
         }
 
         KeyScheduleTrafficWithClientFinishedPending {
@@ -487,7 +465,7 @@ impl KeyScheduleHandshake {
     }
 
     pub(crate) fn is_quic(&self) -> bool {
-        self.ks.protocol.is_quic()
+        self.ks.state.is_quic()
     }
 }
 
@@ -605,15 +583,14 @@ impl KeyScheduleClientBeforeFinished {
             .set_encrypter(client_secret, output.send());
 
         if let Some(quic) = output.quic() {
-            quic.traffic_secrets(
-                client_secret.clone(),
-                server_secret.clone(),
-                quic::Suite {
-                    inner: next.ks.suite,
-                    quic: next.ks.quic.unwrap(),
-                },
-                next.ks.side,
-            );
+            if let Tls13ProtocolSuite::Quic(suite) = next.ks.state {
+                quic.traffic_secrets(
+                    client_secret.clone(),
+                    server_secret.clone(),
+                    suite,
+                    next.ks.side,
+                );
+            }
         }
 
         next.into_traffic(hs_hash)
@@ -727,17 +704,15 @@ impl KeyScheduleTrafficSend {
     }
 
     pub(crate) fn extract(&self) -> Result<ConnectionTrafficSecrets, Error> {
+        let suite = self.ks.state.suite();
         let (key, iv) = expand_secret(
             &self.current,
-            self.ks.suite.hkdf_provider,
-            self.ks.suite.aead_alg.key_len(),
-            self.ks.suite.aead_alg.iv_len(),
+            suite.hkdf_provider,
+            suite.aead_alg.key_len(),
+            suite.aead_alg.iv_len(),
         );
-        Ok(self
-            .ks
-            .suite
-            .aead_alg
-            .extract_keys(key, iv)?)
+
+        Ok(suite.aead_alg.extract_keys(key, iv)?)
     }
 }
 
@@ -765,21 +740,19 @@ impl KeyScheduleTrafficReceive {
     }
 
     pub(crate) fn extract(&self) -> Result<ConnectionTrafficSecrets, Error> {
+        let suite = self.ks.state.suite();
         let (key, iv) = expand_secret(
             &self.current,
-            self.ks.suite.hkdf_provider,
-            self.ks.suite.aead_alg.key_len(),
-            self.ks.suite.aead_alg.iv_len(),
+            suite.hkdf_provider,
+            suite.aead_alg.key_len(),
+            suite.aead_alg.iv_len(),
         );
-        Ok(self
-            .ks
-            .suite
-            .aead_alg
-            .extract_keys(key, iv)?)
+
+        Ok(suite.aead_alg.extract_keys(key, iv)?)
     }
 
     pub(crate) fn is_quic(&self) -> bool {
-        self.ks.protocol.is_quic()
+        self.ks.state.is_quic()
     }
 }
 
@@ -830,53 +803,24 @@ struct KeySchedule {
 }
 
 impl KeySchedule {
-    fn new(
-        side: Side,
-        protocol: Protocol,
-        suite: &'static Tls13CipherSuite,
-        secret: &[u8],
-    ) -> Result<Self, Error> {
-        let quic = match protocol {
-            Protocol::Quic(_) => Some(suite.quic.ok_or(Error::Unreachable(
-                "QUIC connection negotiated a cipher suite without QUIC support",
-            ))?),
-            Protocol::Tcp => None,
-        };
+    fn new(side: Side, suite: Tls13ProtocolSuite, secret: &[u8]) -> Result<Self, Error> {
         Ok(Self {
             current: suite
+                .suite()
                 .hkdf_provider
                 .extract_from_secret(None, secret),
-            inner: KeyScheduleSuite {
-                side,
-                protocol,
-                suite,
-                quic,
-            },
+            inner: KeyScheduleSuite { side, state: suite },
         })
     }
 
     /// Creates a key schedule without a PSK.
-    fn new_with_empty_secret(
-        side: Side,
-        protocol: Protocol,
-        suite: &'static Tls13CipherSuite,
-    ) -> Result<Self, Error> {
-        let quic = match protocol {
-            Protocol::Quic(_) => Some(suite.quic.ok_or(Error::Unreachable(
-                "QUIC connection negotiated a cipher suite without QUIC support",
-            ))?),
-            Protocol::Tcp => None,
-        };
+    fn new_with_empty_secret(side: Side, state: Tls13ProtocolSuite) -> Result<Self, Error> {
         Ok(Self {
-            current: suite
+            current: state
+                .suite()
                 .hkdf_provider
                 .extract_from_zero_ikm(None),
-            inner: KeyScheduleSuite {
-                side,
-                protocol,
-                suite,
-                quic,
-            },
+            inner: KeyScheduleSuite { side, state },
         })
     }
 
@@ -888,7 +832,8 @@ impl KeySchedule {
     fn input_empty(&mut self) {
         let salt = self.derive_for_empty_hash(SecretKind::DerivedSecret);
         self.current = self
-            .suite
+            .state
+            .suite()
             .hkdf_provider
             .extract_from_zero_ikm(Some(salt.as_ref()));
     }
@@ -897,7 +842,8 @@ impl KeySchedule {
     fn input_secret(&mut self, secret: &[u8]) {
         let salt = self.derive_for_empty_hash(SecretKind::DerivedSecret);
         self.current = self
-            .suite
+            .state
+            .suite()
             .hkdf_provider
             .extract_from_secret(Some(salt.as_ref()), secret);
     }
@@ -945,7 +891,7 @@ impl KeySchedule {
     /// - `SecretKind::ResumptionPSKBinderKey`
     /// - `SecretKind::DerivedSecret`
     fn derive_for_empty_hash(&self, kind: SecretKind) -> OkmBlock {
-        let hp = self.suite.common.hash_provider;
+        let hp = self.state.suite().common.hash_provider;
         let empty_hash = hp
             .algorithm()
             .hash_for_empty_input()
@@ -967,24 +913,21 @@ impl Deref for KeySchedule {
 #[derive(Clone, Copy)]
 struct KeyScheduleSuite {
     side: Side,
-    protocol: Protocol,
-    suite: &'static Tls13CipherSuite,
-    // invariant: Some(suite.quic) if protocol is QUIC
-    quic: Option<&'static dyn quic::Algorithm>,
+    state: Tls13ProtocolSuite,
 }
 
 impl KeyScheduleSuite {
     fn set_encrypter(&self, secret: &OkmBlock, send: &mut dyn SendOutput) {
-        let expander = self
-            .suite
+        let suite = self.state.suite();
+        let expander = suite
             .hkdf_provider
             .expander_for_okm(secret);
-        let key = derive_traffic_key(expander.as_ref(), self.suite.aead_alg);
-        let iv = derive_traffic_iv(expander.as_ref(), self.suite.aead_alg.iv_len());
+        let key = derive_traffic_key(expander.as_ref(), suite.aead_alg);
+        let iv = derive_traffic_iv(expander.as_ref(), suite.aead_alg.iv_len());
 
         send.set_encrypter(
-            self.suite.aead_alg.encrypter(key, iv),
-            self.suite.common.confidentiality_limit,
+            suite.aead_alg.encrypter(key, iv),
+            suite.common.confidentiality_limit,
         );
     }
 
@@ -1000,13 +943,13 @@ impl KeyScheduleSuite {
     }
 
     fn derive_decrypter(&self, secret: &OkmBlock) -> Box<dyn MessageDecrypter> {
-        let expander = self
-            .suite
+        let suite = self.state.suite();
+        let expander = suite
             .hkdf_provider
             .expander_for_okm(secret);
-        let key = derive_traffic_key(expander.as_ref(), self.suite.aead_alg);
-        let iv = derive_traffic_iv(expander.as_ref(), self.suite.aead_alg.iv_len());
-        self.suite.aead_alg.decrypter(key, iv)
+        let key = derive_traffic_key(expander.as_ref(), suite.aead_alg);
+        let iv = derive_traffic_iv(expander.as_ref(), suite.aead_alg.iv_len());
+        suite.aead_alg.decrypter(key, iv)
     }
 
     /// Sign the finished message consisting of `hs_hash` using a current
@@ -1022,13 +965,13 @@ impl KeyScheduleSuite {
     ///
     /// See RFC 8446 section 4.4.4.
     fn sign_verify_data(&self, base_key: &OkmBlock, hs_hash: &hash::Output) -> hmac::PublicTag {
-        let expander = self
-            .suite
+        let suite = self.state.suite();
+        let expander = suite
             .hkdf_provider
             .expander_for_okm(base_key);
         let hmac_key = hkdf_expand_label_block(expander.as_ref(), b"finished", &[]);
 
-        self.suite
+        suite
             .hkdf_provider
             .hmac_sign(&hmac_key, hs_hash.as_ref())
             // this is published in the handshake, in the Finished message or PSK binder
@@ -1038,7 +981,8 @@ impl KeyScheduleSuite {
     /// Derive the next application traffic secret, returning it.
     fn derive_next(&self, base_key: &OkmBlock) -> OkmBlock {
         let expander = self
-            .suite
+            .state
+            .suite()
             .hkdf_provider
             .expander_for_okm(base_key);
         hkdf_expand_label_block(expander.as_ref(), b"traffic upd", &[])
@@ -1048,7 +992,8 @@ impl KeyScheduleSuite {
     /// ticket_nonce.
     fn derive_ticket_psk(&self, rms: &OkmBlock, nonce: &[u8]) -> OkmBlock {
         let expander = self
-            .suite
+            .state
+            .suite()
             .hkdf_provider
             .expander_for_okm(rms);
         hkdf_expand_label_block(expander.as_ref(), b"resumption", nonce)
@@ -1061,28 +1006,22 @@ impl KeyScheduleSuite {
         context: Option<&[u8]>,
         out: &mut [u8],
     ) -> Result<(), Error> {
+        let suite = self.state.suite();
         let secret = {
-            let h_empty = self
-                .suite
-                .common
-                .hash_provider
-                .hash(&[]);
+            let h_empty = suite.common.hash_provider.hash(&[]);
 
-            let expander = self
-                .suite
+            let expander = suite
                 .hkdf_provider
                 .expander_for_okm(current_exporter_secret);
             hkdf_expand_label_block(expander.as_ref(), label, h_empty.as_ref())
         };
 
-        let h_context = self
-            .suite
+        let h_context = suite
             .common
             .hash_provider
             .hash(context.unwrap_or(&[]));
 
-        let expander = self
-            .suite
+        let expander = suite
             .hkdf_provider
             .expander_for_okm(&secret);
         hkdf_expand_label_slice(expander.as_ref(), b"exporter", h_context.as_ref(), out)
@@ -1284,6 +1223,7 @@ mod tests {
     use super::*;
     use crate::crypto::TLS13_TEST_SUITE;
     use crate::key_log::KeyLog;
+    use crate::tls13::Tls13CipherSuite;
 
     #[test]
     fn test_vectors() {
@@ -1368,7 +1308,8 @@ mod tests {
 
         let suite = TLS13_TEST_SUITE;
         let mut ks =
-            KeySchedule::new_with_empty_secret(Side::Server, Protocol::Tcp, suite).unwrap();
+            KeySchedule::new_with_empty_secret(Side::Server, Tls13ProtocolSuite::Tcp(suite))
+                .unwrap();
         ks.input_secret(&ecdhe_secret);
 
         assert_traffic_secret(
@@ -1454,9 +1395,7 @@ mod benchmarks {
     fn bench_sha256(b: &mut test::Bencher) {
         use core::fmt::Debug;
 
-        use super::{
-            KeySchedule, Protocol, SecretKind, Side, derive_traffic_iv, derive_traffic_key,
-        };
+        use super::*;
         use crate::KeyLog;
         use crate::crypto::test_provider::TLS13_TEST_SUITE;
 
@@ -1484,9 +1423,11 @@ mod benchmarks {
         }
 
         b.iter(|| {
-            let mut ks =
-                KeySchedule::new_with_empty_secret(Side::Client, Protocol::Tcp, TLS13_TEST_SUITE)
-                    .unwrap();
+            let mut ks = KeySchedule::new_with_empty_secret(
+                Side::Client,
+                Tls13ProtocolSuite::Tcp(TLS13_TEST_SUITE),
+            )
+            .unwrap();
             ks.input_secret(&[0u8; 32]);
 
             extract_traffic_secret(&ks, SecretKind::ClientHandshakeTrafficSecret);

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -372,8 +372,10 @@ impl KeyScheduleHandshakeStart {
             quic.handshake_secrets(
                 client_secret.clone(),
                 server_secret.clone(),
-                self.ks.suite,
-                self.ks.quic.unwrap(),
+                quic::Suite {
+                    inner: self.ks.suite,
+                    quic: self.ks.quic.unwrap(),
+                },
                 self.ks.side,
             );
         }
@@ -455,8 +457,10 @@ impl KeyScheduleHandshake {
             quic.traffic_secrets(
                 client_secret.clone(),
                 server_secret.clone(),
-                before_finished.ks.suite,
-                before_finished.ks.quic.unwrap(),
+                quic::Suite {
+                    inner: before_finished.ks.suite,
+                    quic: before_finished.ks.quic.unwrap(),
+                },
                 before_finished.ks.side,
             );
         }
@@ -604,8 +608,10 @@ impl KeyScheduleClientBeforeFinished {
             quic.traffic_secrets(
                 client_secret.clone(),
                 server_secret.clone(),
-                next.ks.suite,
-                next.ks.quic.unwrap(),
+                quic::Suite {
+                    inner: next.ks.suite,
+                    quic: next.ks.quic.unwrap(),
+                },
                 next.ks.side,
             );
         }

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -51,8 +51,8 @@ impl KeyScheduleEarlyClient {
         );
     }
 
-    pub(crate) fn protocol(&self) -> Protocol {
-        self.0.ks.protocol
+    pub(crate) fn is_quic(&self) -> bool {
+        self.0.ks.protocol.is_quic()
     }
 }
 
@@ -482,8 +482,8 @@ impl KeyScheduleHandshake {
         (KeyScheduleClientBeforeFinished(before_finished), tag)
     }
 
-    pub(crate) fn protocol(&self) -> Protocol {
-        self.ks.protocol
+    pub(crate) fn is_quic(&self) -> bool {
+        self.ks.protocol.is_quic()
     }
 }
 
@@ -772,8 +772,8 @@ impl KeyScheduleTrafficReceive {
             .extract_keys(key, iv)?)
     }
 
-    pub(crate) fn protocol(&self) -> Protocol {
-        self.ks.protocol
+    pub(crate) fn is_quic(&self) -> bool {
+        self.ks.protocol.is_quic()
     }
 }
 

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -82,7 +82,7 @@ impl Tls13CipherSuite {
     /// Returns a `quic::Suite` for the ciphersuite, if supported.
     pub fn quic_suite(&'static self) -> Option<crate::quic::Suite> {
         self.quic
-            .map(|quic| crate::quic::Suite { suite: self, quic })
+            .map(|quic| crate::quic::Suite { inner: self, quic })
     }
 }
 

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -5,10 +5,30 @@ use pki_types::FipsStatus;
 use crate::common_state::Protocol;
 use crate::crypto::{self, SignatureScheme, hash};
 use crate::enums::ProtocolVersion;
+use crate::quic;
 use crate::suites::{CipherSuiteCommon, Suite, SupportedCipherSuite};
 use crate::version::Tls13Version;
 
 pub(crate) mod key_schedule;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Tls13ProtocolSuite {
+    Tcp(&'static Tls13CipherSuite),
+    Quic(quic::Suite),
+}
+
+impl Tls13ProtocolSuite {
+    pub(crate) fn suite(&self) -> &'static Tls13CipherSuite {
+        match self {
+            Self::Tcp(suite) => suite,
+            Self::Quic(quic) => quic.inner,
+        }
+    }
+
+    pub(crate) fn is_quic(&self) -> bool {
+        matches!(self, Self::Quic(_))
+    }
+}
 
 /// A TLS 1.3 cipher suite supported by rustls.
 #[expect(clippy::exhaustive_structs)]
@@ -49,7 +69,7 @@ pub struct Tls13CipherSuite {
     ///
     /// Provide `None` to opt out of QUIC support for this suite.  It will
     /// not be offered in QUIC handshakes.
-    pub quic: Option<&'static dyn crate::quic::Algorithm>,
+    pub quic: Option<&'static dyn quic::Algorithm>,
 }
 
 impl Tls13CipherSuite {
@@ -77,12 +97,6 @@ impl Tls13CipherSuite {
             Some(quic) => Ord::min(status, quic.fips()),
             None => status,
         }
-    }
-
-    /// Returns a `quic::Suite` for the ciphersuite, if supported.
-    pub fn quic_suite(&'static self) -> Option<crate::quic::Suite> {
-        self.quic
-            .map(|quic| crate::quic::Suite { inner: self, quic })
     }
 }
 


### PR DESCRIPTION
Followup from

- #3173 

to try to anchor the difference in the type system. This tries to propagate tracking outward, though it doesn't go as far as adding a separate `quic_cipher_suites` field in `CryptoProvider`. To be continued maybe...