### PR TITLE
enforce handshake size limit for non-coalesced fragments

### DIFF
--- a/rustls/src/msgs/deframer/mod.rs
+++ b/rustls/src/msgs/deframer/mod.rs
@@ -29,6 +29,9 @@ pub(crate) struct Deframer {
     /// Spans covering individual handshake payloads, in order of receipt.
     spans: VecDeque<FragmentSpan>,
 
+    /// Whether any span declared a size exceeding `MAX_HANDSHAKE_SIZE`.
+    too_large: bool,
+
     /// Prefix of the buffer that has been processed so far.
     ///
     /// `processed` may exceed `discard`, that means we have parsed
@@ -151,6 +154,7 @@ impl Deframer {
         };
 
         for span in iter {
+            self.too_large |= span.size.unwrap_or_default() > MAX_HANDSHAKE_SIZE;
             self.spans.push_back(span);
         }
     }
@@ -213,6 +217,12 @@ impl Deframer {
         // for a pair where the first is not complete.  move
         // the second down towards the first, then reparse the contents.
         loop {
+            // this covers spans that never require coalescing, eg. a single
+            // complete QUIC handshake message with an excessive declared size
+            if self.too_large {
+                return Err(InvalidMessage::HandshakePayloadTooLarge);
+            }
+
             let limit = self.spans.len().saturating_sub(1);
             let iter = self.spans.iter();
             let Some(index) = iter
@@ -259,16 +269,9 @@ impl Deframer {
                 bounds: first.bounds.start..first.bounds.end,
             };
 
-            let mut too_large = false;
             for (i, span) in iter.enumerate() {
-                if span.size.unwrap_or_default() > MAX_HANDSHAKE_SIZE {
-                    too_large = true;
-                }
+                self.too_large |= span.size.unwrap_or_default() > MAX_HANDSHAKE_SIZE;
                 self.spans.insert(index + i, span);
-            }
-
-            if too_large {
-                return Err(InvalidMessage::HandshakePayloadTooLarge);
             }
         }
     }
@@ -350,6 +353,7 @@ impl Default for Deframer {
             // capacity: a typical upper limit on handshake messages in
             // a single flight
             spans: VecDeque::with_capacity(16),
+            too_large: false,
             processed: 0,
             discard: 0,
         }
@@ -527,6 +531,22 @@ mod tests {
         // this check in `coalesce()`
         add_bytes(&mut deframer, 0..3, &input);
         add_bytes(&mut deframer, 4..6, &input);
+
+        assert_eq!(
+            deframer.coalesce(&mut input),
+            Err(InvalidMessage::HandshakePayloadTooLarge)
+        );
+    }
+
+    #[test]
+    fn coalesce_rejects_excess_size_message_needing_no_coalescing() {
+        const X: u8 = 0xff;
+        // a 0x010000-byte body (one over `MAX_HANDSHAKE_SIZE`) in a single
+        // fragment, so `coalesce()` performs no merging (the QUIC CRYPTO shape)
+        let mut input = vec![0x21, 0x01, 0x00, 0x00, X, X];
+        let mut deframer = Deframer::default();
+
+        add_bytes(&mut deframer, 0..6, &input);
 
         assert_eq!(
             deframer.coalesce(&mut input),


### PR DESCRIPTION
`coalesce()` returns `Ok(())` for a single oversized fragment:

        assert_eq!(deframer.coalesce(&mut input), Err(HandshakePayloadTooLarge));
        left:  Ok(())
        right: Err(HandshakePayloadTooLarge)

The 64KB `MAX_HANDSHAKE_SIZE` limit is only enforced over spans that get re-dissected while fragments are merged. A message that needs no coalescing skips the check via the early `return Ok(())`. Over QUIC this is reachable pre-auth: `input_quic()` hands the whole application-reassembled CRYPTO buffer to `input_message()`, which produces one complete span whose declared u24 length can be up to the 16MB wire limit, and `coalesce()` then accepts it, so the oversized message is parsed and `into_owned()`-copied. The TCP path already rejects these while coalescing, so this also brings QUIC in line with it.

Moving the check to the loop-exit path covers every span, including an incomplete one whose header length is already known (so an oversized message is rejected as soon as its header is seen, without buffering the body). The existing `coalesce_rejects_excess_size_message` test only exercises the split-header coalescing path, so the added test delivers a single oversized fragment.