### PR TITLE
Expose original ClientHello bytes from Accepted

### DIFF
--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -2012,6 +2012,14 @@ fn large_client_hello_acceptor() {
     let mut state = ServerHandshake::NeedsInput(ServerHandshake::start());
     let mut input = VecInput::default();
     let hello = include_bytes!("../data/bug2227-clienthello.bin");
+    const RECORD_HEADER_LEN: usize = 5;
+    let first_record_end =
+        RECORD_HEADER_LEN + usize::from(u16::from_be_bytes([hello[3], hello[4]]));
+    let expected_hello = [
+        &hello[RECORD_HEADER_LEN..first_record_end],
+        &hello[first_record_end + RECORD_HEADER_LEN..],
+    ]
+    .concat();
     let mut cursor = io::Cursor::new(hello);
 
     loop {
@@ -2023,6 +2031,7 @@ fn large_client_hello_acceptor() {
                 .unwrap(),
             ServerHandshake::Accepted(accepted) => {
                 println!("{accepted:?}");
+                assert_eq!(accepted.client_hello_bytes(), expected_hello);
                 break;
             }
             other => panic!("unexpected {other:?}"),
@@ -2065,6 +2074,34 @@ fn acceptor_with_illegal_max_fragment_size() {
         output.is_empty(),
         "illegal max fragment size should not send an alert, as it is a local configuration issue"
     );
+}
+
+#[test]
+fn acceptor_client_hello_bytes() {
+    let hello = encoding::basic_client_hello(vec![]);
+
+    let receive = ServerHandshake::start();
+    let mut input = VecInput::default();
+    input
+        .read(
+            &mut encoding::record_framing(
+                ContentType::Handshake,
+                ProtocolVersion::TLSv1_2,
+                hello.clone(),
+            )
+            .as_slice(),
+        )
+        .unwrap();
+
+    let mut output = vec![];
+    let ServerHandshake::Accepted(accepted) = receive
+        .process(&mut input, &mut output)
+        .unwrap()
+    else {
+        panic!("unexpected receive state");
+    };
+
+    assert_eq!(accepted.client_hello_bytes(), hello);
 }
 
 #[test]

--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -242,6 +242,7 @@ fn test_quic_acceptor() {
         let mut client_initial = flatten_events(&mut client);
         assert!(client_initial.len() > 8);
         println!("client_initial: {client_initial:x?}");
+        let expected_hello = client_initial.clone();
 
         let ServerHandshake::NeedsInput(needs_input) = needs_input
             .process(&mut SliceInput::new(&mut client_initial[..8]), &mut vec![])
@@ -256,6 +257,8 @@ fn test_quic_acceptor() {
         else {
             panic!("unexpected state after full hello");
         };
+
+        assert_eq!(accepted.client_hello_bytes(), expected_hello);
 
         let client_hello = accepted.client_hello();
         assert_eq!(

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -514,6 +514,18 @@ impl Accepted {
         self.choose_config.client_hello()
     }
 
+    /// Get the raw, wire-encoded `ClientHello`, including information not exposed by
+    /// [`Accepted::client_hello()`], such as extension order and unknown extensions.
+    ///
+    /// # Warning
+    ///
+    /// External parsers may interpret the `ClientHello` differently from rustls.
+    /// Do not use externally parsed values for security-sensitive decisions that
+    /// must agree with rustls's interpretation.
+    pub fn client_hello_bytes(&self) -> &[u8] {
+        self.choose_config.client_hello_bytes()
+    }
+
     /// Choose a [`ServerConfig`] to progress the handshake.
     ///
     /// Resolves an [`Accepted`], providing the [`ServerConfig`] that should be used for

--- a/rustls/src/server/connection.rs
+++ b/rustls/src/server/connection.rs
@@ -358,6 +358,18 @@ impl Accepted {
         ch
     }
 
+    /// Get the raw, wire-encoded `ClientHello`, including information not exposed by
+    /// [`Accepted::client_hello()`], such as extension order and unknown extensions.
+    ///
+    /// # Warning
+    ///
+    /// External parsers may interpret the `ClientHello` differently from rustls.
+    /// Do not use externally parsed values for security-sensitive decisions that
+    /// must agree with rustls's interpretation.
+    pub fn client_hello_bytes(&self) -> &[u8] {
+        self.choose_config.client_hello_bytes()
+    }
+
     /// Choose a [`ServerConfig`] to progress the handshake.
     ///
     /// Output to send to the peer is appended to `output`.  Typically, this is the `ServerHello`,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -446,6 +446,14 @@ impl ChooseConfig {
             .with_input(ClientHelloInput::from_input(&self.client_hello)?, output)
     }
 
+    pub(crate) fn client_hello_bytes(&self) -> &[u8] {
+        let MessagePayload::Handshake { encoded, .. } = &self.client_hello.message.payload else {
+            unreachable!();
+        };
+
+        encoded.bytes()
+    }
+
     pub(crate) fn client_hello(&self) -> ClientHello<'_> {
         let MessagePayload::Handshake {
             parsed: HandshakeMessagePayload(HandshakePayload::ClientHello(client_hello)),


### PR DESCRIPTION
This PR exposes the original ClientHello bytes already retained for the handshake transcript through a borrowed, zero-cost getter, with no new public types.

The typed ClientHello view drops unknown extensions and extension order at parse time.  The encoded message is already retained for the transcript, so offer a borrowed view of the exact received bytes from both the TCP and QUIC acceptor states.

This makes the suggested “write your own parser” approach generally usable (#1815, #2498, quinn-rs/quinn#2644). 