### PR TITLE
Fix malleability of TLS1.3 record headers

### DIFF
--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -256,7 +256,6 @@
     "TLS-TLS12-CHACHA20_POLY1305_SHA256-server": ":INCOMPATIBLE:",
     "TLS13-HRR-InvalidCompressionMethod": ":UNSUPPORTED_COMPRESSION:",
     "TLS13-InvalidCompressionMethod": ":UNSUPPORTED_COMPRESSION_ALGORITHM:",
-    "TLS13-WrongOuterRecord-TLS": ":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:",
     "TooManyChangeCipherSpec-Client-TLS13": ":ILLEGAL_MIDDLEBOX_CHANGE_CIPHER_SPEC:",
     "TooManyChangeCipherSpec-Server-TLS13": ":ILLEGAL_MIDDLEBOX_CHANGE_CIPHER_SPEC:",
     "TrailingKeyShareData-TLS13": ":BAD_HANDSHAKE_MSG:",

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -2188,6 +2188,9 @@ fn handle_err(opts: &Options, err: Error) -> ! {
         Error::PeerMisbehaved(
             PeerMisbehaved::IllegalAlertLevel(_, _) | PeerMisbehaved::IllegalWarningAlert(_),
         ) => quit(":BAD_ALERT:"),
+        Error::PeerMisbehaved(PeerMisbehaved::IllegalTls13ContentType) => {
+            quit(":INVALID_OUTER_RECORD_TYPE:")
+        }
         Error::PeerMisbehaved(_) => panic!("!!! please add error mapping for {err:?}"),
         Error::AlertReceived(AlertDescription::UnexpectedMessage) => quit(":BAD_ALERT:"),
         Error::AlertReceived(AlertDescription::DecompressionFailure) => {

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -228,8 +228,9 @@ impl MessageEncrypter for AeadMessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
 
+        let typ = ContentType::ApplicationData;
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
-        let aad = aead::Aad::from(make_tls13_aad(total_len));
+        let aad = aead::Aad::from(make_tls13_aad(typ, TLS13_LEGACY_RECORD_VERSION, total_len));
         payload.extend_from_chunks(&msg.payload);
         payload.extend_from_slice(&msg.typ.to_array());
 
@@ -242,10 +243,8 @@ impl MessageEncrypter for AeadMessageEncrypter {
         }
 
         Ok(EncodedMessage {
-            typ: ContentType::ApplicationData,
-            // Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
-            // protocol version, see https://www.rfc-editor.org/rfc/rfc9846#section-5.1
-            version: ProtocolVersion::TLSv1_2,
+            typ,
+            version: TLS13_LEGACY_RECORD_VERSION,
             payload: payload.into_written(),
         })
     }
@@ -267,7 +266,7 @@ impl MessageDecrypter for AeadMessageDecrypter {
         }
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
-        let aad = aead::Aad::from(make_tls13_aad(payload.len()));
+        let aad = aead::Aad::from(make_tls13_aad(msg.typ, msg.version, payload.len()));
         let plain_len = self
             .dec_key
             .open_in_place(nonce, aad, payload)
@@ -294,8 +293,9 @@ impl MessageEncrypter for GcmMessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
 
+        let typ = ContentType::ApplicationData;
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
-        let aad = aead::Aad::from(make_tls13_aad(total_len));
+        let aad = aead::Aad::from(make_tls13_aad(typ, TLS13_LEGACY_RECORD_VERSION, total_len));
         payload.extend_from_chunks(&msg.payload);
         payload.extend_from_slice(&msg.typ.to_array());
 
@@ -308,8 +308,8 @@ impl MessageEncrypter for GcmMessageEncrypter {
         }
 
         Ok(EncodedMessage {
-            typ: ContentType::ApplicationData,
-            version: ProtocolVersion::TLSv1_2,
+            typ,
+            version: TLS13_LEGACY_RECORD_VERSION,
             payload: payload.into_written(),
         })
     }
