### PR TITLE
rustls-aws-lc-rs: refactor encrypter/decrypters, share more between protocols

### DIFF
--- a/rustls-aws-lc-rs/src/lib.rs
+++ b/rustls-aws-lc-rs/src/lib.rs
@@ -40,6 +40,8 @@ use alloc::sync::Arc;
 #[cfg(feature = "std")]
 use core::time::Duration;
 
+use aws_lc_rs::aead;
+use aws_lc_rs::error::Unspecified;
 use pki_types::{FipsStatus, PrivateKeyDer};
 use rustls::crypto::{
     CryptoProvider, GetRandomFailed, KeyProvider, SecureRandom, SigningKey, TicketProducer,
@@ -266,6 +268,62 @@ fn record_region(out: &mut [u8], len: usize) -> Result<&mut [u8], Error> {
     }
 }
 
+/// A TLS1.3 sealing key, dispatching to whichever aws-lc-rs key type backs it.
+enum SealKey {
+    LessSafe(aead::LessSafeKey),
+    TlsRecord(aead::TlsRecordSealingKey),
+}
+
+impl SealKey {
+    fn seal_out_of_place_scatter<A: AsRef<[u8]>>(
+        &mut self,
+        nonce: aead::Nonce,
+        aad: aead::Aad<A>,
+        in_plaintext: &[u8],
+        out_ciphertext: &mut [u8],
+        extra_in: &[u8],
+        extra_out_and_tag: &mut [u8],
+    ) -> Result<(), Unspecified> {
+        match self {
+            Self::LessSafe(key) => key.seal_out_of_place_scatter(
+                nonce,
+                aad,
+                in_plaintext,
+                out_ciphertext,
+                extra_in,
+                extra_out_and_tag,
+            ),
+            Self::TlsRecord(key) => key.seal_out_of_place_scatter(
+                nonce,
+                aad,
+                in_plaintext,
+                out_ciphertext,
+                extra_in,
+                extra_out_and_tag,
+            ),
+        }
+    }
+
+    fn seal_in_place_separate_tag<A: AsRef<[u8]>>(
+        &mut self,
+        nonce: aead::Nonce,
+        aad: aead::Aad<A>,
+        in_out: &mut [u8],
+    ) -> Result<aead::Tag, Unspecified> {
+        match self {
+            Self::LessSafe(key) => key.seal_in_place_separate_tag(nonce, aad, in_out),
+            Self::TlsRecord(key) => key.seal_in_place_separate_tag(nonce, aad, in_out),
+        }
+    }
+
+    fn algorithm(&self) -> &'static aead::Algorithm {
+        match self {
+            Self::LessSafe(key) => key.algorithm(),
+            Self::TlsRecord(key) => key.algorithm(),
+        }
+    }
+}
+
 /// Are we in FIPS mode?
 fn fips() -> FipsStatus {
     match aws_lc_rs::try_fips_mode().is_ok() {
@@ -276,7 +334,7 @@ fn fips() -> FipsStatus {
     }
 }
 
-fn unspecified_err(e: aws_lc_rs::error::Unspecified) -> Error {
+fn unspecified_err(e: Unspecified) -> Error {
     Error::Other(OtherError::new(e))
 }
 

--- a/rustls-aws-lc-rs/src/lib.rs
+++ b/rustls-aws-lc-rs/src/lib.rs
@@ -43,6 +43,7 @@ use core::time::Duration;
 use aws_lc_rs::aead;
 use aws_lc_rs::error::Unspecified;
 use pki_types::{FipsStatus, PrivateKeyDer};
+use rustls::crypto::cipher::{EncryptBuffer, OutboundPlain};
 use rustls::crypto::{
     CryptoProvider, GetRandomFailed, KeyProvider, SecureRandom, SigningKey, TicketProducer,
     TicketerFactory,
@@ -253,6 +254,84 @@ mod ring_shim {
     }
 }
 
+/// Seal one record's payload into `out`, returning the written region.
+///
+/// `framing` describes the sealed payload's layout around the ciphertext.
+/// `total_len` is the caller's [`MessageEncrypter::encrypted_payload_len()`]
+/// for the payload, and total encrypted payload with framing must add up to
+/// this value as an invariant of correct usage.
+///
+/// Contiguous plaintext is sealed out-of-place, straight from the borrowed
+/// input. Fragmented plaintext is gathered into `out` and then sealed in
+/// place.
+///
+/// [`MessageEncrypter::encrypted_payload_len()`]: rustls::crypto::cipher::MessageEncrypter::encrypted_payload_len()
+fn seal_record<'a, A: AsRef<[u8]>>(
+    key: &mut SealKey,
+    nonce: aead::Nonce,
+    aad: aead::Aad<A>,
+    payload: &OutboundPlain<'_>,
+    framing: Framing<'_>,
+    total_len: usize,
+    out: &'a mut [u8],
+) -> Result<&'a [u8], Error> {
+    let (prefix, extra_in) = match framing {
+        Framing::None => (&[][..], &[][..]),
+        Framing::UnencryptedPrefix(prefix) => (prefix, &[][..]),
+        Framing::EncryptedTail(extra_in) => (&[][..], extra_in),
+    };
+    debug_assert_eq!(
+        total_len,
+        prefix.len() + payload.len() + extra_in.len() + key.algorithm().tag_len()
+    );
+
+    match payload.single_chunk() {
+        Some(plain) => {
+            let record = record_region(out, total_len)?;
+            let (header, sealed) = record.split_at_mut(prefix.len());
+            header.copy_from_slice(prefix);
+            let (ciphertext, extra_out_and_tag) = sealed.split_at_mut(plain.len());
+            key.seal_out_of_place_scatter(
+                nonce,
+                aad,
+                plain,
+                ciphertext,
+                extra_in,
+                extra_out_and_tag,
+            )
+            .map_err(|_| Error::EncryptError)?;
+            Ok(&*record)
+        }
+        None => {
+            let mut buf = EncryptBuffer::new(out, total_len)?;
+            buf.extend_from_slice(prefix);
+            buf.extend_from_chunks(payload);
+            buf.extend_from_slice(extra_in);
+
+            match key.seal_in_place_separate_tag(nonce, aad, &mut buf.as_mut()[prefix.len()..]) {
+                Ok(tag) => buf.extend_from_slice(tag.as_ref()),
+                Err(_) => return Err(Error::EncryptError),
+            }
+
+            Ok(buf.into_written())
+        }
+    }
+}
+
+/// A sealed record payload's framing around the ciphertext.
+enum Framing<'a> {
+    /// Ciphertext and tag only, no additional framing.
+    None,
+    /// These bytes prefix the ciphertext on the wire, unencrypted.
+    ///
+    /// This is used by TLS1.2 GCM's explicit nonce.
+    UnencryptedPrefix(&'a [u8]),
+    /// These bytes follow the ciphertext on the wire, encrypted.
+    ///
+    /// This is used by TLS1.3's inner content type byte.
+    EncryptedTail(&'a [u8]),
+}
+
 /// The region of `out` that a `len`-byte sealed record payload will occupy.
 ///
 /// If `out` is shorter than `len` bytes, this returns [`ApiMisuse::EncryptBufferTooSmall`].
@@ -268,7 +347,7 @@ fn record_region(out: &mut [u8], len: usize) -> Result<&mut [u8], Error> {
     }
 }
 
