### PR TITLE
Only allow one outstanding `KeyUpdateRequest` at time

### DIFF
--- a/rustls-test/tests/api/crypto.rs
+++ b/rustls-test/tests/api/crypto.rs
@@ -557,6 +557,101 @@ fn test_refresh_traffic_keys() {
 }
 
 #[test]
+fn test_refresh_traffic_keys_is_idempotent() {
+    let mut client_output = Vec::new();
+    let mut server_output = Vec::new();
+    let (mut client, mut server) = make_pair(
+        KeyType::default(),
+        &provider::DEFAULT_PROVIDER,
+        &mut client_output,
+    );
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client_output,
+        &mut client,
+        &mut server_input,
+        &mut server_output,
+        &mut server,
+    );
+    test(
+        &mut client_input,
+        &mut client_output,
+        &mut client,
+        &mut server_input,
+        &mut server_output,
+        &mut server,
+    );
+
+    let mut client_output = Vec::new();
+    let mut server_output = Vec::new();
+    let (mut client, mut server) = make_pair(
+        KeyType::default(),
+        &provider::DEFAULT_PROVIDER,
+        &mut client_output,
+    );
+    let mut client_input = VecInput::default();
+    let mut server_input = VecInput::default();
+    do_handshake(
+        &mut client_input,
+        &mut client_output,
+        &mut client,
+        &mut server_input,
+        &mut server_output,
+        &mut server,
+    );
+    test(
+        &mut server_input,
+        &mut server_output,
+        &mut server,
+        &mut client_input,
+        &mut client_output,
+        &mut client,
+    );
+
+    fn test(
+        left_input: &mut VecInput,
+        left_output: &mut Vec<u8>,
+        left: &mut impl Connection,
+        right_input: &mut VecInput,
+        right_output: &mut Vec<u8>,
+        right: &mut impl Connection,
+    ) {
+        // left sends a request
+        left.refresh_traffic_keys(left_output)
+            .unwrap();
+        assert!(transfer(left_output, right_input) > 0);
+
+        // but subsequent requests are ignored
+        for _ in 0..5 {
+            left.refresh_traffic_keys(left_output)
+                .unwrap();
+            assert_eq!(transfer(left_output, right_input), 0);
+        }
+
+        // left's request is received by right, enacted on next write,
+        // right's response received by left
+        right
+            .process_new_packets(right_input, right_output)
+            .handle_all(&mut Vec::new())
+            .unwrap();
+        right
+            .write_tls(b"yo".into(), right_output)
+            .unwrap();
+        assert!(transfer(right_output, left_input) > 0);
+        left.process_new_packets(left_input, left_output)
+            .handle_all(&mut Vec::new())
+            .unwrap();
+
+        // allows a further update to be sent.
+        left.refresh_traffic_keys(left_output)
+            .unwrap();
+        assert!(transfer(left_output, right_input) > 0);
+    }
+}
+
+#[test]
 fn test_automatic_refresh_traffic_keys() {
     const fn encrypted_size(body: usize) -> usize {
         let padding = 1;

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1519,7 +1519,7 @@ impl ExpectTraffic {
         let proof = input.check_aligned_handshake()?;
 
         match *key_update_request {
-            KeyUpdateRequest::UpdateNotRequested => {}
+            KeyUpdateRequest::UpdateNotRequested => output.send().note_key_update_response(),
             KeyUpdateRequest::UpdateRequested => output
                 .send()
                 .queue_requested_key_update(),

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1520,7 +1520,9 @@ impl ExpectTraffic {
 
         match *key_update_request {
             KeyUpdateRequest::UpdateNotRequested => {}
-            KeyUpdateRequest::UpdateRequested => output.send().ensure_key_update_queued(),
+            KeyUpdateRequest::UpdateRequested => output
+                .send()
+                .queue_requested_key_update(),
             _ => return Err(InvalidMessage::InvalidKeyUpdate.into()),
         }
 

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -76,6 +76,14 @@ pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
 
     /// Sends a TLS1.3 `key_update` message into `tls` to refresh a connection's keys.
     ///
+    /// The main reason to call this manually is to roll keys when it is known
+    /// a connection will be idle for a long period.
+    ///
+    /// rustls implicitly and automatically refreshes traffic keys when needed
+    /// according to the selected cipher suite's cryptographic constraints.  There
+    /// is therefore no need to call this manually to avoid cryptographic keys
+    /// "wearing out".
+    ///
     /// This call refreshes our encryption keys. Once the peer receives the message,
     /// it refreshes _its_ encryption and decryption keys and sends a response.
     /// Once we receive that response, we refresh our decryption keys to match.
@@ -88,14 +96,6 @@ pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
     /// Note that other implementations (including rustls) may enforce limits on
     /// the number of `key_update` messages allowed on a given connection to prevent
     /// denial of service.  Therefore, this should be called sparingly.
-    ///
-    /// rustls implicitly and automatically refreshes traffic keys when needed
-    /// according to the selected cipher suite's cryptographic constraints.  There
-    /// is therefore no need to call this manually to avoid cryptographic keys
-    /// "wearing out".
-    ///
-    /// The main reason to call this manually is to roll keys when it is known
-    /// a connection will be idle for a long period.
     fn refresh_traffic_keys(&mut self, tls: &mut Vec<u8>) -> Result<(), Error>;
 
     /// Writes a `close_notify` warning alert into `tls`.

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -96,6 +96,9 @@ pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
     /// Note that other implementations (including rustls) may enforce limits on
     /// the number of `key_update` messages allowed on a given connection to prevent
     /// denial of service.  Therefore, this should be called sparingly.
+    ///
+    /// rustls only allows one outstanding request at a time; this function succeeds
+    /// but sends nothing if a request is already in-flight.
     fn refresh_traffic_keys(&mut self, tls: &mut Vec<u8>) -> Result<(), Error>;
 
     /// Writes a `close_notify` warning alert into `tls`.

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -19,8 +19,8 @@ pub(crate) struct SendPath {
     /// If we signaled end of stream.
     pub(crate) has_sent_close_notify: bool,
     message_fragmenter: MessageFragmenter,
-    queued_key_update_message: Option<Vec<u8>>,
-    pub(crate) refresh_traffic_keys_pending: bool,
+    key_update_local: KeyUpdateLocal,
+    key_update_remote: KeyUpdateRemote,
     negotiated_version: Option<ProtocolVersion>,
     pub(crate) tls13_key_schedule: Option<Box<KeyScheduleTrafficSend>>,
 }
@@ -47,7 +47,7 @@ impl SendPath {
                 match self.negotiated_version {
                     // driven by caller, as we don't have the `State` here
                     Some(ProtocolVersion::TLSv1_3) => {
-                        self.refresh_traffic_keys_pending = true;
+                        self.key_update_local = KeyUpdateLocal::Requested;
                         Ok(())
                     }
                     _ => {
@@ -129,9 +129,11 @@ impl SendPath {
     }
 
     fn perhaps_write_key_update(&mut self, tls: &mut Vec<u8>) {
-        if let Some(mut message) = self.queued_key_update_message.take() {
-            tls.append(&mut message)
-        }
+        let KeyUpdateRemote::Queued(message) = &mut self.key_update_remote else {
+            return;
+        };
+        tls.append(message);
+        self.key_update_remote = KeyUpdateRemote::Idle;
     }
 
     pub(crate) fn set_max_fragment_size(&mut self, new: Option<usize>) -> Result<(), Error> {
@@ -141,7 +143,7 @@ impl SendPath {
 
     /// Trigger a `refresh_traffic_keys` if required.
     fn maybe_refresh_traffic_keys(&mut self, tls: &mut Vec<u8>) {
-        if self.refresh_traffic_keys_pending {
+        if let KeyUpdateLocal::Requested = self.key_update_local {
             let _ = self.refresh_traffic_keys(tls);
         }
     }
@@ -155,7 +157,7 @@ impl SendPath {
 
         self.send_msg(Message::build_key_update_request(), true, tls);
         ks.update_encrypter(self);
-        self.refresh_traffic_keys_pending = false;
+        self.key_update_local = KeyUpdateLocal::Idle;
         self.tls13_key_schedule = Some(ks);
         Ok(())
     }
@@ -167,15 +169,15 @@ impl SendOutput for SendPath {
     }
 
     fn ensure_key_update_queued(&mut self) {
-        if self.queued_key_update_message.is_some() {
+        if let KeyUpdateRemote::Queued(_) = &self.key_update_remote {
             return;
         }
 
         let message = EncodedMessage::<Payload<'static>>::from(Message::build_key_update_notify());
-        let mut tls = Vec::new();
+        let mut queued = Vec::new();
         self.encrypt_state
-            .encrypt_outgoing(message.borrow_outbound(), &mut tls);
-        self.queued_key_update_message = Some(tls);
+            .encrypt_outgoing(message.borrow_outbound(), &mut queued);
+        self.key_update_remote = KeyUpdateRemote::Queued(queued);
 
         if let Some(mut ks) = self.tls13_key_schedule.take() {
             ks.update_encrypter_for_key_update(self);
@@ -234,12 +236,34 @@ impl Default for SendPath {
             has_sent_fatal_alert: false,
             has_sent_close_notify: false,
             message_fragmenter: MessageFragmenter::default(),
-            queued_key_update_message: None,
-            refresh_traffic_keys_pending: false,
+            key_update_local: KeyUpdateLocal::Idle,
+            key_update_remote: KeyUpdateRemote::Idle,
             negotiated_version: None,
             tls13_key_schedule: None,
         }
     }
+}
+
+/// State machine for TLS1.3 key updates triggered by us.
+///
+/// This sits at [`Self::Idle`] for TLS1.2 connections.
+enum KeyUpdateLocal {
+    /// Nothing is happening.
+    Idle,
+
+    /// A key update request should be sent at the next sending opportunity.
+    Requested,
+}
+
+/// State machine for TLS1.3 key updates triggered by peer.
+///
+/// This sits at [`Self::Idle`] for TLS1.2 connections.
+enum KeyUpdateRemote {
+    /// Nothing is happening.
+    Idle,
+
+    /// A key update response is awaiting sending.
+    Queued(Vec<u8>),
 }
 
 pub(crate) trait SendOutput {

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -168,7 +168,7 @@ impl SendOutput for SendPath {
         self.negotiated_version = Some(version);
     }
 
-    fn ensure_key_update_queued(&mut self) {
+    fn queue_requested_key_update(&mut self) {
         if let KeyUpdateRemote::Queued(_) = &self.key_update_remote {
             return;
         }
@@ -269,7 +269,7 @@ enum KeyUpdateRemote {
 pub(crate) trait SendOutput {
     fn negotiated_version(&mut self, version: ProtocolVersion);
 
-    fn ensure_key_update_queued(&mut self);
+    fn queue_requested_key_update(&mut self);
 
     fn set_encrypter(&mut self, cipher: Box<dyn MessageEncrypter>, max_messages: u64);
 

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -141,14 +141,21 @@ impl SendPath {
             .set_max_fragment_size(new)
     }
 
-    /// Trigger a `refresh_traffic_keys` if required.
+    /// Trigger a `refresh_traffic_keys` if requested.
     fn maybe_refresh_traffic_keys(&mut self, tls: &mut Vec<u8>) {
         if let KeyUpdateLocal::Requested = self.key_update_local {
-            let _ = self.refresh_traffic_keys(tls);
+            let _ = self.send_key_update_request(tls);
         }
     }
 
     pub(crate) fn refresh_traffic_keys(&mut self, tls: &mut Vec<u8>) -> Result<(), Error> {
+        if let KeyUpdateLocal::Outstanding = self.key_update_local {
+            return Ok(());
+        }
+        self.send_key_update_request(tls)
+    }
+
+    fn send_key_update_request(&mut self, tls: &mut Vec<u8>) -> Result<(), Error> {
         let ks = self.tls13_key_schedule.take();
 
         let Some(mut ks) = ks else {
@@ -157,7 +164,7 @@ impl SendPath {
 
         self.send_msg(Message::build_key_update_request(), true, tls);
         ks.update_encrypter(self);
-        self.key_update_local = KeyUpdateLocal::Idle;
+        self.key_update_local = KeyUpdateLocal::Outstanding;
         self.tls13_key_schedule = Some(ks);
         Ok(())
     }
@@ -182,6 +189,12 @@ impl SendOutput for SendPath {
         if let Some(mut ks) = self.tls13_key_schedule.take() {
             ks.update_encrypter_for_key_update(self);
             self.tls13_key_schedule = Some(ks);
+        }
+    }
+
+    fn note_key_update_response(&mut self) {
+        if let KeyUpdateLocal::Outstanding = self.key_update_local {
+            self.key_update_local = KeyUpdateLocal::Idle;
         }
     }
 
@@ -253,6 +266,9 @@ enum KeyUpdateLocal {
 
     /// A key update request should be sent at the next sending opportunity.
     Requested,
+
+    /// A key update request is outstanding; we await a response.
+    Outstanding,
 }
 
 /// State machine for TLS1.3 key updates triggered by peer.
@@ -270,6 +286,8 @@ pub(crate) trait SendOutput {
     fn negotiated_version(&mut self, version: ProtocolVersion);
 
     fn queue_requested_key_update(&mut self);
+
+    fn note_key_update_response(&mut self);
 
     fn set_encrypter(&mut self, cipher: Box<dyn MessageEncrypter>, max_messages: u64);
 

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -146,6 +146,9 @@ impl SendTraffic {
     /// Note that other implementations (including rustls) may enforce limits on
     /// the number of `key_update` messages allowed on a given connection to prevent
     /// denial of service. Therefore, this should be called sparingly.
+    ///
+    /// rustls only allows one outstanding request at a time; this function succeeds
+    /// but sends nothing if a request is already in-flight.
     pub fn refresh_traffic_keys(&mut self, tls: &mut Vec<u8>) -> Result<(), Error> {
         self.0
             .lock()
@@ -485,6 +488,11 @@ impl SendOutput for SendAdapter<'_> {
             .queue_requested_key_update();
     }
 
+    fn note_key_update_response(&mut self) {
+        self.as_locked(false)
+            .note_key_update_response();
+    }
+
     fn set_encrypter(&mut self, cipher: Box<dyn MessageEncrypter>, max_messages: u64) {
         self.as_locked(false)
             .set_encrypter(cipher, max_messages);
@@ -522,6 +530,7 @@ mod tests {
             |adapter| adapter.negotiated_version(ProtocolVersion::TLSv1_3)
         ));
         assert!(send_flag_for(|adapter| adapter.queue_requested_key_update()));
+        assert!(!send_flag_for(|adapter| adapter.note_key_update_response()));
         assert!(!send_flag_for(
             |adapter| adapter.set_encrypter(Box::new(Tls13Cipher), 1234)
         ));

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -478,11 +478,11 @@ impl SendOutput for SendAdapter<'_> {
             .negotiated_version(version);
     }
 
-    fn ensure_key_update_queued(&mut self) {
+    fn queue_requested_key_update(&mut self) {
         // waking the sender here is a policy decision to encourage timely execution of
         // the write-side key update, it is not strictly required at a protocol level.
         self.as_locked(true)
-            .ensure_key_update_queued();
+            .queue_requested_key_update();
     }
 
     fn set_encrypter(&mut self, cipher: Box<dyn MessageEncrypter>, max_messages: u64) {
@@ -521,7 +521,7 @@ mod tests {
         assert!(!send_flag_for(
             |adapter| adapter.negotiated_version(ProtocolVersion::TLSv1_3)
         ));
-        assert!(send_flag_for(|adapter| adapter.ensure_key_update_queued()));
+        assert!(send_flag_for(|adapter| adapter.queue_requested_key_update()));
         assert!(!send_flag_for(
             |adapter| adapter.set_encrypter(Box::new(Tls13Cipher), 1234)
         ));

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1526,7 +1526,9 @@ impl ExpectTraffic {
 
         match *key_update_request {
             KeyUpdateRequest::UpdateNotRequested => {}
-            KeyUpdateRequest::UpdateRequested => output.send().ensure_key_update_queued(),
+            KeyUpdateRequest::UpdateRequested => output
+                .send()
+                .queue_requested_key_update(),
             _ => return Err(InvalidMessage::InvalidKeyUpdate.into()),
         }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1525,7 +1525,7 @@ impl ExpectTraffic {
         let proof = input.check_aligned_handshake()?;
 
         match *key_update_request {
-            KeyUpdateRequest::UpdateNotRequested => {}
+            KeyUpdateRequest::UpdateNotRequested => output.send().note_key_update_response(),
             KeyUpdateRequest::UpdateRequested => output
                 .send()
                 .queue_requested_key_update(),


### PR DESCRIPTION
This is one of the TLS1.3-bis functional changes -- see https://www.rfc-editor.org/info/rfc9846/#section-4.7.3-4