### PR TITLE
docs: fix nightly docs search and external links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,8 +72,9 @@ jobs:
           # lockfile causes deployment step to go wrong, due to permissions
           rm -f target/doc/.lock
           # move the result into website root
-          mv target/doc/* target/website/
-          mv target/website/rustls target/website/docs
+          mkdir target/website/docs
+          mv target/doc/* target/website/docs/
+          echo '<meta http-equiv="refresh" content="0; url=rustls/index.html">' > target/website/docs/index.html
 
       - name: Package and upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -130,7 +130,7 @@ Mitigations:
   compute for this effort.  Fuzzing is performed with a mock provider of cryptography, which is intended to make
   both pre-auth and post-auth code paths reachable to the fuzzer (at the cost of fuzzing not covering the actual
   cryptography implementations).
-- We have [studied and explained](https://rustls.dev/docs/manual/_01_impl_vulnerabilities/index.html#a-review-of-tls-implementation-vulnerabilities)
+- We have [studied and explained](https://rustls.dev/docs/rustls/manual/_01_impl_vulnerabilities/index.html#a-review-of-tls-implementation-vulnerabilities)
   issues encountered in other TLS implementations and discuss further mitigations there.
 - We implement the TLS 1.3 downgrade sentinel (a [standard and required protocol feature](https://datatracker.ietf.org/doc/html/rfc9846#section-4.2.3-8)
   which limits downgrade from TLS 1.3).


### PR DESCRIPTION
Due to our abuse of rustdoc, search on https://rustls.dev/docs/ links to results like https://rustls.dev/rustls/client/fn.verify_identity_signed_by_trust_anchor.html

Despite use of --no-deps, rustdoc still generates links to dependencies for external links, these get picked up by lychee when they appear on (eg) inherent impls.

This breaks all existing links, however this is the zen of nightly documentation (removing/renaming a type also has this effect.)

(will fix docs CI in #3194)