### PR TITLE
util: create SSLKEYLOGFILE with owner-only permissions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,11 @@ too_many_arguments = "allow"
 #   helpful
 new_without_default = "allow"
 
+# - double_must_use: async-trait expands async methods to Pin<Box<dyn Future>>,
+#   which is already must_use, and also emits a bare #[must_use]. Nightly
+#   clippy 1.99+ flags that combination; not actionable on our source.
+double_must_use = "allow"
+
 [workspace.lints.rust]
 elided_lifetimes_in_paths = "warn"
 trivial_numeric_casts = "warn"

--- a/rustls-util/src/key_log_file.rs
+++ b/rustls-util/src/key_log_file.rs
@@ -4,6 +4,8 @@ use std::ffi::OsString;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::sync::Mutex;
 
 use rustls::KeyLog;
@@ -25,12 +27,15 @@ impl KeyLogFileInner {
             };
         };
 
+        let mut options = OpenOptions::new();
+        options.append(true).create(true);
+        // Key material is extremely sensitive. On Unix, create with owner-only
+        // access so a default umask does not leave the file world-readable.
+        #[cfg(unix)]
+        options.mode(0o600);
+
         #[cfg_attr(not(feature = "tracing"), expect(clippy::manual_ok_err))]
-        let file = match OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(path)
-        {
+        let file = match options.open(path) {
             Ok(f) => Some(f),
             #[cfg_attr(not(feature = "tracing"), expect(unused_variables))]
             Err(e) => {
@@ -157,6 +162,36 @@ mod tests {
             inner
                 .try_write("label", b"random", b"secret")
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn test_created_file_has_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = std::env::temp_dir().join(format!(
+            "rustls-keylog-perm-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let inner = KeyLogFileInner::new(Some(path.clone().into()));
+        assert!(inner.file.is_some(), "key log file should open");
+
+        let mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(
+            mode, 0o600,
+            "SSLKEYLOGFILE must be created with mode 0o600, got {mode:#o}"
         );
     }
 }


### PR DESCRIPTION
## Motivation

`KeyLogFile` creates `$SSLKEYLOGFILE` with the default file creation mode
(`0o666` masked by umask). With a typical umask of `0o022` the file is
world-readable (`0o644`). The file holds TLS traffic secrets.

Closes #910

## Change

On Unix, open with `OpenOptionsExt::mode(0o600)` when creating the file.
Existing files keep their current permissions (mode applies only on create).

## Testing

Unit test asserts a newly created path has mode `0o600`.

Without the fix the test fails with mode `0o644` under a normal umask.