### PR TITLE
reject seq_num wraparound in hpke increment_seq_num

### DIFF
--- a/rustls-aws-lc-rs/src/hpke.rs
+++ b/rustls-aws-lc-rs/src/hpke.rs
@@ -737,7 +737,7 @@ struct KeySchedule<const KEY_SIZE: usize> {
     aead: &'static aead::Algorithm,
     key: AeadKey<KEY_SIZE>,
     base_nonce: [u8; NONCE_LEN],
-    seq_num: u32,
+    seq_num: u128,
 }
 
 impl<const KEY_SIZE: usize> KeySchedule<KEY_SIZE> {
@@ -749,12 +749,12 @@ impl<const KEY_SIZE: usize> KeySchedule<KEY_SIZE> {
         //   seq_bytes = I2OSP(seq, Nn)
         //   return xor(self.base_nonce, seq_bytes)
 
-        // Each new N-byte nonce is conceptually two parts:
-        //   * N-4 bytes of the base nonce (0s in `nonce` to XOR in as-is).
-        //   * 4 bytes derived from the sequence number XOR the base nonce.
-        let mut nonce = [0; NONCE_LEN];
+        // `increment_seq_num` bounds `seq_num` below `(1 << (8 * NONCE_LEN)) - 1`, so
+        // the upper bytes of the big-endian encoding are always zero and taking the
+        // low NONCE_LEN bytes is I2OSP(seq, Nn).
         let seq_bytes = self.seq_num.to_be_bytes();
-        nonce[NONCE_LEN - seq_bytes.len()..].copy_from_slice(&seq_bytes);
+        let mut nonce = [0; NONCE_LEN];
+        nonce.copy_from_slice(&seq_bytes[seq_bytes.len() - NONCE_LEN..]);
 
         for (n, &b) in nonce.iter_mut().zip(&self.base_nonce) {
             *n ^= b;
@@ -772,15 +772,16 @@ impl<const KEY_SIZE: usize> KeySchedule<KEY_SIZE> {
         //     raise MessageLimitReachedError
         //   self.seq += 1
 
-        // `seq_num` is a `u32`, and `compute_nonce` only mixes those four bytes into
-        // the nonce, so the usable sequence space ends at `u32::MAX` -- far below the
-        // RFC's `(1 << (8*Nn)) - 1` limit, which a `u32` can never reach. Refuse to
-        // advance past it rather than wrapping back to zero, which would recompute an
-        // already-used nonce and repeat a (key, nonce) pair.
-        self.seq_num = self
-            .seq_num
-            .checked_add(1)
-            .ok_or(aws_lc_rs::error::Unspecified)?;
+        // Determine the maximum sequence number using the AEAD nonce's length in bits.
+        let max_seq_num = (1u128 << (NONCE_LEN * 8)) - 1;
+
+        // Refuse to advance past the maximum: `compute_nonce` only encodes NONCE_LEN
+        // bytes of the counter, so going further would repeat an already-used nonce.
+        if self.seq_num >= max_seq_num {
+            return Err(aws_lc_rs::error::Unspecified);
+        }
+
+        self.seq_num += 1;
         Ok(())
     }
 }
@@ -1039,17 +1040,19 @@ mod tests {
 
     #[test]
     fn seq_num_does_not_wrap() {
-        // At the last representable sequence number the context must refuse to
-        // advance. Otherwise `seq_num` wraps back to zero and `compute_nonce`
-        // reproduces the nonce already used at seq 0, reusing a (key, nonce) pair.
+        // At the last usable sequence number the context must refuse to advance.
+        // Otherwise the counter passes `(1 << (8 * NONCE_LEN)) - 1` and
+        // `compute_nonce` reproduces the nonce already used at seq 0, reusing a
+        // (key, nonce) pair.
+        let max_seq_num = (1u128 << (NONCE_LEN * 8)) - 1;
         let mut ks = KeySchedule::<AES_128_KEY_LEN> {
             aead: &aead::AES_128_GCM,
             key: AeadKey([0u8; AES_128_KEY_LEN]),
             base_nonce: [0u8; NONCE_LEN],
-            seq_num: u32::MAX,
+            seq_num: max_seq_num,
         };
         assert!(ks.increment_seq_num().is_err());
-        assert_eq!(ks.seq_num, u32::MAX);
+        assert_eq!(ks.seq_num, max_seq_num);
     }
 }
 

--- a/rustls-aws-lc-rs/src/hpke.rs
+++ b/rustls-aws-lc-rs/src/hpke.rs
@@ -772,17 +772,15 @@ impl<const KEY_SIZE: usize> KeySchedule<KEY_SIZE> {
         //     raise MessageLimitReachedError
         //   self.seq += 1
 
-        // Determine the maximum sequence number using the AEAD nonce's length in bits.
-        // Do this as an u128 to prevent overflowing.
-        let max_seq_num = (1u128 << (NONCE_LEN * 8)) - 1;
-
-        // Promote the u32 sequence number to an u128 and compare against the maximum allowed
-        // sequence number.
-        if u128::from(self.seq_num) >= max_seq_num {
-            return Err(aws_lc_rs::error::Unspecified);
-        }
-
-        self.seq_num += 1;
+        // `seq_num` is a `u32`, and `compute_nonce` only mixes those four bytes into
+        // the nonce, so the usable sequence space ends at `u32::MAX` -- far below the
+        // RFC's `(1 << (8*Nn)) - 1` limit, which a `u32` can never reach. Refuse to
+        // advance past it rather than wrapping back to zero, which would recompute an
+        // already-used nonce and repeat a (key, nonce) pair.
+        self.seq_num = self
+            .seq_num
+            .checked_add(1)
+            .ok_or(aws_lc_rs::error::Unspecified)?;
         Ok(())
     }
 }
@@ -1037,6 +1035,21 @@ mod tests {
                 ),
             }
         }
