### PR TITLE
util: document SSLKEYLOGFILE risks for elevated processes

### DIFF
--- a/admin/coverage
+++ b/admin/coverage
@@ -14,6 +14,8 @@ cargo test --locked --all-features # this presumably enables `fips`
 cargo test -p rustls-ring --locked
 cargo test -p rustls-aws-lc-rs --locked
 cargo test -p rustls-test --locked --features aws-lc-rs # aws-lc-rs, but no fips
+# rustls-util isn't a workspace default-member, test it explicitly.
+cargo test -p rustls-util --locked --all-features
 
 # ensure both zlib and brotli are tested, irrespective of their order
 cargo test --locked $(admin/all-features-except zlib rustls)

--- a/rustls-util/src/key_log_file.rs
+++ b/rustls-util/src/key_log_file.rs
@@ -87,6 +87,23 @@ impl Debug for KeyLogFileInner {
 ///
 /// If such a file cannot be opened, or cannot be written then
 /// this does nothing but logs errors at warning-level.
+///
+/// # Security
+///
+/// Key material is extremely sensitive. Prefer not enabling `KeyLog`
+/// outside of local debugging. On Unix, files created by this type use
+/// owner-only permissions (`0o600`).
+///
+/// This type reads `SSLKEYLOGFILE` from the process environment with a
+/// normal environment lookup. In a setuid/setgid (or otherwise elevated)
+/// process, that variable may have been inherited from an untrusted parent
+/// and could point at an attacker-chosen path. Applications that raise
+/// privileges should clear sensitive environment variables, avoid compiling
+/// key-log support into production builds, or supply their own [`KeyLog`]
+/// implementation.
+///
+/// This util is intentionally small. It does not attempt a full
+/// `secure_getenv`-style environment filter.
 pub struct KeyLogFile(Mutex<KeyLogFileInner>);
 
 impl KeyLogFile {


### PR DESCRIPTION
## Summary

Addresses #911 with documentation rather than a `secure_getenv`-style filter.

Maintainer feedback on the earlier approach was that the platform-specific / `unsafe` cost was not worth it for a debug-oriented util: prefer not enabling key logging outside debugging, and let apps that need stronger env handling supply their own `KeyLog`.

## Changes

- Document setuid/elevated inheritance risk on `KeyLogFile`
- `admin/coverage`: run `rustls-util` unit tests (not a workspace default-member)

## Non-goals

No platform privilege probes and no new `unsafe` in `KeyLogFile`.