@@ -318,6 +318,10 @@ impl MessageEncrypter for GcmMessageEncrypter {
         payload_len + 1 + self.enc_key.algorithm().tag_len()
     }
 }
+
+// Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
+// protocol version, see https://www.rfc-editor.org/rfc/rfc9846#section-5.1
+const TLS13_LEGACY_RECORD_VERSION: ProtocolVersion = ProtocolVersion::TLSv1_2;
 
 struct GcmMessageDecrypter {
     dec_key: aead::TlsRecordOpeningKey,
@@ -336,7 +340,7 @@ impl MessageDecrypter for GcmMessageDecrypter {
         }
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
-        let aad = aead::Aad::from(make_tls13_aad(payload.len()));
+        let aad = aead::Aad::from(make_tls13_aad(msg.typ, msg.version, payload.len()));
         let plain_len = self
             .dec_key
             .open_in_place(nonce, aad, payload)

--- a/rustls-ring/src/tls13.rs
+++ b/rustls-ring/src/tls13.rs
@@ -204,8 +204,9 @@ impl MessageEncrypter for Tls13MessageEncrypter {
         let total_len = self.encrypted_payload_len(msg.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
 
+        let typ = ContentType::ApplicationData;
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
-        let aad = aead::Aad::from(make_tls13_aad(total_len));
+        let aad = aead::Aad::from(make_tls13_aad(typ, TLS13_LEGACY_RECORD_VERSION, total_len));
         payload.extend_from_chunks(&msg.payload);
         payload.extend_from_slice(&msg.typ.to_array());
 
@@ -218,10 +219,8 @@ impl MessageEncrypter for Tls13MessageEncrypter {
         }
 
         Ok(EncodedMessage {
-            typ: ContentType::ApplicationData,
-            // Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
-            // protocol version, see https://www.rfc-editor.org/rfc/rfc9846#section-5.1
-            version: ProtocolVersion::TLSv1_2,
+            typ,
+            version: TLS13_LEGACY_RECORD_VERSION,
             payload: payload.into_written(),
         })
     }
@@ -243,7 +242,7 @@ impl MessageDecrypter for Tls13MessageDecrypter {
         }
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
-        let aad = aead::Aad::from(make_tls13_aad(payload.len()));
+        let aad = aead::Aad::from(make_tls13_aad(msg.typ, msg.version, payload.len()));
         let plain_len = self
             .dec_key
             .open_in_place(nonce, aad, payload)
@@ -254,6 +253,10 @@ impl MessageDecrypter for Tls13MessageDecrypter {
         msg.into_tls13_unpadded_message()
     }
 }
+
+// Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
+// protocol version, see https://www.rfc-editor.org/rfc/rfc9846#section-5.1
+const TLS13_LEGACY_RECORD_VERSION: ProtocolVersion = ProtocolVersion::TLSv1_2;
 
 struct RingHkdf(hkdf::Algorithm, hmac::Algorithm);
 

--- a/rustls-test/tests/api/crypto.rs
+++ b/rustls-test/tests/api/crypto.rs
@@ -11,9 +11,10 @@ use rustls::{
     ServerConfig, ServerConnection, SupportedCipherSuite, VecInput,
 };
 use rustls_test::{
-    ClientConfigExt, KeyType, ServerConfigExt, aes_128_gcm_with_1024_confidentiality_limit,
-    do_handshake, make_client_config, make_pair, make_pair_for_arc_configs, make_pair_for_configs,
-    make_server_config, provider_with_one_suite, transfer,
+    ClientConfigExt, KeyType, MultiTest, ServerConfigExt,
+    aes_128_gcm_with_1024_confidentiality_limit, do_handshake, make_client_config, make_pair,
+    make_pair_for_arc_configs, make_pair_for_configs, make_server_config, provider_with_one_suite,
+    transfer,
 };
 
 use super::provider;
@@ -682,6 +683,57 @@ fn test_keys_match_for_all_signing_key_types() {
             .unwrap();
         let _ = Credentials::new(kt.client_identity(), key).expect("keys match");
         println!("{kt:?} ok");
+    }
+}
+
+#[test]
+fn test_wire_version_passed_to_aad() {
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        println!("{expect:?}");
+
+        // corrupt type and low-byte of version
+        for byte in [0, 2] {
+            let mut client_output = Vec::new();
+            let mut server_output = Vec::new();
+            let (mut client, mut server) =
+                make_pair_for_arc_configs(&client_config, &server_config, &mut client_output);
+            let mut client_input = VecInput::default();
+            let mut server_input = VecInput::default();
+            do_handshake(
+                &mut client_input,
+                &mut client_output,
+                &mut client,
+                &mut server_input,
+                &mut server_output,
+                &mut server,
+            );
+
+            // base case
+            client
+                .write_tls(b"hello".into(), &mut client_output)
+                .unwrap();
+            transfer(&mut client_output, &mut server_input);
+            let mut server_received = Vec::new();
+            server
+                .process_new_packets(&mut server_input, &mut server_output)
+                .handle_all(&mut server_received)
+                .unwrap();
+            assert_eq!(server_received, b"hello");
+
+            // fail case
+            client
+                .write_tls(b"world".into(), &mut client_output)
+                .unwrap();
+            client_output[byte] ^= 0x01;
+            transfer(&mut client_output, &mut server_input);
+            assert_eq!(
+                server
+                    .process_new_packets(&mut server_input, &mut server_output)
+                    .handle_all(&mut server_received)
+                    .unwrap_err(),
+                Error::DecryptError
+            );
+        }
     }
 }
 

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -87,6 +87,10 @@ impl<'a> EncodedMessage<InboundOpaque<'a>> {
     pub fn into_tls13_unpadded_message(mut self) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let payload = &mut self.payload;
 
+        if self.typ != ContentType::ApplicationData {
+            return Err(PeerMisbehaved::IllegalTls13ContentType.into());
+        }
+
         if payload.len() > MAX_FRAGMENT_LEN + 1 {
             return Err(Error::PeerSentOversizedRecord);
         }

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -324,13 +324,15 @@ pub const NONCE_LEN: usize = 12;
 
 /// Returns a TLS1.3 `additional_data` encoding.
 ///
+/// For decryption, the parameters should be those that were received on the wire.
+/// For encryption, the parameters should be those that will be put on the wire.
+///
 /// See RFC 9846 s5.2 for the `additional_data` definition.
 #[inline]
-pub fn make_tls13_aad(payload_len: usize) -> [u8; 5] {
-    let version = ProtocolVersion::TLSv1_2.to_array();
+pub fn make_tls13_aad(typ: ContentType, version: ProtocolVersion, payload_len: usize) -> [u8; 5] {
+    let version = version.to_array();
     [
-        ContentType::ApplicationData.into(),
-        // Note: this is `legacy_record_version`, i.e. TLS1.2 even for TLS1.3.
+        typ.into(),
         version[0],
         version[1],
         (payload_len >> 8) as u8,

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1243,6 +1243,7 @@ pub enum PeerMisbehaved {
     UnsolicitedServerHelloExtension,
     WrongGroupForKeyShare,
     UnsolicitedEchExtension,
+    IllegalTls13ContentType,
 }
 
 impl From<PeerMisbehaved> for AlertDescription {
@@ -1257,7 +1258,8 @@ impl From<PeerMisbehaved> for AlertDescription {
 
             PeerMisbehaved::IllegalMiddleboxChangeCipherSpec
             | PeerMisbehaved::KeyEpochWithPendingFragment
-            | PeerMisbehaved::KeyUpdateReceivedInQuicConnection => Self::UnexpectedMessage,
+            | PeerMisbehaved::KeyUpdateReceivedInQuicConnection
+            | PeerMisbehaved::IllegalTls13ContentType => Self::UnexpectedMessage,
 
             PeerMisbehaved::IllegalWarningAlert(_) => Self::DecodeError,
 


### PR DESCRIPTION
This started as a testing gap found while reviewing #3112 

While this is malleability of network data, the header fields are not actually consulted for anything.

Unfortunately cannot be easily backported.