### PR TITLE
aws-lc-rs 1.18: stable MLDSA & out-of-place AEAD encrypter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.16"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b00953a69b2cfb471d13d72538d2e66930832340b0f31deadd404b48c573c5"
+checksum = "118303cd75f63d1933a90c2ceb7e697281ac6acbdbcc490b46419f25a527ab90"
 dependencies = [
  "bindgen",
  "cc",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ edition = "2024"
 anyhow = "1.0.73"
 asn1 = "0.24"
 async-trait = "0.1.74"
-aws-lc-rs = { version = "1.14", default-features = false }
+aws-lc-rs = { version = "1.18", default-features = false }
 base64 = "0.23"
 bencher = "0.1.5"
 brotli = { version = "8", default-features = false, features = ["std"] }

--- a/rustls-aws-lc-rs/src/lib.rs
+++ b/rustls-aws-lc-rs/src/lib.rs
@@ -45,7 +45,7 @@ use rustls::crypto::{
     CryptoProvider, GetRandomFailed, KeyProvider, SecureRandom, SigningKey, TicketProducer,
     TicketerFactory,
 };
-use rustls::error::{Error, OtherError};
+use rustls::error::{ApiMisuse, Error, OtherError};
 #[cfg(feature = "std")]
 use rustls::ticketer::TicketRotator;
 
@@ -248,6 +248,21 @@ mod ring_shim {
         agreement::agree_ephemeral(priv_key, peer_key, (), |secret| {
             Ok(SharedSecret::from(secret))
         })
+    }
+}
+
+/// The region of `out` that a `len`-byte sealed record payload will occupy.
+///
+/// If `out` is shorter than `len` bytes, this returns [`ApiMisuse::EncryptBufferTooSmall`].
+fn record_region(out: &mut [u8], len: usize) -> Result<&mut [u8], Error> {
+    let provided = out.len();
+    match out.get_mut(..len) {
+        Some(record) => Ok(record),
+        None => Err(ApiMisuse::EncryptBufferTooSmall {
+            required: len,
+            provided,
+        }
+        .into()),
     }
 }
 

--- a/rustls-aws-lc-rs/src/tls12.rs
+++ b/rustls-aws-lc-rs/src/tls12.rs
@@ -16,7 +16,7 @@ use rustls::version::TLS12_VERSION;
 use rustls::{CipherSuiteCommon, ConnectionTrafficSecrets, Tls12CipherSuite};
 use zeroize::Zeroizing;
 
-use crate::MAX_FRAGMENT_LEN;
+use crate::{MAX_FRAGMENT_LEN, record_region};
 
 /// The TLS1.2 cipher suite configuration that an application should use by default.
 ///
@@ -334,26 +334,47 @@ impl MessageEncrypter for GcmMessageEncrypter {
         out: &'a mut [u8],
     ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
-        payload.extend_from_slice(&nonce.as_ref()[4..]);
-        payload.extend_from_chunks(&msg.payload);
 
-        match self.enc_key.seal_in_place_separate_tag(
-            nonce,
-            aad,
-            &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..],
-        ) {
-            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-            Err(_) => return Err(Error::EncryptError),
-        }
+        let payload = match msg.payload.single_chunk() {
+            // Contiguous plaintext is sealed out-of-place, straight from the
+            // borrowed input.
+            Some(plain) => {
+                let record = record_region(out, total_len)?;
+                let (explicit_nonce, sealed) = record.split_at_mut(GCM_EXPLICIT_NONCE_LEN);
+                explicit_nonce.copy_from_slice(&nonce.as_ref()[4..]);
+                let (ciphertext, tag) = sealed.split_at_mut(plain.len());
+                self.enc_key
+                    .seal_out_of_place_scatter(nonce, aad, plain, ciphertext, &[], tag)
+                    .map_err(|_| Error::EncryptError)?;
+                &*record
+            }
+            // Fragmented plaintext is gathered into `out` and then sealed in place.
+            // We can't use the out-of-place seal as it requires contiguous input.
+            None => {
+                let mut payload = EncryptBuffer::new(out, total_len)?;
+                payload.extend_from_slice(&nonce.as_ref()[4..]);
+                payload.extend_from_chunks(&msg.payload);
+
+                match self.enc_key.seal_in_place_separate_tag(
+                    nonce,
+                    aad,
+                    &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..],
+                ) {
+                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+                    Err(_) => return Err(Error::EncryptError),
+                }
+
+                payload.into_written()
+            }
+        };
 
         Ok(EncodedMessage {
             typ: msg.typ,
             version: msg.version,
-            payload: payload.into_written(),
+            payload,
         })
     }
 
