### PR TITLE
conn: use associated type for Connection's side

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -46,8 +46,8 @@ use rustls::server::{
     ServerSessionKey, Tls13Tickets, WebPkiClientVerifier,
 };
 use rustls::{
-    Connection, DistinguishedName, HandshakeKind, IoState, RootCertStore, SideData, TlsInputBuffer,
-    VecInput, compress,
+    Connection, DistinguishedName, HandshakeKind, IoState, RootCertStore, TlsInputBuffer, VecInput,
+    compress,
 };
 use rustls_aws_lc_rs::hpke;
 use tracing_subscriber::layer::SubscriberExt;
@@ -147,9 +147,9 @@ pub fn main() {
     }
 }
 
-fn exec<S: SideData>(
+fn exec(
     opts: &Options,
-    mut sess: impl Connection<S> + 'static,
+    mut sess: impl Connection + 'static,
     mut output: Vec<u8>,
     key_log: &KeyLogMemo,
     count: usize,
@@ -440,8 +440,8 @@ fn server(conn: &mut dyn Any) -> &mut ServerConnection {
 /// is still in progress.
 ///
 /// Queued plaintext is sent by `after_read()` once the handshake completes.
-fn write_or_queue<S: SideData>(
-    sess: &mut impl Connection<S>,
+fn write_or_queue(
+    sess: &mut impl Connection,
     plaintext: &[u8],
     pending: &mut Vec<u8>,
     output: &mut Vec<u8>,
@@ -459,13 +459,13 @@ fn write_or_queue<S: SideData>(
     }
 }
 
-fn read_n_bytes<S: SideData>(
+fn read_n_bytes(
     buf: &mut Vec<u8>,
     opts: &Options,
     input: &mut VecInput,
     output: &mut Vec<u8>,
     pending: &mut Vec<u8>,
-    sess: &mut impl Connection<S>,
+    sess: &mut impl Connection,
     conn: &mut net::TcpStream,
     n: usize,
 ) -> Option<IoState> {
@@ -484,13 +484,13 @@ fn read_n_bytes<S: SideData>(
     after_read(buf, opts, input, output, pending, sess, conn)
 }
 
-fn read_all_bytes<S: SideData>(
+fn read_all_bytes(
     buf: &mut Vec<u8>,
     opts: &Options,
     input: &mut VecInput,
     output: &mut Vec<u8>,
     pending: &mut Vec<u8>,
-    sess: &mut impl Connection<S>,
+    sess: &mut impl Connection,
     conn: &mut net::TcpStream,
 ) -> Option<IoState> {
     match input.read(conn) {
@@ -502,13 +502,13 @@ fn read_all_bytes<S: SideData>(
     after_read(buf, opts, input, output, pending, sess, conn)
 }
 
-fn after_read<S: SideData>(
+fn after_read(
     buf: &mut Vec<u8>,
     opts: &Options,
     input: &mut VecInput,
     output: &mut Vec<u8>,
     pending: &mut Vec<u8>,
-    sess: &mut impl Connection<S>,
+    sess: &mut impl Connection,
     conn: &mut net::TcpStream,
 ) -> Option<IoState> {
     let state = match sess

--- a/ci-bench/src/util.rs
+++ b/ci-bench/src/util.rs
@@ -366,7 +366,7 @@ pub(crate) mod transport {
     use std::io::Cursor;
 
     use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-    use rustls::{ClientConnection, Connection, ServerConnection, SideData, VecInput};
+    use rustls::{ClientConnection, Connection, ServerConnection, VecInput};
 
     use super::async_io::{AsyncRead, AsyncWrite};
 
@@ -400,10 +400,10 @@ pub(crate) mod transport {
     ///
     /// Used in combination with [`send_handshake_message`] (see that function's documentation for
     /// more details).
-    pub(crate) async fn read_handshake_message<S: SideData>(
+    pub(crate) async fn read_handshake_message(
         input: &mut VecInput,
         output: &mut Vec<u8>,
-        conn: &mut impl Connection<S>,
+        conn: &mut impl Connection,
         reader: &mut dyn AsyncRead,
         buf: &mut [u8],
     ) -> anyhow::Result<usize> {

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -18,7 +18,7 @@ use rustls::enums::ProtocolVersion;
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::{
     ClientConfig, ClientConnection, Connection, HandshakeKind, RootCertStore, ServerConfig,
-    ServerConnection, SideData, VecInput,
+    ServerConnection, VecInput,
 };
 use rustls_test::KeyType;
 
@@ -1037,11 +1037,11 @@ where
     r
 }
 
-fn transfer<S: SideData>(
+fn transfer(
     left_buffers: &mut TempBuffers,
     right_input: &mut VecInput,
     right_buffers: &mut TempBuffers,
-    right: &mut impl Connection<S>,
+    right: &mut impl Connection,
     expect_data: Option<usize>,
 ) -> f64 {
     let mut read_time = 0f64;

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -1,5 +1,4 @@
 use core::hash::Hasher;
-use core::marker::PhantomData;
 use core::{fmt, mem};
 use std::borrow::Cow;
 use std::io;
@@ -7,8 +6,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerIdentity, ServerVerifier};
 use rustls::client::{
-    ClientSessionKey, ClientSide, ServerVerifierBuilder, Tls13Session, WantsClientCert,
-    WebPkiServerVerifier,
+    ClientSessionKey, ServerVerifierBuilder, Tls13Session, WantsClientCert, WebPkiServerVerifier,
 };
 use rustls::crypto::cipher::{
     EncodedMessage, InboundOpaque, MessageDecrypter, MessageEncrypter, Payload,
@@ -28,7 +26,7 @@ use rustls::pki_types::{
 };
 use rustls::server::danger::{ClientIdentity, ClientVerifier, SignatureVerificationInput};
 use rustls::server::{
-    ClientHello, ClientVerifierBuilder, ServerCredentialResolver, ServerSide, WebPkiClientVerifier,
+    ClientHello, ClientVerifierBuilder, ServerCredentialResolver, WebPkiClientVerifier,
 };
 use rustls::{
     ClientConfig, ClientConnection, ConfigBuilder, Connection, ConnectionTrafficSecrets,
@@ -892,10 +890,10 @@ pub fn make_disjoint_suite_configs(provider: CryptoProvider) -> (ClientConfig, S
 pub fn do_handshake(
     client_input: &mut VecInput,
     client_output: &mut Vec<u8>,
-    client: &mut impl Connection<ClientSide>,
+    client: &mut impl Connection,
     server_input: &mut VecInput,
     server_output: &mut Vec<u8>,
-    server: &mut impl Connection<ServerSide>,
+    server: &mut impl Connection,
 ) -> (usize, usize) {
     do_handshake_collecting(
         client_input,
@@ -913,11 +911,11 @@ pub fn do_handshake(
 pub fn do_handshake_collecting(
     client_input: &mut VecInput,
     client_output: &mut Vec<u8>,
-    client: &mut impl Connection<ClientSide>,
+    client: &mut impl Connection,
     client_received: &mut Vec<u8>,
     server_input: &mut VecInput,
     server_output: &mut Vec<u8>,
-    server: &mut impl Connection<ServerSide>,
+    server: &mut impl Connection,
     server_received: &mut Vec<u8>,
 ) -> (usize, usize) {
     let (mut to_client, mut to_server) = (0, 0);
@@ -1766,7 +1764,7 @@ impl ServerCredentialResolver for ServerCheckCertResolve {
     }
 }
 
-pub struct OtherSession<'a, S: SideData, C: Connection<S>> {
+pub struct OtherSession<'a, C: Connection> {
     sess: &'a mut C,
     input: &'a mut VecInput,
     output: &'a mut Vec<u8>,
@@ -1779,10 +1777,9 @@ pub struct OtherSession<'a, S: SideData, C: Connection<S>> {
     pub buffered: bool,
     buffer: Vec<Vec<u8>>,
     pub received: Vec<u8>,
-    side: PhantomData<S>,
 }
 
-impl<'a, S: SideData, C: Connection<S>> OtherSession<'a, S, C> {
+impl<'a, C: Connection> OtherSession<'a, C> {
     pub fn new(input: &'a mut VecInput, output: &'a mut Vec<u8>, sess: &'a mut C) -> Self {
         OtherSession {
             sess,
@@ -1796,7 +1793,6 @@ impl<'a, S: SideData, C: Connection<S>> OtherSession<'a, S, C> {
             buffered: false,
             buffer: vec![],
             received: vec![],
-            side: PhantomData,
         }
     }
 
@@ -1889,7 +1885,7 @@ impl<'a, S: SideData, C: Connection<S>> OtherSession<'a, S, C> {
     }
 }
 
-impl<S: SideData, C: Connection<S>> io::Read for OtherSession<'_, S, C> {
+impl<C: Connection> io::Read for OtherSession<'_, C> {
     fn read(&mut self, b: &mut [u8]) -> io::Result<usize> {
         self.reads += 1;
         let n = Ord::min(b.len(), self.output.len());
@@ -1899,7 +1895,7 @@ impl<S: SideData, C: Connection<S>> io::Read for OtherSession<'_, S, C> {
     }
 }
 
-impl<S: SideData, C: Connection<S>> io::Write for OtherSession<'_, S, C> {
+impl<C: Connection> io::Write for OtherSession<'_, C> {
     fn write(&mut self, b: &[u8]) -> io::Result<usize> {
         self.write_vectored(&[io::IoSlice::new(b)])
     }

--- a/rustls-util/src/lib.rs
+++ b/rustls-util/src/lib.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use rustls::{Connection, SideData, VecInput};
+use rustls::{Connection, VecInput};
 
 mod key_log_file;
 pub use key_log_file::KeyLogFile;
@@ -42,7 +42,7 @@ pub fn complete_io(
     input: &mut VecInput,
     received_plaintext: &mut Vec<u8>,
     output: &mut Vec<u8>,
-    conn: &mut dyn Connection<impl SideData>,
+    conn: &mut impl Connection,
 ) -> Result<(usize, usize), io::Error> {
     let mut eof = false;
     let mut wrlen = 0;

--- a/rustls-util/src/stream.rs
+++ b/rustls-util/src/stream.rs
@@ -1,9 +1,8 @@
 #![allow(clippy::std_instead_of_core)] // awaits core::io::IoSlice in stable (1.98)
 use std::io::{BufRead, Error, ErrorKind, IoSlice, Read, Result, Write};
-use std::marker::PhantomData;
 
 use rustls::crypto::cipher::OutboundPlain;
-use rustls::{Connection, SideData, TlsInputBuffer, VecInput};
+use rustls::{Connection, TlsInputBuffer, VecInput};
 
 use crate::complete_io;
 
@@ -17,7 +16,7 @@ use crate::complete_io;
 /// [`complete_io()`]: crate::complete_io()
 #[expect(clippy::exhaustive_structs)]
 #[derive(Debug)]
-pub struct Stream<'a, C: 'a + ?Sized, S, T: 'a + Read + Write + ?Sized> {
+pub struct Stream<'a, C: 'a + ?Sized, T: 'a + Read + Write + ?Sized> {
     /// Our TLS connection
     pub conn: &'a mut C,
 
@@ -43,15 +42,11 @@ pub struct Stream<'a, C: 'a + ?Sized, S, T: 'a + Read + Write + ?Sized> {
     ///
     /// Defaults to 64KB.
     pub limit: usize,
-
-    /// Marker for the side of the connection (client or server)
-    pub side: PhantomData<S>,
 }
 
-impl<'a, C, S, T> Stream<'a, C, S, T>
+impl<'a, C, T> Stream<'a, C, T>
 where
-    C: 'a + Connection<S>,
-    S: SideData,
+    C: 'a + Connection,
     T: 'a + Read + Write,
 {
     /// Make a new Stream using the Connection `conn` and socket-like object
@@ -70,7 +65,6 @@ where
             received_plaintext,
             output,
             limit: DEFAULT_BUFFER_LIMIT,
-            side: PhantomData,
         }
     }
 
@@ -136,10 +130,9 @@ where
     }
 }
 
-impl<'a, C, S, T> Read for Stream<'a, C, S, T>
+impl<'a, C, T> Read for Stream<'a, C, T>
 where
-    C: 'a + Connection<S>,
-    S: SideData,
+    C: 'a + Connection,
     T: 'a + Read + Write,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -162,11 +155,10 @@ where
     }
 }
 
-impl<'a, C, S, T> BufRead for Stream<'a, C, S, T>
+impl<'a, C, T> BufRead for Stream<'a, C, T>
 where
-    C: 'a + Connection<S>,
+    C: 'a + Connection,
     T: 'a + Read + Write,
-    S: SideData,
 {
     fn fill_buf(&mut self) -> Result<&[u8]> {
         self.prepare_read()?;
@@ -178,10 +170,9 @@ where
     }
 }
 
-impl<'a, C, S, T> Write for Stream<'a, C, S, T>
+impl<'a, C, T> Write for Stream<'a, C, T>
 where
-    C: 'a + Connection<S>,
-    S: SideData,
+    C: 'a + Connection,
     T: 'a + Read + Write,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
@@ -272,7 +263,7 @@ where
 /// [`complete_io()`]: crate::complete_io()
 #[expect(clippy::exhaustive_structs)]
 #[derive(Debug)]
-pub struct StreamOwned<C: Sized, S, T: Read + Write + Sized> {
+pub struct StreamOwned<C: Sized, T: Read + Write + Sized> {
     /// Our connection
     pub conn: C,
 
@@ -298,15 +289,11 @@ pub struct StreamOwned<C: Sized, S, T: Read + Write + Sized> {
     ///
     /// Defaults to 64KB.
     pub limit: usize,
-
-    /// Marker for the side of the connection (client or server)
-    pub side: PhantomData<S>,
 }
 
-impl<C, S, T> StreamOwned<C, S, T>
+impl<C, T> StreamOwned<C, T>
 where
-    C: Connection<S>,
-    S: SideData,
+    C: Connection,
     T: Read + Write,
 {
     /// Make a new StreamOwned taking the Connection `conn` and socket-like
@@ -325,7 +312,6 @@ where
             received_plaintext: Vec::new(),
             output,
             limit: DEFAULT_BUFFER_LIMIT,
-            side: PhantomData,
         }
     }
 
@@ -345,13 +331,12 @@ where
     }
 }
 
-impl<'a, C, S, T> StreamOwned<C, S, T>
+impl<'a, C, T> StreamOwned<C, T>
 where
-    C: Connection<S>,
-    S: SideData,
+    C: Connection,
     T: Read + Write,
 {
-    fn as_stream(&'a mut self) -> Stream<'a, C, S, T> {
+    fn as_stream(&'a mut self) -> Stream<'a, C, T> {
         Stream {
             conn: &mut self.conn,
             sock: &mut self.sock,
@@ -359,15 +344,13 @@ where
             received_plaintext: &mut self.received_plaintext,
             output: &mut self.output,
             limit: self.limit,
-            side: PhantomData,
         }
     }
 }
 
-impl<C, S, T> Read for StreamOwned<C, S, T>
+impl<C, T> Read for StreamOwned<C, T>
 where
-    C: Connection<S>,
-    S: SideData,
+    C: Connection,
     T: Read + Write,
 {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -375,10 +358,9 @@ where
     }
 }
 
-impl<C, S, T> BufRead for StreamOwned<C, S, T>
+impl<C, T> BufRead for StreamOwned<C, T>
 where
-    C: Connection<S>,
-    S: SideData,
+    C: Connection,
     T: Read + Write,
 {
     fn fill_buf(&mut self) -> Result<&[u8]> {
@@ -391,10 +373,9 @@ where
     }
 }
 
-impl<C, S, T> Write for StreamOwned<C, S, T>
+impl<C, T> Write for StreamOwned<C, T>
 where
-    C: Connection<S>,
-    S: SideData,
+    C: Connection,
     T: Read + Write,
 {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
@@ -413,24 +394,22 @@ const DEFAULT_BUFFER_LIMIT: usize = 64 * 1024;
 mod tests {
     use std::net::TcpStream;
 
-    use rustls::client::ClientSide;
-    use rustls::server::ServerSide;
     use rustls::{ClientConnection, ServerConnection};
 
     use super::{Stream, StreamOwned};
 
     #[test]
     fn stream_can_be_created_for_connection_and_tcpstream() {
-        type _Test<'a> = Stream<'a, ClientConnection, ClientSide, TcpStream>;
+        type _Test<'a> = Stream<'a, ClientConnection, TcpStream>;
     }
 
     #[test]
     fn streamowned_can_be_created_for_client_and_tcpstream() {
-        type _Test = StreamOwned<ClientConnection, ClientSide, TcpStream>;
+        type _Test = StreamOwned<ClientConnection, TcpStream>;
     }
 
     #[test]
     fn streamowned_can_be_created_for_server_and_tcpstream() {
-        type _Test = StreamOwned<ServerConnection, ServerSide, TcpStream>;
+        type _Test = StreamOwned<ServerConnection, TcpStream>;
     }
 }

--- a/rustls/src/client/connection.rs
+++ b/rustls/src/client/connection.rs
@@ -109,7 +109,9 @@ impl ClientConnection {
     }
 }
 
-impl Connection<ClientSide> for ClientConnection {
+impl Connection for ClientConnection {
+    type Side = ClientSide;
+
     fn write_tls(&mut self, plaintext: OutboundPlain<'_>, tls: &mut Vec<u8>) -> Result<(), Error> {
         self.inner.write_tls(plaintext, tls)
     }

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -33,7 +33,10 @@ pub(crate) mod split;
 use split::SplitConnection;
 
 /// A trait generalizing over buffered client or server connections.
-pub trait Connection<Side: SideData>: Debug + Deref<Target = ConnectionOutputs> {
+pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
+    /// The side (client or server) that this type implements.
+    type Side: SideData;
+
     /// Writes the application data from `plaintext` into TLS records and appends them to `tls`.
     ///
     /// This will fail if either the handshake is not complete yet (because we don't yet have the
@@ -49,7 +52,7 @@ pub trait Connection<Side: SideData>: Debug + Deref<Target = ConnectionOutputs> 
         &'a mut self,
         input: &'m mut dyn TlsInputBuffer,
         tls: &'a mut Vec<u8>,
-    ) -> MessageHandler<'a, 'm, Side>;
+    ) -> MessageHandler<'a, 'm, Self::Side>;
 
     /// Returns an object that can derive key material from the agreed connection secrets.
     ///

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -136,7 +136,9 @@ impl ServerConnection {
     }
 }
 
-impl Connection<ServerSide> for ServerConnection {
+impl Connection for ServerConnection {
+    type Side = ServerSide;
+
     fn write_tls(&mut self, plaintext: OutboundPlain<'_>, tls: &mut Vec<u8>) -> Result<(), Error> {
         self.inner.write_tls(plaintext, tls)
     }


### PR DESCRIPTION
Generally seems like an improvement.

I think we were already monomorphizing in practice due to taking the `SideData` as a generic argument anyway.