### PR TITLE
Re-expose `KernelConnection` and test it

### DIFF
--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -529,21 +529,28 @@ pub struct MultiTest {
 impl MultiTest {
     pub fn new(provider: CryptoProvider) -> Self {
         let key_types = KeyType::all_for_provider(&provider).to_vec();
-        let mut providers = vec![(ProtocolVersion::TLSv1_3, Arc::new(provider.clone()))];
-        providers.push((
-            ProtocolVersion::TLSv1_3,
-            Arc::new(CryptoProvider {
-                tls12_cipher_suites: Cow::Borrowed(&[]),
-                ..provider.clone()
-            }),
-        ));
-        providers.push((
-            ProtocolVersion::TLSv1_2,
-            Arc::new(CryptoProvider {
-                tls13_cipher_suites: Cow::Borrowed(&[]),
-                ..provider
-            }),
-        ));
+        let mut providers = vec![];
+
+        if !provider.tls13_cipher_suites.is_empty() {
+            providers.push((ProtocolVersion::TLSv1_3, Arc::new(provider.clone())));
+            providers.push((
+                ProtocolVersion::TLSv1_3,
+                Arc::new(CryptoProvider {
+                    tls12_cipher_suites: Cow::Borrowed(&[]),
+                    ..provider.clone()
+                }),
+            ));
+        }
+
+        if !provider.tls12_cipher_suites.is_empty() {
+            providers.push((
+                ProtocolVersion::TLSv1_2,
+                Arc::new(CryptoProvider {
+                    tls13_cipher_suites: Cow::Borrowed(&[]),
+                    ..provider
+                }),
+            ));
+        }
 
         Self {
             providers,

--- a/rustls-test/tests/api.rs
+++ b/rustls-test/tests/api.rs
@@ -19,6 +19,8 @@ mod tests_with_ring {
     mod ffdhe;
     #[path = "api/io.rs"]
     mod io;
+    #[path = "api/kernel.rs"]
+    mod kernel;
     #[path = "api/kx.rs"]
     mod kx;
     #[path = "api/quic.rs"]
@@ -54,6 +56,8 @@ mod tests_with_aws_lc_rs {
     mod ffdhe;
     #[path = "api/io.rs"]
     mod io;
+    #[path = "api/kernel.rs"]
+    mod kernel;
     #[path = "api/kx.rs"]
     mod kx;
     #[path = "api/quic.rs"]

--- a/rustls-test/tests/api/kernel.rs
+++ b/rustls-test/tests/api/kernel.rs
@@ -101,6 +101,21 @@ fn kernel_connection() {
     }
 }
 
+#[test]
+fn tls12_handle_new_session_ticket() {
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_TLS12_PROVIDER) {
+        let ((_, mut client_kernel), _) = kernel_pair(client_config, server_config);
+        assert_eq!(expect.version, ProtocolVersion::TLSv1_2);
+        assert_eq!(client_kernel.protocol_version(), ProtocolVersion::TLSv1_2);
+        assert_eq!(
+            client_kernel
+                .handle_new_session_ticket(b"")
+                .err(),
+            Some(ApiMisuse::KernelSessionTicketHandlingNotAvailableForTls12.into())
+        )
+    }
+}
+
 fn kernel_pair(
     client_config: Arc<ClientConfig>,
     server_config: Arc<ServerConfig>,

--- a/rustls-test/tests/api/kernel.rs
+++ b/rustls-test/tests/api/kernel.rs
@@ -6,13 +6,15 @@
 
 use std::sync::Arc;
 
-use rustls::client::ClientSide;
+use rustls::client::{ClientSide, Resumption};
 use rustls::enums::ProtocolVersion;
-use rustls::error::ApiMisuse;
+use rustls::error::{ApiMisuse, InvalidMessage};
 use rustls::kernel::KernelConnection;
 use rustls::server::ServerSide;
-use rustls::{ClientConfig, ConnectionTrafficSecrets, ExtractedSecrets, ServerConfig, VecInput};
-use rustls_test::{MultiTest, do_handshake, make_pair_for_configs};
+use rustls::{
+    ClientConfig, ConnectionTrafficSecrets, Error, ExtractedSecrets, ServerConfig, VecInput,
+};
+use rustls_test::{ClientStorage, ClientStorageOp, MultiTest, do_handshake, make_pair_for_configs};
 
 use super::provider;
 
@@ -113,6 +115,58 @@ fn tls12_handle_new_session_ticket() {
                 .err(),
             Some(ApiMisuse::KernelSessionTicketHandlingNotAvailableForTls12.into())
         )
+    }
+}
+
+#[test]
+fn tls13_handle_new_session_ticket() {
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_TLS13_PROVIDER) {
+        let storage = Arc::new(ClientStorage::new());
+
+        let mut client_config = Arc::unwrap_or_clone(client_config);
+        client_config.resumption = Resumption::store(storage.clone());
+        let client_config = Arc::new(client_config);
+
+        let ((_, mut client_kernel), _) = kernel_pair(client_config, server_config);
+
+        assert_eq!(expect.version, ProtocolVersion::TLSv1_3);
+        assert_eq!(client_kernel.protocol_version(), ProtocolVersion::TLSv1_3);
+
+        // malformed tickets are rejected
+        assert!(matches!(
+            client_kernel
+                .handle_new_session_ticket(b"")
+                .err(),
+            Some(Error::InvalidMessage(InvalidMessage::MissingData(_)))
+        ));
+        assert!(matches!(
+            client_kernel
+                .handle_new_session_ticket(
+                    b"\x01\x02\x03\x04\
+                      \xf1\xf2\xf3\xf4\
+                      \x03\x6e\x6e\x6e\
+                      \x00\x02\x74\x74\
+                      \x00\x00\xee"
+                )
+                .err(),
+            Some(Error::InvalidMessage(InvalidMessage::TrailingData(_)))
+        ));
+
+        // valid ticket is stored
+        storage.ops_and_reset();
+        client_kernel
+            .handle_new_session_ticket(
+                b"\x01\x02\x03\x04\
+                  \xf1\xf2\xf3\xf4\
+                  \x03\x6e\x6e\x6e\
+                  \x00\x02\x74\x74\
+                  \x00\x00",
+            )
+            .unwrap();
+        assert!(matches!(
+            storage.ops_and_reset()[..],
+            [ClientStorageOp::InsertTls13Ticket(_)]
+        ));
     }
 }
 

--- a/rustls-test/tests/api/kernel.rs
+++ b/rustls-test/tests/api/kernel.rs
@@ -1,0 +1,158 @@
+//! Tests for the kernel connection API.
+//!
+//! See [`rustls::kernel`] for what this API is for.
+
+#![allow(clippy::disallowed_types, clippy::duplicate_mod)]
+
+use std::sync::Arc;
+
+use rustls::client::ClientSide;
+use rustls::enums::ProtocolVersion;
+use rustls::error::ApiMisuse;
+use rustls::kernel::KernelConnection;
+use rustls::server::ServerSide;
+use rustls::{ClientConfig, ConnectionTrafficSecrets, ExtractedSecrets, ServerConfig, VecInput};
+use rustls_test::{MultiTest, do_handshake, make_pair_for_configs};
+
+use super::provider;
+
+#[test]
+fn kernel_connection() {
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let ((client_secrets, mut client_kernel), (server_secrets, mut server_kernel)) =
+            kernel_pair(client_config, server_config);
+
+        // the negotiated facts survive the transition
+        assert_eq!(client_kernel.protocol_version(), expect.version);
+        assert_eq!(server_kernel.protocol_version(), expect.version);
+        assert_eq!(
+            client_kernel
+                .negotiated_cipher_suite()
+                .suite(),
+            server_kernel
+                .negotiated_cipher_suite()
+                .suite()
+        );
+
+        // the extracted secrets agree, in both directions
+        let client_tx = Secrets::new(client_secrets.tx);
+        let client_rx = Secrets::new(client_secrets.rx);
+        assert_eq!(client_tx, Secrets::new(server_secrets.rx));
+        assert_eq!(client_rx, Secrets::new(server_secrets.tx));
+
+        // Key update tests below are TLS1.3-only
+        let ProtocolVersion::TLSv1_3 = expect.version else {
+            assert_eq!(
+                client_kernel.update_tx_secret().err(),
+                Some(ApiMisuse::KeyUpdateNotAvailableForTls12.into())
+            );
+            assert_eq!(
+                server_kernel.update_tx_secret().err(),
+                Some(ApiMisuse::KeyUpdateNotAvailableForTls12.into())
+            );
+
+            assert_eq!(
+                client_kernel.update_rx_secret().err(),
+                Some(ApiMisuse::KeyUpdateNotAvailableForTls12.into())
+            );
+            assert_eq!(
+                server_kernel.update_rx_secret().err(),
+                Some(ApiMisuse::KeyUpdateNotAvailableForTls12.into())
+            );
+            continue;
+        };
+
+        // and so do the secrets each end derives for a key update
+        let client_tx_next = Secrets::new(
+            client_kernel
+                .update_tx_secret()
+                .unwrap(),
+        );
+        assert_eq!(
+            client_tx_next,
+            Secrets::new(
+                server_kernel
+                    .update_rx_secret()
+                    .unwrap()
+            )
+        );
+
+        let client_rx_next = Secrets::new(
+            client_kernel
+                .update_rx_secret()
+                .unwrap(),
+        );
+        assert_eq!(
+            client_rx_next,
+            Secrets::new(
+                server_kernel
+                    .update_tx_secret()
+                    .unwrap()
+            )
+        );
+
+        // the key update really rolled the keys, and restarted the sequence
+        assert_ne!(client_tx_next.key, client_tx.key);
+        assert_ne!(client_tx_next.iv, client_tx.iv);
+        assert_ne!(client_rx_next.key, client_rx.key);
+        assert_ne!(client_rx_next.iv, client_rx.iv);
+        assert_eq!(client_tx_next.seq, 0);
+        assert_eq!(client_rx_next.seq, 0);
+    }
+}
+
+fn kernel_pair(
+    client_config: Arc<ClientConfig>,
+    server_config: Arc<ServerConfig>,
+) -> (
+    (ExtractedSecrets, KernelConnection<ClientSide>),
+    (ExtractedSecrets, KernelConnection<ServerSide>),
+) {
+    // secret extraction must be opted into by both ends
+    let mut client_config = Arc::unwrap_or_clone(client_config);
+    client_config.enable_secret_extraction = true;
+    let mut server_config = Arc::unwrap_or_clone(server_config);
+    server_config.enable_secret_extraction = true;
+
+    let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+    do_handshake(
+        &mut VecInput::default(),
+        &mut client,
+        &mut VecInput::default(),
+        &mut server,
+    );
+
+    (
+        client
+            .split()
+            .unwrap()
+            .dangerous_into_kernel_connection()
+            .unwrap(),
+        server
+            .split()
+            .unwrap()
+            .dangerous_into_kernel_connection()
+            .unwrap(),
+    )
+}
+
+/// `ConnectionTrafficSecrets` counterpart that does `Debug` and `PartialEq`
+#[derive(Debug, PartialEq)]
+struct Secrets {
+    seq: u64,
+    key: Vec<u8>,
+    iv: Vec<u8>,
+}
+
+impl Secrets {
+    fn new((seq, secrets): (u64, ConnectionTrafficSecrets)) -> Self {
+        match secrets {
+            ConnectionTrafficSecrets::Aes128Gcm { key, iv } => Self {
+                seq,
+                key: key.as_ref().to_vec(),
+                iv: iv.as_ref().to_vec(),
+            },
+            _ => panic!("unexpected secret type"),
+        }
+    }
+}

--- a/rustls/src/conn/kernel.rs
+++ b/rustls/src/conn/kernel.rs
@@ -197,9 +197,7 @@ impl KernelConnection<ClientSide> {
         // on a non-TLS 1.3 connection since a parsing error isn't the real issue
         // here.
         if self.protocol_version() != ProtocolVersion::TLSv1_3 {
-            return Err(Error::General(
-                "TLS 1.2 session tickets may not be sent once the handshake has completed".into(),
-            ));
+            return Err(ApiMisuse::KernelSessionTicketHandlingNotAvailableForTls12.into());
         }
 
         let nst = NewSessionTicketPayloadTls13::read_bytes(payload)?;

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -7,6 +7,7 @@ use std::sync::MutexGuard;
 use super::receive::{Discard, JoinOutput};
 use crate::client::ClientSide;
 use crate::common_state::UnborrowedPayload;
+use crate::conn::kernel::KernelConnection;
 use crate::conn::{
     ConnectionCore, MessageIter, ReceivePath, SendOutput, SendPath, TlsInputBuffer, WrittenInto,
 };
@@ -17,7 +18,7 @@ use crate::lock::Mutex;
 use crate::msgs::{AlertLevel, Delocator, Message};
 use crate::sync::Arc;
 use crate::tls13::key_schedule::KeyScheduleTrafficSend;
-use crate::{ConnectionOutputs, Error, SideData};
+use crate::{ConnectionOutputs, Error, ExtractedSecrets, SideData};
 
 /// A post-handshake connection which has been split by direction.
 ///
@@ -32,6 +33,50 @@ pub struct SplitConnection<Side: SideData> {
     pub receive: ReceiveTraffic<Side>,
     /// Facts about the connection established during the handshake.
     pub outputs: ConnectionOutputs,
+}
+
+impl<Side: SideData> SplitConnection<Side> {
+    /// Extract secrets and a [`KernelConnection`], so they can be used when
+    /// configuring kTLS, for example.
+    ///
+    /// Should be used with care as it exposes secret key material.
+    ///
+    /// The returned [`KernelConnection`] continues to own the connection's
+    /// secrets, so it can compute new traffic secrets on key update and (for
+    /// client connections) accept session tickets.  See the [`kernel`] module
+    /// documentation for the details.
+    ///
+    /// This fails if:
+    ///
+    /// - the connection was not made with [`enable_secret_extraction`] set.
+    /// - there is any buffered TLS data to send.  Obtain it first with
+    ///   [`SendTraffic::take_data()`].
+    ///
+    /// [`kernel`]: crate::kernel
+    /// [`enable_secret_extraction`]: crate::ClientConfig::enable_secret_extraction
+    pub fn dangerous_into_kernel_connection(
+        self,
+    ) -> Result<(ExtractedSecrets, KernelConnection<Side>), Error> {
+        let Self {
+            send,
+            receive,
+            outputs,
+        } = self;
+
+        // drop our handle on the send path, so `receive` holds the only one.
+        drop(send);
+
+        let ReceiveTraffic {
+            state, recv, send, ..
+        } = receive;
+
+        ConnectionCore::<Side>::from_parts_into_kernel_connection(
+            &mut send.lock().unwrap(),
+            recv,
+            outputs,
+            state,
+        )
+    }
 }
 
 impl<Side: SideData> TryFrom<ConnectionCore<Side>> for SplitConnection<Side> {

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1679,6 +1679,11 @@ pub enum ApiMisuse {
     /// [`KernelConnection::update_tx_secret()`]: crate::conn::kernel::KernelConnection::update_tx_secret()
     KeyUpdateNotAvailableForTls12,
 
+    /// [`KernelConnection::handle_new_session_ticket()`] and associated are not available for TLS1.2 connections.
+    ///
+    /// [`KernelConnection::handle_new_session_ticket()`]: crate::conn::kernel::KernelConnection::handle_new_session_ticket()
+    KernelSessionTicketHandlingNotAvailableForTls12,
+
     /// [`ClientConnection::split()`] or [`ServerConnection::split()`] called during handshake.
     ///
     /// [`ServerConnection::split()`]: crate::server::ServerConnection::split()


### PR DESCRIPTION
`KernelConnection` was introduced on this branch but was only accessible from the unbuffered API.  The unbuffered API was then removed.

This commit makes it accessible from a `SplitConnection`, which is a "sideways" lossy conversion between types that are logically very similar.