@@ -425,25 +446,44 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
         out: &'a mut [u8],
     ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce =
             aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
-        payload.extend_from_chunks(&msg.payload);
 
-        match self
-            .enc_key
-            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-        {
-            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-            Err(_) => return Err(Error::EncryptError),
-        }
+        let payload = match msg.payload.single_chunk() {
+            // Contiguous plaintext is sealed out-of-place, straight from the
+            // borrowed input.
+            Some(plain) => {
+                let record = record_region(out, total_len)?;
+                let (ciphertext, tag) = record.split_at_mut(plain.len());
+                self.enc_key
+                    .seal_out_of_place_scatter(nonce, aad, plain, ciphertext, &[], tag)
+                    .map_err(|_| Error::EncryptError)?;
+                &*record
+            }
+            // Fragmented plaintext is gathered into `out` and then sealed in place.
+            // We can't use the out-of-place seal as it requires contiguous input.
+            None => {
+                let mut payload = EncryptBuffer::new(out, total_len)?;
+                payload.extend_from_chunks(&msg.payload);
+
+                match self
+                    .enc_key
+                    .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
+                {
+                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+                    Err(_) => return Err(Error::EncryptError),
+                }
+
+                payload.into_written()
+            }
+        };
 
         Ok(EncodedMessage {
             typ: msg.typ,
             version: msg.version,
-            payload: payload.into_written(),
+            payload,
         })
     }
 
@@ -537,4 +577,83 @@ impl AsRef<[u8]> for Secret {
             Self::KeyExchange(kx) => kx.secret_bytes(),
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+    use std::vec::Vec;
+
+    use rustls::crypto::cipher::InboundOpaque;
+    use rustls::enums::ContentType;
+
+    use super::*;
+
+    /// Test that contiguous plaintext and fragmented plaintext are handled identically.
+    #[test]
+    fn out_of_place_sealing_matches_in_place() {
+        let plain = b"the quick brown fox jumps over the lazy dog";
+        let chunks = [&plain[..3], &plain[3..27], &plain[27..]];
+
+        for suite in ALL_TLS12_CIPHER_SUITES {
+            // Different `fill` values prove both paths write every output byte.
+            let contiguous = seal(suite, OutboundPlain::from(plain), 0x00);
+            let fragmented = seal(suite, OutboundPlain::new(&chunks), 0xff);
+            assert_eq!(contiguous, fragmented, "{:?}", suite.common.suite);
+        }
+    }
+
+    /// Sealed records must open through the corresponding decrypter.
+    #[test]
+    fn sealed_records_open() {
+        for suite in ALL_TLS12_CIPHER_SUITES {
+            for plain in [&b""[..], b"hello"] {
+                let mut sealed = seal(suite, OutboundPlain::from(plain), 0x00);
+                let msg = EncodedMessage::new(
+                    ContentType::ApplicationData,
+                    ProtocolVersion::TLSv1_2,
+                    InboundOpaque(&mut sealed),
+                );
+                let shape = suite.aead_alg.key_block_shape();
+                let mut decrypter = suite
+                    .aead_alg
+                    .decrypter(test_key(shape.enc_key_len), &TEST_IV[..shape.fixed_iv_len]);
+                let opened = decrypter
+                    .decrypt(msg, TEST_SEQ)
+                    .unwrap();
+                assert_eq!(opened.payload, plain, "{:?}", suite.common.suite);
+            }
+        }
+    }
+
+    fn seal(suite: &Tls12CipherSuite, payload: OutboundPlain<'_>, fill: u8) -> Vec<u8> {
+        let shape = suite.aead_alg.key_block_shape();
+        let mut encrypter = suite.aead_alg.encrypter(
+            test_key(shape.enc_key_len),
+            &TEST_IV[..shape.fixed_iv_len],
+            &TEST_EXPLICIT[..shape.explicit_nonce_len],
+        );
+        let msg = EncodedMessage::new(
+            ContentType::ApplicationData,
+            ProtocolVersion::TLSv1_2,
+            payload,
+        );
+        let mut out = vec![fill; encrypter.encrypted_payload_len(msg.payload.len())];
+        encrypter
+            .encrypt(msg, TEST_SEQ, &mut out)
+            .unwrap()
+            .payload
+            .to_vec()
+    }
+
+    fn test_key(len: usize) -> AeadKey {
+        match len {
+            16 => AeadKey::from([0x22; 16]),
+            _ => AeadKey::from([0x22; 32]),
+        }
+    }
+
+    const TEST_IV: [u8; NONCE_LEN] = [0x55; NONCE_LEN];
+    const TEST_EXPLICIT: [u8; GCM_EXPLICIT_NONCE_LEN] = [0x66; GCM_EXPLICIT_NONCE_LEN];
+    const TEST_SEQ: u64 = 7;
 }

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -14,6 +14,8 @@ use rustls::error::Error;
 use rustls::version::TLS13_VERSION;
 use rustls::{CipherSuiteCommon, ConnectionTrafficSecrets, Tls13CipherSuite};
 
