### PR TITLE
reject zero-length ResponderID in ocsp status_request

### DIFF
--- a/rustls/src/msgs/client_hello.rs
+++ b/rustls/src/msgs/client_hello.rs
@@ -708,7 +708,10 @@ impl Codec<'_> for OcspCertificateStatusRequest {
     }
 }
 
-wrapped_payload!(pub(crate) struct ResponderId, SizedPayload<u16, MaybeEmpty>,);
+wrapped_payload!(
+    /// RFC 6066: `opaque ResponderID<1..2^16-1>;`
+    pub(crate) struct ResponderId, SizedPayload<u16, NonEmpty>,
+);
 
 /// RFC 6066: `ResponderID responder_id_list<0..2^16-1>;`
 impl TlsListElement for ResponderId {

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -509,6 +509,21 @@ fn can_round_trip_cert_status_req_for_ocsp() {
 }
 
 #[test]
+fn refuses_ocsp_status_request_with_empty_responder_id() {
+    // RFC 6066 defines `opaque ResponderID<1..2^16-1>;`, so a zero-length
+    // ResponderID is not a legal encoding. The `status_request` extension body:
+    //   0x01        CertificateStatusType::OCSP
+    //   0x00 0x02   responder_id_list length (2 bytes follow)
+    //   0x00 0x00   one ResponderID, length 0
+    //   0x00 0x00   request_extensions length (0)
+    let bytes = [0x01u8, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00];
+    assert_eq!(
+        CertificateStatusRequest::read(&mut Reader::new(&bytes)).unwrap_err(),
+        InvalidMessage::IllegalEmptyList("SizedPayload")
+    );
+}
+
+#[test]
 fn can_round_trip_cert_status_req_for_other() {
     let bytes = [
         0, 5, 2, // !OCSP


### PR DESCRIPTION
`CertificateStatusRequest::read`, one zero-length ResponderID in an OCSP `status_request` (`01 00 02 00 00 00 00`):

    Ok(Ocsp(OcspCertificateStatusRequest { responder_ids: [ResponderId()], extensions:  }))

RFC 6066 has `opaque ResponderID<1..2^16-1>`, so an empty entry is not a legal encoding. `ResponderId` wrapped `SizedPayload<u16, MaybeEmpty>`, which skips the length check; the sibling opaque vectors here (`PresharedKeyIdentity.identity`, `PresharedKeyBinder`, `DistinguishedName`) all use `NonEmpty` with the RFC bound cited. Switch `ResponderId` to `NonEmpty` so an empty entry is refused with `IllegalEmptyList`.