-/// A TLS1.3 sealing key, dispatching to whichever aws-lc-rs key type backs it.
+/// A sealing key, dispatching to whichever aws-lc-rs key type backs it.
 enum SealKey {
     LessSafe(aead::LessSafeKey),
     TlsRecord(aead::TlsRecordSealingKey),

--- a/rustls-aws-lc-rs/src/tls12.rs
+++ b/rustls-aws-lc-rs/src/tls12.rs
@@ -385,7 +385,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
 
 /// The RFC 7905/RFC 7539 ChaCha20Poly1305 construction.
 /// This implementation does the AAD construction required in TLS1.2.
-/// TLS1.3 uses `AeadMessageEncrypter`.
+/// TLS1.3 uses `Tls13MessageEncrypter`.
 struct ChaCha20Poly1305MessageEncrypter {
     enc_key: aead::LessSafeKey,
     enc_offset: Iv,
@@ -393,7 +393,7 @@ struct ChaCha20Poly1305MessageEncrypter {
 
 /// The RFC 7905/RFC 7539 ChaCha20Poly1305 construction.
 /// This implementation does the AAD construction required in TLS1.2.
-/// TLS1.3 uses `AeadMessageDecrypter`.
+/// TLS1.3 uses `Tls13MessageDecrypter`.
 struct ChaCha20Poly1305MessageDecrypter {
     dec_key: aead::LessSafeKey,
     dec_offset: Iv,

--- a/rustls-aws-lc-rs/src/tls12.rs
+++ b/rustls-aws-lc-rs/src/tls12.rs
@@ -3,9 +3,8 @@ use alloc::boxed::Box;
 use aws_lc_rs::{aead, tls_prf};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter,
-    MessageEncrypter, NONCE_LEN, Nonce, OutboundPlain, Tls12AeadAlgorithm,
-    UnsupportedOperationError, make_tls12_aad,
+    AeadKey, EncodedMessage, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
+    NONCE_LEN, Nonce, OutboundPlain, Tls12AeadAlgorithm, UnsupportedOperationError, make_tls12_aad,
 };
 use rustls::crypto::kx::{ActiveKeyExchange, KeyExchangeAlgorithm, SharedSecret};
 use rustls::crypto::tls12::{Prf, PrfSecret};
@@ -16,7 +15,7 @@ use rustls::version::TLS12_VERSION;
 use rustls::{CipherSuiteCommon, ConnectionTrafficSecrets, Tls12CipherSuite};
 use zeroize::Zeroizing;
 
-use crate::{MAX_FRAGMENT_LEN, record_region};
+use crate::{Framing, MAX_FRAGMENT_LEN, SealKey, seal_record};
 
 /// The TLS1.2 cipher suite configuration that an application should use by default.
 ///
@@ -187,7 +186,10 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
             aead::TlsRecordSealingKey::new(self.0, aead::TlsProtocolId::TLS13, enc_key.as_ref())
                 .unwrap();
         let iv = gcm_iv(write_iv, explicit);
-        Box::new(GcmMessageEncrypter { enc_key, iv })
+        Box::new(GcmMessageEncrypter {
+            enc_key: SealKey::TlsRecord(enc_key),
+            iv,
+        })
     }
 
     fn key_block_shape(&self) -> KeyBlockShape {
@@ -235,7 +237,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
             aead::UnboundKey::new(&aead::CHACHA20_POLY1305, enc_key.as_ref()).unwrap(),
         );
         Box::new(ChaCha20Poly1305MessageEncrypter {
-            enc_key,
+            enc_key: SealKey::LessSafe(enc_key),
             enc_offset: Iv::new(enc_iv).expect("IV length validated by key_block_shape"),
         })
     }
@@ -269,7 +271,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
 
 /// A `MessageEncrypter` for AES-GCM AEAD ciphersuites. TLS 1.2 only.
 struct GcmMessageEncrypter {
-    enc_key: aead::TlsRecordSealingKey,
+    enc_key: SealKey,
     iv: Iv,
 }
 
@@ -338,38 +340,18 @@ impl MessageEncrypter for GcmMessageEncrypter {
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
 
-        let payload = match msg.payload.single_chunk() {
-            // Contiguous plaintext is sealed out-of-place, straight from the
-            // borrowed input.
-            Some(plain) => {
-                let record = record_region(out, total_len)?;
-                let (explicit_nonce, sealed) = record.split_at_mut(GCM_EXPLICIT_NONCE_LEN);
-                explicit_nonce.copy_from_slice(&nonce.as_ref()[4..]);
-                let (ciphertext, tag) = sealed.split_at_mut(plain.len());
-                self.enc_key
-                    .seal_out_of_place_scatter(nonce, aad, plain, ciphertext, &[], tag)
-                    .map_err(|_| Error::EncryptError)?;
-                &*record
-            }
-            // Fragmented plaintext is gathered into `out` and then sealed in place.
-            // We can't use the out-of-place seal as it requires contiguous input.
-            None => {
-                let mut payload = EncryptBuffer::new(out, total_len)?;
-                payload.extend_from_slice(&nonce.as_ref()[4..]);
-                payload.extend_from_chunks(&msg.payload);
+        let mut explicit_nonce = [0u8; GCM_EXPLICIT_NONCE_LEN];
+        explicit_nonce.copy_from_slice(&nonce.as_ref()[4..]);
 
-                match self.enc_key.seal_in_place_separate_tag(
-                    nonce,
-                    aad,
-                    &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..],
-                ) {
-                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-                    Err(_) => return Err(Error::EncryptError),
-                }
-
-                payload.into_written()
-            }
-        };
+        let payload = seal_record(
+            &mut self.enc_key,
+            nonce,
+            aad,
+            &msg.payload,
+            Framing::UnencryptedPrefix(&explicit_nonce),
+            total_len,
+            out,
+        )?;
 
         Ok(EncodedMessage {
             typ: msg.typ,
@@ -387,7 +369,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
 /// This implementation does the AAD construction required in TLS1.2.
 /// TLS1.3 uses `Tls13MessageEncrypter`.
 struct ChaCha20Poly1305MessageEncrypter {
-    enc_key: aead::LessSafeKey,
+    enc_key: SealKey,
     enc_offset: Iv,
 }
 
@@ -451,34 +433,15 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
             aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(seq, msg.typ, msg.version, msg.payload.len()));
 
-        let payload = match msg.payload.single_chunk() {
-            // Contiguous plaintext is sealed out-of-place, straight from the
-            // borrowed input.
-            Some(plain) => {
-                let record = record_region(out, total_len)?;
-                let (ciphertext, tag) = record.split_at_mut(plain.len());
-                self.enc_key
-                    .seal_out_of_place_scatter(nonce, aad, plain, ciphertext, &[], tag)
-                    .map_err(|_| Error::EncryptError)?;
-                &*record
-            }
-            // Fragmented plaintext is gathered into `out` and then sealed in place.
-            // We can't use the out-of-place seal as it requires contiguous input.
-            None => {
-                let mut payload = EncryptBuffer::new(out, total_len)?;
-                payload.extend_from_chunks(&msg.payload);
-
-                match self
-                    .enc_key
-                    .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-                {
-                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-                    Err(_) => return Err(Error::EncryptError),
-                }
-
-                payload.into_written()
-            }
-        };
+        let payload = seal_record(
+            &mut self.enc_key,
+            nonce,
+            aad,
+            &msg.payload,
+            Framing::None,
+            total_len,
+            out,
+        )?;
 
         Ok(EncodedMessage {
             typ: msg.typ,

--- a/rustls-aws-lc-rs/src/tls12.rs
+++ b/rustls-aws-lc-rs/src/tls12.rs
@@ -385,7 +385,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
 
 /// The RFC 7905/RFC 7539 ChaCha20Poly1305 construction.
 /// This implementation does the AAD construction required in TLS1.2.
-/// TLS1.3 uses `TLS13MessageEncrypter`.
+/// TLS1.3 uses `AeadMessageEncrypter`.
 struct ChaCha20Poly1305MessageEncrypter {
     enc_key: aead::LessSafeKey,
     enc_offset: Iv,
@@ -393,7 +393,7 @@ struct ChaCha20Poly1305MessageEncrypter {
 
 /// The RFC 7905/RFC 7539 ChaCha20Poly1305 construction.
 /// This implementation does the AAD construction required in TLS1.2.
-/// TLS1.3 uses `TLS13MessageDecrypter`.
+/// TLS1.3 uses `AeadMessageDecrypter`.
 struct ChaCha20Poly1305MessageDecrypter {
     dec_key: aead::LessSafeKey,
     dec_offset: Iv,

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -233,11 +233,6 @@ struct AeadMessageEncrypter {
     iv: Iv,
 }
 
-struct AeadMessageDecrypter {
-    dec_key: aead::LessSafeKey,
-    iv: Iv,
-}
-
 impl MessageEncrypter for AeadMessageEncrypter {
     fn encrypt<'a>(
         &mut self,
@@ -298,6 +293,11 @@ impl MessageEncrypter for AeadMessageEncrypter {
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
         payload_len + 1 + self.enc_key.algorithm().tag_len()
     }
+}
+
+struct AeadMessageDecrypter {
+    dec_key: aead::LessSafeKey,
+    iv: Iv,
 }
 
 impl MessageDecrypter for AeadMessageDecrypter {

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -5,8 +5,8 @@ use aws_lc_rs::hkdf::KeyType;
 use aws_lc_rs::{aead, hkdf, hmac};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter,
-    Nonce, OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
+    AeadKey, EncodedMessage, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter, Nonce,
+    OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
 };
 use rustls::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use rustls::crypto::{self, CipherSuite};
@@ -15,7 +15,7 @@ use rustls::error::Error;
 use rustls::version::TLS13_VERSION;
 use rustls::{CipherSuiteCommon, ConnectionTrafficSecrets, Tls13CipherSuite};
 
-use crate::{SealKey, record_region};
+use crate::{Framing, SealKey, seal_record};
 
 /// The TLS1.3 cipher suite configuration that an application should use by default.
 ///
@@ -248,42 +248,15 @@ impl MessageEncrypter for Tls13MessageEncrypter {
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(typ, TLS13_LEGACY_RECORD_VERSION, total_len));
 
-        let payload = match msg.payload.single_chunk() {
-            // Contiguous plaintext is sealed out-of-place, straight from the borrowed
-            // input and the inner content type byte is specified as `extra_in`.
-            Some(plain) => {
-                let record = record_region(out, total_len)?;
-                let (ciphertext, typ_and_tag) = record.split_at_mut(plain.len());
-                self.enc_key
-                    .seal_out_of_place_scatter(
-                        nonce,
-                        aad,
-                        plain,
-                        ciphertext,
-                        &msg.typ.to_array(),
-                        typ_and_tag,
-                    )
-                    .map_err(|_| Error::EncryptError)?;
-                &*record
-            }
-            // Fragmented plaintext is gathered into `out` and then sealed in place.
-            // We can't use the out-of-place seal as it requires contiguous input.
-            None => {
-                let mut payload = EncryptBuffer::new(out, total_len)?;
-                payload.extend_from_chunks(&msg.payload);
-                payload.extend_from_slice(&msg.typ.to_array());
-
-                match self
-                    .enc_key
-                    .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-                {
-                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-                    Err(_) => return Err(Error::EncryptError),
-                }
-
-                payload.into_written()
-            }
-        };
+        let payload = seal_record(
+            &mut self.enc_key,
+            nonce,
+            aad,
+            &msg.payload,
+            Framing::EncryptedTail(&msg.typ.to_array()),
+            total_len,
+            out,
+        )?;
 
         Ok(EncodedMessage {
             typ,

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -391,10 +391,6 @@ impl MessageEncrypter for GcmMessageEncrypter {
     }
 }
 
-// Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
-// protocol version, see https://www.rfc-editor.org/rfc/rfc9846#section-5.1
-const TLS13_LEGACY_RECORD_VERSION: ProtocolVersion = ProtocolVersion::TLSv1_2;
-
 struct GcmMessageDecrypter {
     dec_key: aead::TlsRecordOpeningKey,
     iv: Iv,
@@ -502,6 +498,10 @@ impl KeyType for Len {
         self.0
     }
 }
+
+// Note: all TLS 1.3 application data records use TLSv1_2 (0x0303) as the legacy record
+// protocol version, see https://www.rfc-editor.org/rfc/rfc9846#section-5.1
+const TLS13_LEGACY_RECORD_VERSION: ProtocolVersion = ProtocolVersion::TLSv1_2;
 
 #[cfg(test)]
 mod tests {

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 
+use aws_lc_rs::error::Unspecified;
 use aws_lc_rs::hkdf::KeyType;
 use aws_lc_rs::{aead, hkdf, hmac};
 use pki_types::FipsStatus;
@@ -100,16 +101,20 @@ struct Chacha20Poly1305Aead(AeadAlgorithm);
 impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
     fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
         // safety: the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
-        Box::new(AeadMessageEncrypter {
-            enc_key: aead::LessSafeKey::new(aead::UnboundKey::new(self.0.0, key.as_ref()).unwrap()),
+        Box::new(Tls13MessageEncrypter {
+            enc_key: SealKey::LessSafe(aead::LessSafeKey::new(
+                aead::UnboundKey::new(self.0.0, key.as_ref()).unwrap(),
+            )),
             iv,
         })
     }
 
     fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
         // safety: the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
-        Box::new(AeadMessageDecrypter {
-            dec_key: aead::LessSafeKey::new(aead::UnboundKey::new(self.0.0, key.as_ref()).unwrap()),
+        Box::new(Tls13MessageDecrypter {
+            dec_key: OpenKey::LessSafe(aead::LessSafeKey::new(
+                aead::UnboundKey::new(self.0.0, key.as_ref()).unwrap(),
+            )),
             iv,
         })
     }
@@ -196,13 +201,11 @@ impl AeadAlgorithm {
         // safety:
         // - the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
         // - this function should only be used for `Algorithm::AES_128_GCM` or `Algorithm::AES_256_GCM`
-        Box::new(GcmMessageEncrypter {
-            enc_key: aead::TlsRecordSealingKey::new(
-                self.0,
-                aead::TlsProtocolId::TLS13,
-                key.as_ref(),
-            )
-            .unwrap(),
+        Box::new(Tls13MessageEncrypter {
+            enc_key: SealKey::TlsRecord(
+                aead::TlsRecordSealingKey::new(self.0, aead::TlsProtocolId::TLS13, key.as_ref())
+                    .unwrap(),
+            ),
             iv,
         })
     }
@@ -212,13 +215,11 @@ impl AeadAlgorithm {
         // safety:
         // - the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
         // - this function should only be used for `Algorithm::AES_128_GCM` or `Algorithm::AES_256_GCM`
-        Box::new(GcmMessageDecrypter {
-            dec_key: aead::TlsRecordOpeningKey::new(
-                self.0,
-                aead::TlsProtocolId::TLS13,
-                key.as_ref(),
-            )
-            .unwrap(),
+        Box::new(Tls13MessageDecrypter {
+            dec_key: OpenKey::TlsRecord(
+                aead::TlsRecordOpeningKey::new(self.0, aead::TlsProtocolId::TLS13, key.as_ref())
+                    .unwrap(),
+            ),
             iv,
         })
     }
@@ -228,12 +229,13 @@ impl AeadAlgorithm {
     }
 }
 
-struct AeadMessageEncrypter {
-    enc_key: aead::LessSafeKey,
+/// A `MessageEncrypter` for all of this provider's TLS1.3 AEAD ciphersuites.
+struct Tls13MessageEncrypter {
+    enc_key: SealKey,
     iv: Iv,
 }
 
-impl MessageEncrypter for AeadMessageEncrypter {
+impl MessageEncrypter for Tls13MessageEncrypter {
     fn encrypt<'a>(
         &mut self,
         msg: EncodedMessage<OutboundPlain<'_>>,
@@ -295,12 +297,13 @@ impl MessageEncrypter for AeadMessageEncrypter {
     }
 }
 
-struct AeadMessageDecrypter {
-    dec_key: aead::LessSafeKey,
+/// A `MessageDecrypter` for all of this provider's TLS1.3 AEAD ciphersuites.
+struct Tls13MessageDecrypter {
+    dec_key: OpenKey,
     iv: Iv,
 }
 
-impl MessageDecrypter for AeadMessageDecrypter {
+impl MessageDecrypter for Tls13MessageDecrypter {
     fn decrypt<'a>(
         &mut self,
         mut msg: EncodedMessage<InboundOpaque<'a>>,
@@ -324,99 +327,86 @@ impl MessageDecrypter for AeadMessageDecrypter {
     }
 }
 
-struct GcmMessageEncrypter {
-    enc_key: aead::TlsRecordSealingKey,
-    iv: Iv,
+/// A TLS1.3 sealing key, dispatching to whichever aws-lc-rs key type backs it.
+enum SealKey {
+    LessSafe(aead::LessSafeKey),
+    TlsRecord(aead::TlsRecordSealingKey),
 }
 
-impl MessageEncrypter for GcmMessageEncrypter {
-    fn encrypt<'a>(
+impl SealKey {
+    fn seal_out_of_place_scatter<A: AsRef<[u8]>>(
         &mut self,
-        msg: EncodedMessage<OutboundPlain<'_>>,
-        seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let total_len = self.encrypted_payload_len(msg.payload.len());
-
-        let typ = ContentType::ApplicationData;
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
-        let aad = aead::Aad::from(make_tls13_aad(typ, TLS13_LEGACY_RECORD_VERSION, total_len));
-
-        let payload = match msg.payload.single_chunk() {
-            // Contiguous plaintext is sealed out-of-place, straight from the borrowed
-            // input and the inner content type byte is specified as `extra_in`.
-            Some(plain) => {
-                let record = record_region(out, total_len)?;
-                let (ciphertext, typ_and_tag) = record.split_at_mut(plain.len());
-                self.enc_key
-                    .seal_out_of_place_scatter(
-                        nonce,
-                        aad,
-                        plain,
-                        ciphertext,
-                        &msg.typ.to_array(),
-                        typ_and_tag,
-                    )
-                    .map_err(|_| Error::EncryptError)?;
-                &*record
-            }
-            // Fragmented plaintext is gathered into `out` and then sealed in place.
-            // We can't use the out-of-place seal as it requires contiguous input.
-            None => {
-                let mut payload = EncryptBuffer::new(out, total_len)?;
-                payload.extend_from_chunks(&msg.payload);
-                payload.extend_from_slice(&msg.typ.to_array());
-
-                match self
-                    .enc_key
-                    .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-                {
-                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-                    Err(_) => return Err(Error::EncryptError),
-                }
-
-                payload.into_written()
-            }
-        };
-
-        Ok(EncodedMessage {
-            typ,
-            version: TLS13_LEGACY_RECORD_VERSION,
-            payload,
-        })
-    }
-
-    fn encrypted_payload_len(&self, payload_len: usize) -> usize {
-        payload_len + 1 + self.enc_key.algorithm().tag_len()
-    }
-}
-
-struct GcmMessageDecrypter {
-    dec_key: aead::TlsRecordOpeningKey,
-    iv: Iv,
-}
-
-impl MessageDecrypter for GcmMessageDecrypter {
-    fn decrypt<'a>(
-        &mut self,
-        mut msg: EncodedMessage<InboundOpaque<'a>>,
-        seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &mut msg.payload;
-        if payload.len() < self.dec_key.algorithm().tag_len() {
-            return Err(Error::DecryptError);
+        nonce: aead::Nonce,
+        aad: aead::Aad<A>,
+        in_plaintext: &[u8],
+        out_ciphertext: &mut [u8],
+        extra_in: &[u8],
+        extra_out_and_tag: &mut [u8],
+    ) -> Result<(), Unspecified> {
+        match self {
+            Self::LessSafe(key) => key.seal_out_of_place_scatter(
+                nonce,
+                aad,
+                in_plaintext,
+                out_ciphertext,
+                extra_in,
+                extra_out_and_tag,
+            ),
+            Self::TlsRecord(key) => key.seal_out_of_place_scatter(
+                nonce,
+                aad,
+                in_plaintext,
+                out_ciphertext,
+                extra_in,
+                extra_out_and_tag,
+            ),
         }
+    }
 
-        let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
-        let aad = aead::Aad::from(make_tls13_aad(msg.typ, msg.version, payload.len()));
-        let plain_len = self
-            .dec_key
-            .open_in_place(nonce, aad, payload)
-            .map_err(|_| Error::DecryptError)?
-            .len();
+    fn seal_in_place_separate_tag<A: AsRef<[u8]>>(
+        &mut self,
+        nonce: aead::Nonce,
+        aad: aead::Aad<A>,
+        in_out: &mut [u8],
+    ) -> Result<aead::Tag, Unspecified> {
+        match self {
+            Self::LessSafe(key) => key.seal_in_place_separate_tag(nonce, aad, in_out),
+            Self::TlsRecord(key) => key.seal_in_place_separate_tag(nonce, aad, in_out),
+        }
+    }
 
-        payload.truncate(plain_len);
-        msg.into_tls13_unpadded_message()
+    fn algorithm(&self) -> &'static aead::Algorithm {
+        match self {
+            Self::LessSafe(key) => key.algorithm(),
+            Self::TlsRecord(key) => key.algorithm(),
+        }
+    }
+}
+
+/// A TLS1.3 opening key, dispatching to whichever aws-lc-rs key type backs it.
+enum OpenKey {
+    LessSafe(aead::LessSafeKey),
+    TlsRecord(aead::TlsRecordOpeningKey),
+}
+
+impl OpenKey {
+    fn open_in_place<'io, A: AsRef<[u8]>>(
+        &self,
+        nonce: aead::Nonce,
+        aad: aead::Aad<A>,
+        in_out: &'io mut [u8],
+    ) -> Result<&'io mut [u8], Unspecified> {
+        match self {
+            Self::LessSafe(key) => key.open_in_place(nonce, aad, in_out),
+            Self::TlsRecord(key) => key.open_in_place(nonce, aad, in_out),
+        }
+    }
+
+    fn algorithm(&self) -> &'static aead::Algorithm {
+        match self {
+            Self::LessSafe(key) => key.algorithm(),
+            Self::TlsRecord(key) => key.algorithm(),
+        }
     }
 }
 

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -15,7 +15,7 @@ use rustls::error::Error;
 use rustls::version::TLS13_VERSION;
 use rustls::{CipherSuiteCommon, ConnectionTrafficSecrets, Tls13CipherSuite};
 
-use crate::record_region;
+use crate::{SealKey, record_region};
 
 /// The TLS1.3 cipher suite configuration that an application should use by default.
 ///
@@ -324,62 +324,6 @@ impl MessageDecrypter for Tls13MessageDecrypter {
 
         payload.truncate(plain_len);
         msg.into_tls13_unpadded_message()
-    }
-}
-
-/// A TLS1.3 sealing key, dispatching to whichever aws-lc-rs key type backs it.
-enum SealKey {
-    LessSafe(aead::LessSafeKey),
-    TlsRecord(aead::TlsRecordSealingKey),
-}
-
-impl SealKey {
-    fn seal_out_of_place_scatter<A: AsRef<[u8]>>(
-        &mut self,
-        nonce: aead::Nonce,
-        aad: aead::Aad<A>,
-        in_plaintext: &[u8],
-        out_ciphertext: &mut [u8],
-        extra_in: &[u8],
-        extra_out_and_tag: &mut [u8],
-    ) -> Result<(), Unspecified> {
-        match self {
-            Self::LessSafe(key) => key.seal_out_of_place_scatter(
-                nonce,
-                aad,
-                in_plaintext,
-                out_ciphertext,
-                extra_in,
-                extra_out_and_tag,
-            ),
-            Self::TlsRecord(key) => key.seal_out_of_place_scatter(
-                nonce,
-                aad,
-                in_plaintext,
-                out_ciphertext,
-                extra_in,
-                extra_out_and_tag,
-            ),
-        }
-    }
-
-    fn seal_in_place_separate_tag<A: AsRef<[u8]>>(
-        &mut self,
-        nonce: aead::Nonce,
-        aad: aead::Aad<A>,
-        in_out: &mut [u8],
-    ) -> Result<aead::Tag, Unspecified> {
-        match self {
-            Self::LessSafe(key) => key.seal_in_place_separate_tag(nonce, aad, in_out),
-            Self::TlsRecord(key) => key.seal_in_place_separate_tag(nonce, aad, in_out),
-        }
-    }
-
-    fn algorithm(&self) -> &'static aead::Algorithm {
-        match self {
-            Self::LessSafe(key) => key.algorithm(),
-            Self::TlsRecord(key) => key.algorithm(),
-        }
     }
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/rustls/rustls/pull/3203 trying to dedupe/tighten up some of the `aws-lc-rs` provider code. I think it might also be helpful as a partial step towards something like https://github.com/rustls/rustls/issues/3109. I'm sort of imagining next steps involving lifting some of the `seal_record()` & `Framing` bits into something that's broader than a single provider. Happy to take that on next if folks are interested.