### PR TITLE
Account for encryption overhead in `max_fragment_size` fragmentation

### DIFF
--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -142,6 +142,7 @@
 
 #ifdef RING
     "*-ECDSA_P521_SHA512-*": "no p521 signatures/verification",
+    "MaxSendFragment-TLS13-TooLarge": "due to no ML-KEM, and thanks to an impedance mismatch between the OpenSSL API that bogo tests, this test can't pass",
 #endif
 
 #if defined(AWS_LC_RS) && defined(FIPS)

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -783,7 +783,8 @@ impl Options {
             }
             "-max-send-fragment" => {
                 let max_fragment = args.remove(0).parse::<usize>().unwrap();
-                self.max_fragment = Some(max_fragment + 5); // ours includes header
+                // ours includes header and overhead, OpenSSL includes neither.
+                self.max_fragment = Some(max_fragment + 5);
             }
             "-read-size" => {
                 let rdsz = args.remove(0).parse::<usize>().unwrap();

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1840,7 +1840,6 @@ fn test_server_mtu_reduction() {
     let mut server_input = VecInput::default();
 
     let big_data = [0u8; 2048];
-    let encryption_overhead = 20; // FIXME: see issue #991
 
     transfer(&mut client_output, &mut server_input);
     server
@@ -1854,7 +1853,7 @@ fn test_server_mtu_reduction() {
         .write_tls((&big_data).into(), &mut server_output)
         .unwrap();
     for length in message_lengths(&server_output) {
-        assert!(length <= 64 + encryption_overhead);
+        assert!(length <= 64);
     }
     transfer(&mut server_output, &mut client_input);
 
@@ -1868,7 +1867,7 @@ fn test_server_mtu_reduction() {
         .handle_all(&mut Vec::new())
         .unwrap();
     for length in message_lengths(&server_output) {
-        assert!(length <= 64 + encryption_overhead);
+        assert!(length <= 64);
     }
     transfer(&mut server_output, &mut client_input);
 

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1806,16 +1806,13 @@ fn client_handshake_flights() {
 
 #[test]
 fn test_client_mtu_reduction() {
-    let provider = provider::DEFAULT_PROVIDER;
-    for kt in KeyType::all_for_provider(&provider) {
-        let mut client_config = make_client_config(*kt, &provider);
+    for (client_config, server_config, _) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let mut client_config = Arc::unwrap_or_clone(client_config);
         client_config.max_fragment_size = Some(64);
+
         let mut client_output = Vec::new();
-        let (_client, _server) = make_pair_for_configs(
-            client_config,
-            make_server_config(KeyType::default(), &provider),
-            &mut client_output,
-        );
+        let (_client, _server) =
+            make_pair_for_arc_configs(&Arc::new(client_config), &server_config, &mut client_output);
 
         for length in message_lengths(&client_output) {
             assert!(length <= 64);

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -1822,57 +1822,61 @@ fn test_client_mtu_reduction() {
 
 #[test]
 fn test_server_mtu_reduction() {
-    let provider = provider::DEFAULT_PROVIDER;
-    let mut server_config = make_server_config(KeyType::default(), &provider);
-    server_config.max_fragment_size = Some(64);
-    server_config.send_half_rtt_data = true;
-    let mut client_output = Vec::new();
-    let mut server_output = Vec::new();
-    let (mut client, mut server) = make_pair_for_configs(
-        make_client_config(KeyType::default(), &provider),
-        server_config,
-        &mut client_output,
-    );
-    let mut client_input = VecInput::default();
-    let mut server_input = VecInput::default();
+    for (client_config, server_config, expect) in MultiTest::new(provider::DEFAULT_PROVIDER) {
+        let mut server_config = Arc::unwrap_or_clone(server_config);
+        server_config.max_fragment_size = Some(64);
+        server_config.send_half_rtt_data = true;
 
-    let big_data = [0u8; 2048];
+        let mut client_output = Vec::new();
+        let mut server_output = Vec::new();
+        let (mut client, mut server) =
+            make_pair_for_arc_configs(&client_config, &Arc::new(server_config), &mut client_output);
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
 
-    transfer(&mut client_output, &mut server_input);
-    server
-        .process_new_packets(&mut server_input, &mut server_output)
-        .handle_all(&mut Vec::new())
-        .unwrap();
-    // The 0.5-RTT application data is delivered across the handshake flights (fragmented by
-    // the reduced MTU), so accumulate everything the client decrypts.
-    let mut received = Vec::new();
-    server
-        .write_tls((&big_data).into(), &mut server_output)
-        .unwrap();
-    for length in message_lengths(&server_output) {
-        assert!(length <= 64);
+        let big_data = [0u8; 2048];
+
+        transfer(&mut client_output, &mut server_input);
+        server
+            .process_new_packets(&mut server_input, &mut server_output)
+            .handle_all(&mut Vec::new())
+            .unwrap();
+
+        let mut received = Vec::new();
+        if expect.version == ProtocolVersion::TLSv1_3 && !expect.client_auth {
+            // The 0.5-RTT application data is delivered across the handshake flights (fragmented by
+            // the reduced MTU), so accumulate everything the client decrypts.
+            server
+                .write_tls((&big_data).into(), &mut server_output)
+                .unwrap();
+            for length in message_lengths(&server_output) {
+                assert!(length <= 64);
+            }
+            transfer(&mut server_output, &mut client_input);
+        }
+
+        client
+            .process_new_packets(&mut client_input, &mut client_output)
+            .handle_all(&mut received)
+            .unwrap();
+        transfer(&mut client_output, &mut server_input);
+        server
+            .process_new_packets(&mut server_input, &mut server_output)
+            .handle_all(&mut Vec::new())
+            .unwrap();
+        for length in message_lengths(&server_output) {
+            assert!(length <= 64);
+        }
+        transfer(&mut server_output, &mut client_input);
+
+        if expect.version == ProtocolVersion::TLSv1_3 && !expect.client_auth {
+            client
+                .process_new_packets(&mut client_input, &mut client_output)
+                .handle_all(&mut received)
+                .unwrap();
+            assert_eq!(received, big_data);
+        }
     }
-    transfer(&mut server_output, &mut client_input);
-
-    client
-        .process_new_packets(&mut client_input, &mut client_output)
-        .handle_all(&mut received)
-        .unwrap();
-    transfer(&mut client_output, &mut server_input);
-    server
-        .process_new_packets(&mut server_input, &mut server_output)
-        .handle_all(&mut Vec::new())
-        .unwrap();
-    for length in message_lengths(&server_output) {
-        assert!(length <= 64);
-    }
-    transfer(&mut server_output, &mut client_input);
-
-    client
-        .process_new_packets(&mut client_input, &mut client_output)
-        .handle_all(&mut received)
-        .unwrap();
-    assert_eq!(received, big_data);
 }
 
 fn check_client_max_fragment_size(size: usize) -> Option<Error> {

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -77,6 +77,8 @@ impl SendPath {
                 ContentType::ApplicationData,
                 ProtocolVersion::TLSv1_2,
                 payload,
+                self.encrypt_state
+                    .encrypted_record_overhead(),
             ),
             tls,
         );
@@ -232,6 +234,8 @@ impl SendOutput for SendPath {
             encoded.typ,
             encoded.version,
             encoded.payload.bytes().into(),
+            self.encrypt_state
+                .encrypted_record_overhead(),
         );
 
         match must_encrypt {

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -6,7 +6,7 @@ use crate::crypto::cipher::{
 };
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{AlertDescription, Error};
-use crate::msgs::{AlertLevel, HEADER_SIZE, Message, MessageFragmenter};
+use crate::msgs::{AlertLevel, Fragmenter, HEADER_SIZE, Message};
 use crate::tls13::key_schedule::KeyScheduleTrafficSend;
 use crate::tracing::{debug, error};
 
@@ -18,7 +18,7 @@ pub(crate) struct SendPath {
     has_sent_fatal_alert: bool,
     /// If we signaled end of stream.
     pub(crate) has_sent_close_notify: bool,
-    message_fragmenter: MessageFragmenter,
+    message_fragmenter: Fragmenter,
     key_update_local: KeyUpdateLocal,
     key_update_remote: KeyUpdateRemote,
     negotiated_version: Option<ProtocolVersion>,
@@ -249,7 +249,7 @@ impl Default for SendPath {
             may_send_half_rtt_data: false,
             has_sent_fatal_alert: false,
             has_sent_close_notify: false,
-            message_fragmenter: MessageFragmenter::default(),
+            message_fragmenter: Fragmenter::default(),
             key_update_local: KeyUpdateLocal::Idle,
             key_update_remote: KeyUpdateRemote::Idle,
             negotiated_version: None,

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -73,12 +73,11 @@ impl SendPath {
     ) -> usize {
         let len = payload.len();
         self.send_messages::<true>(
-            self.message_fragmenter
-                .fragment_payload(
-                    ContentType::ApplicationData,
-                    ProtocolVersion::TLSv1_2,
-                    payload,
-                ),
+            self.message_fragmenter.fragment(
+                ContentType::ApplicationData,
+                ProtocolVersion::TLSv1_2,
+                payload,
+            ),
             tls,
         );
         self.maybe_refresh_traffic_keys(tls);
@@ -229,9 +228,11 @@ impl SendOutput for SendPath {
     /// Send a raw TLS message, fragmenting it if needed.
     fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool, tls: &mut Vec<u8>) {
         let encoded = EncodedMessage::from(m);
-        let fragments = self
-            .message_fragmenter
-            .fragment_message(&encoded);
+        let fragments = self.message_fragmenter.fragment(
+            encoded.typ,
+            encoded.version,
+            encoded.payload.bytes().into(),
+        );
 
         match must_encrypt {
             true => self.send_messages::<true>(fragments, tls),

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -91,7 +91,7 @@ impl<'a> EncodedMessage<InboundOpaque<'a>> {
             return Err(PeerMisbehaved::IllegalTls13ContentType.into());
         }
 
-        if payload.len() > MAX_FRAGMENT_LEN + 1 {
+        if payload.len() > MAX_FRAGMENT_LEN.get() + 1 {
             return Err(Error::PeerSentOversizedRecord);
         }
 
@@ -100,7 +100,7 @@ impl<'a> EncodedMessage<InboundOpaque<'a>> {
             return Err(PeerMisbehaved::IllegalTlsInnerPlaintext.into());
         }
 
-        if payload.len() > MAX_FRAGMENT_LEN {
+        if payload.len() > MAX_FRAGMENT_LEN.get() {
             return Err(Error::PeerSentOversizedRecord);
         }
 

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -178,8 +178,13 @@ pub trait MessageEncrypter: Send + Sync {
         out: &'a mut [u8],
     ) -> Result<EncodedMessage<&'a [u8]>, Error>;
 
-    /// Return the length of the ciphertext that results from encrypting plaintext of
-    /// length `payload_len`
+    /// Return the length of the ciphertext that results from encrypting plaintext of length `payload_len`.
+    ///
+    /// For a zero `payload_len` this should return the _minimum_ overhead for any
+    /// message.  Then, to fragment a long message into chunks of length `F`,
+    /// Rustls will first set `A := encrypted_payload_len(0)` and then supply the
+    /// message to [`Self::encrypt()`] in chunks of length `F - A`.  Each `encrypt()`
+    /// is then free to pad or otherwise transform the length at its option.
     fn encrypted_payload_len(&self, payload_len: usize) -> usize;
 }
 

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -130,6 +130,11 @@ impl EncryptionState {
             .unwrap_or_default()
     }
 
+    /// Number of bytes added to a plaintext fragment by record protection.
+    pub(crate) fn encrypted_record_overhead(&self) -> usize {
+        self.encrypted_len(0)
+    }
+
     pub(crate) fn is_encrypting(&self) -> bool {
         self.message_encrypter.is_some()
     }

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use crate::crypto::cipher::{EncodedMessage, OutboundPlain, Payload};
+use crate::crypto::cipher::{EncodedMessage, OutboundPlain};
 use crate::enums::{ContentType, ProtocolVersion};
 
 pub(crate) const MAX_FRAGMENT_LEN: usize = 16384;
@@ -19,20 +19,6 @@ impl Default for MessageFragmenter {
 }
 
 impl MessageFragmenter {
-    /// Take `msg` and fragment it into new messages with the same type and version.
-    ///
-    /// Each returned message size is no more than `max_frag`.
-    ///
-    /// Return an iterator across those messages.
-    ///
-    /// Payloads are borrowed from `msg`.
-    pub(crate) fn fragment_message<'a>(
-        &self,
-        msg: &'a EncodedMessage<Payload<'_>>,
-    ) -> impl ExactSizeIterator<Item = EncodedMessage<OutboundPlain<'a>>> + 'a + use<'a> {
-        self.fragment_payload(msg.typ, msg.version, msg.payload.bytes().into())
-    }
-
     /// Take `payload` and fragment it into new messages with given type and version.
     ///
     /// Each returned message size is no more than `max_frag`.
@@ -40,7 +26,7 @@ impl MessageFragmenter {
     /// Return an iterator across those messages.
     ///
     /// Payloads are borrowed from `payload`.
-    pub(crate) fn fragment_payload<'a>(
+    pub(crate) fn fragment<'a>(
         &self,
         typ: ContentType,
         version: ProtocolVersion,
@@ -146,7 +132,7 @@ mod tests {
         frag.set_max_fragment_size(Some(32))
             .unwrap();
         let q = frag
-            .fragment_message(&m)
+            .fragment(m.typ, m.version, m.payload.bytes().into())
             .collect::<Vec<_>>();
         assert_eq!(q.len(), 3);
         msg_eq(
@@ -190,7 +176,7 @@ mod tests {
         frag.set_max_fragment_size(Some(32))
             .unwrap();
         let q = frag
-            .fragment_message(&m)
+            .fragment(m.typ, m.version, m.payload.bytes().into())
             .collect::<Vec<_>>();
         assert_eq!(q.len(), 1);
         msg_eq(
@@ -213,7 +199,7 @@ mod tests {
             .unwrap();
 
         let fragments = frag
-            .fragment_payload(typ, version, borrowed_payload)
+            .fragment(typ, version, borrowed_payload)
             .collect::<Vec<_>>();
         assert_eq!(fragments.len(), 3);
         msg_eq(

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -1,13 +1,15 @@
+use core::num::NonZeroUsize;
+
 use crate::Error;
 use crate::crypto::cipher::{EncodedMessage, OutboundPlain};
 use crate::enums::{ContentType, ProtocolVersion};
 
-pub(crate) const MAX_FRAGMENT_LEN: usize = 16384;
+pub(crate) const MAX_FRAGMENT_LEN: NonZeroUsize = NonZeroUsize::new(16384).unwrap();
 pub(crate) const PACKET_OVERHEAD: usize = 1 + 2 + 2;
-pub(crate) const MAX_FRAGMENT_SIZE: usize = MAX_FRAGMENT_LEN + PACKET_OVERHEAD;
+pub(crate) const MAX_FRAGMENT_SIZE: usize = MAX_FRAGMENT_LEN.get() + PACKET_OVERHEAD;
 
 pub(crate) struct Fragmenter {
-    max_frag: usize,
+    max_frag: NonZeroUsize,
 }
 
 impl Fragmenter {
@@ -44,7 +46,7 @@ impl Fragmenter {
         max_fragment_size: Option<usize>,
     ) -> Result<(), Error> {
         self.max_frag = match max_fragment_size {
-            Some(sz @ 32..=MAX_FRAGMENT_SIZE) => sz - PACKET_OVERHEAD,
+            Some(sz @ 32..=MAX_FRAGMENT_SIZE) => NonZeroUsize::new(sz - PACKET_OVERHEAD).unwrap(),
             None => MAX_FRAGMENT_LEN,
             _ => return Err(Error::BadMaxFragmentSize),
         };
@@ -63,11 +65,11 @@ impl Default for Fragmenter {
 /// An iterator over borrowed fragments of a payload
 struct Chunker<'a> {
     payload: OutboundPlain<'a>,
-    limit: usize,
+    limit: NonZeroUsize,
 }
 
 impl<'a> Chunker<'a> {
-    fn new(payload: OutboundPlain<'a>, limit: usize) -> Self {
+    fn new(payload: OutboundPlain<'a>, limit: NonZeroUsize) -> Self {
         Self { payload, limit }
     }
 }
@@ -80,7 +82,7 @@ impl<'a> Iterator for Chunker<'a> {
             return None;
         }
 
-        let (before, after) = self.payload.split_at(self.limit);
+        let (before, after) = self.payload.split_at(self.limit.get());
         self.payload = after;
         Some(before)
     }
@@ -88,7 +90,9 @@ impl<'a> Iterator for Chunker<'a> {
 
 impl ExactSizeIterator for Chunker<'_> {
     fn len(&self) -> usize {
-        self.payload.len().div_ceil(self.limit)
+        self.payload
+            .len()
+            .div_ceil(self.limit.get())
     }
 }
 

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -6,19 +6,11 @@ pub(crate) const MAX_FRAGMENT_LEN: usize = 16384;
 pub(crate) const PACKET_OVERHEAD: usize = 1 + 2 + 2;
 pub(crate) const MAX_FRAGMENT_SIZE: usize = MAX_FRAGMENT_LEN + PACKET_OVERHEAD;
 
-pub(crate) struct MessageFragmenter {
+pub(crate) struct Fragmenter {
     max_frag: usize,
 }
 
-impl Default for MessageFragmenter {
-    fn default() -> Self {
-        Self {
-            max_frag: MAX_FRAGMENT_LEN,
-        }
-    }
-}
-
-impl MessageFragmenter {
+impl Fragmenter {
     /// Take `payload` and fragment it into new messages with given type and version.
     ///
     /// Each returned message size is no more than `max_frag`.
@@ -60,6 +52,14 @@ impl MessageFragmenter {
     }
 }
 
+impl Default for Fragmenter {
+    fn default() -> Self {
+        Self {
+            max_frag: MAX_FRAGMENT_LEN,
+        }
+    }
+}
+
 /// An iterator over borrowed fragments of a payload
 struct Chunker<'a> {
     payload: OutboundPlain<'a>,
@@ -97,7 +97,7 @@ mod tests {
     use alloc::vec::Vec;
     use std::vec;
 
-    use super::{MessageFragmenter, PACKET_OVERHEAD};
+    use super::{Fragmenter, PACKET_OVERHEAD};
     use crate::crypto::cipher::{EncodedMessage, OutboundPlain, Payload};
     use crate::enums::{ContentType, ProtocolVersion};
 
@@ -128,7 +128,7 @@ mod tests {
             payload: Payload::new(data),
         };
 
-        let mut frag = MessageFragmenter::default();
+        let mut frag = Fragmenter::default();
         frag.set_max_fragment_size(Some(32))
             .unwrap();
         let q = frag
@@ -172,7 +172,7 @@ mod tests {
             payload: Payload::new(b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec()),
         };
 
-        let mut frag = MessageFragmenter::default();
+        let mut frag = Fragmenter::default();
         frag.set_max_fragment_size(Some(32))
             .unwrap();
         let q = frag
@@ -194,7 +194,7 @@ mod tests {
         let version = ProtocolVersion::TLSv1_2;
         let payload_owner: Vec<&[u8]> = vec![&[b'a'; 8], &[b'b'; 12], &[b'c'; 32], &[b'd'; 20]];
         let borrowed_payload = OutboundPlain::new(&payload_owner);
-        let mut frag = MessageFragmenter::default();
+        let mut frag = Fragmenter::default();
         frag.set_max_fragment_size(Some(37)) // 32 + packet overhead
             .unwrap();
 

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -15,7 +15,9 @@ pub(crate) struct Fragmenter {
 impl Fragmenter {
     /// Take `payload` and fragment it into new messages with given type and version.
     ///
-    /// Each returned message size is no more than `max_frag`.
+    /// Each returned message size is no more than the most recently configured
+    /// `set_max_fragment_size()`, less an allowance for `encryption_overhead` which
+    /// should be zero if no encryption will be performed.
     ///
     /// Return an iterator across those messages.
     ///
@@ -25,8 +27,15 @@ impl Fragmenter {
         typ: ContentType,
         version: ProtocolVersion,
         payload: OutboundPlain<'a>,
+        encryption_overhead: usize,
     ) -> impl ExactSizeIterator<Item = EncodedMessage<OutboundPlain<'a>>> + use<'a> {
-        Chunker::new(payload, self.max_frag).map(move |payload| EncodedMessage {
+        let max_plaintext = NonZeroUsize::new(
+            self.max_frag
+                .get()
+                .saturating_sub(encryption_overhead),
+        )
+        .unwrap_or(NonZeroUsize::MIN);
+        Chunker::new(payload, max_plaintext).map(move |payload| EncodedMessage {
             typ,
             version,
             payload,
@@ -35,8 +44,9 @@ impl Fragmenter {
 
     /// Set the maximum fragment size that will be produced.
     ///
-    /// This includes overhead. A `max_fragment_size` of 10 will produce TLS fragments
-    /// up to 10 bytes long.
+    /// This is the maximum size of each TLS record on the wire, including the
+    /// five-byte record header. When records are encrypted, plaintext is fragmented
+    /// more aggressively so the protected record still fits in this limit.
     ///
     /// A `max_fragment_size` of `None` sets the highest allowable fragment size.
     ///
@@ -136,7 +146,7 @@ mod tests {
         frag.set_max_fragment_size(Some(32))
             .unwrap();
         let q = frag
-            .fragment(m.typ, m.version, m.payload.bytes().into())
+            .fragment(m.typ, m.version, m.payload.bytes().into(), 0)
             .collect::<Vec<_>>();
         assert_eq!(q.len(), 3);
         msg_eq(
@@ -180,7 +190,7 @@ mod tests {
         frag.set_max_fragment_size(Some(32))
             .unwrap();
         let q = frag
-            .fragment(m.typ, m.version, m.payload.bytes().into())
+            .fragment(m.typ, m.version, m.payload.bytes().into(), 0)
             .collect::<Vec<_>>();
         assert_eq!(q.len(), 1);
         msg_eq(
@@ -203,7 +213,7 @@ mod tests {
             .unwrap();
 
         let fragments = frag
-            .fragment(typ, version, borrowed_payload)
+            .fragment(typ, version, borrowed_payload, 0)
             .collect::<Vec<_>>();
         assert_eq!(fragments.len(), 3);
         msg_eq(
@@ -221,5 +231,34 @@ mod tests {
             b"ccccccccccccccccccccdddddddddddd",
         );
         msg_eq(&fragments[2], 13, &typ, &version, b"dddddddd");
+    }
+
+    #[test]
+    fn fragment_respects_overhead() {
+        let mut frag = Fragmenter::default();
+        frag.set_max_fragment_size(Some(32))
+            .unwrap();
+
+        let p = Payload::new((0..128).collect::<Vec<u8>>());
+        let q = frag
+            .fragment(
+                ContentType::Handshake,
+                ProtocolVersion::TLSv1_2,
+                p.bytes().into(),
+                13,
+            )
+            .collect::<Vec<_>>();
+
+        let each_len = 32 - PACKET_OVERHEAD - 13;
+
+        let mut expect = vec![each_len; 128usize.div_euclid(each_len)];
+        expect.push(128usize.rem_euclid(each_len));
+
+        assert_eq!(
+            q.iter()
+                .map(|m| m.payload.len())
+                .collect::<Vec<usize>>(),
+            expect
+        );
     }
 }

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -110,7 +110,7 @@ pub mod fuzzing {
         let mut frg = Fragmenter::default();
         frg.set_max_fragment_size(Some(32))
             .unwrap();
-        for msg in frg.fragment(msg.typ, msg.version, msg.payload.bytes().into()) {
+        for msg in frg.fragment(msg.typ, msg.version, msg.payload.bytes().into(), 0) {
             Message::try_from(&EncodedMessage {
                 typ: msg.typ,
                 version: msg.version,

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -69,7 +69,7 @@ pub(crate) use enums::{
 };
 
 mod fragmenter;
-pub(crate) use fragmenter::{MAX_FRAGMENT_LEN, MessageFragmenter};
+pub(crate) use fragmenter::{Fragmenter, MAX_FRAGMENT_LEN};
 
 #[macro_use]
 mod handshake;
@@ -98,7 +98,7 @@ mod handshake_test;
 
 pub mod fuzzing {
     pub use super::deframer::fuzz_deframer;
-    use super::{Codec, EncodedMessage, Message, MessageFragmenter, Payload, Reader};
+    use super::{Codec, EncodedMessage, Fragmenter, Message, Payload, Reader};
     use crate::server::ServerSessionValue;
 
     pub fn fuzz_fragmenter(data: &[u8]) {
@@ -107,7 +107,7 @@ pub mod fuzzing {
             return;
         };
 
-        let mut frg = MessageFragmenter::default();
+        let mut frg = Fragmenter::default();
         frg.set_max_fragment_size(Some(32))
             .unwrap();
         for msg in frg.fragment(msg.typ, msg.version, msg.payload.bytes().into()) {

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -107,14 +107,10 @@ pub mod fuzzing {
             return;
         };
 
-        let Ok(msg) = Message::try_from(&msg) else {
-            return;
-        };
-
         let mut frg = MessageFragmenter::default();
         frg.set_max_fragment_size(Some(32))
             .unwrap();
-        for msg in frg.fragment_message(&EncodedMessage::<Payload<'_>>::from(msg)) {
+        for msg in frg.fragment(msg.typ, msg.version, msg.payload.bytes().into()) {
             Message::try_from(&EncodedMessage {
                 typ: msg.typ,
                 version: msg.version,


### PR DESCRIPTION
This takes #3141 forward, and simplifies it significantly.

fixes #3141 fixes #991