+use crate::record_region;
+
 /// The TLS1.3 cipher suite configuration that an application should use by default.
 ///
 /// This will be [`ALL_TLS13_CIPHER_SUITES`] sans any supported cipher suites that
@@ -244,26 +246,52 @@ impl MessageEncrypter for AeadMessageEncrypter {
         out: &'a mut [u8],
     ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let typ = ContentType::ApplicationData;
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(typ, TLS13_LEGACY_RECORD_VERSION, total_len));
-        payload.extend_from_chunks(&msg.payload);
-        payload.extend_from_slice(&msg.typ.to_array());
 
-        match self
-            .enc_key
-            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-        {
-            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-            Err(_) => return Err(Error::EncryptError),
-        }
+        let payload = match msg.payload.single_chunk() {
+            // Contiguous plaintext is sealed out-of-place, straight from the borrowed
+            // input and the inner content type byte is specified as `extra_in`.
+            Some(plain) => {
+                let record = record_region(out, total_len)?;
+                let (ciphertext, typ_and_tag) = record.split_at_mut(plain.len());
+                self.enc_key
+                    .seal_out_of_place_scatter(
+                        nonce,
+                        aad,
+                        plain,
+                        ciphertext,
+                        &msg.typ.to_array(),
+                        typ_and_tag,
+                    )
+                    .map_err(|_| Error::EncryptError)?;
+                &*record
+            }
+            // Fragmented plaintext is gathered into `out` and then sealed in place.
+            // We can't use the out-of-place seal as it requires contiguous input.
+            None => {
+                let mut payload = EncryptBuffer::new(out, total_len)?;
+                payload.extend_from_chunks(&msg.payload);
+                payload.extend_from_slice(&msg.typ.to_array());
+
+                match self
+                    .enc_key
+                    .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
+                {
+                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+                    Err(_) => return Err(Error::EncryptError),
+                }
+
+                payload.into_written()
+            }
+        };
 
         Ok(EncodedMessage {
             typ,
             version: TLS13_LEGACY_RECORD_VERSION,
-            payload: payload.into_written(),
+            payload,
         })
     }
 
@@ -309,26 +337,52 @@ impl MessageEncrypter for GcmMessageEncrypter {
         out: &'a mut [u8],
     ) -> Result<EncodedMessage<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let typ = ContentType::ApplicationData;
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(typ, TLS13_LEGACY_RECORD_VERSION, total_len));
-        payload.extend_from_chunks(&msg.payload);
-        payload.extend_from_slice(&msg.typ.to_array());
 
-        match self
-            .enc_key
-            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-        {
-            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-            Err(_) => return Err(Error::EncryptError),
-        }
+        let payload = match msg.payload.single_chunk() {
+            // Contiguous plaintext is sealed out-of-place, straight from the borrowed
+            // input and the inner content type byte is specified as `extra_in`.
+            Some(plain) => {
+                let record = record_region(out, total_len)?;
+                let (ciphertext, typ_and_tag) = record.split_at_mut(plain.len());
+                self.enc_key
+                    .seal_out_of_place_scatter(
+                        nonce,
+                        aad,
+                        plain,
+                        ciphertext,
+                        &msg.typ.to_array(),
+                        typ_and_tag,
+                    )
+                    .map_err(|_| Error::EncryptError)?;
+                &*record
+            }
+            // Fragmented plaintext is gathered into `out` and then sealed in place.
+            // We can't use the out-of-place seal as it requires contiguous input.
+            None => {
+                let mut payload = EncryptBuffer::new(out, total_len)?;
+                payload.extend_from_chunks(&msg.payload);
+                payload.extend_from_slice(&msg.typ.to_array());
+
+                match self
+                    .enc_key
+                    .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
+                {
+                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
+                    Err(_) => return Err(Error::EncryptError),
+                }
+
+                payload.into_written()
+            }
+        };
 
         Ok(EncodedMessage {
             typ,
             version: TLS13_LEGACY_RECORD_VERSION,
-            payload: payload.into_written(),
+            payload,
         })
     }
 