+    }
+
+    #[test]
+    fn seq_num_does_not_wrap() {
+        // At the last representable sequence number the context must refuse to
+        // advance. Otherwise `seq_num` wraps back to zero and `compute_nonce`
+        // reproduces the nonce already used at seq 0, reusing a (key, nonce) pair.
+        let mut ks = KeySchedule::<AES_128_KEY_LEN> {
+            aead: &aead::AES_128_GCM,
+            key: AeadKey([0u8; AES_128_KEY_LEN]),
+            base_nonce: [0u8; NONCE_LEN],
+            seq_num: u32::MAX,
+        };
+        assert!(ks.increment_seq_num().is_err());
+        assert_eq!(ks.seq_num, u32::MAX);
     }
 }
 

--- a/rustls-aws-lc-rs/src/hpke.rs
+++ b/rustls-aws-lc-rs/src/hpke.rs
@@ -749,9 +749,6 @@ impl<const KEY_SIZE: usize> KeySchedule<KEY_SIZE> {
         //   seq_bytes = I2OSP(seq, Nn)
         //   return xor(self.base_nonce, seq_bytes)
 
-        // `increment_seq_num` bounds `seq_num` below `(1 << (8 * NONCE_LEN)) - 1`, so
-        // the upper bytes of the big-endian encoding are always zero and taking the
-        // low NONCE_LEN bytes is I2OSP(seq, Nn).
         let seq_bytes = self.seq_num.to_be_bytes();
         let mut nonce = [0; NONCE_LEN];
         nonce.copy_from_slice(&seq_bytes[seq_bytes.len() - NONCE_LEN..]);
@@ -775,8 +772,7 @@ impl<const KEY_SIZE: usize> KeySchedule<KEY_SIZE> {
         // Determine the maximum sequence number using the AEAD nonce's length in bits.
         let max_seq_num = (1u128 << (NONCE_LEN * 8)) - 1;
 
-        // Refuse to advance past the maximum: `compute_nonce` only encodes NONCE_LEN
-        // bytes of the counter, so going further would repeat an already-used nonce.
+        // Ensure the counter portion of the nonce does not wrap when truncated to 96-bits.
         if self.seq_num >= max_seq_num {
             return Err(aws_lc_rs::error::Unspecified);
         }
@@ -1040,10 +1036,6 @@ mod tests {
 
     #[test]
     fn seq_num_does_not_wrap() {
-        // At the last usable sequence number the context must refuse to advance.
-        // Otherwise the counter passes `(1 << (8 * NONCE_LEN)) - 1` and
-        // `compute_nonce` reproduces the nonce already used at seq 0, reusing a
-        // (key, nonce) pair.
         let max_seq_num = (1u128 << (NONCE_LEN * 8)) - 1;
         let mut ks = KeySchedule::<AES_128_KEY_LEN> {
             aead: &aead::AES_128_GCM,


### PR DESCRIPTION
`cargo test` with debug assertions on:

    thread 'hpke::tests::seq_num_does_not_wrap' panicked at
    rustls-aws-lc-rs/src/hpke.rs:785:9:
    attempt to add with overflow

`KeySchedule::increment_seq_num` bounds the nonce counter against `(1u128 << (NONCE_LEN * 8)) - 1`, i.e. 2^96-1 for a 12-byte nonce, but `seq_num` is a `u32`. `u128::from(self.seq_num)` can never reach that value, so the guard is dead and the following `self.seq_num += 1` runs unchecked. At `u32::MAX` it wraps back to 0 in release (panics in debug). `compute_nonce` only mixes those four bytes into the base nonce, so the wrapped counter recomputes the nonce already used at seq 0 and repeats a (key, nonce) pair on the same AEAD key.

The counter is driven one step per seal/open, so this is reachable through the public `HpkeSealer`/`HpkeOpener` API after 2^32 operations on a single context; ECH itself performs far fewer.

Per review feedback, the fix widens `seq_num` to `u128` so the RFC 9180 `(1 << (8*Nn)) - 1` guard is actually reachable and stays as written. `compute_nonce` takes the low `NONCE_LEN` bytes of the big-endian encoding, which is I2OSP(seq, Nn) given the bound. The regression test drives a `KeySchedule` to the limit and asserts it refuses to advance.