@@ -447,4 +501,78 @@ impl KeyType for Len {
     fn len(&self) -> usize {
         self.0
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+    use std::vec::Vec;
+
+    use rustls::crypto::cipher::InboundOpaque;
+
+    use super::*;
+
+    /// Test that contiguous plaintext and fragmented plaintext are handled identically.
+    #[test]
+    fn out_of_place_sealing_matches_in_place() {
+        let plain = b"the quick brown fox jumps over the lazy dog";
+        let chunks = [&plain[..3], &plain[3..27], &plain[27..]];
+
+        for suite in ALL_TLS13_CIPHER_SUITES {
+            // Different `fill` values prove both paths write every output byte.
+            let contiguous = seal(suite, OutboundPlain::from(plain), 0x00);
+            let fragmented = seal(suite, OutboundPlain::new(&chunks), 0xff);
+            assert_eq!(contiguous, fragmented, "{:?}", suite.common.suite);
+        }
+    }
+
+    /// Sealed records must open through the corresponding decrypter.
+    #[test]
+    fn sealed_records_open() {
+        for suite in ALL_TLS13_CIPHER_SUITES {
+            for plain in [&b""[..], b"hello"] {
+                let mut sealed = seal(suite, OutboundPlain::from(plain), 0x00);
+                let msg = EncodedMessage::new(
+                    ContentType::ApplicationData,
+                    TLS13_LEGACY_RECORD_VERSION,
+                    InboundOpaque(&mut sealed),
+                );
+                let mut decrypter = suite
+                    .aead_alg
+                    .decrypter(test_key(suite.aead_alg.key_len()), Iv::from(TEST_IV));
+                let opened = decrypter
+                    .decrypt(msg, TEST_SEQ)
+                    .unwrap();
+                assert_eq!(opened.typ, ContentType::ApplicationData);
+                assert_eq!(opened.payload, plain, "{:?}", suite.common.suite);
+            }
+        }
+    }
+
+    fn seal(suite: &Tls13CipherSuite, payload: OutboundPlain<'_>, fill: u8) -> Vec<u8> {
+        let mut encrypter = suite
+            .aead_alg
+            .encrypter(test_key(suite.aead_alg.key_len()), Iv::from(TEST_IV));
+        let msg = EncodedMessage::new(
+            ContentType::ApplicationData,
+            ProtocolVersion::TLSv1_3,
+            payload,
+        );
+        let mut out = vec![fill; encrypter.encrypted_payload_len(msg.payload.len())];
+        encrypter
+            .encrypt(msg, TEST_SEQ, &mut out)
+            .unwrap()
+            .payload
+            .to_vec()
+    }
+
+    fn test_key(len: usize) -> AeadKey {
+        match len {
+            16 => AeadKey::from([0x22; 16]),
+            _ => AeadKey::from([0x22; 32]),
+        }
+    }
+
+    const TEST_IV: [u8; 12] = [0x55; 12];
+    const TEST_SEQ: u64 = 7;
 }

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "cryptography"]
 autobenches = false
 
 [dependencies]
-aws-lc-rs = { workspace = true, features = ["unstable"] }
+aws-lc-rs = { workspace = true }
 rustls-aws-lc-rs = { version = "0.1.0-dev.1", path = "../rustls-aws-lc-rs" }
 rustls = { path = "../rustls", version = "0.24.0-dev.0", default-features = false }
 

--- a/rustls-post-quantum/src/lib.rs
+++ b/rustls-post-quantum/src/lib.rs
@@ -13,9 +13,9 @@
 use core::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
-use aws_lc_rs::signature::KeyPair;
-use aws_lc_rs::unstable::signature::{
-    ML_DSA_44_SIGNING, ML_DSA_65_SIGNING, ML_DSA_87_SIGNING, PqdsaKeyPair, PqdsaSigningAlgorithm,
+use aws_lc_rs::signature::{
+    KeyPair, ML_DSA_44_SIGNING, ML_DSA_65_SIGNING, ML_DSA_87_SIGNING, PqdsaKeyPair,
+    PqdsaSigningAlgorithm,
 };
 use rustls::Error;
 use rustls::crypto::{
@@ -263,7 +263,7 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = match WebPkiSupportedAlgo
 pub static ML_DSA_44: &dyn SignatureVerificationAlgorithm = &AwsLcRsVerificationAlgorithm {
     public_key_alg_id: alg_id::ML_DSA_44,
     signature_alg_id: alg_id::ML_DSA_44,
-    verification_alg: &aws_lc_rs::unstable::signature::ML_DSA_44,
+    verification_alg: &aws_lc_rs::signature::ML_DSA_44,
     // Not included in AWS-LC-FIPS 3.0 FIPS scope
     in_fips_submission: false,
 };
@@ -272,7 +272,7 @@ pub static ML_DSA_44: &dyn SignatureVerificationAlgorithm = &AwsLcRsVerification
 pub static ML_DSA_65: &dyn SignatureVerificationAlgorithm = &AwsLcRsVerificationAlgorithm {
     public_key_alg_id: alg_id::ML_DSA_65,
     signature_alg_id: alg_id::ML_DSA_65,
-    verification_alg: &aws_lc_rs::unstable::signature::ML_DSA_65,
+    verification_alg: &aws_lc_rs::signature::ML_DSA_65,
     // Not included in AWS-LC-FIPS 3.0 FIPS scope
     in_fips_submission: false,
 };
@@ -281,7 +281,7 @@ pub static ML_DSA_65: &dyn SignatureVerificationAlgorithm = &AwsLcRsVerification
 pub static ML_DSA_87: &dyn SignatureVerificationAlgorithm = &AwsLcRsVerificationAlgorithm {
     public_key_alg_id: alg_id::ML_DSA_87,
     signature_alg_id: alg_id::ML_DSA_87,
-    verification_alg: &aws_lc_rs::unstable::signature::ML_DSA_87,
+    verification_alg: &aws_lc_rs::signature::ML_DSA_87,
     // Not included in AWS-LC-FIPS 3.0 FIPS scope
     in_fips_submission: false,
 };

--- a/rustls-post-quantum/src/lib.rs
+++ b/rustls-post-quantum/src/lib.rs
@@ -1,9 +1,5 @@
-//! This crate provide a [`CryptoProvider`] built on the default aws-lc-rs default provider.
-//!
-//! Features:
-//!
-//! - `aws-lc-rs-unstable`: adds support for three variants of the experimental ML-DSA signature
-//!   algorithm.
+//! This crate provides a [`CryptoProvider`] built on the default aws-lc-rs provider,
+//! with added support for three variants of the ML-DSA signature algorithm.
 //!
 //! Before rustls 0.23.22, this crate additionally provided support for the ML-KEM key exchange
 //! (both "pure" and hybrid variants), but these have been moved to the rustls crate itself.

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -254,6 +254,17 @@ impl<'a> OutboundPlain<'a> {
         }
     }
 
+    /// The payload's single contiguous chunk, or `None` if it is fragmented.
+    ///
+    /// An empty payload is treated as a single empty chunk, and a [`Self::Multiple`]
+    /// payload yields `None` even when its chunks happen to form a contiguous whole.
+    pub fn single_chunk(&self) -> Option<&'a [u8]> {
+        match *self {
+            Self::Single(chunk) => Some(chunk),
+            Self::Multiple { .. } => None,
+        }
+    }
+
     /// Split self in two, around an index
     /// Works similarly to `split_at` in the core library, except it doesn't panic if out of bound
     pub(crate) fn split_at(&self, mid: usize) -> (Self, Self) {


### PR DESCRIPTION
This branch is picking up the AEAD API optimization discussed in https://github.com/aws/aws-lc-rs/issues/1182

I'm playing with an idea to reduce some of the duplication in the `MessageEncrypter` impls but I'm not confident it'll be a productive avenue and in the mean time we don't need to block the optimization work on that.