### PR TITLE
Clarify naming of records and messages

### DIFF
--- a/rustls-aws-lc-rs/src/tls12.rs
+++ b/rustls-aws-lc-rs/src/tls12.rs
@@ -3,9 +3,9 @@ use alloc::boxed::Box;
 use aws_lc_rs::{aead, tls_prf};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter,
-    MessageEncrypter, NONCE_LEN, Nonce, OutboundPlain, Tls12AeadAlgorithm,
-    UnsupportedOperationError, make_tls12_aad,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
+    NONCE_LEN, Nonce, OutboundPlain, Record, Tls12AeadAlgorithm, UnsupportedOperationError,
+    make_tls12_aad,
 };
 use rustls::crypto::kx::{ActiveKeyExchange, KeyExchangeAlgorithm, SharedSecret};
 use rustls::crypto::tls12::{Prf, PrfSecret};
@@ -285,10 +285,10 @@ const GCM_OVERHEAD: usize = GCM_EXPLICIT_NONCE_LEN + 16;
 impl MessageDecrypter for GcmMessageDecrypter {
     fn decrypt<'a>(
         &mut self,
-        mut msg: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &msg.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &record.payload;
         if payload.len() < GCM_OVERHEAD {
             return Err(Error::DecryptError);
         }
@@ -302,12 +302,12 @@ impl MessageDecrypter for GcmMessageDecrypter {
 
         let aad = aead::Aad::from(make_tls12_aad(
             seq,
-            msg.typ,
-            msg.version.version(),
+            record.typ,
+            record.version.version(),
             payload.len() - GCM_OVERHEAD,
         ));
 
-        let payload = &mut msg.payload;
+        let payload = &mut record.payload;
         let plain_len = self
             .dec_key
             .open_in_place(nonce, aad, &mut payload[GCM_EXPLICIT_NONCE_LEN..])
@@ -318,21 +318,18 @@ impl MessageDecrypter for GcmMessageDecrypter {
             return Err(Error::PeerSentOversizedRecord);
         }
 
-        Ok(
-            msg.into_plain_message_range(
-                GCM_EXPLICIT_NONCE_LEN..GCM_EXPLICIT_NONCE_LEN + plain_len,
-            ),
-        )
+        Ok(record
+            .into_plain_record_range(GCM_EXPLICIT_NONCE_LEN..GCM_EXPLICIT_NONCE_LEN + plain_len))
     }
 }
 
 impl MessageEncrypter for GcmMessageEncrypter {
     fn encrypt<'a>(
         &mut self,
-        msg: EncodedMessage<OutboundPlain<'_>>,
+        msg: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
+    ) -> Result<Record<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
@@ -376,7 +373,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
             }
         };
 
-        Ok(EncodedMessage {
+        Ok(Record {
             typ: msg.typ,
             version: msg.version,
             payload,
@@ -409,10 +406,10 @@ const CHACHAPOLY1305_OVERHEAD: usize = 16;
 impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
     fn decrypt<'a>(
         &mut self,
-        mut msg: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &msg.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &record.payload;
 
         if payload.len() < CHACHAPOLY1305_OVERHEAD {
             return Err(Error::DecryptError);
@@ -423,12 +420,12 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
 
         let aad = aead::Aad::from(make_tls12_aad(
             seq,
-            msg.typ,
-            msg.version.version(),
+            record.typ,
+            record.version.version(),
             payload.len() - CHACHAPOLY1305_OVERHEAD,
         ));
 
-        let payload = &mut msg.payload;
+        let payload = &mut record.payload;
         let plain_len = self
             .dec_key
             .open_in_place(nonce, aad, payload)
@@ -440,17 +437,17 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
         }
 
         payload.truncate(plain_len);
-        Ok(msg.into_plain_message())
+        Ok(record.into_plain_record())
     }
 }
 
 impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
     fn encrypt<'a>(
         &mut self,
-        msg: EncodedMessage<OutboundPlain<'_>>,
+        msg: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
+    ) -> Result<Record<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
 
         let nonce =
@@ -491,7 +488,7 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
             }
         };
 
-        Ok(EncodedMessage {
+        Ok(Record {
             typ: msg.typ,
             version: msg.version,
             payload,
@@ -620,7 +617,7 @@ mod tests {
         for suite in ALL_TLS12_CIPHER_SUITES {
             for plain in [&b""[..], b"hello"] {
                 let mut sealed = seal(suite, OutboundPlain::from(plain), 0x00);
-                let msg = EncodedMessage::new(
+                let record = Record::new(
                     ContentType::ApplicationData,
                     EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
                     InboundOpaque(&mut sealed),
@@ -630,7 +627,7 @@ mod tests {
                     .aead_alg
                     .decrypter(test_key(shape.enc_key_len), &TEST_IV[..shape.fixed_iv_len]);
                 let opened = decrypter
-                    .decrypt(msg, TEST_SEQ)
+                    .decrypt(record, TEST_SEQ)
                     .unwrap();
                 assert_eq!(opened.payload, plain, "{:?}", suite.common.suite);
             }
@@ -644,14 +641,14 @@ mod tests {
             &TEST_IV[..shape.fixed_iv_len],
             &TEST_EXPLICIT[..shape.explicit_nonce_len],
         );
-        let msg = EncodedMessage::new(
+        let record = Record::new(
             ContentType::ApplicationData,
             EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
             payload,
         );
-        let mut out = vec![fill; encrypter.encrypted_payload_len(msg.payload.len())];
+        let mut out = vec![fill; encrypter.encrypted_payload_len(record.payload.len())];
         encrypter
-            .encrypt(msg, TEST_SEQ, &mut out)
+            .encrypt(record, TEST_SEQ, &mut out)
             .unwrap()
             .payload
             .to_vec()

--- a/rustls-aws-lc-rs/src/tls12.rs
+++ b/rustls-aws-lc-rs/src/tls12.rs
@@ -3,8 +3,8 @@ use alloc::boxed::Box;
 use aws_lc_rs::{aead, tls_prf};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
-    NONCE_LEN, Nonce, OutboundPlain, Record, Tls12AeadAlgorithm, UnsupportedOperationError,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, NONCE_LEN, Nonce, OutboundPlain,
+    Record, RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, UnsupportedOperationError,
     make_tls12_aad,
 };
 use rustls::crypto::kx::{ActiveKeyExchange, KeyExchangeAlgorithm, SharedSecret};
@@ -149,13 +149,13 @@ pub(crate) static AES256_GCM: GcmAlgorithm = GcmAlgorithm(&aead::AES_256_GCM);
 pub(crate) struct GcmAlgorithm(&'static aead::Algorithm);
 
 impl Tls12AeadAlgorithm for GcmAlgorithm {
-    fn decrypter(&self, dec_key: AeadKey, dec_iv: &[u8]) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, dec_key: AeadKey, dec_iv: &[u8]) -> Box<dyn RecordDecrypter> {
         // safety: see `encrypter()`.
         let dec_key =
             aead::TlsRecordOpeningKey::new(self.0, aead::TlsProtocolId::TLS12, dec_key.as_ref())
                 .unwrap();
 
-        let mut ret = GcmMessageDecrypter {
+        let mut ret = GcmRecordDecrypter {
             dec_key,
             dec_salt: [0u8; 4],
         };
@@ -170,7 +170,7 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
         enc_key: AeadKey,
         write_iv: &[u8],
         explicit: &[u8],
-    ) -> Box<dyn MessageEncrypter> {
+    ) -> Box<dyn RecordEncrypter> {
         // safety: `TlsRecordSealingKey::new` fails if
         // - `enc_key`'s length is wrong for `algorithm`.  But the length is defined by
         //   `algorithm.key_len()` in `key_block_shape()`, below.
@@ -187,7 +187,7 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
             aead::TlsRecordSealingKey::new(self.0, aead::TlsProtocolId::TLS13, enc_key.as_ref())
                 .unwrap();
         let iv = gcm_iv(write_iv, explicit);
-        Box::new(GcmMessageEncrypter { enc_key, iv })
+        Box::new(GcmRecordEncrypter { enc_key, iv })
     }
 
     fn key_block_shape(&self) -> KeyBlockShape {
@@ -220,21 +220,21 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
 pub(crate) struct ChaCha20Poly1305;
 
 impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
-    fn decrypter(&self, dec_key: AeadKey, iv: &[u8]) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, dec_key: AeadKey, iv: &[u8]) -> Box<dyn RecordDecrypter> {
         let dec_key = aead::LessSafeKey::new(
             aead::UnboundKey::new(&aead::CHACHA20_POLY1305, dec_key.as_ref()).unwrap(),
         );
-        Box::new(ChaCha20Poly1305MessageDecrypter {
+        Box::new(ChaCha20Poly1305RecordDecrypter {
             dec_key,
             dec_offset: Iv::new(iv).expect("IV length validated by key_block_shape"),
         })
     }
 
-    fn encrypter(&self, enc_key: AeadKey, enc_iv: &[u8], _: &[u8]) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, enc_key: AeadKey, enc_iv: &[u8], _: &[u8]) -> Box<dyn RecordEncrypter> {
         let enc_key = aead::LessSafeKey::new(
             aead::UnboundKey::new(&aead::CHACHA20_POLY1305, enc_key.as_ref()).unwrap(),
         );
-        Box::new(ChaCha20Poly1305MessageEncrypter {
+        Box::new(ChaCha20Poly1305RecordEncrypter {
             enc_key,
             enc_offset: Iv::new(enc_iv).expect("IV length validated by key_block_shape"),
         })
@@ -267,14 +267,14 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
     }
 }
 
-/// A `MessageEncrypter` for AES-GCM AEAD ciphersuites. TLS 1.2 only.
-struct GcmMessageEncrypter {
+/// A `RecordEncrypter` for AES-GCM AEAD ciphersuites. TLS 1.2 only.
+struct GcmRecordEncrypter {
     enc_key: aead::TlsRecordSealingKey,
     iv: Iv,
 }
 
-/// A `MessageDecrypter` for AES-GCM AEAD ciphersuites.  TLS1.2 only.
-struct GcmMessageDecrypter {
+/// A `RecordDecrypter` for AES-GCM AEAD ciphersuites.  TLS1.2 only.
+struct GcmRecordDecrypter {
     dec_key: aead::TlsRecordOpeningKey,
     dec_salt: [u8; 4],
 }
@@ -282,7 +282,7 @@ struct GcmMessageDecrypter {
 const GCM_EXPLICIT_NONCE_LEN: usize = 8;
 const GCM_OVERHEAD: usize = GCM_EXPLICIT_NONCE_LEN + 16;
 
-impl MessageDecrypter for GcmMessageDecrypter {
+impl RecordDecrypter for GcmRecordDecrypter {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,
@@ -323,7 +323,7 @@ impl MessageDecrypter for GcmMessageDecrypter {
     }
 }
 
-impl MessageEncrypter for GcmMessageEncrypter {
+impl RecordEncrypter for GcmRecordEncrypter {
     fn encrypt<'a>(
         &mut self,
         msg: Record<OutboundPlain<'_>>,
@@ -387,23 +387,23 @@ impl MessageEncrypter for GcmMessageEncrypter {
 
 /// The RFC 7905/RFC 7539 ChaCha20Poly1305 construction.
 /// This implementation does the AAD construction required in TLS1.2.
-/// TLS1.3 uses `TLS13MessageEncrypter`.
-struct ChaCha20Poly1305MessageEncrypter {
+/// TLS1.3 uses `Tls13RecordEncrypter`.
+struct ChaCha20Poly1305RecordEncrypter {
     enc_key: aead::LessSafeKey,
     enc_offset: Iv,
 }
 
 /// The RFC 7905/RFC 7539 ChaCha20Poly1305 construction.
 /// This implementation does the AAD construction required in TLS1.2.
-/// TLS1.3 uses `TLS13MessageDecrypter`.
-struct ChaCha20Poly1305MessageDecrypter {
+/// TLS1.3 uses `Tls13RecordDecrypter`.
+struct ChaCha20Poly1305RecordDecrypter {
     dec_key: aead::LessSafeKey,
     dec_offset: Iv,
 }
 
 const CHACHAPOLY1305_OVERHEAD: usize = 16;
 
-impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
+impl RecordDecrypter for ChaCha20Poly1305RecordDecrypter {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,
@@ -441,7 +441,7 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
     }
 }
 
-impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
+impl RecordEncrypter for ChaCha20Poly1305RecordEncrypter {
     fn encrypt<'a>(
         &mut self,
         msg: Record<OutboundPlain<'_>>,

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -4,8 +4,8 @@ use aws_lc_rs::hkdf::KeyType;
 use aws_lc_rs::{aead, hkdf, hmac};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter, Nonce,
-    OutboundPlain, Record, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, Nonce, OutboundPlain, Record, RecordDecrypter,
+    RecordEncrypter, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
 };
 use rustls::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use rustls::crypto::{self, CipherSuite};
@@ -98,17 +98,17 @@ pub static TLS13_AES_128_GCM_SHA256: &Tls13CipherSuite = &Tls13CipherSuite {
 struct Chacha20Poly1305Aead(AeadAlgorithm);
 
 impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
-    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordEncrypter> {
         // safety: the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
-        Box::new(AeadMessageEncrypter {
+        Box::new(AeadRecordEncrypter {
             enc_key: aead::LessSafeKey::new(aead::UnboundKey::new(self.0.0, key.as_ref()).unwrap()),
             iv,
         })
     }
 
-    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordDecrypter> {
         // safety: the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
-        Box::new(AeadMessageDecrypter {
+        Box::new(AeadRecordDecrypter {
             dec_key: aead::LessSafeKey::new(aead::UnboundKey::new(self.0.0, key.as_ref()).unwrap()),
             iv,
         })
@@ -134,11 +134,11 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
 struct Aes256GcmAead(AeadAlgorithm);
 
 impl Tls13AeadAlgorithm for Aes256GcmAead {
-    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordEncrypter> {
         self.0.encrypter(key, iv)
     }
 
-    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordDecrypter> {
         self.0.decrypter(key, iv)
     }
 
@@ -162,11 +162,11 @@ impl Tls13AeadAlgorithm for Aes256GcmAead {
 struct Aes128GcmAead(AeadAlgorithm);
 
 impl Tls13AeadAlgorithm for Aes128GcmAead {
-    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordEncrypter> {
         self.0.encrypter(key, iv)
     }
 
-    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordDecrypter> {
         self.0.decrypter(key, iv)
     }
 
@@ -192,11 +192,11 @@ struct AeadAlgorithm(&'static aead::Algorithm);
 
 impl AeadAlgorithm {
     // using aead::TlsRecordSealingKey
-    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordEncrypter> {
         // safety:
         // - the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
         // - this function should only be used for `Algorithm::AES_128_GCM` or `Algorithm::AES_256_GCM`
-        Box::new(GcmMessageEncrypter {
+        Box::new(GcmRecordEncrypter {
             enc_key: aead::TlsRecordSealingKey::new(
                 self.0,
                 aead::TlsProtocolId::TLS13,
@@ -208,11 +208,11 @@ impl AeadAlgorithm {
     }
 
     // using aead::TlsRecordOpeningKey
-    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordDecrypter> {
         // safety:
         // - the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
         // - this function should only be used for `Algorithm::AES_128_GCM` or `Algorithm::AES_256_GCM`
-        Box::new(GcmMessageDecrypter {
+        Box::new(GcmRecordDecrypter {
             dec_key: aead::TlsRecordOpeningKey::new(
                 self.0,
                 aead::TlsProtocolId::TLS13,
@@ -228,17 +228,17 @@ impl AeadAlgorithm {
     }
 }
 
-struct AeadMessageEncrypter {
+struct AeadRecordEncrypter {
     enc_key: aead::LessSafeKey,
     iv: Iv,
 }
 
-struct AeadMessageDecrypter {
+struct AeadRecordDecrypter {
     dec_key: aead::LessSafeKey,
     iv: Iv,
 }
 
-impl MessageEncrypter for AeadMessageEncrypter {
+impl RecordEncrypter for AeadRecordEncrypter {
     fn encrypt<'a>(
         &mut self,
         msg: Record<OutboundPlain<'_>>,
@@ -300,7 +300,7 @@ impl MessageEncrypter for AeadMessageEncrypter {
     }
 }
 
-impl MessageDecrypter for AeadMessageDecrypter {
+impl RecordDecrypter for AeadRecordDecrypter {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,
@@ -328,12 +328,12 @@ impl MessageDecrypter for AeadMessageDecrypter {
     }
 }
 
-struct GcmMessageEncrypter {
+struct GcmRecordEncrypter {
     enc_key: aead::TlsRecordSealingKey,
     iv: Iv,
 }
 
-impl MessageEncrypter for GcmMessageEncrypter {
+impl RecordEncrypter for GcmRecordEncrypter {
     fn encrypt<'a>(
         &mut self,
         msg: Record<OutboundPlain<'_>>,
@@ -395,12 +395,12 @@ impl MessageEncrypter for GcmMessageEncrypter {
     }
 }
 
-struct GcmMessageDecrypter {
+struct GcmRecordDecrypter {
     dec_key: aead::TlsRecordOpeningKey,
     iv: Iv,
 }
 
-impl MessageDecrypter for GcmMessageDecrypter {
+impl RecordDecrypter for GcmRecordDecrypter {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -4,8 +4,8 @@ use aws_lc_rs::hkdf::KeyType;
 use aws_lc_rs::{aead, hkdf, hmac};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter,
-    Nonce, OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter, Nonce,
+    OutboundPlain, Record, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
 };
 use rustls::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use rustls::crypto::{self, CipherSuite};
@@ -241,10 +241,10 @@ struct AeadMessageDecrypter {
 impl MessageEncrypter for AeadMessageEncrypter {
     fn encrypt<'a>(
         &mut self,
-        msg: EncodedMessage<OutboundPlain<'_>>,
+        msg: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
+    ) -> Result<Record<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
 
         let typ = ContentType::ApplicationData;
@@ -288,7 +288,7 @@ impl MessageEncrypter for AeadMessageEncrypter {
             }
         };
 
-        Ok(EncodedMessage {
+        Ok(Record {
             typ,
             version: msg.version,
             payload,
@@ -303,18 +303,18 @@ impl MessageEncrypter for AeadMessageEncrypter {
 impl MessageDecrypter for AeadMessageDecrypter {
     fn decrypt<'a>(
         &mut self,
-        mut msg: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &mut msg.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &mut record.payload;
         if payload.len() < self.dec_key.algorithm().tag_len() {
             return Err(Error::DecryptError);
         }
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(
-            msg.typ,
-            msg.version.version(),
+            record.typ,
+            record.version.version(),
             payload.len(),
         ));
         let plain_len = self
@@ -324,7 +324,7 @@ impl MessageDecrypter for AeadMessageDecrypter {
             .len();
 
         payload.truncate(plain_len);
-        msg.into_tls13_unpadded_message()
+        record.into_tls13_unpadded_record()
     }
 }
 
@@ -336,10 +336,10 @@ struct GcmMessageEncrypter {
 impl MessageEncrypter for GcmMessageEncrypter {
     fn encrypt<'a>(
         &mut self,
-        msg: EncodedMessage<OutboundPlain<'_>>,
+        msg: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
+    ) -> Result<Record<&'a [u8]>, Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
 
         let typ = ContentType::ApplicationData;
@@ -383,7 +383,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
             }
         };
 
-        Ok(EncodedMessage {
+        Ok(Record {
             typ,
             version: msg.version,
             payload,
@@ -403,18 +403,18 @@ struct GcmMessageDecrypter {
 impl MessageDecrypter for GcmMessageDecrypter {
     fn decrypt<'a>(
         &mut self,
-        mut msg: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &mut msg.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &mut record.payload;
         if payload.len() < self.dec_key.algorithm().tag_len() {
             return Err(Error::DecryptError);
         }
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(
-            msg.typ,
-            msg.version.version(),
+            record.typ,
+            record.version.version(),
             payload.len(),
         ));
         let plain_len = self
@@ -424,7 +424,7 @@ impl MessageDecrypter for GcmMessageDecrypter {
             .len();
 
         payload.truncate(plain_len);
-        msg.into_tls13_unpadded_message()
+        record.into_tls13_unpadded_record()
     }
 }
 
@@ -537,7 +537,7 @@ mod tests {
         for suite in ALL_TLS13_CIPHER_SUITES {
             for plain in [&b""[..], b"hello"] {
                 let mut sealed = seal(suite, OutboundPlain::from(plain), 0x00);
-                let msg = EncodedMessage::new(
+                let record = Record::new(
                     ContentType::ApplicationData,
                     EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
                     InboundOpaque(&mut sealed),
@@ -546,7 +546,7 @@ mod tests {
                     .aead_alg
                     .decrypter(test_key(suite.aead_alg.key_len()), Iv::from(TEST_IV));
                 let opened = decrypter
-                    .decrypt(msg, TEST_SEQ)
+                    .decrypt(record, TEST_SEQ)
                     .unwrap();
                 assert_eq!(opened.typ, ContentType::ApplicationData);
                 assert_eq!(opened.payload, plain, "{:?}", suite.common.suite);
@@ -558,14 +558,14 @@ mod tests {
         let mut encrypter = suite
             .aead_alg
             .encrypter(test_key(suite.aead_alg.key_len()), Iv::from(TEST_IV));
-        let msg = EncodedMessage::new(
+        let record = Record::new(
             ContentType::ApplicationData,
             EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
             payload,
         );
-        let mut out = vec![fill; encrypter.encrypted_payload_len(msg.payload.len())];
+        let mut out = vec![fill; encrypter.encrypted_payload_len(record.payload.len())];
         encrypter
-            .encrypt(msg, TEST_SEQ, &mut out)
+            .encrypt(record, TEST_SEQ, &mut out)
             .unwrap()
             .payload
             .to_vec()

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -5,9 +5,8 @@ use std::sync::Arc;
 use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::ServerVerifier;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter,
-    MessageEncrypter, OutboundPlain, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
-    UnsupportedOperationError,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
+    OutboundPlain, Record, Tls12AeadAlgorithm, Tls13AeadAlgorithm, UnsupportedOperationError,
 };
 use rustls::crypto::kx::{
     KeyExchangeAlgorithm, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup,
@@ -320,15 +319,15 @@ struct Tls13Cipher;
 impl MessageEncrypter for Tls13Cipher {
     fn encrypt<'a>(
         &mut self,
-        m: EncodedMessage<OutboundPlain<'_>>,
+        record: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let total_len = self.encrypted_payload_len(m.payload.len());
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let total_len = self.encrypted_payload_len(record.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
 
-        payload.extend_from_chunks(&m.payload);
-        payload.extend_from_slice(&m.typ.to_array());
+        payload.extend_from_chunks(&record.payload);
+        payload.extend_from_slice(&record.typ.to_array());
 
         for (p, mask) in payload
             .as_mut()
@@ -341,9 +340,9 @@ impl MessageEncrypter for Tls13Cipher {
         payload.extend_from_slice(&seq.to_be_bytes());
         payload.extend_from_slice(AEAD_TAG);
 
-        Ok(EncodedMessage {
+        Ok(Record {
             typ: ContentType::ApplicationData,
-            version: m.version,
+            version: record.version,
             payload: payload.into_written(),
         })
     }
@@ -356,10 +355,10 @@ impl MessageEncrypter for Tls13Cipher {
 impl MessageDecrypter for Tls13Cipher {
     fn decrypt<'a>(
         &mut self,
-        mut m: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &mut m.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &mut record.payload;
 
         let mut expected_tag = vec![];
         expected_tag.extend_from_slice(&seq.to_be_bytes());
@@ -381,7 +380,7 @@ impl MessageDecrypter for Tls13Cipher {
             *p ^= *mask;
         }
 
-        m.into_tls13_unpadded_message()
+        record.into_tls13_unpadded_record()
     }
 }
 
@@ -390,13 +389,13 @@ struct Tls12Cipher;
 impl MessageEncrypter for Tls12Cipher {
     fn encrypt<'a>(
         &mut self,
-        m: EncodedMessage<OutboundPlain<'_>>,
+        record: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let total_len = self.encrypted_payload_len(m.payload.len());
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let total_len = self.encrypted_payload_len(record.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
-        payload.extend_from_chunks(&m.payload);
+        payload.extend_from_chunks(&record.payload);
 
         for (p, mask) in payload
             .as_mut()
@@ -409,9 +408,9 @@ impl MessageEncrypter for Tls12Cipher {
         payload.extend_from_slice(&seq.to_be_bytes());
         payload.extend_from_slice(AEAD_TAG);
 
-        Ok(EncodedMessage {
-            typ: m.typ,
-            version: m.version,
+        Ok(Record {
+            typ: record.typ,
+            version: record.version,
             payload: payload.into_written(),
         })
     }
@@ -424,10 +423,10 @@ impl MessageEncrypter for Tls12Cipher {
 impl MessageDecrypter for Tls12Cipher {
     fn decrypt<'a>(
         &mut self,
-        mut m: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &mut m.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &mut record.payload;
 
         let mut expected_tag = vec![];
         expected_tag.extend_from_slice(&seq.to_be_bytes());
@@ -449,7 +448,7 @@ impl MessageDecrypter for Tls12Cipher {
             *p ^= *mask;
         }
 
-        Ok(m.into_plain_message())
+        Ok(record.into_plain_record())
     }
 }
 

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::ServerVerifier;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
-    OutboundPlain, Record, Tls12AeadAlgorithm, Tls13AeadAlgorithm, UnsupportedOperationError,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, OutboundPlain, Record,
+    RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
+    UnsupportedOperationError,
 };
 use rustls::crypto::kx::{
     KeyExchangeAlgorithm, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup,
@@ -266,11 +267,11 @@ const KX_SHARED_SECRET: &[u8] = b"KxSharedSecretKxSharedSecret";
 struct Aead;
 
 impl Tls13AeadAlgorithm for Aead {
-    fn encrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn RecordEncrypter> {
         Box::new(Tls13Cipher)
     }
 
-    fn decrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn RecordDecrypter> {
         Box::new(Tls13Cipher)
     }
 
@@ -288,11 +289,11 @@ impl Tls13AeadAlgorithm for Aead {
 }
 
 impl Tls12AeadAlgorithm for Aead {
-    fn encrypter(&self, _key: AeadKey, _iv: &[u8], _: &[u8]) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, _key: AeadKey, _iv: &[u8], _: &[u8]) -> Box<dyn RecordEncrypter> {
         Box::new(Tls12Cipher)
     }
 
-    fn decrypter(&self, _key: AeadKey, _iv: &[u8]) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, _key: AeadKey, _iv: &[u8]) -> Box<dyn RecordDecrypter> {
         Box::new(Tls12Cipher)
     }
 
@@ -316,7 +317,7 @@ impl Tls12AeadAlgorithm for Aead {
 
 struct Tls13Cipher;
 
-impl MessageEncrypter for Tls13Cipher {
+impl RecordEncrypter for Tls13Cipher {
     fn encrypt<'a>(
         &mut self,
         record: Record<OutboundPlain<'_>>,
@@ -352,7 +353,7 @@ impl MessageEncrypter for Tls13Cipher {
     }
 }
 
-impl MessageDecrypter for Tls13Cipher {
+impl RecordDecrypter for Tls13Cipher {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,
@@ -386,7 +387,7 @@ impl MessageDecrypter for Tls13Cipher {
 
 struct Tls12Cipher;
 
-impl MessageEncrypter for Tls12Cipher {
+impl RecordEncrypter for Tls12Cipher {
     fn encrypt<'a>(
         &mut self,
         record: Record<OutboundPlain<'_>>,
@@ -420,7 +421,7 @@ impl MessageEncrypter for Tls12Cipher {
     }
 }
 
-impl MessageDecrypter for Tls12Cipher {
+impl RecordDecrypter for Tls12Cipher {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,

--- a/rustls-ring/src/tls12.rs
+++ b/rustls-ring/src/tls12.rs
@@ -3,8 +3,8 @@ use alloc::boxed::Box;
 use pki_types::FipsStatus;
 use ring::aead;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
-    NONCE_LEN, Nonce, OutboundPlain, Record, Tls12AeadAlgorithm, UnsupportedOperationError,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, NONCE_LEN, Nonce, OutboundPlain,
+    Record, RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, UnsupportedOperationError,
     make_tls12_aad,
 };
 use rustls::crypto::kx::KeyExchangeAlgorithm;
@@ -136,11 +136,11 @@ pub(crate) static AES256_GCM: GcmAlgorithm = GcmAlgorithm(&aead::AES_256_GCM);
 pub(crate) struct GcmAlgorithm(&'static aead::Algorithm);
 
 impl Tls12AeadAlgorithm for GcmAlgorithm {
-    fn decrypter(&self, dec_key: AeadKey, dec_iv: &[u8]) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, dec_key: AeadKey, dec_iv: &[u8]) -> Box<dyn RecordDecrypter> {
         let dec_key =
             aead::LessSafeKey::new(aead::UnboundKey::new(self.0, dec_key.as_ref()).unwrap());
 
-        let mut ret = GcmMessageDecrypter {
+        let mut ret = GcmRecordDecrypter {
             dec_key,
             dec_salt: [0u8; 4],
         };
@@ -155,11 +155,11 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
         enc_key: AeadKey,
         write_iv: &[u8],
         explicit: &[u8],
-    ) -> Box<dyn MessageEncrypter> {
+    ) -> Box<dyn RecordEncrypter> {
         let enc_key =
             aead::LessSafeKey::new(aead::UnboundKey::new(self.0, enc_key.as_ref()).unwrap());
         let iv = gcm_iv(write_iv, explicit);
-        Box::new(GcmMessageEncrypter { enc_key, iv })
+        Box::new(GcmRecordEncrypter { enc_key, iv })
     }
 
     fn key_block_shape(&self) -> KeyBlockShape {
@@ -192,21 +192,21 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
 pub(crate) struct ChaCha20Poly1305;
 
 impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
-    fn decrypter(&self, dec_key: AeadKey, iv: &[u8]) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, dec_key: AeadKey, iv: &[u8]) -> Box<dyn RecordDecrypter> {
         let dec_key = aead::LessSafeKey::new(
             aead::UnboundKey::new(&aead::CHACHA20_POLY1305, dec_key.as_ref()).unwrap(),
         );
-        Box::new(ChaCha20Poly1305MessageDecrypter {
+        Box::new(ChaCha20Poly1305RecordDecrypter {
             dec_key,
             dec_offset: Iv::new(iv).expect("IV length validated by key_block_shape"),
         })
     }
 
-    fn encrypter(&self, enc_key: AeadKey, enc_iv: &[u8], _: &[u8]) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, enc_key: AeadKey, enc_iv: &[u8], _: &[u8]) -> Box<dyn RecordEncrypter> {
         let enc_key = aead::LessSafeKey::new(
             aead::UnboundKey::new(&aead::CHACHA20_POLY1305, enc_key.as_ref()).unwrap(),
         );
-        Box::new(ChaCha20Poly1305MessageEncrypter {
+        Box::new(ChaCha20Poly1305RecordEncrypter {
             enc_key,
             enc_offset: Iv::new(enc_iv).expect("IV length validated by key_block_shape"),
         })
@@ -239,14 +239,14 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
     }
 }
 
-/// A `MessageEncrypter` for AES-GCM AEAD ciphersuites. TLS 1.2 only.
-struct GcmMessageEncrypter {
+/// A `RecordEncrypter` for AES-GCM AEAD ciphersuites. TLS 1.2 only.
+struct GcmRecordEncrypter {
     enc_key: aead::LessSafeKey,
     iv: Iv,
 }
 
-/// A `MessageDecrypter` for AES-GCM AEAD ciphersuites.  TLS1.2 only.
-struct GcmMessageDecrypter {
+/// A `RecordDecrypter` for AES-GCM AEAD ciphersuites.  TLS1.2 only.
+struct GcmRecordDecrypter {
     dec_key: aead::LessSafeKey,
     dec_salt: [u8; 4],
 }
@@ -254,7 +254,7 @@ struct GcmMessageDecrypter {
 const GCM_EXPLICIT_NONCE_LEN: usize = 8;
 const GCM_OVERHEAD: usize = GCM_EXPLICIT_NONCE_LEN + 16;
 
-impl MessageDecrypter for GcmMessageDecrypter {
+impl RecordDecrypter for GcmRecordDecrypter {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,
@@ -295,7 +295,7 @@ impl MessageDecrypter for GcmMessageDecrypter {
     }
 }
 
-impl MessageEncrypter for GcmMessageEncrypter {
+impl RecordEncrypter for GcmRecordEncrypter {
     fn encrypt<'a>(
         &mut self,
         record: Record<OutboundPlain<'_>>,
@@ -338,23 +338,23 @@ impl MessageEncrypter for GcmMessageEncrypter {
 
 /// The RFC 7905/RFC 7539 ChaCha20Poly1305 construction.
 /// This implementation does the AAD construction required in TLS1.2.
-/// TLS1.3 uses `TLS13MessageEncrypter`.
-struct ChaCha20Poly1305MessageEncrypter {
+/// TLS1.3 uses `Tls13RecordEncrypter`.
+struct ChaCha20Poly1305RecordEncrypter {
     enc_key: aead::LessSafeKey,
     enc_offset: Iv,
 }
 
 /// The RFC 7905/RFC 7539 ChaCha20Poly1305 construction.
 /// This implementation does the AAD construction required in TLS1.2.
-/// TLS1.3 uses `TLS13MessageDecrypter`.
-struct ChaCha20Poly1305MessageDecrypter {
+/// TLS1.3 uses `Tls13RecordDecrypter`.
+struct ChaCha20Poly1305RecordDecrypter {
     dec_key: aead::LessSafeKey,
     dec_offset: Iv,
 }
 
 const CHACHAPOLY1305_OVERHEAD: usize = 16;
 
-impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
+impl RecordDecrypter for ChaCha20Poly1305RecordDecrypter {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,
@@ -391,7 +391,7 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
     }
 }
 
-impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
+impl RecordEncrypter for ChaCha20Poly1305RecordEncrypter {
     fn encrypt<'a>(
         &mut self,
         record: Record<OutboundPlain<'_>>,

--- a/rustls-ring/src/tls12.rs
+++ b/rustls-ring/src/tls12.rs
@@ -3,9 +3,9 @@ use alloc::boxed::Box;
 use pki_types::FipsStatus;
 use ring::aead;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter,
-    MessageEncrypter, NONCE_LEN, Nonce, OutboundPlain, Tls12AeadAlgorithm,
-    UnsupportedOperationError, make_tls12_aad,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
+    NONCE_LEN, Nonce, OutboundPlain, Record, Tls12AeadAlgorithm, UnsupportedOperationError,
+    make_tls12_aad,
 };
 use rustls::crypto::kx::KeyExchangeAlgorithm;
 use rustls::crypto::tls12::PrfUsingHmac;
@@ -257,10 +257,10 @@ const GCM_OVERHEAD: usize = GCM_EXPLICIT_NONCE_LEN + 16;
 impl MessageDecrypter for GcmMessageDecrypter {
     fn decrypt<'a>(
         &mut self,
-        mut msg: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &msg.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &record.payload;
         if payload.len() < GCM_OVERHEAD {
             return Err(Error::DecryptError);
         }
@@ -274,12 +274,12 @@ impl MessageDecrypter for GcmMessageDecrypter {
 
         let aad = aead::Aad::from(make_tls12_aad(
             seq,
-            msg.typ,
-            msg.version.version(),
+            record.typ,
+            record.version.version(),
             payload.len() - GCM_OVERHEAD,
         ));
 
-        let payload = &mut msg.payload;
+        let payload = &mut record.payload;
         let plain_len = self
             .dec_key
             .open_within(nonce, aad, payload, GCM_EXPLICIT_NONCE_LEN..)
@@ -291,29 +291,29 @@ impl MessageDecrypter for GcmMessageDecrypter {
         }
 
         payload.truncate(plain_len);
-        Ok(msg.into_plain_message())
+        Ok(record.into_plain_record())
     }
 }
 
 impl MessageEncrypter for GcmMessageEncrypter {
     fn encrypt<'a>(
         &mut self,
-        msg: EncodedMessage<OutboundPlain<'_>>,
+        record: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let total_len = self.encrypted_payload_len(msg.payload.len());
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let total_len = self.encrypted_payload_len(record.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(
             seq,
-            msg.typ,
-            msg.version.encode(),
-            msg.payload.len(),
+            record.typ,
+            record.version.encode(),
+            record.payload.len(),
         ));
         payload.extend_from_slice(&nonce.as_ref()[4..]);
-        payload.extend_from_chunks(&msg.payload);
+        payload.extend_from_chunks(&record.payload);
 
         match self.enc_key.seal_in_place_separate_tag(
             nonce,
@@ -324,9 +324,9 @@ impl MessageEncrypter for GcmMessageEncrypter {
             Err(_) => return Err(Error::EncryptError),
         }
 
-        Ok(EncodedMessage {
-            typ: msg.typ,
-            version: msg.version,
+        Ok(Record {
+            typ: record.typ,
+            version: record.version,
             payload: payload.into_written(),
         })
     }
@@ -357,10 +357,10 @@ const CHACHAPOLY1305_OVERHEAD: usize = 16;
 impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
     fn decrypt<'a>(
         &mut self,
-        mut msg: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &msg.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &record.payload;
 
         if payload.len() < CHACHAPOLY1305_OVERHEAD {
             return Err(Error::DecryptError);
@@ -370,12 +370,12 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
             aead::Nonce::assume_unique_for_key(Nonce::new(&self.dec_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(
             seq,
-            msg.typ,
-            msg.version.version(),
+            record.typ,
+            record.version.version(),
             payload.len() - CHACHAPOLY1305_OVERHEAD,
         ));
 
-        let payload = &mut msg.payload;
+        let payload = &mut record.payload;
         let plain_len = self
             .dec_key
             .open_in_place(nonce, aad, payload)
@@ -387,29 +387,29 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
         }
 
         payload.truncate(plain_len);
-        Ok(msg.into_plain_message())
+        Ok(record.into_plain_record())
     }
 }
 
 impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
     fn encrypt<'a>(
         &mut self,
-        msg: EncodedMessage<OutboundPlain<'_>>,
+        record: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let total_len = self.encrypted_payload_len(msg.payload.len());
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let total_len = self.encrypted_payload_len(record.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let nonce =
             aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(
             seq,
-            msg.typ,
-            msg.version.encode(),
-            msg.payload.len(),
+            record.typ,
+            record.version.encode(),
+            record.payload.len(),
         ));
-        payload.extend_from_chunks(&msg.payload);
+        payload.extend_from_chunks(&record.payload);
 
         match self
             .enc_key
@@ -419,9 +419,9 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
             Err(_) => return Err(Error::EncryptError),
         }
 
-        Ok(EncodedMessage {
-            typ: msg.typ,
-            version: msg.version,
+        Ok(Record {
+            typ: record.typ,
+            version: record.version,
             payload: payload.into_written(),
         })
     }

--- a/rustls-ring/src/tls13.rs
+++ b/rustls-ring/src/tls13.rs
@@ -5,8 +5,8 @@ use ring::hkdf::{self, KeyType};
 use ring::{aead, hmac};
 use rustls::crypto::CipherSuite;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter, Nonce,
-    OutboundPlain, Record, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, Nonce, OutboundPlain, Record, RecordDecrypter,
+    RecordEncrypter, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
 };
 use rustls::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use rustls::enums::ContentType;
@@ -91,11 +91,11 @@ pub static TLS13_AES_128_GCM_SHA256: &Tls13CipherSuite = &Tls13CipherSuite {
 struct Chacha20Poly1305Aead(AeadAlgorithm);
 
 impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
-    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordEncrypter> {
         self.0.encrypter(key, iv)
     }
 
-    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordDecrypter> {
         self.0.decrypter(key, iv)
     }
 
@@ -119,11 +119,11 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
 struct Aes256GcmAead(AeadAlgorithm);
 
 impl Tls13AeadAlgorithm for Aes256GcmAead {
-    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordEncrypter> {
         self.0.encrypter(key, iv)
     }
 
-    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordDecrypter> {
         self.0.decrypter(key, iv)
     }
 
@@ -147,11 +147,11 @@ impl Tls13AeadAlgorithm for Aes256GcmAead {
 struct Aes128GcmAead(AeadAlgorithm);
 
 impl Tls13AeadAlgorithm for Aes128GcmAead {
-    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordEncrypter> {
         self.0.encrypter(key, iv)
     }
 
-    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordDecrypter> {
         self.0.decrypter(key, iv)
     }
 
@@ -176,17 +176,17 @@ impl Tls13AeadAlgorithm for Aes128GcmAead {
 struct AeadAlgorithm(&'static aead::Algorithm);
 
 impl AeadAlgorithm {
-    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordEncrypter> {
         // safety: the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
-        Box::new(Tls13MessageEncrypter {
+        Box::new(Tls13RecordEncrypter {
             enc_key: aead::LessSafeKey::new(aead::UnboundKey::new(self.0, key.as_ref()).unwrap()),
             iv,
         })
     }
 
-    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordDecrypter> {
         // safety: the caller arranges that `key` is `key_len()` in bytes, so this unwrap is safe.
-        Box::new(Tls13MessageDecrypter {
+        Box::new(Tls13RecordDecrypter {
             dec_key: aead::LessSafeKey::new(aead::UnboundKey::new(self.0, key.as_ref()).unwrap()),
             iv,
         })
@@ -197,17 +197,17 @@ impl AeadAlgorithm {
     }
 }
 
-struct Tls13MessageEncrypter {
+struct Tls13RecordEncrypter {
     enc_key: aead::LessSafeKey,
     iv: Iv,
 }
 
-struct Tls13MessageDecrypter {
+struct Tls13RecordDecrypter {
     dec_key: aead::LessSafeKey,
     iv: Iv,
 }
 
-impl MessageEncrypter for Tls13MessageEncrypter {
+impl RecordEncrypter for Tls13RecordEncrypter {
     fn encrypt<'a>(
         &mut self,
         record: Record<OutboundPlain<'_>>,
@@ -243,7 +243,7 @@ impl MessageEncrypter for Tls13MessageEncrypter {
     }
 }
 
-impl MessageDecrypter for Tls13MessageDecrypter {
+impl RecordDecrypter for Tls13RecordDecrypter {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,

--- a/rustls-ring/src/tls13.rs
+++ b/rustls-ring/src/tls13.rs
@@ -5,8 +5,8 @@ use ring::hkdf::{self, KeyType};
 use ring::{aead, hmac};
 use rustls::crypto::CipherSuite;
 use rustls::crypto::cipher::{
-    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter,
-    Nonce, OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter, Nonce,
+    OutboundPlain, Record, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
 };
 use rustls::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use rustls::enums::ContentType;
@@ -210,18 +210,18 @@ struct Tls13MessageDecrypter {
 impl MessageEncrypter for Tls13MessageEncrypter {
     fn encrypt<'a>(
         &mut self,
-        msg: EncodedMessage<OutboundPlain<'_>>,
+        record: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let total_len = self.encrypted_payload_len(msg.payload.len());
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let total_len = self.encrypted_payload_len(record.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
 
         let typ = ContentType::ApplicationData;
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
-        let aad = aead::Aad::from(make_tls13_aad(typ, msg.version.encode(), total_len));
-        payload.extend_from_chunks(&msg.payload);
-        payload.extend_from_slice(&msg.typ.to_array());
+        let aad = aead::Aad::from(make_tls13_aad(typ, record.version.encode(), total_len));
+        payload.extend_from_chunks(&record.payload);
+        payload.extend_from_slice(&record.typ.to_array());
 
         match self
             .enc_key
@@ -231,9 +231,9 @@ impl MessageEncrypter for Tls13MessageEncrypter {
             Err(_) => return Err(Error::EncryptError),
         }
 
-        Ok(EncodedMessage {
+        Ok(Record {
             typ,
-            version: msg.version,
+            version: record.version,
             payload: payload.into_written(),
         })
     }
@@ -246,18 +246,18 @@ impl MessageEncrypter for Tls13MessageEncrypter {
 impl MessageDecrypter for Tls13MessageDecrypter {
     fn decrypt<'a>(
         &mut self,
-        mut msg: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &mut msg.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &mut record.payload;
         if payload.len() < self.dec_key.algorithm().tag_len() {
             return Err(Error::DecryptError);
         }
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(
-            msg.typ,
-            msg.version.version(),
+            record.typ,
+            record.version.version(),
             payload.len(),
         ));
         let plain_len = self
@@ -267,7 +267,7 @@ impl MessageDecrypter for Tls13MessageDecrypter {
             .len();
 
         payload.truncate(plain_len);
-        msg.into_tls13_unpadded_message()
+        record.into_tls13_unpadded_record()
     }
 }
 

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -264,18 +264,18 @@ where
             payload,
         };
 
-        let message_enc = match filter(&mut record) {
+        let record_enc = match filter(&mut record) {
             Altered::InPlace => {
-                encoding::message_framing(record.typ, version, record.payload.clone())
+                encoding::record_framing(record.typ, version, record.payload.clone())
             }
             Altered::Raw(data) => data,
         };
 
-        let message_enc_reader: &mut dyn io::Read = &mut &message_enc[..];
+        let record_enc_reader: &mut dyn io::Read = &mut &record_enc[..];
         let len = right_input
-            .read(message_enc_reader)
+            .read(record_enc_reader)
             .unwrap();
-        assert_eq!(len, message_enc.len());
+        assert_eq!(len, record_enc.len());
     }
 
     left_output.clear();
@@ -1854,7 +1854,7 @@ impl<'a, C: Connection> OtherSession<'a, C> {
             .collect()
     }
 
-    pub fn message_lengths(&self) -> Vec<usize> {
+    pub fn record_lengths(&self) -> Vec<usize> {
         let mut buffer = vec![];
         for writev in &self.writevs {
             for chunk in writev {
@@ -2344,7 +2344,7 @@ pub mod encoding {
     }
 
     /// Apply message framing to `body`.
-    pub fn message_framing(ty: ContentType, vers: ProtocolVersion, body: Vec<u8>) -> Vec<u8> {
+    pub fn record_framing(ty: ContentType, vers: ProtocolVersion, body: Vec<u8>) -> Vec<u8> {
         let mut body = len_u16(body);
         body.splice(0..0, vers.to_array());
         body.splice(0..0, ty.to_array());
@@ -2450,12 +2450,12 @@ pub mod encoding {
     pub fn alert(desc: AlertDescription, suffix: &[u8]) -> Vec<u8> {
         let mut body = vec![ALERT_LEVEL_FATAL, desc.into()];
         body.extend_from_slice(suffix);
-        message_framing(ContentType::Alert, ProtocolVersion::TLSv1_2, body)
+        record_framing(ContentType::Alert, ProtocolVersion::TLSv1_2, body)
     }
 
     /// Return a full TLS message containing a warning alert.
     pub fn warning_alert(desc: AlertDescription) -> Vec<u8> {
-        message_framing(
+        record_framing(
             ContentType::Alert,
             ProtocolVersion::TLSv1_2,
             vec![ALERT_LEVEL_WARNING, desc.into()],

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -9,7 +9,7 @@ use rustls::client::{
     ClientSessionKey, ServerVerifierBuilder, Tls13Session, WantsClientCert, WebPkiServerVerifier,
 };
 use rustls::crypto::cipher::{
-    EncodableVersion, InboundOpaque, MessageDecrypter, MessageEncrypter, Payload, Record,
+    EncodableVersion, InboundOpaque, Payload, Record, RecordDecrypter, RecordEncrypter,
 };
 use rustls::crypto::kx::{NamedGroup, SupportedKxGroup};
 use rustls::crypto::{
@@ -1451,9 +1451,9 @@ impl ClientVerifier for MockClientVerifier {
 /// It consumes one of the peers, extracts its secrets, and then reconstitutes the
 /// message encrypter/decrypter.  It does not do fragmentation/joining.
 pub struct RawTls {
-    encrypter: Box<dyn MessageEncrypter>,
+    encrypter: Box<dyn RecordEncrypter>,
     enc_seq: u64,
-    decrypter: Box<dyn MessageDecrypter>,
+    decrypter: Box<dyn RecordDecrypter>,
     dec_seq: u64,
 }
 
@@ -1977,8 +1977,8 @@ pub fn certificate_error_expecting_name(expected: &str) -> CertificateError {
 mod plaintext {
     use rustls::ConnectionTrafficSecrets;
     use rustls::crypto::cipher::{
-        AeadKey, EncryptBuffer, InboundOpaque, Iv, MessageDecrypter, MessageEncrypter,
-        OutboundPlain, Tls13AeadAlgorithm, UnsupportedOperationError,
+        AeadKey, EncryptBuffer, InboundOpaque, Iv, OutboundPlain, RecordDecrypter, RecordEncrypter,
+        Tls13AeadAlgorithm, UnsupportedOperationError,
     };
 
     use super::*;
@@ -1986,11 +1986,11 @@ mod plaintext {
     pub(super) struct Aead;
 
     impl Tls13AeadAlgorithm for Aead {
-        fn encrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn MessageEncrypter> {
+        fn encrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn RecordEncrypter> {
             Box::new(Encrypter)
         }
 
-        fn decrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn MessageDecrypter> {
+        fn decrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn RecordDecrypter> {
             Box::new(Decrypter)
         }
 
@@ -2009,7 +2009,7 @@ mod plaintext {
 
     struct Encrypter;
 
-    impl MessageEncrypter for Encrypter {
+    impl RecordEncrypter for Encrypter {
         fn encrypt<'a>(
             &mut self,
             record: Record<OutboundPlain<'_>>,
@@ -2033,7 +2033,7 @@ mod plaintext {
 
     struct Decrypter;
 
-    impl MessageDecrypter for Decrypter {
+    impl RecordDecrypter for Decrypter {
         fn decrypt<'a>(
             &mut self,
             record: Record<InboundOpaque<'a>>,

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -9,7 +9,7 @@ use rustls::client::{
     ClientSessionKey, ServerVerifierBuilder, Tls13Session, WantsClientCert, WebPkiServerVerifier,
 };
 use rustls::crypto::cipher::{
-    EncodableVersion, EncodedMessage, InboundOpaque, MessageDecrypter, MessageEncrypter, Payload,
+    EncodableVersion, InboundOpaque, MessageDecrypter, MessageEncrypter, Payload, Record,
 };
 use rustls::crypto::kx::{NamedGroup, SupportedKxGroup};
 use rustls::crypto::{
@@ -231,7 +231,7 @@ pub fn transfer_altered<F>(
     right_input: &mut VecInput,
 ) -> usize
 where
-    F: Fn(&mut EncodedMessage<Vec<u8>>) -> Altered,
+    F: Fn(&mut Record<Vec<u8>>) -> Altered,
 {
     let sz = left_output.len();
 
@@ -258,15 +258,15 @@ where
         let payload = left_output[offset + 5..offset + 5 + payload_len].to_vec();
         offset += 5 + payload_len;
 
-        let mut encoded = EncodedMessage {
+        let mut record = Record {
             typ,
             version: EncodableVersion::Legacy(version),
             payload,
         };
 
-        let message_enc = match filter(&mut encoded) {
+        let message_enc = match filter(&mut record) {
             Altered::InPlace => {
-                encoding::message_framing(encoded.typ, version, encoded.payload.clone())
+                encoding::message_framing(record.typ, version, record.payload.clone())
             }
             Altered::Raw(data) => data,
         };
@@ -1532,11 +1532,7 @@ impl RawTls {
         }
     }
 
-    pub fn encrypt_and_send(
-        &mut self,
-        msg: &EncodedMessage<Payload<'_>>,
-        peer_input: &mut VecInput,
-    ) {
+    pub fn encrypt_and_send(&mut self, msg: &Record<Payload<'_>>, peer_input: &mut VecInput) {
         /// The length of a TLS record header: 1 byte type, 2 bytes version, 2 bytes length.
         const HEADER_SIZE: usize = 5;
 
@@ -1570,11 +1566,7 @@ impl RawTls {
             .unwrap();
     }
 
-    pub fn receive_and_decrypt(
-        &mut self,
-        peer_output: &mut Vec<u8>,
-        f: impl Fn(EncodedMessage<&[u8]>),
-    ) {
+    pub fn receive_and_decrypt(&mut self, peer_output: &mut Vec<u8>, f: impl Fn(Record<&[u8]>)) {
         let mut data = mem::take(peer_output);
 
         // Parse TLS record header: 1 byte type, 2 bytes version, 2 bytes length
@@ -1585,21 +1577,21 @@ impl RawTls {
         let left = &mut data[5..];
         assert_eq!(len, left.len());
 
-        let inbound = EncodedMessage {
+        let inbound = Record {
             typ,
             version: EncodableVersion::Legacy(version),
             payload: InboundOpaque(left),
         };
 
-        let msg = self
+        let record = self
             .decrypter
             .decrypt(inbound, self.dec_seq)
             .unwrap();
         self.dec_seq += 1;
 
-        println!("receive_and_decrypt: {msg:?}");
+        println!("receive_and_decrypt: {record:?}");
 
-        f(msg);
+        f(record);
     }
 }
 
@@ -2020,16 +2012,16 @@ mod plaintext {
     impl MessageEncrypter for Encrypter {
         fn encrypt<'a>(
             &mut self,
-            msg: EncodedMessage<OutboundPlain<'_>>,
+            record: Record<OutboundPlain<'_>>,
             _seq: u64,
             out: &'a mut [u8],
-        ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-            let mut payload = EncryptBuffer::new(out, msg.payload.len())?;
-            payload.extend_from_chunks(&msg.payload);
+        ) -> Result<Record<&'a [u8]>, Error> {
+            let mut payload = EncryptBuffer::new(out, record.payload.len())?;
+            payload.extend_from_chunks(&record.payload);
 
-            Ok(EncodedMessage {
+            Ok(Record {
                 typ: ContentType::ApplicationData,
-                version: msg.version,
+                version: record.version,
                 payload: payload.into_written(),
             })
         }
@@ -2044,10 +2036,10 @@ mod plaintext {
     impl MessageDecrypter for Decrypter {
         fn decrypt<'a>(
             &mut self,
-            msg: EncodedMessage<InboundOpaque<'a>>,
+            record: Record<InboundOpaque<'a>>,
             _seq: u64,
-        ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-            Ok(msg.into_plain_message())
+        ) -> Result<Record<&'a [u8]>, Error> {
+            Ok(record.into_plain_record())
         }
     }
 }

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use pki_types::{DnsName, FipsStatus, SubjectPublicKeyInfoDer};
 use provider::cipher_suite;
 use rustls::client::Resumption;
-use rustls::crypto::cipher::{EncodableVersion, EncodedMessage, Payload};
+use rustls::crypto::cipher::{EncodableVersion, Payload, Record};
 use rustls::crypto::kx::NamedGroup;
 use rustls::crypto::{
     CipherSuite, Credentials, CryptoProvider, Identity, InconsistentKeys, SelectedCredential,
@@ -727,7 +727,7 @@ fn server_rejects_empty_post_handshake_alert_fragment() {
     // Per RFC 9846 section 5.4, empty handshake and alert fragments must be rejected.
     let mut raw_client = RawTls::new_client(client);
     raw_client.encrypt_and_send(
-        &EncodedMessage {
+        &Record {
             typ: ContentType::Alert,
             version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
             payload: Payload::new(vec![]),
@@ -1380,9 +1380,9 @@ fn connection_types_are_not_huge() {
 
 #[test]
 fn test_client_rejects_illegal_tls13_ccs() {
-    fn corrupt_ccs(msg: &mut EncodedMessage<Vec<u8>>) -> Altered {
-        if msg.typ == ContentType::ChangeCipherSpec {
-            println!("seen CCS {:?}", msg.typ);
+    fn corrupt_ccs(record: &mut Record<Vec<u8>>) -> Altered {
+        if record.typ == ContentType::ChangeCipherSpec {
+            println!("seen CCS {:?}", record.typ);
             return Altered::Raw(encoding::message_framing(
                 ContentType::ChangeCipherSpec,
                 ProtocolVersion::TLSv1_2,
@@ -1582,8 +1582,8 @@ fn test_client_construction_requires_66_bytes_of_random_material() {
 
 #[test]
 fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message() {
-    fn inject_corrupt_finished_message(msg: &mut EncodedMessage<Vec<u8>>) -> Altered {
-        if msg.typ == ContentType::ChangeCipherSpec {
+    fn inject_corrupt_finished_message(record: &mut Record<Vec<u8>>) -> Altered {
+        if record.typ == ContentType::ChangeCipherSpec {
             // interdict "real" ChangeCipherSpec with its encoding, plus a faulty encrypted Finished.
             let mut raw_change_cipher_spec = encoding::message_framing(
                 ContentType::ChangeCipherSpec,
@@ -1800,7 +1800,7 @@ fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
 
     let mut raw_server = RawTls::new_server(server);
 
-    let msg = EncodedMessage {
+    let record = Record {
         typ: ContentType::Handshake,
         version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
         payload: Payload::new(encoding::handshake_framing(
@@ -1808,7 +1808,7 @@ fn test_illegal_server_renegotiation_attempt_after_tls13_handshake() {
             vec![],
         )),
     };
-    raw_server.encrypt_and_send(&msg, &mut client_input);
+    raw_server.encrypt_and_send(&record, &mut client_input);
     let err = client
         .process_new_packets(&mut client_input, &mut client_output)
         .handle_all(&mut Vec::new())
@@ -1846,7 +1846,7 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
 
     let mut raw_server = RawTls::new_server(server);
 
-    let msg = EncodedMessage {
+    let record = Record {
         typ: ContentType::Handshake,
         version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
         payload: Payload::new(encoding::handshake_framing(
@@ -1856,7 +1856,7 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
     };
 
     // one is allowed (and elicits a warning alert)
-    raw_server.encrypt_and_send(&msg, &mut client_input);
+    raw_server.encrypt_and_send(&record, &mut client_input);
     client
         .process_new_packets(&mut client_input, &mut client_output)
         .handle_all(&mut Vec::new())
@@ -1868,7 +1868,7 @@ fn test_illegal_server_renegotiation_attempt_after_tls12_handshake() {
     });
 
     // second is fatal
-    raw_server.encrypt_and_send(&msg, &mut client_input);
+    raw_server.encrypt_and_send(&record, &mut client_input);
     assert_eq!(
         client
             .process_new_packets(&mut client_input, &mut client_output)
@@ -1902,12 +1902,12 @@ fn test_illegal_client_renegotiation_attempt_after_tls13_handshake() {
 
     let mut raw_client = RawTls::new_client(client);
 
-    let msg = EncodedMessage {
+    let record = Record {
         typ: ContentType::Handshake,
         version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
         payload: Payload::new(encoding::basic_client_hello(vec![])),
     };
-    raw_client.encrypt_and_send(&msg, &mut server_input);
+    raw_client.encrypt_and_send(&record, &mut server_input);
     let err = server
         .process_new_packets(&mut server_input, &mut server_output)
         .handle_all(&mut Vec::new())
@@ -2093,14 +2093,14 @@ fn server_invalid_sni_policy() {
     const SERVER_NAME_BAD: &str = "[XXXxxxXXX]";
     const SERVER_NAME_IPV4: &str = "10.11.12.13";
 
-    fn replace_sni(sni_replacement: &str) -> impl Fn(&mut EncodedMessage<Vec<u8>>) -> Altered + '_ {
+    fn replace_sni(sni_replacement: &str) -> impl Fn(&mut Record<Vec<u8>>) -> Altered + '_ {
         assert_eq!(sni_replacement.len(), SERVER_NAME_GOOD.len());
-        move |m: &mut EncodedMessage<Vec<u8>>| {
-            if m.typ != ContentType::Handshake {
+        move |record: &mut Record<Vec<u8>>| {
+            if record.typ != ContentType::Handshake {
                 return Altered::InPlace;
             }
 
-            let Some(start) = m
+            let Some(start) = record
                 .payload
                 .windows(SERVER_NAME_GOOD.len())
                 .position(|w| w == SERVER_NAME_GOOD.as_bytes())
@@ -2108,7 +2108,7 @@ fn server_invalid_sni_policy() {
                 return Altered::InPlace;
             };
 
-            m.payload[start..][..SERVER_NAME_GOOD.len()]
+            record.payload[start..][..SERVER_NAME_GOOD.len()]
                 .copy_from_slice(sni_replacement.as_bytes());
             Altered::InPlace
         }

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -212,7 +212,7 @@ fn unoffered_alpn_test(check_selected_alpn: bool) -> Result<rustls::IoState, Err
     let mut input = VecInput::default();
     input
         .read(
-            &mut encoding::message_framing(
+            &mut encoding::record_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
                 encoding::server_hello(
@@ -1383,7 +1383,7 @@ fn test_client_rejects_illegal_tls13_ccs() {
     fn corrupt_ccs(record: &mut Record<Vec<u8>>) -> Altered {
         if record.typ == ContentType::ChangeCipherSpec {
             println!("seen CCS {:?}", record.typ);
-            return Altered::Raw(encoding::message_framing(
+            return Altered::Raw(encoding::record_framing(
                 ContentType::ChangeCipherSpec,
                 ProtocolVersion::TLSv1_2,
                 vec![0x01, 0x02],
@@ -1581,16 +1581,16 @@ fn test_client_construction_requires_66_bytes_of_random_material() {
 }
 
 #[test]
-fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message() {
-    fn inject_corrupt_finished_message(record: &mut Record<Vec<u8>>) -> Altered {
+fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_record() {
+    fn inject_corrupt_finished_record(record: &mut Record<Vec<u8>>) -> Altered {
         if record.typ == ContentType::ChangeCipherSpec {
             // interdict "real" ChangeCipherSpec with its encoding, plus a faulty encrypted Finished.
-            let mut raw_change_cipher_spec = encoding::message_framing(
+            let mut raw_change_cipher_spec = encoding::record_framing(
                 ContentType::ChangeCipherSpec,
                 ProtocolVersion::TLSv1_2,
                 vec![0x01],
             );
-            let mut corrupt_finished = encoding::message_framing(
+            let mut corrupt_finished = encoding::record_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
                 vec![0u8; 0x28],
@@ -1643,7 +1643,7 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
         .unwrap();
     transfer_altered(
         &mut server_output,
-        inject_corrupt_finished_message,
+        inject_corrupt_finished_record,
         &mut client_input,
     );
 
@@ -2039,7 +2039,7 @@ fn acceptor_with_illegal_max_fragment_size() {
     let mut input = VecInput::default();
     input
         .read(
-            &mut encoding::message_framing(
+            &mut encoding::record_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
                 encoding::basic_client_hello(vec![]),
@@ -2073,7 +2073,7 @@ fn excess_client_hello_acceptor() {
     let mut hello = encoding::basic_client_hello(vec![]);
     hello.extend(&hello[..10].to_vec());
     let mut hello =
-        encoding::message_framing(ContentType::Handshake, ProtocolVersion::TLSv1_2, hello);
+        encoding::record_framing(ContentType::Handshake, ProtocolVersion::TLSv1_2, hello);
 
     let receive = ServerHandshake::start();
     let mut output = vec![];

--- a/rustls-test/tests/api/io.rs
+++ b/rustls-test/tests/api/io.rs
@@ -413,8 +413,8 @@ fn client_complete_io_for_write() {
             )
             .unwrap();
             assert!(rdlen == 0 && wrlen > 0);
-            println!("{:?}", pipe.message_lengths());
-            assert_eq!(pipe.message_lengths(), vec![42, 42]);
+            println!("{:?}", pipe.record_lengths());
+            assert_eq!(pipe.record_lengths(), vec![42, 42]);
             assert_eq!(&pipe.received, b"0123456789012345678901234567890123456789",);
         }
     }
@@ -626,8 +626,8 @@ fn buffered_client_complete_io_for_write() {
             )
             .unwrap();
             assert!(rdlen == 0 && wrlen > 0);
-            println!("{:?}", pipe.message_lengths());
-            assert_eq!(pipe.message_lengths(), vec![42, 42]);
+            println!("{:?}", pipe.record_lengths());
+            assert_eq!(pipe.record_lengths(), vec![42, 42]);
             assert_eq!(&pipe.received, b"0123456789012345678901234567890123456789",);
         }
     }
@@ -760,7 +760,7 @@ fn server_complete_io_for_write() {
             )
             .unwrap();
             assert!(rdlen == 0 && wrlen > 0);
-            assert_eq!(pipe.message_lengths(), vec![42, 42]);
+            assert_eq!(pipe.record_lengths(), vec![42, 42]);
             assert_eq!(&pipe.received, b"0123456789012345678901234567890123456789",);
         }
     }
@@ -1570,7 +1570,7 @@ fn server_appdata_record_layout() {
         .write_tls(b"01234567890123456789".into(), &mut server_output)
         .unwrap();
     assert_eq!(84, server_output.len());
-    assert_eq!(message_lengths(&server_output), vec![42, 42]);
+    assert_eq!(record_lengths(&server_output), vec![42, 42]);
     transfer(&mut server_output, &mut client_input);
     let mut received = Vec::new();
     client
@@ -1608,7 +1608,7 @@ fn client_appdata_record_layout() {
         .write_tls(b"01234567890123456789".into(), &mut client_output)
         .unwrap();
     assert_eq!(84, client_output.len());
-    assert_eq!(message_lengths(&client_output), vec![42, 42]);
+    assert_eq!(record_lengths(&client_output), vec![42, 42]);
     transfer(&mut client_output, &mut server_input);
     let mut received = Vec::new();
     server
@@ -1647,7 +1647,7 @@ fn server_handshake_with_half_rtt_data() {
 
     // don't assert exact sizes here, to avoid a brittle test
     assert!(server_output.len() > 2400); // its pretty big (contains cert chain)
-    assert_eq!(message_lengths(&server_output).len(), 5); // at least a server hello/ccs/cert/serverkx/0.5rtt data
+    assert_eq!(record_lengths(&server_output).len(), 5); // at least a server hello/ccs/cert/serverkx/0.5rtt data
     transfer(&mut server_output, &mut client_input);
 
     // The client decrypts the 0.5-RTT application data as part of this flight.
@@ -1701,7 +1701,7 @@ fn check_half_rtt_does_not_work(server_config: ServerConfig) {
 
     // don't assert exact sizes here, to avoid a brittle test
     assert!(server_output.len() > 2400); // its pretty big (contains cert chain)
-    assert_eq!(message_lengths(&server_output).len(), 3); // at least a server hello/ccs/cert/serverkx data
+    assert_eq!(record_lengths(&server_output).len(), 3); // at least a server hello/ccs/cert/serverkx data
     transfer(&mut server_output, &mut client_input);
 
     // client second flight
@@ -1725,7 +1725,7 @@ fn check_half_rtt_does_not_work(server_config: ServerConfig) {
         .write_tls(b"0123456789".into(), &mut server_output)
         .unwrap();
     assert_eq!(server_output.len(), 258);
-    let lengths = message_lengths(&server_output);
+    let lengths = record_lengths(&server_output);
     assert_eq!(lengths[lengths.len() - 2..], [42, 32]);
     transfer(&mut server_output, &mut client_input);
     let mut received = Vec::new();
@@ -1770,7 +1770,7 @@ fn client_handshake_flights() {
 
     // don't assert exact sizes here, to avoid a brittle test
     assert!(client_output.len() > 200); // just the client hello
-    assert_eq!(message_lengths(&client_output).len(), 1); // only a client hello
+    assert_eq!(record_lengths(&client_output).len(), 1); // only a client hello
     transfer(&mut client_output, &mut server_input);
     server
         .process_new_packets(&mut server_input, &mut server_output)
@@ -1791,7 +1791,7 @@ fn client_handshake_flights() {
 
     // CCS, finished, then two application data records
     assert_eq!(client_output.len(), 138);
-    assert_eq!(message_lengths(&client_output), vec![6, 58, 42, 32]);
+    assert_eq!(record_lengths(&client_output), vec![6, 58, 42, 32]);
     transfer(&mut client_output, &mut server_input);
     let mut received = Vec::new();
     server
@@ -1814,7 +1814,7 @@ fn test_client_mtu_reduction() {
         let (_client, _server) =
             make_pair_for_arc_configs(&Arc::new(client_config), &server_config, &mut client_output);
 
-        for length in message_lengths(&client_output) {
+        for length in record_lengths(&client_output) {
             assert!(length <= 64);
         }
     }
@@ -1849,7 +1849,7 @@ fn test_server_mtu_reduction() {
             server
                 .write_tls((&big_data).into(), &mut server_output)
                 .unwrap();
-            for length in message_lengths(&server_output) {
+            for length in record_lengths(&server_output) {
                 assert!(length <= 64);
             }
             transfer(&mut server_output, &mut client_input);
@@ -1864,7 +1864,7 @@ fn test_server_mtu_reduction() {
             .process_new_packets(&mut server_input, &mut server_output)
             .handle_all(&mut Vec::new())
             .unwrap();
-        for length in message_lengths(&server_output) {
+        for length in record_lengths(&server_output) {
             assert!(length <= 64);
         }
         transfer(&mut server_output, &mut client_input);
@@ -2117,7 +2117,7 @@ fn test_server_handshake() {
         // Minimal valid 1-byte application data message is not a handshake message
         acceptor_input
             .read(
-                &mut encoding::message_framing(
+                &mut encoding::record_framing(
                     ContentType::ApplicationData,
                     ProtocolVersion::TLSv1_2,
                     vec![0x00],
@@ -2138,7 +2138,7 @@ fn test_server_handshake() {
         // Minimal 1-byte ClientHello message is not a legal handshake message
         acceptor_input
             .read(
-                &mut encoding::message_framing(
+                &mut encoding::record_framing(
                     ContentType::Handshake,
                     ProtocolVersion::TLSv1_2,
                     encoding::handshake_framing(HandshakeType::ClientHello, vec![0x00]),
@@ -2641,7 +2641,7 @@ fn test_close_notify_sent_prior_to_handshake_complete() {
     let mut server_output = Vec::new();
     server_input
         .read(
-            &mut encoding::message_framing(
+            &mut encoding::record_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
                 encoding::basic_client_hello(vec![]),
@@ -2746,7 +2746,7 @@ fn test_read_tls_artificial_eof_after_close_notify() {
     );
 }
 
-fn message_lengths(mut tls: &[u8]) -> Vec<usize> {
+fn record_lengths(mut tls: &[u8]) -> Vec<usize> {
     let mut lengths = Vec::new();
     while !tls.is_empty() {
         let length = 5 + u16::from_be_bytes([tls[3], tls[4]]) as usize;

--- a/rustls-test/tests/api/kx.rs
+++ b/rustls-test/tests/api/kx.rs
@@ -163,7 +163,7 @@ fn test_client_sends_helloretryrequest() {
             .unwrap();
         client_output.clear();
         assert!(wrlen > 200);
-        assert_eq!(pipe.message_lengths().len(), 1);
+        assert_eq!(pipe.record_lengths().len(), 1);
     }
 
     assert_eq!(client.handshake_kind(), None);
@@ -177,7 +177,7 @@ fn test_client_sends_helloretryrequest() {
             .unwrap();
         server_output.clear();
         assert!(wrlen < 100); // just the hello retry request
-        assert_eq!(pipe.message_lengths().len(), 2); // hello retry request and CCS
+        assert_eq!(pipe.record_lengths().len(), 2); // hello retry request and CCS
     }
 
     assert_eq!(client.handshake_kind(), None);
@@ -191,7 +191,7 @@ fn test_client_sends_helloretryrequest() {
             .unwrap();
         client_output.clear();
         assert!(wrlen > 200); // just the client hello retry
-        assert_eq!(pipe.message_lengths().len(), 2); // only a CCS & client hello retry
+        assert_eq!(pipe.record_lengths().len(), 2); // only a CCS & client hello retry
     }
 
     // server completes handshake
@@ -202,7 +202,7 @@ fn test_client_sends_helloretryrequest() {
             .unwrap();
         server_output.clear();
         assert!(wrlen > 200);
-        assert_eq!(pipe.message_lengths().len(), 2); // { server hello / encrypted exts / cert / cert-verify } / finished
+        assert_eq!(pipe.record_lengths().len(), 2); // { server hello / encrypted exts / cert / cert-verify } / finished
     }
 
     assert_eq!(
@@ -437,7 +437,7 @@ fn test_server_rejects_clients_without_any_kx_groups() {
     let mut server_input = VecInput::default();
     server_input
         .read(
-            &mut encoding::message_framing(
+            &mut encoding::record_framing(
                 ContentType::Handshake,
                 ProtocolVersion::TLSv1_2,
                 encoding::client_hello_with_extensions(vec![

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -865,7 +865,7 @@ mod tests {
         Tls13ClientSessionInput, VerifiedIdentity,
     };
     use crate::conn::Connection;
-    use crate::crypto::cipher::EncodedMessage;
+    use crate::crypto::cipher::Record;
     use crate::crypto::hpke::{HpkeAead, HpkeKdf};
     use crate::crypto::{CipherSuite, GetRandomFailed, Identity, TEST_PROVIDER, tls13_only};
     use crate::msgs::{
@@ -1090,7 +1090,7 @@ mod tests {
         fn client_hello_in(bytes: &[u8]) -> ClientHelloPayload {
             let mut reader = Reader::new(bytes);
             while reader.any_left() {
-                let encoded = EncodedMessage::<Payload<'_>>::read(&mut reader)
+                let record = Record::<Payload<'_>>::read(&mut reader)
                     .unwrap()
                     .into_owned();
                 if let Ok(Message {
@@ -1100,7 +1100,7 @@ mod tests {
                             ..
                         },
                     ..
-                }) = Message::try_from(&encoded)
+                }) = Message::try_from(&record)
                 {
                     return ch;
                 }

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -12,7 +12,7 @@ use pki_types::{CertificateDer, FipsStatus, ServerName, UnixTime};
 use super::{Tls12Session, Tls13ClientSessionInput, Tls13Session};
 use crate::client::{ClientConfig, ClientConnection, Resumption, Tls12Resumption};
 use crate::crypto::cipher::{
-    EncodableVersion, MessageEncrypter, Payload, Record, encode_record_header,
+    EncodableVersion, Payload, Record, RecordEncrypter, encode_record_header,
 };
 use crate::crypto::kx::{self, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup};
 use crate::crypto::test_provider::{FakeKeyExchangeGroup, KEY_EXCHANGE_GROUP, TLS_TEST_SUITE};
@@ -768,7 +768,7 @@ impl FakeServerCrypto {
         }
     }
 
-    fn server_handshake_encrypter(&self) -> Box<dyn MessageEncrypter> {
+    fn server_handshake_encrypter(&self) -> Box<dyn RecordEncrypter> {
         let secret = self
             .server_handshake_secret
             .get()

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -12,7 +12,7 @@ use pki_types::{CertificateDer, FipsStatus, ServerName, UnixTime};
 use super::{Tls12Session, Tls13ClientSessionInput, Tls13Session};
 use crate::client::{ClientConfig, ClientConnection, Resumption, Tls12Resumption};
 use crate::crypto::cipher::{
-    EncodableVersion, EncodedMessage, MessageEncrypter, Payload, encode_record_header,
+    EncodableVersion, MessageEncrypter, Payload, Record, encode_record_header,
 };
 use crate::crypto::kx::{self, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup};
 use crate::crypto::test_provider::{FakeKeyExchangeGroup, KEY_EXCHANGE_GROUP, TLS_TEST_SUITE};
@@ -552,7 +552,7 @@ fn client_requiring_rpk_receives_server_ee(
     };
 
     let mut encrypter = fake_server_crypto.server_handshake_encrypter();
-    let ee = EncodedMessage::<Payload<'_>>::from(ee);
+    let ee = Record::<Payload<'_>>::from(ee);
     let ee = ee.borrow_outbound();
     let mut enc_ee = vec![0u8; HEADER_SIZE + encrypter.encrypted_payload_len(ee.payload.len())];
     let encrypted = encrypter
@@ -850,10 +850,10 @@ fn client_hello_sent_for_config(config: ClientConfig) -> Result<ClientHelloPaylo
         .connect(ServerName::try_from("localhost").unwrap())
         .build(&mut bytes)?;
 
-    let message = EncodedMessage::<Payload<'_>>::read(&mut Reader::new(&bytes))
+    let record = Record::<Payload<'_>>::read(&mut Reader::new(&bytes))
         .unwrap()
         .into_owned();
-    match Message::try_from(&message).unwrap() {
+    match Message::try_from(&record).unwrap() {
         Message {
             payload:
                 MessagePayload::Handshake {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -15,7 +15,7 @@ use crate::check::{inappropriate_handshake_message, inappropriate_message};
 use crate::common_state::{HandshakeKind, Output, OutputEvent, Side};
 use crate::conn::kernel::KernelState;
 use crate::conn::{ConnectionRandoms, Input};
-use crate::crypto::cipher::{EncodableVersion, MessageDecrypter, MessageEncrypter, Payload};
+use crate::crypto::cipher::{EncodableVersion, Payload, RecordDecrypter, RecordEncrypter};
 use crate::crypto::kx::KeyExchangeAlgorithm;
 use crate::crypto::{Identity, Signer};
 use crate::enums::{CertificateType, ContentType, HandshakeType, ProtocolVersion};
@@ -927,8 +927,8 @@ struct ExpectNewTicket {
     hs: HandshakeState,
     secrets: ConnectionSecrets,
     peer_identity: VerifiedIdentity<'static>,
-    resuming: Option<(Tls12Session, Box<dyn MessageEncrypter>)>,
-    pending_decrypter: Box<dyn MessageDecrypter>,
+    resuming: Option<(Tls12Session, Box<dyn RecordEncrypter>)>,
+    pending_decrypter: Box<dyn RecordDecrypter>,
     sig_verified: HandshakeSignatureValid,
 }
 
@@ -970,8 +970,8 @@ struct ExpectCcs {
     hs: HandshakeState,
     secrets: ConnectionSecrets,
     peer_identity: VerifiedIdentity<'static>,
-    resuming: Option<(Tls12Session, Box<dyn MessageEncrypter>)>,
-    pending_decrypter: Box<dyn MessageDecrypter>,
+    resuming: Option<(Tls12Session, Box<dyn RecordEncrypter>)>,
+    pending_decrypter: Box<dyn RecordDecrypter>,
     ticket: Option<NewSessionTicketPayload>,
     sig_verified: HandshakeSignatureValid,
 }
@@ -999,7 +999,7 @@ impl ExpectCcs {
         output
             .receive()
             .decrypt_state
-            .set_message_decrypter(self.pending_decrypter, &proof);
+            .set_record_decrypter(self.pending_decrypter, &proof);
 
         Ok(Box::new(ExpectFinished {
             hs: self.hs,
@@ -1022,7 +1022,7 @@ impl From<Box<ExpectCcs>> for ClientState {
 pub(super) struct ExpectFinished {
     hs: HandshakeState,
     peer_identity: VerifiedIdentity<'static>,
-    resuming: Option<(Tls12Session, Box<dyn MessageEncrypter>)>,
+    resuming: Option<(Tls12Session, Box<dyn RecordEncrypter>)>,
     ticket: Option<NewSessionTicketPayload>,
     secrets: ConnectionSecrets,
     sig_verified: HandshakeSignatureValid,

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -145,7 +145,7 @@ impl<'a, 'm, Side: SideData, Send: SendOutput + 'a> MessageIter<'a, 'm, Side, Se
             let result =
                 match output
                     .recv
-                    .receive_message(record, hs_aligned, output.tls, output.other.send)
+                    .receive_record(record, hs_aligned, output.tls, output.other.send)
                 {
                     Ok(Some(input)) => st.handle(input, &mut output),
                     Ok(None) => Ok(st),
@@ -234,15 +234,15 @@ impl ReceivePath {
         }
     }
 
-    /// Pull a message out of the deframer and send any messages that need to be sent as a result.
+    /// Pull a potentially coalesced record out of the deframer.
     fn deframe<'b>(&mut self, buffer: &'b mut [u8]) -> Result<Option<Decrypted<'b>>, Error> {
         let locator = Locator::new(buffer);
 
         let mut want_close_before_decrypt = false;
         loop {
-            // before processing any more of `buffer`, return any extant messages from `deframer`
+            // before processing any more of `buffer`, return any extant records from `deframer`
             if let Some(span) = self.deframer.complete_span() {
-                let plaintext = self.deframer.message(span, buffer);
+                let plaintext = self.deframer.record(span, buffer);
 
                 // trial decryption finishes with the first handshake message after it started.
                 self.decrypt_state
@@ -293,7 +293,7 @@ impl ReceivePath {
             // do an end-run around the borrow checker, converting `record` (containing
             // a borrowed slice) to an unborrowed one (containing a `Range` into the
             // same buffer).  the reborrow happens inside the branch that returns the
-            // message.
+            // record.
             //
             // is fixed by -Zpolonius
             // https://github.com/rust-lang/rfcs/blob/master/text/2094-nll.md#problem-case-3-conditional-control-flow-across-functions
@@ -332,7 +332,7 @@ impl ReceivePath {
             // Alerts are allowed to be plaintext if-and-only-if:
             // * The negotiated protocol version is TLS 1.3. - In TLS 1.2 it is unambiguous when
             //   keying changes based on the CCS message. Only TLS 1.3 requires these heuristics.
-            // * We have not yet decrypted any messages from the peer - if we have we don't
+            // * We have not yet decrypted any records from the peer - if we have we don't
             //   expect any plaintext.
             // * The payload size is indicative of a plaintext alert message.
             ContentType::Alert
@@ -342,7 +342,7 @@ impl ReceivePath {
             {
                 true
             }
-            // In other circumstances, we expect all messages to be encrypted.
+            // In other circumstances, we expect all records to be encrypted.
             _ => false,
         };
 
@@ -377,16 +377,16 @@ impl ReceivePath {
         }
     }
 
-    /// Take a TLS message `record` and map it into an `Input`
+    /// Take a TLS record and map it into an `Input`
     ///
     /// `Input` is the input to our state machine.
     ///
-    /// The message is mapped into `None` if it should be dropped with no further
+    /// The record is mapped into `None` if it should be dropped with no further
     /// action.
     ///
     /// Otherwise the caller must present the returned `Input` to the state machine to
     /// progress the connection.
-    pub(crate) fn receive_message<'a>(
+    pub(crate) fn receive_record<'a>(
         &mut self,
         record: Record<&'a [u8]>,
         aligned_handshake: Option<HandshakeAlignedProof>,
@@ -399,7 +399,7 @@ impl ReceivePath {
             return Ok(None);
         }
 
-        // Now we can fully parse the message payload.
+        // Now we can fully parse the record payload.
         let message = Message::try_from(record)?;
 
         // For alerts, we have separate logic.
@@ -798,7 +798,7 @@ impl VecInput {
         }
 
         // Try to do the largest reads possible. Note that if
-        // we get a message with a length field out of range here,
+        // we get a record with a length field out of range here,
         // we do a zero length read.  That looks like an EOF to
         // the next layer up, which is fine.
         let new_bytes = rd.read(&mut self.buf[self.used..])?;

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -12,9 +12,7 @@ use crate::common_state::{
 };
 use crate::conn::private::SideOutput;
 use crate::conn::{ConnectionCommon, StateMachine};
-use crate::crypto::cipher::{
-    Decrypted, DecryptionState, EncodableVersion, EncodedMessage, Payload,
-};
+use crate::crypto::cipher::{Decrypted, DecryptionState, EncodableVersion, Payload, Record};
 use crate::enums::{ContentType, HandshakeType, ProtocolVersion};
 use crate::error::{AlertDescription, Error, PeerMisbehaved};
 use crate::msgs::{
@@ -102,8 +100,8 @@ impl<'a, 'm, Side: SideData, Send: SendOutput + 'a> MessageIter<'a, 'm, Side, Se
                 _message_lifetime: PhantomData,
             };
 
-            let opt_msg = match res {
-                Ok(opt_msg) => opt_msg,
+            let opt_record = match res {
+                Ok(opt_record) => opt_record,
                 Err(e) => {
                     maybe_send_fatal_alert(output.other.send, &e, output.tls);
                     if let Error::DecryptError = e {
@@ -114,14 +112,14 @@ impl<'a, 'm, Side: SideData, Send: SendOutput + 'a> MessageIter<'a, 'm, Side, Se
                 }
             };
 
-            let Some(msg) = opt_msg else {
+            let Some(record) = opt_record else {
                 break;
             };
 
             let Decrypted {
-                plaintext: msg,
+                plaintext: record,
                 want_close_before_decrypt,
-            } = msg;
+            } = record;
 
             if want_close_before_decrypt {
                 output.other.send.send_alert(
@@ -129,8 +127,8 @@ impl<'a, 'm, Side: SideData, Send: SendOutput + 'a> MessageIter<'a, 'm, Side, Se
                     AlertDescription::CloseNotify,
                     output.tls,
                 );
-            } else if msg.payload.is_empty()
-                && matches!(msg.typ, ContentType::Handshake | ContentType::Alert)
+            } else if record.payload.is_empty()
+                && matches!(record.typ, ContentType::Handshake | ContentType::Alert)
             {
                 // <https://datatracker.ietf.org/doc/html/rfc9846#section-5.4>
                 output.other.send.send_alert(
@@ -147,7 +145,7 @@ impl<'a, 'm, Side: SideData, Send: SendOutput + 'a> MessageIter<'a, 'm, Side, Se
             let result =
                 match output
                     .recv
-                    .receive_message(msg, hs_aligned, output.tls, output.other.send)
+                    .receive_message(record, hs_aligned, output.tls, output.other.send)
                 {
                     Ok(Some(input)) => st.handle(input, &mut output),
                     Ok(None) => Ok(st),
@@ -256,7 +254,7 @@ impl ReceivePath {
                 }));
             }
 
-            let (message, bounds) = loop {
+            let (record, bounds) = loop {
                 match self.deframe_decrypted(buffer, &locator)? {
                     DeframeResult::Decrypted(decrypted, bounds) => break (decrypted, bounds),
                     DeframeResult::DecryptionFailed => continue,
@@ -264,13 +262,13 @@ impl ReceivePath {
                 }
             };
 
-            want_close_before_decrypt = message.want_close_before_decrypt;
+            want_close_before_decrypt = record.want_close_before_decrypt;
             let Decrypted {
-                plaintext: message,
+                plaintext: record,
                 want_close_before_decrypt: _,
-            } = message;
+            } = record;
 
-            if self.deframer.aligned().is_none() && message.typ != ContentType::Handshake {
+            if self.deframer.aligned().is_none() && record.typ != ContentType::Handshake {
                 // "Handshake messages MUST NOT be interleaved with other record
                 // types.  That is, if a handshake message is split over two or more
                 // records, there MUST NOT be any other records between them."
@@ -278,7 +276,7 @@ impl ReceivePath {
                 return Err(PeerMisbehaved::MessageInterleavedWithHandshakeMessage.into());
             }
 
-            match message.payload.len() {
+            match record.payload.len() {
                 0 => {
                     if self.seen_consecutive_empty_fragments
                         == ALLOWED_CONSECUTIVE_EMPTY_FRAGMENTS_MAX
@@ -292,27 +290,27 @@ impl ReceivePath {
                 }
             };
 
-            // do an end-run around the borrow checker, converting `message` (containing
+            // do an end-run around the borrow checker, converting `record` (containing
             // a borrowed slice) to an unborrowed one (containing a `Range` into the
             // same buffer).  the reborrow happens inside the branch that returns the
             // message.
             //
             // is fixed by -Zpolonius
             // https://github.com/rust-lang/rfcs/blob/master/text/2094-nll.md#problem-case-3-conditional-control-flow-across-functions
-            let unborrowed = InboundUnborrowedMessage::unborrow(&locator, message);
+            let unborrowed = InboundUnborrowedRecord::unborrow(&locator, record);
 
             if unborrowed.typ != ContentType::Handshake {
-                let message = unborrowed.reborrow(&Delocator::new(buffer));
+                let record = unborrowed.reborrow(&Delocator::new(buffer));
                 self.deframer.discard_processed();
                 return Ok(Some(Decrypted {
-                    plaintext: message,
+                    plaintext: record,
                     want_close_before_decrypt,
                 }));
             }
 
-            let message = unborrowed.reborrow(&Delocator::new(buffer));
+            let record = unborrowed.reborrow(&Delocator::new(buffer));
             self.deframer
-                .input_message(message.version.version(), bounds, buffer);
+                .input_message(record.version.version(), bounds, buffer);
             self.deframer.coalesce(buffer)?;
         }
     }
@@ -322,13 +320,13 @@ impl ReceivePath {
         buffer: &'b mut [u8],
         locator: &Locator,
     ) -> Result<DeframeResult<'b>, Error> {
-        let (message, bounds) = match self.deframer.deframe(buffer) {
-            Some(Ok(Deframed { message, bounds })) => (message, bounds),
+        let (record, bounds) = match self.deframer.deframe(buffer) {
+            Some(Ok(Deframed { record, bounds })) => (record, bounds),
             Some(Err(err)) => return Err(err),
             None => return Ok(DeframeResult::None),
         };
 
-        let allowed_plaintext = match message.typ {
+        let allowed_plaintext = match record.typ {
             // CCS messages are always plaintext.
             ContentType::ChangeCipherSpec => true,
             // Alerts are allowed to be plaintext if-and-only-if:
@@ -340,7 +338,7 @@ impl ReceivePath {
             ContentType::Alert
                 if matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
                     && !self.decrypt_state.has_decrypted()
-                    && message.payload.len() <= 2 =>
+                    && record.payload.len() <= 2 =>
             {
                 true
             }
@@ -351,7 +349,7 @@ impl ReceivePath {
         if allowed_plaintext && !self.deframer.is_active() {
             return Ok(DeframeResult::Decrypted(
                 Decrypted {
-                    plaintext: message.into_plain_message(),
+                    plaintext: record.into_plain_record(),
                     want_close_before_decrypt: false,
                 },
                 bounds,
@@ -360,7 +358,7 @@ impl ReceivePath {
 
         match self
             .decrypt_state
-            .decrypt_incoming(message)?
+            .decrypt_incoming(record)?
         {
             Some(decrypted) => {
                 // After decryption, the payload is shorter
@@ -379,7 +377,7 @@ impl ReceivePath {
         }
     }
 
-    /// Take a TLS message `msg` and map it into an `Input`
+    /// Take a TLS message `record` and map it into an `Input`
     ///
     /// `Input` is the input to our state machine.
     ///
@@ -390,19 +388,19 @@ impl ReceivePath {
     /// progress the connection.
     pub(crate) fn receive_message<'a>(
         &mut self,
-        msg: EncodedMessage<&'a [u8]>,
+        record: Record<&'a [u8]>,
         aligned_handshake: Option<HandshakeAlignedProof>,
         tls: &mut Vec<u8>,
         send: &mut dyn SendOutput,
     ) -> Result<Option<Input<'a>>, Error> {
         // Drop CCS messages during handshake in TLS1.3
-        if msg.typ == ContentType::ChangeCipherSpec && self.drop_tls13_ccs(&msg)? {
+        if record.typ == ContentType::ChangeCipherSpec && self.drop_tls13_ccs(&record)? {
             trace!("Dropping CCS");
             return Ok(None);
         }
 
         // Now we can fully parse the message payload.
-        let message = Message::try_from(msg)?;
+        let message = Message::try_from(record)?;
 
         // For alerts, we have separate logic.
         if let MessagePayload::Alert(alert) = &message.payload {
@@ -422,14 +420,14 @@ impl ReceivePath {
         }))
     }
 
-    fn drop_tls13_ccs(&mut self, msg: &EncodedMessage<&'_ [u8]>) -> Result<bool, Error> {
+    fn drop_tls13_ccs(&mut self, record: &Record<&'_ [u8]>) -> Result<bool, Error> {
         if self.may_receive_application_data
             || !matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
         {
             return Ok(false);
         }
 
-        if !msg.is_valid_ccs() {
+        if !record.is_valid_ccs() {
             // "An implementation which receives any other change_cipher_spec value or
             //  which receives a protected change_cipher_spec record MUST abort the
             //  handshake with an "unexpected_message" alert."
@@ -714,25 +712,25 @@ impl Input<'_> {
     }
 }
 
-/// An [`EncodedMessage<Payload<'_>>`] which does not borrow its payload, but
+/// An [`Record<Payload<'_>>`] which does not borrow its payload, but
 /// references a range that can later be borrowed.
-struct InboundUnborrowedMessage {
+struct InboundUnborrowedRecord {
     typ: ContentType,
     version: EncodableVersion,
     bounds: Range<usize>,
 }
 
-impl InboundUnborrowedMessage {
-    fn unborrow(locator: &Locator, msg: EncodedMessage<&'_ [u8]>) -> Self {
+impl InboundUnborrowedRecord {
+    fn unborrow(locator: &Locator, record: Record<&'_ [u8]>) -> Self {
         Self {
-            typ: msg.typ,
-            version: msg.version,
-            bounds: locator.locate(msg.payload),
+            typ: record.typ,
+            version: record.version,
+            bounds: locator.locate(record.payload),
         }
     }
 
-    fn reborrow<'b>(self, delocator: &Delocator<'b>) -> EncodedMessage<&'b [u8]> {
-        EncodedMessage {
+    fn reborrow<'b>(self, delocator: &Delocator<'b>) -> Record<&'b [u8]> {
+        Record {
             typ: self.typ,
             version: self.version,
             payload: delocator.slice_from_range(&self.bounds),

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -2,8 +2,8 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use crate::crypto::cipher::{
-    EncodableVersion, EncryptionState, MessageEncrypter, OutboundPlain, Payload, PreEncryptAction,
-    Record,
+    EncodableVersion, EncryptionState, OutboundPlain, Payload, PreEncryptAction, Record,
+    RecordEncrypter,
 };
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{AlertDescription, Error};
@@ -200,9 +200,9 @@ impl SendOutput for SendPath {
         }
     }
 
-    fn set_encrypter(&mut self, encrypter: Box<dyn MessageEncrypter>, max_messages: u64) {
+    fn set_encrypter(&mut self, encrypter: Box<dyn RecordEncrypter>, max_records: u64) {
         self.encrypt_state
-            .set_message_encrypter(encrypter, max_messages);
+            .set_record_encrypter(encrypter, max_records);
     }
 
     fn update_key_schedule(&mut self, schedule: Box<KeyScheduleTrafficSend>) {
@@ -295,7 +295,7 @@ pub(crate) trait SendOutput {
 
     fn note_key_update_response(&mut self);
 
-    fn set_encrypter(&mut self, cipher: Box<dyn MessageEncrypter>, max_messages: u64);
+    fn set_encrypter(&mut self, cipher: Box<dyn RecordEncrypter>, max_records: u64);
 
     fn update_key_schedule(&mut self, schedule: Box<KeyScheduleTrafficSend>);
 

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -19,7 +19,7 @@ pub(crate) struct SendPath {
     has_sent_fatal_alert: bool,
     /// If we signaled end of stream.
     pub(crate) has_sent_close_notify: bool,
-    message_fragmenter: Fragmenter,
+    fragmenter: Fragmenter,
     key_update_local: KeyUpdateLocal,
     key_update_remote: KeyUpdateRemote,
     negotiated_version: Option<ProtocolVersion>,
@@ -73,8 +73,8 @@ impl SendPath {
         tls: &mut Vec<u8>,
     ) -> usize {
         let len = payload.len();
-        self.send_messages::<true>(
-            self.message_fragmenter.fragment(
+        self.send_records::<true>(
+            self.fragmenter.fragment(
                 ContentType::ApplicationData,
                 EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
                 payload,
@@ -88,7 +88,7 @@ impl SendPath {
     }
 
     /// Encrypt and queue each fragment in `iter`.
-    fn send_messages<'a, const MUST_ENCRYPT: bool>(
+    fn send_records<'a, const MUST_ENCRYPT: bool>(
         &mut self,
         iter: impl ExactSizeIterator<Item = Record<OutboundPlain<'a>>>,
         tls: &mut Vec<u8>,
@@ -139,7 +139,7 @@ impl SendPath {
     }
 
     pub(crate) fn set_max_fragment_size(&mut self, new: Option<usize>) -> Result<(), Error> {
-        self.message_fragmenter
+        self.fragmenter
             .set_max_fragment_size(new)
     }
 
@@ -231,7 +231,7 @@ impl SendOutput for SendPath {
     /// Send a raw TLS message, fragmenting it if needed.
     fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool, tls: &mut Vec<u8>) {
         let record = Record::from(m);
-        let fragments = self.message_fragmenter.fragment(
+        let fragments = self.fragmenter.fragment(
             record.typ,
             record.version,
             record.payload.bytes().into(),
@@ -240,8 +240,8 @@ impl SendOutput for SendPath {
         );
 
         match must_encrypt {
-            true => self.send_messages::<true>(fragments, tls),
-            false => self.send_messages::<false>(fragments, tls),
+            true => self.send_records::<true>(fragments, tls),
+            false => self.send_records::<false>(fragments, tls),
         }
     }
 }
@@ -254,7 +254,7 @@ impl Default for SendPath {
             may_send_half_rtt_data: false,
             has_sent_fatal_alert: false,
             has_sent_close_notify: false,
-            message_fragmenter: Fragmenter::default(),
+            fragmenter: Fragmenter::default(),
             key_update_local: KeyUpdateLocal::Idle,
             key_update_remote: KeyUpdateRemote::Idle,
             negotiated_version: None,

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -2,8 +2,8 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use crate::crypto::cipher::{
-    EncodableVersion, EncodedMessage, EncryptionState, MessageEncrypter, OutboundPlain, Payload,
-    PreEncryptAction,
+    EncodableVersion, EncryptionState, MessageEncrypter, OutboundPlain, Payload, PreEncryptAction,
+    Record,
 };
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{AlertDescription, Error};
@@ -90,7 +90,7 @@ impl SendPath {
     /// Encrypt and queue each fragment in `iter`.
     fn send_messages<'a, const MUST_ENCRYPT: bool>(
         &mut self,
-        iter: impl ExactSizeIterator<Item = EncodedMessage<OutboundPlain<'a>>>,
+        iter: impl ExactSizeIterator<Item = Record<OutboundPlain<'a>>>,
         tls: &mut Vec<u8>,
     ) {
         self.perhaps_write_key_update(tls);
@@ -107,10 +107,10 @@ impl SendPath {
             tls.reserve(count * record_len);
         }
 
-        for m in iter {
+        for record in iter {
             // Alerts are always sendable -- never quashed by a PreEncryptAction.
             if MUST_ENCRYPT
-                && m.typ != ContentType::Alert
+                && record.typ != ContentType::Alert
                 && self.preflight_encrypt(0, tls).is_err()
             {
                 return;
@@ -119,8 +119,8 @@ impl SendPath {
             match MUST_ENCRYPT {
                 true => self
                     .encrypt_state
-                    .encrypt_outgoing(m, tls),
-                false => m.encode_unencrypted(tls),
+                    .encrypt_outgoing(record, tls),
+                false => record.encode_unencrypted(tls),
             }
         }
     }
@@ -182,10 +182,10 @@ impl SendOutput for SendPath {
             return;
         }
 
-        let message = EncodedMessage::<Payload<'static>>::from(Message::build_key_update_notify());
+        let record = Record::<Payload<'static>>::from(Message::build_key_update_notify());
         let mut queued = Vec::new();
         self.encrypt_state
-            .encrypt_outgoing(message.borrow_outbound(), &mut queued);
+            .encrypt_outgoing(record.borrow_outbound(), &mut queued);
         self.key_update_remote = KeyUpdateRemote::Queued(queued);
 
         if let Some(mut ks) = self.tls13_key_schedule.take() {
@@ -230,11 +230,11 @@ impl SendOutput for SendPath {
 
     /// Send a raw TLS message, fragmenting it if needed.
     fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool, tls: &mut Vec<u8>) {
-        let encoded = EncodedMessage::from(m);
+        let record = Record::from(m);
         let fragments = self.message_fragmenter.fragment(
-            encoded.typ,
-            encoded.version,
-            encoded.payload.bytes().into(),
+            record.typ,
+            record.version,
+            record.payload.bytes().into(),
             self.encrypt_state
                 .encrypted_record_overhead(),
         );

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -11,7 +11,7 @@ use crate::conn::kernel::KernelConnection;
 use crate::conn::{
     ConnectionCommon, MessageIter, ReceivePath, SendOutput, SendPath, TlsInputBuffer,
 };
-use crate::crypto::cipher::{MessageEncrypter, OutboundPlain};
+use crate::crypto::cipher::{OutboundPlain, RecordEncrypter};
 use crate::enums::ProtocolVersion;
 use crate::error::{AlertDescription, ErrorWithAlert};
 use crate::lock::Mutex;
@@ -494,9 +494,9 @@ impl SendOutput for SendAdapter<'_> {
             .note_key_update_response();
     }
 
-    fn set_encrypter(&mut self, cipher: Box<dyn MessageEncrypter>, max_messages: u64) {
+    fn set_encrypter(&mut self, cipher: Box<dyn RecordEncrypter>, max_records: u64) {
         self.as_locked(false)
-            .set_encrypter(cipher, max_messages);
+            .set_encrypter(cipher, max_records);
     }
 
     fn update_key_schedule(&mut self, schedule: Box<KeyScheduleTrafficSend>) {

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -116,7 +116,7 @@ impl<'a> Record<InboundOpaque<'a>> {
     ///
     /// This should only be used for messages that are known to be in plaintext. Otherwise, the
     /// [`Record<InboundOpaque<'_>>`] should be decrypted into an
-    /// `Record<&'_ [u8]>` using a `MessageDecrypter`.
+    /// `Record<&'_ [u8]>` using a `RecordDecrypter`.
     pub fn into_plain_record_range(self, range: Range<usize>) -> Record<&'a [u8]> {
         Record {
             typ: self.typ,
@@ -129,7 +129,7 @@ impl<'a> Record<InboundOpaque<'a>> {
     ///
     /// This should only be used for messages that are known to be in plaintext. Otherwise, the
     /// [`Record<InboundOpaque<'a>>`] should be decrypted into a
-    /// `Record<&'a [u8]>` using a `MessageDecrypter`.
+    /// `Record<&'a [u8]>` using a `RecordDecrypter`.
     pub fn into_plain_record(self) -> Record<&'a [u8]> {
         Record {
             typ: self.typ,
@@ -374,24 +374,24 @@ impl<'a> From<&'a Vec<u8>> for OutboundPlain<'a> {
     }
 }
 
-/// A fixed-size buffer into which a [`MessageEncrypter`][] writes an encrypted message payload.
+/// A fixed-size buffer into which a [`RecordEncrypter`][] writes an encrypted message payload.
 ///
-/// This wraps the output buffer passed to [`MessageEncrypter::encrypt()`][], tracking how
+/// This wraps the output buffer passed to [`RecordEncrypter::encrypt()`][], tracking how
 /// much of it has been written as the append methods fill it front-to-back. It writes
 /// into caller-owned memory and cannot grow. [`Self::new()`] checks that the caller's
 /// buffer can hold the `len` bytes the encrypter declared, and the append methods then
 /// panic if the writes exceed that length.
 ///
-/// Such a panic always indicates a bug in the `MessageEncrypter` implementation, not a
+/// Such a panic always indicates a bug in the `RecordEncrypter` implementation, not a
 /// runtime condition the caller can handle. The same implementation declares the total
-/// length up front (via [`MessageEncrypter::encrypted_payload_len()`]) and performs the
+/// length up front (via [`RecordEncrypter::encrypted_payload_len()`]) and performs the
 /// writes, so overflowing the buffer means the two disagree. The record layer also
 /// relies on that declared length for framing, so there is no way to recover from the
 /// mismatch after the fact.
 ///
-/// [`MessageEncrypter`]: crate::crypto::cipher::MessageEncrypter
-/// [`MessageEncrypter::encrypt()`]: crate::crypto::cipher::MessageEncrypter::encrypt()
-/// [`MessageEncrypter::encrypted_payload_len()`]: crate::crypto::cipher::MessageEncrypter::encrypted_payload_len()
+/// [`RecordEncrypter`]: crate::crypto::cipher::RecordEncrypter
+/// [`RecordEncrypter::encrypt()`]: crate::crypto::cipher::RecordEncrypter::encrypt()
+/// [`RecordEncrypter::encrypted_payload_len()`]: crate::crypto::cipher::RecordEncrypter::encrypted_payload_len()
 pub struct EncryptBuffer<'a> {
     buf: &'a mut [u8],
     used: usize,
@@ -416,7 +416,7 @@ impl<'a> EncryptBuffer<'a> {
     /// Append bytes from an `OutboundPlain`'s chunks.
     ///
     /// Panics if the write would extend beyond the `len` given to [`Self::new()`],
-    /// which indicates a bug in the calling `MessageEncrypter` implementation (see
+    /// which indicates a bug in the calling `RecordEncrypter` implementation (see
     /// the type-level documentation).
     pub fn extend_from_chunks(&mut self, chunks: &OutboundPlain<'_>) {
         match chunks {
@@ -433,7 +433,7 @@ impl<'a> EncryptBuffer<'a> {
     /// Append bytes from a slice.
     ///
     /// Panics if the write would extend beyond the `len` given to [`Self::new()`],
-    /// which indicates a bug in the calling `MessageEncrypter` implementation (see
+    /// which indicates a bug in the calling `RecordEncrypter` implementation (see
     /// the type-level documentation).
     pub fn extend_from_slice(&mut self, slice: &[u8]) {
         self.buf[self.used..self.used + slice.len()].copy_from_slice(slice);
@@ -456,7 +456,7 @@ impl AsMut<[u8]> for EncryptBuffer<'_> {
 ///
 /// When encountered in an [`Record`], it represents a plaintext payload. It can be
 /// decrypted from an [`InboundOpaque`] or encrypted by a
-/// [`MessageEncrypter`](crate::crypto::cipher::MessageEncrypter), and it is also used for
+/// [`RecordEncrypter`](crate::crypto::cipher::RecordEncrypter), and it is also used for
 /// joining and fragmenting.
 #[non_exhaustive]
 #[derive(Clone, Eq, PartialEq)]

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -11,7 +11,7 @@ use crate::msgs::{Codec, HEADER_SIZE, MAX_FRAGMENT_LEN, Reader, hex, read_opaque
 /// A TLS message with encoded (but not necessarily encrypted) payload.
 #[expect(clippy::exhaustive_structs)]
 #[derive(Clone, Debug)]
-pub struct EncodedMessage<P> {
+pub struct Record<P> {
     /// The content type of this message.
     pub typ: ContentType,
     /// The protocol version of this message.
@@ -20,8 +20,8 @@ pub struct EncodedMessage<P> {
     pub payload: P,
 }
 
-impl<P> EncodedMessage<P> {
-    /// Create a new `EncodedMessage` with the given fields.
+impl<P> Record<P> {
+    /// Create a new `Record` with the given fields.
     pub fn new(typ: ContentType, version: EncodableVersion, payload: P) -> Self {
         Self {
             typ,
@@ -31,17 +31,17 @@ impl<P> EncodedMessage<P> {
     }
 }
 
-impl<'a> EncodedMessage<Payload<'a>> {
+impl<'a> Record<Payload<'a>> {
     /// Construct by decoding from a [`Reader`].
     ///
-    /// `MessageError` allows callers to distinguish between valid prefixes (might
+    /// `RecordError` allows callers to distinguish between valid prefixes (might
     /// become valid if we read more data) and invalid data.
-    pub(crate) fn read(r: &mut Reader<'a>) -> Result<Self, MessageError> {
+    pub(crate) fn read(r: &mut Reader<'a>) -> Result<Self, RecordError> {
         let (typ, version, len) = read_opaque_message_header(r)?;
 
         let content = r
             .take(len as usize)
-            .ok_or(MessageError::TooShortForLength)?;
+            .ok_or(RecordError::TooShortForLength)?;
 
         Ok(Self {
             typ,
@@ -50,16 +50,16 @@ impl<'a> EncodedMessage<Payload<'a>> {
         })
     }
 
-    /// Borrow as an [`EncodedMessage<OutboundPlain<'a>>`].
-    pub fn borrow_outbound(&'a self) -> EncodedMessage<OutboundPlain<'a>> {
-        EncodedMessage {
+    /// Borrow as an [`Record<OutboundPlain<'a>>`].
+    pub fn borrow_outbound(&'a self) -> Record<OutboundPlain<'a>> {
+        Record {
             typ: self.typ,
             version: self.version,
             payload: self.payload.bytes().into(),
         }
     }
 
-    /// Convert into an owned `EncodedMessage<Plain<'static>>`.
+    /// Convert into an owned `Record<Plain<'static>>`.
     pub fn into_owned(self) -> Self {
         Self {
             typ: self.typ,
@@ -69,7 +69,7 @@ impl<'a> EncodedMessage<Payload<'a>> {
     }
 }
 
-impl EncodedMessage<&'_ [u8]> {
+impl Record<&'_ [u8]> {
     /// Returns true if the payload is a CCS message.
     ///
     /// We passthrough ChangeCipherSpec messages in the deframer without decrypting them.
@@ -80,12 +80,12 @@ impl EncodedMessage<&'_ [u8]> {
     }
 }
 
-impl<'a> EncodedMessage<InboundOpaque<'a>> {
+impl<'a> Record<InboundOpaque<'a>> {
     /// For TLS1.3 (only), checks the length msg.payload is valid and removes the padding.
     ///
     /// Returns an error if the message (pre-unpadding) is too long, or the padding is invalid,
     /// or the message (post-unpadding) is too long.
-    pub fn into_tls13_unpadded_message(mut self) -> Result<EncodedMessage<&'a [u8]>, Error> {
+    pub fn into_tls13_unpadded_record(mut self) -> Result<Record<&'a [u8]>, Error> {
         let payload = &mut self.payload;
 
         if self.typ != ContentType::ApplicationData {
@@ -106,7 +106,7 @@ impl<'a> EncodedMessage<InboundOpaque<'a>> {
         }
 
         self.version = EncodableVersion::Legacy(ProtocolVersion::TLSv1_3);
-        Ok(self.into_plain_message())
+        Ok(self.into_plain_record())
     }
 
     /// Force conversion into a plaintext message.
@@ -115,10 +115,10 @@ impl<'a> EncodedMessage<InboundOpaque<'a>> {
     /// the underlying message payload.
     ///
     /// This should only be used for messages that are known to be in plaintext. Otherwise, the
-    /// [`EncodedMessage<InboundOpaque<'_>>`] should be decrypted into an
-    /// `EncodedMessage<&'_ [u8]>` using a `MessageDecrypter`.
-    pub fn into_plain_message_range(self, range: Range<usize>) -> EncodedMessage<&'a [u8]> {
-        EncodedMessage {
+    /// [`Record<InboundOpaque<'_>>`] should be decrypted into an
+    /// `Record<&'_ [u8]>` using a `MessageDecrypter`.
+    pub fn into_plain_record_range(self, range: Range<usize>) -> Record<&'a [u8]> {
+        Record {
             typ: self.typ,
             version: self.version,
             payload: &self.payload.into_inner()[range],
@@ -128,10 +128,10 @@ impl<'a> EncodedMessage<InboundOpaque<'a>> {
     /// Force conversion into a plaintext message.
     ///
     /// This should only be used for messages that are known to be in plaintext. Otherwise, the
-    /// [`EncodedMessage<InboundOpaque<'a>>`] should be decrypted into a
-    /// `EncodedMessage<&'a [u8]>` using a `MessageDecrypter`.
-    pub fn into_plain_message(self) -> EncodedMessage<&'a [u8]> {
-        EncodedMessage {
+    /// [`Record<InboundOpaque<'a>>`] should be decrypted into a
+    /// `Record<&'a [u8]>` using a `MessageDecrypter`.
+    pub fn into_plain_record(self) -> Record<&'a [u8]> {
+        Record {
             typ: self.typ,
             version: self.version,
             payload: self.payload.into_inner(),
@@ -139,7 +139,7 @@ impl<'a> EncodedMessage<InboundOpaque<'a>> {
     }
 }
 
-impl EncodedMessage<OutboundPlain<'_>> {
+impl Record<OutboundPlain<'_>> {
     /// Encode this message into its unencrypted wire representation, including
     /// its record header.
     pub(crate) fn to_unencrypted_bytes(&self) -> Vec<u8> {
@@ -454,7 +454,7 @@ impl AsMut<[u8]> for EncryptBuffer<'_> {
 
 /// An externally length'd payload
 ///
-/// When encountered in an [`EncodedMessage`], it represents a plaintext payload. It can be
+/// When encountered in an [`Record`], it represents a plaintext payload. It can be
 /// decrypted from an [`InboundOpaque`] or encrypted by a
 /// [`MessageEncrypter`](crate::crypto::cipher::MessageEncrypter), and it is also used for
 /// joining and fragmenting.
@@ -620,7 +620,7 @@ fn unpad_tls13_payload(p: &mut InboundOpaque<'_>) -> ContentType {
 #[expect(missing_docs)]
 #[non_exhaustive]
 #[derive(Debug)]
-pub enum MessageError {
+pub enum RecordError {
     TooShortForHeader,
     TooShortForLength,
     InvalidEmptyPayload,
@@ -815,13 +815,13 @@ mod tests {
                 ProtocolVersion::TLSv1_2,
             ),
         ] {
-            let encoded_message = EncodedMessage {
+            let record = Record {
                 typ: ContentType::Handshake,
                 version,
                 payload: OutboundPlain::Single(&[0, 1, 2, 3, 4]),
             };
-            let encoded = encoded_message.to_unencrypted_bytes();
-            let decoded = EncodedMessage::<Payload<'_>>::read(&mut Reader::new(&encoded)).unwrap();
+            let encoded = record.to_unencrypted_bytes();
+            let decoded = Record::<Payload<'_>>::read(&mut Reader::new(&encoded)).unwrap();
             assert_eq!(decoded.version.version(), expect);
         }
     }

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -6,17 +6,17 @@ use crate::Protocol;
 use crate::crypto::cipher::EncryptionState;
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{ApiMisuse, Error, InvalidMessage, PeerMisbehaved};
-use crate::msgs::{Codec, HEADER_SIZE, MAX_FRAGMENT_LEN, Reader, hex, read_opaque_message_header};
+use crate::msgs::{Codec, HEADER_SIZE, MAX_FRAGMENT_LEN, Reader, hex, read_record_header};
 
-/// A TLS message with encoded (but not necessarily encrypted) payload.
+/// A TLS record with encoded (but not necessarily encrypted) payload.
 #[expect(clippy::exhaustive_structs)]
 #[derive(Clone, Debug)]
 pub struct Record<P> {
-    /// The content type of this message.
+    /// The content type of this record.
     pub typ: ContentType,
-    /// The protocol version of this message.
+    /// The protocol version of this record.
     pub version: EncodableVersion,
-    /// The payload of this message.
+    /// The payload of this record.
     pub payload: P,
 }
 
@@ -37,7 +37,7 @@ impl<'a> Record<Payload<'a>> {
     /// `RecordError` allows callers to distinguish between valid prefixes (might
     /// become valid if we read more data) and invalid data.
     pub(crate) fn read(r: &mut Reader<'a>) -> Result<Self, RecordError> {
-        let (typ, version, len) = read_opaque_message_header(r)?;
+        let (typ, version, len) = read_record_header(r)?;
 
         let content = r
             .take(len as usize)
@@ -81,10 +81,10 @@ impl Record<&'_ [u8]> {
 }
 
 impl<'a> Record<InboundOpaque<'a>> {
-    /// For TLS1.3 (only), checks the length msg.payload is valid and removes the padding.
+    /// For TLS1.3 (only), checks the length record.payload is valid and removes the padding.
     ///
-    /// Returns an error if the message (pre-unpadding) is too long, or the padding is invalid,
-    /// or the message (post-unpadding) is too long.
+    /// Returns an error if the record payload (pre-unpadding) is too long, or the padding is invalid,
+    /// or the record payload (post-unpadding) is too long.
     pub fn into_tls13_unpadded_record(mut self) -> Result<Record<&'a [u8]>, Error> {
         let payload = &mut self.payload;
 
@@ -109,12 +109,12 @@ impl<'a> Record<InboundOpaque<'a>> {
         Ok(self.into_plain_record())
     }
 
-    /// Force conversion into a plaintext message.
+    /// Force conversion into a plaintext record.
     ///
-    /// `range` restricts the resulting message: this function panics if it is out of range for
-    /// the underlying message payload.
+    /// `range` restricts the resulting record: this function panics if it is out of range for
+    /// the underlying record payload.
     ///
-    /// This should only be used for messages that are known to be in plaintext. Otherwise, the
+    /// This should only be used for records that are known to be in plaintext. Otherwise, the
     /// [`Record<InboundOpaque<'_>>`] should be decrypted into an
     /// `Record<&'_ [u8]>` using a `RecordDecrypter`.
     pub fn into_plain_record_range(self, range: Range<usize>) -> Record<&'a [u8]> {
@@ -125,9 +125,9 @@ impl<'a> Record<InboundOpaque<'a>> {
         }
     }
 
-    /// Force conversion into a plaintext message.
+    /// Force conversion into a plaintext record.
     ///
-    /// This should only be used for messages that are known to be in plaintext. Otherwise, the
+    /// This should only be used for records that are known to be in plaintext. Otherwise, the
     /// [`Record<InboundOpaque<'a>>`] should be decrypted into a
     /// `Record<&'a [u8]>` using a `RecordDecrypter`.
     pub fn into_plain_record(self) -> Record<&'a [u8]> {
@@ -140,7 +140,7 @@ impl<'a> Record<InboundOpaque<'a>> {
 }
 
 impl Record<OutboundPlain<'_>> {
-    /// Encode this message into its unencrypted wire representation, including
+    /// Encode this record into its unencrypted wire representation, including
     /// its record header.
     pub(crate) fn to_unencrypted_bytes(&self) -> Vec<u8> {
         let len = self.payload.len();
@@ -374,7 +374,7 @@ impl<'a> From<&'a Vec<u8>> for OutboundPlain<'a> {
     }
 }
 
-/// A fixed-size buffer into which a [`RecordEncrypter`][] writes an encrypted message payload.
+/// A fixed-size buffer into which a [`RecordEncrypter`][] writes an encrypted record payload.
 ///
 /// This wraps the output buffer passed to [`RecordEncrypter::encrypt()`][], tracking how
 /// much of it has been written as the append methods fill it front-to-back. It writes
@@ -601,11 +601,11 @@ impl EncodableVersion {
 
 /// Decode a TLS1.3 `TLSInnerPlaintext` encoding.
 ///
-/// `p` is a message payload, immediately post-decryption.  This function
+/// `p` is a record payload, immediately post-decryption.  This function
 /// removes zero padding bytes, until a non-zero byte is encountered which is
 /// the content type, which is returned.  See RFC 9846 s5.2.
 ///
-/// ContentType(0) is returned if the message payload is empty or all zeroes.
+/// ContentType(0) is returned if the record payload is empty or all zeroes.
 fn unpad_tls13_payload(p: &mut InboundOpaque<'_>) -> ContentType {
     loop {
         match p.pop() {
@@ -616,7 +616,7 @@ fn unpad_tls13_payload(p: &mut InboundOpaque<'_>) -> ContentType {
     }
 }
 
-/// Errors from trying to parse a TLS message.
+/// Errors from trying to parse a TLS record.
 #[expect(missing_docs)]
 #[non_exhaustive]
 #[derive(Debug)]
@@ -796,7 +796,7 @@ mod tests {
     }
 
     #[test]
-    fn encoded_message_encoding_version() {
+    fn record_encoding_version() {
         for (version, expect) in [
             (
                 EncodableVersion::InitialClientHello(Protocol::Tcp),

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -13,8 +13,7 @@ use crate::suites::ConnectionTrafficSecrets;
 mod messages;
 pub(crate) use messages::encode_record_header;
 pub use messages::{
-    EncodableVersion, EncodedMessage, EncryptBuffer, InboundOpaque, MessageError, OutboundPlain,
-    Payload,
+    EncodableVersion, EncryptBuffer, InboundOpaque, OutboundPlain, Payload, Record, RecordError,
 };
 
 mod record_layer;
@@ -148,18 +147,18 @@ pub struct KeyBlockShape {
 
 /// Objects with this trait can decrypt TLS messages.
 pub trait MessageDecrypter: Send + Sync {
-    /// Decrypt the given TLS message `msg`, using the sequence number
+    /// Decrypt the given TLS message `record`, using the sequence number
     /// `seq` which can be used to derive a unique [`Nonce`].
     fn decrypt<'a>(
         &mut self,
-        msg: EncodedMessage<InboundOpaque<'a>>,
+        record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error>;
+    ) -> Result<Record<&'a [u8]>, Error>;
 }
 
 /// Objects with this trait can encrypt TLS messages.
 pub trait MessageEncrypter: Send + Sync {
-    /// Encrypt the given TLS message `msg` into `out`, using the sequence number
+    /// Encrypt the given TLS message `record` into `out`, using the sequence number
     /// `seq` which can be used to derive a unique [`Nonce`].
     ///
     /// The encrypted payload including all framing the ciphersuite requires, such
@@ -174,10 +173,10 @@ pub trait MessageEncrypter: Send + Sync {
     /// write it to `out` themselves.
     fn encrypt<'a>(
         &mut self,
-        msg: EncodedMessage<OutboundPlain<'_>>,
+        record: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error>;
+    ) -> Result<Record<&'a [u8]>, Error>;
 
     /// Return the length of the ciphertext that results from encrypting plaintext of length `payload_len`.
     ///

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -145,9 +145,9 @@ pub struct KeyBlockShape {
     pub explicit_nonce_len: usize,
 }
 
-/// Objects with this trait can decrypt TLS messages.
+/// Objects with this trait can decrypt TLS records.
 pub trait RecordDecrypter: Send + Sync {
-    /// Decrypt the given TLS message `record`, using the sequence number
+    /// Decrypt the given TLS record, using the sequence number
     /// `seq` which can be used to derive a unique [`Nonce`].
     fn decrypt<'a>(
         &mut self,
@@ -156,9 +156,9 @@ pub trait RecordDecrypter: Send + Sync {
     ) -> Result<Record<&'a [u8]>, Error>;
 }
 
-/// Objects with this trait can encrypt TLS messages.
+/// Objects with this trait can encrypt TLS records.
 pub trait RecordEncrypter: Send + Sync {
-    /// Encrypt the given TLS message `record` into `out`, using the sequence number
+    /// Encrypt the given TLS record into `out`, using the sequence number
     /// `seq` which can be used to derive a unique [`Nonce`].
     ///
     /// The encrypted payload including all framing the ciphersuite requires, such
@@ -166,7 +166,7 @@ pub trait RecordEncrypter: Send + Sync {
     /// front of `out`. `out` must be at least [`Self::encrypted_payload_len()`] bytes
     /// long. See [`EncryptBuffer`] for a convenient wrapper.
     ///
-    /// The returned message describes the resulting record: its payload borrows the
+    /// The return value describes the resulting record: its payload borrows the
     /// written prefix of `out`, and its `typ` and `version` are what the record
     /// header should carry on the wire. Encoding the record header is the caller's
     /// responsibility and implementations of the `RecordEncrypter` trait must not
@@ -181,9 +181,9 @@ pub trait RecordEncrypter: Send + Sync {
     /// Return the length of the ciphertext that results from encrypting plaintext of length `payload_len`.
     ///
     /// For a zero `payload_len` this should return the _minimum_ overhead for any
-    /// message.  Then, to fragment a long message into chunks of length `F`,
+    /// payload.  Then, to fragment a long payload into chunks of length `F`,
     /// Rustls will first set `A := encrypted_payload_len(0)` and then supply the
-    /// message to [`Self::encrypt()`] in chunks of length `F - A`.  Each `encrypt()`
+    /// payload to [`Self::encrypt()`] in chunks of length `F - A`.  Each `encrypt()`
     /// is then free to pad or otherwise transform the length at its option.
     fn encrypted_payload_len(&self, payload_len: usize) -> usize;
 }
@@ -237,7 +237,7 @@ impl AsRef<[u8]> for Iv {
     }
 }
 
-/// A nonce.  This is unique for all messages on a connection.
+/// A nonce.  This is unique for all records on a connection.
 pub struct Nonce {
     buf: [u8; Iv::MAX_LEN],
     len: usize,

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -19,13 +19,13 @@ pub use messages::{
 mod record_layer;
 pub(crate) use record_layer::{Decrypted, DecryptionState, EncryptionState, PreEncryptAction};
 
-/// Factory trait for building `MessageEncrypter` and `MessageDecrypter` for a TLS1.3 cipher suite.
+/// Factory trait for building `RecordEncrypter` and `RecordDecrypter` for a TLS1.3 cipher suite.
 pub trait Tls13AeadAlgorithm: Send + Sync {
-    /// Build a `MessageEncrypter` for the given key/iv.
-    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter>;
+    /// Build a `RecordEncrypter` for the given key/iv.
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordEncrypter>;
 
-    /// Build a `MessageDecrypter` for the given key/iv.
-    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter>;
+    /// Build a `RecordDecrypter` for the given key/iv.
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn RecordDecrypter>;
 
     /// The length of key in bytes required by `encrypter()` and `decrypter()`.
     fn key_len(&self) -> usize;
@@ -51,9 +51,9 @@ pub trait Tls13AeadAlgorithm: Send + Sync {
     }
 }
 
-/// Factory trait for building `MessageEncrypter` and `MessageDecrypter` for a TLS1.2 cipher suite.
+/// Factory trait for building `RecordEncrypter` and `RecordDecrypter` for a TLS1.2 cipher suite.
 pub trait Tls12AeadAlgorithm: Send + Sync + 'static {
-    /// Build a `MessageEncrypter` for the given key/iv and extra key block (which can be used for
+    /// Build a `RecordEncrypter` for the given key/iv and extra key block (which can be used for
     /// improving explicit nonce size security, if needed).
     ///
     /// The length of `key` is set by [`KeyBlockShape::enc_key_len`].
@@ -61,14 +61,14 @@ pub trait Tls12AeadAlgorithm: Send + Sync + 'static {
     /// The length of `iv` is set by [`KeyBlockShape::fixed_iv_len`].
     ///
     /// The length of `extra` is set by [`KeyBlockShape::explicit_nonce_len`].
-    fn encrypter(&self, key: AeadKey, iv: &[u8], extra: &[u8]) -> Box<dyn MessageEncrypter>;
+    fn encrypter(&self, key: AeadKey, iv: &[u8], extra: &[u8]) -> Box<dyn RecordEncrypter>;
 
-    /// Build a `MessageDecrypter` for the given key/iv.
+    /// Build a `RecordDecrypter` for the given key/iv.
     ///
     /// The length of `key` is set by [`KeyBlockShape::enc_key_len`].
     ///
     /// The length of `iv` is set by [`KeyBlockShape::fixed_iv_len`].
-    fn decrypter(&self, key: AeadKey, iv: &[u8]) -> Box<dyn MessageDecrypter>;
+    fn decrypter(&self, key: AeadKey, iv: &[u8]) -> Box<dyn RecordDecrypter>;
 
     /// Return a `KeyBlockShape` that defines how large the `key_block` is and how it
     /// is split up prior to calling `encrypter()`, `decrypter()` and/or `extract_keys()`.
@@ -146,7 +146,7 @@ pub struct KeyBlockShape {
 }
 
 /// Objects with this trait can decrypt TLS messages.
-pub trait MessageDecrypter: Send + Sync {
+pub trait RecordDecrypter: Send + Sync {
     /// Decrypt the given TLS message `record`, using the sequence number
     /// `seq` which can be used to derive a unique [`Nonce`].
     fn decrypt<'a>(
@@ -157,7 +157,7 @@ pub trait MessageDecrypter: Send + Sync {
 }
 
 /// Objects with this trait can encrypt TLS messages.
-pub trait MessageEncrypter: Send + Sync {
+pub trait RecordEncrypter: Send + Sync {
     /// Encrypt the given TLS message `record` into `out`, using the sequence number
     /// `seq` which can be used to derive a unique [`Nonce`].
     ///
@@ -169,7 +169,7 @@ pub trait MessageEncrypter: Send + Sync {
     /// The returned message describes the resulting record: its payload borrows the
     /// written prefix of `out`, and its `typ` and `version` are what the record
     /// header should carry on the wire. Encoding the record header is the caller's
-    /// responsibility and implementations of the `MessageEncrypter` trait must not
+    /// responsibility and implementations of the `RecordEncrypter` trait must not
     /// write it to `out` themselves.
     fn encrypt<'a>(
         &mut self,
@@ -430,11 +430,11 @@ pub(crate) struct FakeAead;
 
 #[cfg(test)]
 impl Tls12AeadAlgorithm for FakeAead {
-    fn encrypter(&self, _: AeadKey, _: &[u8], _: &[u8]) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, _: AeadKey, _: &[u8], _: &[u8]) -> Box<dyn RecordEncrypter> {
         todo!()
     }
 
-    fn decrypter(&self, _: AeadKey, _: &[u8]) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, _: AeadKey, _: &[u8]) -> Box<dyn RecordDecrypter> {
         todo!()
     }
 

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use core::cmp::min;
 
 use crate::crypto::cipher::{
-    InboundOpaque, MessageDecrypter, MessageEncrypter, OutboundPlain, Record, encode_record_header,
+    InboundOpaque, OutboundPlain, Record, RecordDecrypter, RecordEncrypter, encode_record_header,
 };
 use crate::error::Error;
 use crate::msgs::{HEADER_SIZE, HandshakeAlignedProof};
@@ -11,7 +11,7 @@ use crate::tracing::trace;
 
 /// Record layer that tracks encryption keys.
 pub(crate) struct EncryptionState {
-    message_encrypter: Option<Box<dyn MessageEncrypter>>,
+    record_encrypter: Option<Box<dyn RecordEncrypter>>,
     write_seq_max: u64,
     write_seq: u64,
 }
@@ -20,7 +20,7 @@ impl EncryptionState {
     /// Create new record layer with no keys.
     pub(crate) fn new() -> Self {
         Self {
-            message_encrypter: None,
+            record_encrypter: None,
             write_seq_max: 0,
             write_seq: 0,
         }
@@ -46,7 +46,7 @@ impl EncryptionState {
         let written = self.encrypt_outgoing_into(plain, &mut output[start..]);
         debug_assert_eq!(
             written, needed,
-            "MessageEncrypter::encrypt() returned wrong length"
+            "RecordEncrypter::encrypt() returned wrong length"
         );
         output.truncate(start + written);
     }
@@ -66,7 +66,7 @@ impl EncryptionState {
         out: &mut [u8],
     ) -> usize {
         assert!(self.pre_encrypt_action(0) != Some(PreEncryptAction::Refuse));
-        let encrypter = self.message_encrypter.as_mut().unwrap();
+        let encrypter = self.record_encrypter.as_mut().unwrap();
 
         let seq = self.write_seq;
         self.write_seq += 1;
@@ -79,7 +79,7 @@ impl EncryptionState {
 
         #[cfg(debug_assertions)]
         {
-            // `MessageEncrypter::encrypt()` requires the returned payload to be
+            // `RecordEncrypter::encrypt()` requires the returned payload to be
             // the written prefix of the passed-in buffer. Try to catch misbehaving
             // implementations in debug mode. In release builds a violation would corrupt
             // the sent stream.
@@ -96,16 +96,16 @@ impl EncryptionState {
         HEADER_SIZE + len
     }
 
-    /// Set and start using the given `MessageEncrypter` for future outgoing
+    /// Set and start using the given `RecordEncrypter` for future outgoing
     /// message encryption.
-    pub(crate) fn set_message_encrypter(
+    pub(crate) fn set_record_encrypter(
         &mut self,
-        cipher: Box<dyn MessageEncrypter>,
-        max_messages: u64,
+        cipher: Box<dyn RecordEncrypter>,
+        max_records: u64,
     ) {
         *self = Self {
-            message_encrypter: Some(cipher),
-            write_seq_max: min(SEQ_SOFT_LIMIT, max_messages),
+            record_encrypter: Some(cipher),
+            write_seq_max: min(SEQ_SOFT_LIMIT, max_records),
             write_seq: 0,
         };
     }
@@ -123,7 +123,7 @@ impl EncryptionState {
     }
 
     pub(crate) fn encrypted_len(&self, payload_len: usize) -> usize {
-        self.message_encrypter
+        self.record_encrypter
             .as_ref()
             .map(|enc| enc.encrypted_payload_len(payload_len))
             .unwrap_or_default()
@@ -135,7 +135,7 @@ impl EncryptionState {
     }
 
     pub(crate) fn is_encrypting(&self) -> bool {
-        self.message_encrypter.is_some()
+        self.record_encrypter.is_some()
     }
 
     pub(crate) fn write_seq(&self) -> u64 {
@@ -145,7 +145,7 @@ impl EncryptionState {
 
 /// Record layer that tracks decryption keys.
 pub(crate) struct DecryptionState {
-    message_decrypter: Option<Box<dyn MessageDecrypter>>,
+    record_decrypter: Option<Box<dyn RecordDecrypter>>,
     read_seq: u64,
     has_decrypted: bool,
 
@@ -159,7 +159,7 @@ impl DecryptionState {
     /// Create new record layer with no keys.
     pub(crate) fn new() -> Self {
         Self {
-            message_decrypter: None,
+            record_decrypter: None,
             read_seq: 0,
             has_decrypted: false,
             trial_decryption_len: None,
@@ -175,7 +175,7 @@ impl DecryptionState {
         &mut self,
         encr: Record<InboundOpaque<'a>>,
     ) -> Result<Option<Decrypted<'a>>, Error> {
-        let Some(decrypter) = &mut self.message_decrypter else {
+        let Some(decrypter) = &mut self.record_decrypter else {
             return Ok(Some(Decrypted {
                 want_close_before_decrypt: false,
                 plaintext: encr.into_plain_record(),
@@ -212,28 +212,28 @@ impl DecryptionState {
         }
     }
 
-    /// Set and start using the given `MessageDecrypter` for future incoming
+    /// Set and start using the given `RecordDecrypter` for future incoming
     /// message decryption.
-    pub(crate) fn set_message_decrypter(
+    pub(crate) fn set_record_decrypter(
         &mut self,
-        cipher: Box<dyn MessageDecrypter>,
+        cipher: Box<dyn RecordDecrypter>,
         _proof: &HandshakeAlignedProof,
     ) {
-        self.message_decrypter = Some(cipher);
+        self.record_decrypter = Some(cipher);
         self.read_seq = 0;
         self.trial_decryption_len = None;
     }
 
-    /// Set and start using the given `MessageDecrypter` for future incoming
+    /// Set and start using the given `RecordDecrypter` for future incoming
     /// message decryption, and enable "trial decryption" mode for when TLS1.3
     /// 0-RTT is attempted but rejected by the server.
-    pub(crate) fn set_message_decrypter_with_trial_decryption(
+    pub(crate) fn set_record_decrypter_with_trial_decryption(
         &mut self,
-        cipher: Box<dyn MessageDecrypter>,
+        cipher: Box<dyn RecordDecrypter>,
         max_length: usize,
         _proof: &HandshakeAlignedProof,
     ) {
-        self.message_decrypter = Some(cipher);
+        self.record_decrypter = Some(cipher);
         self.read_seq = 0;
         self.trial_decryption_len = Some(max_length);
     }
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_has_decrypted() {
         struct PassThroughDecrypter;
-        impl MessageDecrypter for PassThroughDecrypter {
+        impl RecordDecrypter for PassThroughDecrypter {
             fn decrypt<'a>(
                 &mut self,
                 record: Record<InboundOpaque<'a>>,
@@ -319,7 +319,7 @@ mod tests {
 
         // A record layer starts out invalid, having never decrypted.
         let mut record_layer = DecryptionState::new();
-        assert!(record_layer.message_decrypter.is_none());
+        assert!(record_layer.record_decrypter.is_none());
         assert_eq!(record_layer.read_seq, 0);
         assert!(!record_layer.has_decrypted());
 
@@ -327,8 +327,8 @@ mod tests {
         // has decrypted.
         let deframer = Deframer::default();
         record_layer
-            .set_message_decrypter(Box::new(PassThroughDecrypter), &deframer.aligned().unwrap());
-        assert!(record_layer.message_decrypter.is_some());
+            .set_record_decrypter(Box::new(PassThroughDecrypter), &deframer.aligned().unwrap());
+        assert!(record_layer.record_decrypter.is_some());
         assert_eq!(record_layer.read_seq, 0);
         assert!(!record_layer.has_decrypted());
 
@@ -347,7 +347,7 @@ mod tests {
         // Resetting the record layer message decrypter (as if a key update occurred) should reset
         // the read_seq number, but not our knowledge of whether we have decrypted previously.
         record_layer
-            .set_message_decrypter(Box::new(PassThroughDecrypter), &deframer.aligned().unwrap());
+            .set_record_decrypter(Box::new(PassThroughDecrypter), &deframer.aligned().unwrap());
         assert_eq!(record_layer.read_seq, 0);
         assert!(record_layer.has_decrypted());
     }

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -26,9 +26,9 @@ impl EncryptionState {
         }
     }
 
-    /// Encrypt a TLS message, returning the fully-encoded record.
+    /// Encrypt a TLS record, returning the fully-encoded record.
     ///
-    /// `plain` is a TLS message we'd like to send.  This function
+    /// `plain` is a TLS record we'd like to send.  This function
     /// panics if the requisite keying material hasn't been established yet.
     ///
     /// The result including framing is appended to `output`.
@@ -51,7 +51,7 @@ impl EncryptionState {
         output.truncate(start + written);
     }
 
-    /// Encrypt a TLS message directly into `out`, returning the encoded
+    /// Encrypt a TLS record directly into `out`, returning the encoded
     /// record's length.
     ///
     /// The record, header included, is written to the front of `out`,
@@ -97,7 +97,7 @@ impl EncryptionState {
     }
 
     /// Set and start using the given `RecordEncrypter` for future outgoing
-    /// message encryption.
+    /// record encryption.
     pub(crate) fn set_record_encrypter(
         &mut self,
         cipher: Box<dyn RecordEncrypter>,
@@ -110,10 +110,10 @@ impl EncryptionState {
         };
     }
 
-    /// Return a remedial action when we are near to encrypting too many messages.
+    /// Return a remedial action when we are near to encrypting too many records.
     ///
     /// `add` is added to the current sequence number.  `add` as `0` means
-    /// "the next message processed by `encrypt_outgoing`"
+    /// "the next record processed by `encrypt_outgoing`"
     pub(crate) fn pre_encrypt_action(&self, add: u64) -> Option<PreEncryptAction> {
         match self.write_seq.saturating_add(add) {
             v if v == self.write_seq_max => Some(PreEncryptAction::RefreshOrClose),
@@ -149,9 +149,9 @@ pub(crate) struct DecryptionState {
     read_seq: u64,
     has_decrypted: bool,
 
-    // Message encrypted with other keys may be encountered, so failures
+    // Records encrypted with other keys may be encountered, so failures
     // should be swallowed by the caller.  This struct tracks the amount
-    // of message size this is allowed for.
+    // of record size this is allowed for.
     trial_decryption_len: Option<usize>,
 }
 
@@ -166,9 +166,9 @@ impl DecryptionState {
         }
     }
 
-    /// Decrypt a TLS message.
+    /// Decrypt a TLS record.
     ///
-    /// `encr` is a decoded message allegedly received from the peer.
+    /// `encr` is a decoded record allegedly received from the peer.
     /// If it can be decrypted, its decryption is returned.  Otherwise,
     /// an error is returned.
     pub(crate) fn decrypt_incoming<'a>(
@@ -183,7 +183,7 @@ impl DecryptionState {
         };
 
         // Set to `true` if the peer appears to getting close to encrypting
-        // too many messages with this key.
+        // too many records with this key.
         //
         // Perhaps if we send an alert well before their counter wraps, a
         // buggy peer won't make a terrible mistake here?
@@ -205,7 +205,7 @@ impl DecryptionState {
                 }))
             }
             Err(Error::DecryptError) if self.doing_trial_decryption(encrypted_len) => {
-                trace!("Dropping undecryptable message after aborted early_data");
+                trace!("Dropping undecryptable record after aborted early_data");
                 Ok(None)
             }
             Err(err) => Err(err),
@@ -213,7 +213,7 @@ impl DecryptionState {
     }
 
     /// Set and start using the given `RecordDecrypter` for future incoming
-    /// message decryption.
+    /// record decryption.
     pub(crate) fn set_record_decrypter(
         &mut self,
         cipher: Box<dyn RecordDecrypter>,
@@ -225,7 +225,7 @@ impl DecryptionState {
     }
 
     /// Set and start using the given `RecordDecrypter` for future incoming
-    /// message decryption, and enable "trial decryption" mode for when TLS1.3
+    /// record decryption, and enable "trial decryption" mode for when TLS1.3
     /// 0-RTT is attempted but rejected by the server.
     pub(crate) fn set_record_decrypter_with_trial_decryption(
         &mut self,
@@ -242,7 +242,7 @@ impl DecryptionState {
         self.trial_decryption_len = None;
     }
 
-    /// Return true if we have ever decrypted a message. This is used in place
+    /// Return true if we have ever decrypted a record. This is used in place
     /// of checking the read_seq since that will be reset on key updates.
     pub(crate) fn has_decrypted(&self) -> bool {
         self.has_decrypted
@@ -269,9 +269,9 @@ impl DecryptionState {
 /// Result of decryption.
 #[derive(Debug)]
 pub(crate) struct Decrypted<'a> {
-    /// Whether the peer appears to be getting close to encrypting too many messages with this key.
+    /// Whether the peer appears to be getting close to encrypting too many records with this key.
     pub(crate) want_close_before_decrypt: bool,
-    /// The decrypted message.
+    /// The decrypted record.
     pub(crate) plaintext: Record<&'a [u8]>,
 }
 
@@ -332,7 +332,7 @@ mod tests {
         assert_eq!(record_layer.read_seq, 0);
         assert!(!record_layer.has_decrypted());
 
-        // Decrypting a message should update the read_seq and track that we have now performed
+        // Decrypting a record should update the read_seq and track that we have now performed
         // a decryption.
         record_layer
             .decrypt_incoming(Record::new(
@@ -344,7 +344,7 @@ mod tests {
         assert_eq!(record_layer.read_seq, 1);
         assert!(record_layer.has_decrypted());
 
-        // Resetting the record layer message decrypter (as if a key update occurred) should reset
+        // Resetting the record layer decrypter (as if a key update occurred) should reset
         // the read_seq number, but not our knowledge of whether we have decrypted previously.
         record_layer
             .set_record_decrypter(Box::new(PassThroughDecrypter), &deframer.aligned().unwrap());

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -3,8 +3,7 @@ use alloc::vec::Vec;
 use core::cmp::min;
 
 use crate::crypto::cipher::{
-    EncodedMessage, InboundOpaque, MessageDecrypter, MessageEncrypter, OutboundPlain,
-    encode_record_header,
+    InboundOpaque, MessageDecrypter, MessageEncrypter, OutboundPlain, Record, encode_record_header,
 };
 use crate::error::Error;
 use crate::msgs::{HEADER_SIZE, HandshakeAlignedProof};
@@ -35,7 +34,7 @@ impl EncryptionState {
     /// The result including framing is appended to `output`.
     pub(crate) fn encrypt_outgoing(
         &mut self,
-        plain: EncodedMessage<OutboundPlain<'_>>,
+        plain: Record<OutboundPlain<'_>>,
         output: &mut Vec<u8>,
     ) {
         // Contents are fully overwritten below, so zeroing is pure cost.
@@ -63,7 +62,7 @@ impl EncryptionState {
     /// established yet.
     pub(crate) fn encrypt_outgoing_into(
         &mut self,
-        plain: EncodedMessage<OutboundPlain<'_>>,
+        plain: Record<OutboundPlain<'_>>,
         out: &mut [u8],
     ) -> usize {
         assert!(self.pre_encrypt_action(0) != Some(PreEncryptAction::Refuse));
@@ -174,12 +173,12 @@ impl DecryptionState {
     /// an error is returned.
     pub(crate) fn decrypt_incoming<'a>(
         &mut self,
-        encr: EncodedMessage<InboundOpaque<'a>>,
+        encr: Record<InboundOpaque<'a>>,
     ) -> Result<Option<Decrypted<'a>>, Error> {
         let Some(decrypter) = &mut self.message_decrypter else {
             return Ok(Some(Decrypted {
                 want_close_before_decrypt: false,
-                plaintext: encr.into_plain_message(),
+                plaintext: encr.into_plain_record(),
             }));
         };
 
@@ -273,7 +272,7 @@ pub(crate) struct Decrypted<'a> {
     /// Whether the peer appears to be getting close to encrypting too many messages with this key.
     pub(crate) want_close_before_decrypt: bool,
     /// The decrypted message.
-    pub(crate) plaintext: EncodedMessage<&'a [u8]>,
+    pub(crate) plaintext: Record<&'a [u8]>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -311,10 +310,10 @@ mod tests {
         impl MessageDecrypter for PassThroughDecrypter {
             fn decrypt<'a>(
                 &mut self,
-                m: EncodedMessage<InboundOpaque<'a>>,
+                record: Record<InboundOpaque<'a>>,
                 _: u64,
-            ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-                Ok(m.into_plain_message())
+            ) -> Result<Record<&'a [u8]>, Error> {
+                Ok(record.into_plain_record())
             }
         }
 
@@ -336,7 +335,7 @@ mod tests {
         // Decrypting a message should update the read_seq and track that we have now performed
         // a decryption.
         record_layer
-            .decrypt_incoming(EncodedMessage::new(
+            .decrypt_incoming(Record::new(
                 ContentType::Handshake,
                 EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
                 InboundOpaque(&mut [0xC0, 0xFF, 0xEE]),

--- a/rustls/src/crypto/test_provider.rs
+++ b/rustls/src/crypto/test_provider.rs
@@ -5,8 +5,9 @@ use core::time::Duration;
 use std::borrow::Cow;
 
 use crate::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
-    OutboundPlain, Record, Tls12AeadAlgorithm, Tls13AeadAlgorithm, UnsupportedOperationError,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, OutboundPlain, Record,
+    RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
+    UnsupportedOperationError,
 };
 use crate::crypto::kx::{
     KeyExchangeAlgorithm, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup,
@@ -315,11 +316,11 @@ const KX_SHARED_SECRET: &[u8] = b"KxSharedSecretKxSharedSecret";
 struct Aead;
 
 impl Tls13AeadAlgorithm for Aead {
-    fn encrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn RecordEncrypter> {
         Box::new(Tls13Cipher)
     }
 
-    fn decrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, _key: AeadKey, _iv: Iv) -> Box<dyn RecordDecrypter> {
         Box::new(Tls13Cipher)
     }
 
@@ -337,11 +338,11 @@ impl Tls13AeadAlgorithm for Aead {
 }
 
 impl Tls12AeadAlgorithm for Aead {
-    fn encrypter(&self, _key: AeadKey, _iv: &[u8], _: &[u8]) -> Box<dyn MessageEncrypter> {
+    fn encrypter(&self, _key: AeadKey, _iv: &[u8], _: &[u8]) -> Box<dyn RecordEncrypter> {
         Box::new(Tls12Cipher)
     }
 
-    fn decrypter(&self, _key: AeadKey, _iv: &[u8]) -> Box<dyn MessageDecrypter> {
+    fn decrypter(&self, _key: AeadKey, _iv: &[u8]) -> Box<dyn RecordDecrypter> {
         Box::new(Tls12Cipher)
     }
 
@@ -365,7 +366,7 @@ impl Tls12AeadAlgorithm for Aead {
 
 pub(crate) struct Tls13Cipher;
 
-impl MessageEncrypter for Tls13Cipher {
+impl RecordEncrypter for Tls13Cipher {
     fn encrypt<'a>(
         &mut self,
         record: Record<OutboundPlain<'_>>,
@@ -401,7 +402,7 @@ impl MessageEncrypter for Tls13Cipher {
     }
 }
 
-impl MessageDecrypter for Tls13Cipher {
+impl RecordDecrypter for Tls13Cipher {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,
@@ -435,7 +436,7 @@ impl MessageDecrypter for Tls13Cipher {
 
 struct Tls12Cipher;
 
-impl MessageEncrypter for Tls12Cipher {
+impl RecordEncrypter for Tls12Cipher {
     fn encrypt<'a>(
         &mut self,
         record: Record<OutboundPlain<'_>>,
@@ -469,7 +470,7 @@ impl MessageEncrypter for Tls12Cipher {
     }
 }
 
-impl MessageDecrypter for Tls12Cipher {
+impl RecordDecrypter for Tls12Cipher {
     fn decrypt<'a>(
         &mut self,
         mut record: Record<InboundOpaque<'a>>,

--- a/rustls/src/crypto/test_provider.rs
+++ b/rustls/src/crypto/test_provider.rs
@@ -5,9 +5,8 @@ use core::time::Duration;
 use std::borrow::Cow;
 
 use crate::crypto::cipher::{
-    AeadKey, EncodedMessage, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter,
-    MessageEncrypter, OutboundPlain, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
-    UnsupportedOperationError,
+    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter,
+    OutboundPlain, Record, Tls12AeadAlgorithm, Tls13AeadAlgorithm, UnsupportedOperationError,
 };
 use crate::crypto::kx::{
     KeyExchangeAlgorithm, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup,
@@ -369,15 +368,15 @@ pub(crate) struct Tls13Cipher;
 impl MessageEncrypter for Tls13Cipher {
     fn encrypt<'a>(
         &mut self,
-        m: EncodedMessage<OutboundPlain<'_>>,
+        record: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let total_len = self.encrypted_payload_len(m.payload.len());
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let total_len = self.encrypted_payload_len(record.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
 
-        payload.extend_from_chunks(&m.payload);
-        payload.extend_from_slice(&m.typ.to_array());
+        payload.extend_from_chunks(&record.payload);
+        payload.extend_from_slice(&record.typ.to_array());
 
         for (p, mask) in payload
             .as_mut()
@@ -390,9 +389,9 @@ impl MessageEncrypter for Tls13Cipher {
         payload.extend_from_slice(&seq.to_be_bytes());
         payload.extend_from_slice(AEAD_TAG);
 
-        Ok(EncodedMessage {
+        Ok(Record {
             typ: ContentType::ApplicationData,
-            version: m.version,
+            version: record.version,
             payload: payload.into_written(),
         })
     }
@@ -405,10 +404,10 @@ impl MessageEncrypter for Tls13Cipher {
 impl MessageDecrypter for Tls13Cipher {
     fn decrypt<'a>(
         &mut self,
-        mut m: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &mut m.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &mut record.payload;
 
         let mut expected_tag = vec![];
         expected_tag.extend_from_slice(&seq.to_be_bytes());
@@ -430,7 +429,7 @@ impl MessageDecrypter for Tls13Cipher {
             *p ^= *mask;
         }
 
-        m.into_tls13_unpadded_message()
+        record.into_tls13_unpadded_record()
     }
 }
 
@@ -439,13 +438,13 @@ struct Tls12Cipher;
 impl MessageEncrypter for Tls12Cipher {
     fn encrypt<'a>(
         &mut self,
-        m: EncodedMessage<OutboundPlain<'_>>,
+        record: Record<OutboundPlain<'_>>,
         seq: u64,
         out: &'a mut [u8],
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let total_len = self.encrypted_payload_len(m.payload.len());
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let total_len = self.encrypted_payload_len(record.payload.len());
         let mut payload = EncryptBuffer::new(out, total_len)?;
-        payload.extend_from_chunks(&m.payload);
+        payload.extend_from_chunks(&record.payload);
 
         for (p, mask) in payload
             .as_mut()
@@ -458,9 +457,9 @@ impl MessageEncrypter for Tls12Cipher {
         payload.extend_from_slice(&seq.to_be_bytes());
         payload.extend_from_slice(AEAD_TAG);
 
-        Ok(EncodedMessage {
-            typ: m.typ,
-            version: m.version,
+        Ok(Record {
+            typ: record.typ,
+            version: record.version,
             payload: payload.into_written(),
         })
     }
@@ -473,10 +472,10 @@ impl MessageEncrypter for Tls12Cipher {
 impl MessageDecrypter for Tls12Cipher {
     fn decrypt<'a>(
         &mut self,
-        mut m: EncodedMessage<InboundOpaque<'a>>,
+        mut record: Record<InboundOpaque<'a>>,
         seq: u64,
-    ) -> Result<EncodedMessage<&'a [u8]>, Error> {
-        let payload = &mut m.payload;
+    ) -> Result<Record<&'a [u8]>, Error> {
+        let payload = &mut record.payload;
 
         let mut expected_tag = vec![];
         expected_tag.extend_from_slice(&seq.to_be_bytes());
@@ -498,7 +497,7 @@ impl MessageDecrypter for Tls12Cipher {
             *p ^= *mask;
         }
 
-        Ok(m.into_plain_message())
+        Ok(record.into_plain_record())
     }
 }
 

--- a/rustls/src/msgs/deframer/mod.rs
+++ b/rustls/src/msgs/deframer/mod.rs
@@ -2,7 +2,7 @@ use core::mem;
 use core::ops::Range;
 use std::collections::VecDeque;
 
-use crate::crypto::cipher::{EncodableVersion, EncodedMessage, InboundOpaque, MessageError};
+use crate::crypto::cipher::{EncodableVersion, InboundOpaque, Record, RecordError};
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage};
 use crate::msgs::codec::{Codec, Reader, U24};
@@ -59,13 +59,13 @@ impl Deframer {
             Ok(header) => header,
             Err(err) => {
                 let err = match err {
-                    MessageError::TooShortForHeader | MessageError::TooShortForLength => {
+                    RecordError::TooShortForHeader | RecordError::TooShortForLength => {
                         return None;
                     }
-                    MessageError::InvalidEmptyPayload => InvalidMessage::InvalidEmptyPayload,
-                    MessageError::MessageTooLarge => InvalidMessage::MessageTooLarge,
-                    MessageError::InvalidContentType => InvalidMessage::InvalidContentType,
-                    MessageError::UnknownProtocolVersion => InvalidMessage::UnknownProtocolVersion,
+                    RecordError::InvalidEmptyPayload => InvalidMessage::InvalidEmptyPayload,
+                    RecordError::MessageTooLarge => InvalidMessage::MessageTooLarge,
+                    RecordError::InvalidContentType => InvalidMessage::InvalidContentType,
+                    RecordError::UnknownProtocolVersion => InvalidMessage::UnknownProtocolVersion,
                 };
                 return Some(Err(err.into()));
             }
@@ -79,7 +79,7 @@ impl Deframer {
         self.processed = end;
 
         Some(Ok(Deframed {
-            message: EncodedMessage {
+            record: Record {
                 typ,
                 version: EncodableVersion::Legacy(version),
                 payload: InboundOpaque(&mut head[bounds.start + HEADER_SIZE..]),
@@ -257,7 +257,7 @@ impl Deframer {
             first.bounds.end += len;
 
             // finally, attempt to re-dissect `first`
-            let msg = EncodedMessage {
+            let record = Record {
                 typ: ContentType::Handshake,
                 version: EncodableVersion::Legacy(first.version),
                 payload: delocator.slice_from_range(&first.bounds),
@@ -265,7 +265,7 @@ impl Deframer {
 
             let iter = DissectHandshakeIter {
                 version: first.version,
-                payload: msg.payload,
+                payload: record.payload,
                 bounds: first.bounds.start..first.bounds.end,
             };
 
@@ -284,12 +284,12 @@ impl Deframer {
         &mut self,
         next_span: FragmentSpan,
         containing_buffer: &'b [u8],
-    ) -> EncodedMessage<&'b [u8]> {
+    ) -> Record<&'b [u8]> {
         if self.spans.is_empty() {
             self.discard = self.processed;
         }
 
-        EncodedMessage {
+        Record {
             typ: ContentType::Handshake,
             version: EncodableVersion::Legacy(next_span.version),
             payload: Delocator::new(containing_buffer).slice_from_range(&next_span.bounds),
@@ -435,7 +435,7 @@ impl FragmentSpan {
 }
 
 pub(crate) struct Deframed<'a> {
-    pub(crate) message: EncodedMessage<InboundOpaque<'a>>,
+    pub(crate) record: Record<InboundOpaque<'a>>,
     pub(crate) bounds: Range<usize>,
 }
 
@@ -488,11 +488,11 @@ mod tests {
         std::println!("after:  {deframer:?}");
 
         let span = deframer.complete_span().unwrap();
-        let msg = deframer.message(span, &input);
-        std::println!("msg {msg:?}");
-        assert_eq!(msg.typ, ContentType::Handshake);
-        assert_eq!(msg.version.version(), ProtocolVersion::TLSv1_3);
-        assert_eq!(msg.payload, &[0x21, 0x00, 0x00, 0x01, 0xff]);
+        let record = deframer.message(span, &input);
+        std::println!("record {record:?}");
+        assert_eq!(record.typ, ContentType::Handshake);
+        assert_eq!(record.version.version(), ProtocolVersion::TLSv1_3);
+        assert_eq!(record.payload, &[0x21, 0x00, 0x00, 0x01, 0xff]);
 
         input.drain(..deframer.take_discard());
 
@@ -511,10 +511,10 @@ mod tests {
         deframer.coalesce(&mut input).unwrap();
         let span = deframer.complete_span().unwrap();
 
-        let msg = std::dbg!(deframer.message(span, &input));
-        assert_eq!(msg.typ, ContentType::Handshake);
-        assert_eq!(msg.version.version(), ProtocolVersion::TLSv1_3);
-        assert_eq!(msg.payload, &[0x21, 0x00, 0x00, 0x05, 1, 2, 3, 4, 5]);
+        let record = std::dbg!(deframer.message(span, &input));
+        assert_eq!(record.typ, ContentType::Handshake);
+        assert_eq!(record.version.version(), ProtocolVersion::TLSv1_3);
+        assert_eq!(record.payload, &[0x21, 0x00, 0x00, 0x05, 1, 2, 3, 4, 5]);
 
         input.drain(..deframer.take_discard());
 
@@ -564,12 +564,12 @@ mod tests {
         add_bytes(&mut deframer, 8..12, &input);
 
         let span = deframer.complete_span().unwrap();
-        let msg = deframer.message(span, &input);
+        let record = deframer.message(span, &input);
         assert!(deframer.complete_span().is_none());
 
-        assert_eq!(msg.typ, ContentType::Handshake);
-        assert_eq!(msg.version.version(), ProtocolVersion::TLSv1_3);
-        assert_eq!(msg.payload, &[0x21, 0x00, 0x00, 0x01, 0xab]);
+        assert_eq!(record.typ, ContentType::Handshake);
+        assert_eq!(record.version.version(), ProtocolVersion::TLSv1_3);
+        assert_eq!(record.payload, &[0x21, 0x00, 0x00, 0x01, 0xab]);
         // second span is incomplete, so no discard yet
         assert_eq!(deframer.discard, 0);
     }
@@ -581,8 +581,8 @@ mod tests {
 
         let mut deframer = Deframer::default();
         while let Some(result) = deframer.deframe(&mut input) {
-            let Deframed { message, bounds } = result.unwrap();
-            let plain = message.into_plain_message();
+            let Deframed { record, bounds } = result.unwrap();
+            let plain = record.into_plain_record();
             std::println!("message {plain:?}");
 
             deframer.input_message(
@@ -598,10 +598,10 @@ mod tests {
 
         for _ in 0..4 {
             let span = deframer.complete_span().unwrap();
-            let msg = deframer.message(span, &input[..]);
+            let record = deframer.message(span, &input[..]);
             assert!(matches!(
-                msg,
-                EncodedMessage {
+                record,
+                Record {
                     typ: ContentType::Handshake,
                     ..
                 }
@@ -610,10 +610,10 @@ mod tests {
         }
 
         let span = deframer.complete_span().unwrap();
-        let msg = deframer.message(span, &input[..]);
+        let record = deframer.message(span, &input[..]);
         assert!(matches!(
-            msg,
-            EncodedMessage {
+            record,
+            Record {
                 typ: ContentType::Handshake,
                 ..
             }
@@ -664,12 +664,12 @@ mod tests {
         let mut buffer = [0x17, 0x03, 0x03, 0x00, 0x01, 0x00];
         let mut deframer = Deframer::default();
 
-        let Deframed { message, bounds } = deframer
+        let Deframed { record, bounds } = deframer
             .deframe(&mut buffer)
             .unwrap()
             .unwrap();
 
-        assert_eq!(message.typ, ContentType::ApplicationData);
+        assert_eq!(record.typ, ContentType::ApplicationData);
         assert_eq!(bounds.end, 6);
         assert!(deframer.deframe(&mut buffer).is_none());
     }
@@ -681,20 +681,20 @@ mod tests {
         ];
         let mut deframer = Deframer::default();
 
-        let Deframed { message, bounds } = deframer
+        let Deframed { record, bounds } = deframer
             .deframe(&mut buffer)
             .unwrap()
             .unwrap();
 
-        assert_eq!(message.typ, ContentType::Handshake);
+        assert_eq!(record.typ, ContentType::Handshake);
         assert_eq!(bounds.end, 6);
 
-        let Deframed { message, bounds } = deframer
+        let Deframed { record, bounds } = deframer
             .deframe(&mut buffer)
             .unwrap()
             .unwrap();
 
-        assert_eq!(message.typ, ContentType::ApplicationData);
+        assert_eq!(record.typ, ContentType::ApplicationData);
         assert_eq!(bounds.end, 12);
         assert!(deframer.deframe(&mut buffer).is_none());
     }
@@ -757,8 +757,8 @@ mod tests {
         let mut end = 0;
 
         while let Some(result) = deframer.deframe(&mut buffer) {
-            let Deframed { message, bounds } = result.unwrap();
-            assert_eq!(ContentType::Handshake, message.typ);
+            let Deframed { record, bounds } = result.unwrap();
+            assert_eq!(ContentType::Handshake, record.typ);
             count += 1;
             end = bounds.end;
         }

--- a/rustls/src/msgs/deframer/mod.rs
+++ b/rustls/src/msgs/deframer/mod.rs
@@ -6,7 +6,7 @@ use crate::crypto::cipher::{EncodableVersion, InboundOpaque, Record, RecordError
 use crate::enums::{ContentType, ProtocolVersion};
 use crate::error::{Error, InvalidMessage};
 use crate::msgs::codec::{Codec, Reader, U24};
-use crate::msgs::{HEADER_SIZE, read_opaque_message_header};
+use crate::msgs::{HEADER_SIZE, read_record_header};
 
 mod buffers;
 use buffers::Coalescer;
@@ -55,7 +55,7 @@ impl Deframer {
     pub(crate) fn deframe<'a>(&mut self, buf: &'a mut [u8]) -> Option<Result<Deframed<'a>, Error>> {
         let mut reader = Reader::new(buf.get(self.processed..)?);
 
-        let (typ, version, len) = match read_opaque_message_header(&mut reader) {
+        let (typ, version, len) = match read_record_header(&mut reader) {
             Ok(header) => header,
             Err(err) => {
                 let err = match err {
@@ -166,8 +166,8 @@ impl Deframer {
     ///
     /// In a normal TLS stream, handshake messages need not be contiguous.
     /// For example, each handshake message could be delivered in its own
-    /// outer TLS message.  This would mean the handshake messages are
-    /// separated by the outer TLS message headers, and likely also
+    /// outer TLS record.  This would mean the handshake messages are
+    /// separated by the outer TLS record headers, and likely also
     /// separated by encryption overhead (any explicit nonce in front,
     /// any padding and authentication tag afterwards).
     ///
@@ -280,7 +280,7 @@ impl Deframer {
     ///
     /// If this was the last pending handshake message, marks the processed
     /// buffer region for discard.
-    pub(crate) fn message<'b>(
+    pub(crate) fn record<'b>(
         &mut self,
         next_span: FragmentSpan,
         containing_buffer: &'b [u8],
@@ -410,7 +410,7 @@ impl Iterator for DissectHandshakeIter<'_> {
 
 #[derive(Debug)]
 pub(crate) struct FragmentSpan {
-    /// version taken from containing message.
+    /// version taken from containing record.
     version: ProtocolVersion,
 
     /// size of the handshake message body (excluding header)
@@ -488,7 +488,7 @@ mod tests {
         std::println!("after:  {deframer:?}");
 
         let span = deframer.complete_span().unwrap();
-        let record = deframer.message(span, &input);
+        let record = deframer.record(span, &input);
         std::println!("record {record:?}");
         assert_eq!(record.typ, ContentType::Handshake);
         assert_eq!(record.version.version(), ProtocolVersion::TLSv1_3);
@@ -511,7 +511,7 @@ mod tests {
         deframer.coalesce(&mut input).unwrap();
         let span = deframer.complete_span().unwrap();
 
-        let record = std::dbg!(deframer.message(span, &input));
+        let record = std::dbg!(deframer.record(span, &input));
         assert_eq!(record.typ, ContentType::Handshake);
         assert_eq!(record.version.version(), ProtocolVersion::TLSv1_3);
         assert_eq!(record.payload, &[0x21, 0x00, 0x00, 0x05, 1, 2, 3, 4, 5]);
@@ -527,7 +527,7 @@ mod tests {
         let mut input = vec![0x21, 0x01, 0x00, X, 0x00, 0xab, X];
         let mut deframer = Deframer::default();
 
-        // split header over multiple messages, which motivates doing
+        // split header over multiple records, which motivates doing
         // this check in `coalesce()`
         add_bytes(&mut deframer, 0..3, &input);
         add_bytes(&mut deframer, 4..6, &input);
@@ -564,7 +564,7 @@ mod tests {
         add_bytes(&mut deframer, 8..12, &input);
 
         let span = deframer.complete_span().unwrap();
-        let record = deframer.message(span, &input);
+        let record = deframer.record(span, &input);
         assert!(deframer.complete_span().is_none());
 
         assert_eq!(record.typ, ContentType::Handshake);
@@ -583,7 +583,7 @@ mod tests {
         while let Some(result) = deframer.deframe(&mut input) {
             let Deframed { record, bounds } = result.unwrap();
             let plain = record.into_plain_record();
-            std::println!("message {plain:?}");
+            std::println!("record {plain:?}");
 
             deframer.input_message(
                 plain.version.version(),
@@ -598,7 +598,7 @@ mod tests {
 
         for _ in 0..4 {
             let span = deframer.complete_span().unwrap();
-            let record = deframer.message(span, &input[..]);
+            let record = deframer.record(span, &input[..]);
             assert!(matches!(
                 record,
                 Record {
@@ -610,7 +610,7 @@ mod tests {
         }
 
         let span = deframer.complete_span().unwrap();
-        let record = deframer.message(span, &input[..]);
+        let record = deframer.record(span, &input[..]);
         assert!(matches!(
             record,
             Record {
@@ -660,7 +660,7 @@ mod tests {
     }
 
     #[test]
-    fn iterate_one_message() {
+    fn iterate_one_record() {
         let mut buffer = [0x17, 0x03, 0x03, 0x00, 0x01, 0x00];
         let mut deframer = Deframer::default();
 
@@ -675,7 +675,7 @@ mod tests {
     }
 
     #[test]
-    fn iterate_two_messages() {
+    fn iterate_two_records() {
         let mut buffer = [
             0x16, 0x03, 0x03, 0x00, 0x01, 0x00, 0x17, 0x03, 0x03, 0x00, 0x01, 0x00,
         ];
@@ -724,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    fn iterator_excess_message_length_rejected() {
+    fn iterator_excess_record_length_rejected() {
         let mut buffer = include_bytes!("../../testdata/deframer-invalid-length.bin").to_vec();
         let mut deframer = Deframer::default();
         let result = deframer.deframe(&mut buffer).unwrap();
@@ -735,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    fn iterator_zero_message_length_rejected() {
+    fn iterator_zero_record_length_rejected() {
         let mut buffer = include_bytes!("../../testdata/deframer-invalid-empty.bin").to_vec();
         let mut deframer = Deframer::default();
         let result = deframer.deframe(&mut buffer).unwrap();
@@ -746,7 +746,7 @@ mod tests {
     }
 
     #[test]
-    fn iterator_over_many_messages() {
+    fn iterator_over_many_records() {
         let client_hello = include_bytes!("../../testdata/deframer-test.1.bin");
         let mut buffer = Vec::with_capacity(3 * client_hello.len());
         buffer.extend(client_hello);

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -13,13 +13,13 @@ pub(crate) struct Fragmenter {
 }
 
 impl Fragmenter {
-    /// Take `payload` and fragment it into new messages with given type and version.
+    /// Take `payload` and fragment it into new records with given type and version.
     ///
-    /// Each returned message size is no more than the most recently configured
+    /// Each returned record size is no more than the most recently configured
     /// `set_max_fragment_size()`, less an allowance for `encryption_overhead` which
     /// should be zero if no encryption will be performed.
     ///
-    /// Return an iterator across those messages.
+    /// Return an iterator across those records.
     ///
     /// Payloads are borrowed from `payload`.
     pub(crate) fn fragment<'a>(
@@ -115,7 +115,7 @@ mod tests {
     use crate::crypto::cipher::{EncodableVersion, OutboundPlain, Payload, Record};
     use crate::enums::{ContentType, ProtocolVersion};
 
-    fn msg_eq(
+    fn record_eq(
         record: &Record<OutboundPlain<'_>>,
         total_len: usize,
         typ: &ContentType,
@@ -149,7 +149,7 @@ mod tests {
             .fragment(record.typ, record.version, record.payload.bytes().into(), 0)
             .collect::<Vec<_>>();
         assert_eq!(q.len(), 3);
-        msg_eq(
+        record_eq(
             &q[0],
             32,
             &typ,
@@ -159,7 +159,7 @@ mod tests {
                 24, 25, 26, 27,
             ],
         );
-        msg_eq(
+        record_eq(
             &q[1],
             32,
             &typ,
@@ -169,7 +169,7 @@ mod tests {
                 49, 50, 51, 52, 53, 54,
             ],
         );
-        msg_eq(
+        record_eq(
             &q[2],
             20,
             &typ,
@@ -193,7 +193,7 @@ mod tests {
             .fragment(record.typ, record.version, record.payload.bytes().into(), 0)
             .collect::<Vec<_>>();
         assert_eq!(q.len(), 1);
-        msg_eq(
+        record_eq(
             &q[0],
             PACKET_OVERHEAD + 8,
             &ContentType::Handshake,
@@ -216,21 +216,21 @@ mod tests {
             .fragment(typ, version, borrowed_payload, 0)
             .collect::<Vec<_>>();
         assert_eq!(fragments.len(), 3);
-        msg_eq(
+        record_eq(
             &fragments[0],
             37,
             &typ,
             &version,
             b"aaaaaaaabbbbbbbbbbbbcccccccccccc",
         );
-        msg_eq(
+        record_eq(
             &fragments[1],
             37,
             &typ,
             &version,
             b"ccccccccccccccccccccdddddddddddd",
         );
-        msg_eq(&fragments[2], 13, &typ, &version, b"dddddddd");
+        record_eq(&fragments[2], 13, &typ, &version, b"dddddddd");
     }
 
     #[test]

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -1,7 +1,7 @@
 use core::num::NonZeroUsize;
 
 use crate::Error;
-use crate::crypto::cipher::{EncodableVersion, EncodedMessage, OutboundPlain};
+use crate::crypto::cipher::{EncodableVersion, OutboundPlain, Record};
 use crate::enums::ContentType;
 
 pub(crate) const MAX_FRAGMENT_LEN: NonZeroUsize = NonZeroUsize::new(16384).unwrap();
@@ -28,14 +28,14 @@ impl Fragmenter {
         version: EncodableVersion,
         payload: OutboundPlain<'a>,
         encryption_overhead: usize,
-    ) -> impl ExactSizeIterator<Item = EncodedMessage<OutboundPlain<'a>>> + use<'a> {
+    ) -> impl ExactSizeIterator<Item = Record<OutboundPlain<'a>>> + use<'a> {
         let max_plaintext = NonZeroUsize::new(
             self.max_frag
                 .get()
                 .saturating_sub(encryption_overhead),
         )
         .unwrap_or(NonZeroUsize::MIN);
-        Chunker::new(payload, max_plaintext).map(move |payload| EncodedMessage {
+        Chunker::new(payload, max_plaintext).map(move |payload| Record {
             typ,
             version,
             payload,
@@ -112,21 +112,21 @@ mod tests {
     use std::vec;
 
     use super::{Fragmenter, PACKET_OVERHEAD};
-    use crate::crypto::cipher::{EncodableVersion, EncodedMessage, OutboundPlain, Payload};
+    use crate::crypto::cipher::{EncodableVersion, OutboundPlain, Payload, Record};
     use crate::enums::{ContentType, ProtocolVersion};
 
     fn msg_eq(
-        m: &EncodedMessage<OutboundPlain<'_>>,
+        record: &Record<OutboundPlain<'_>>,
         total_len: usize,
         typ: &ContentType,
         version: &EncodableVersion,
         bytes: &[u8],
     ) {
-        assert_eq!(&m.typ, typ);
-        assert_eq!(&m.version, version);
-        assert_eq!(m.payload.to_vec(), bytes);
+        assert_eq!(&record.typ, typ);
+        assert_eq!(&record.version, version);
+        assert_eq!(record.payload.to_vec(), bytes);
 
-        let buf = m.to_unencrypted_bytes();
+        let buf = record.to_unencrypted_bytes();
 
         assert_eq!(total_len, buf.len());
     }
@@ -136,7 +136,7 @@ mod tests {
         let typ = ContentType::Handshake;
         let version = EncodableVersion::Legacy(ProtocolVersion::TLSv1_2);
         let data: Vec<u8> = (1..70u8).collect();
-        let m = EncodedMessage {
+        let record = Record {
             typ,
             version,
             payload: Payload::new(data),
@@ -146,7 +146,7 @@ mod tests {
         frag.set_max_fragment_size(Some(32))
             .unwrap();
         let q = frag
-            .fragment(m.typ, m.version, m.payload.bytes().into(), 0)
+            .fragment(record.typ, record.version, record.payload.bytes().into(), 0)
             .collect::<Vec<_>>();
         assert_eq!(q.len(), 3);
         msg_eq(
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn non_fragment() {
-        let m = EncodedMessage {
+        let record = Record {
             typ: ContentType::Handshake,
             version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
             payload: Payload::new(b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec()),
@@ -190,7 +190,7 @@ mod tests {
         frag.set_max_fragment_size(Some(32))
             .unwrap();
         let q = frag
-            .fragment(m.typ, m.version, m.payload.bytes().into(), 0)
+            .fragment(record.typ, record.version, record.payload.bytes().into(), 0)
             .collect::<Vec<_>>();
         assert_eq!(q.len(), 1);
         msg_eq(
@@ -256,7 +256,7 @@ mod tests {
 
         assert_eq!(
             q.iter()
-                .map(|m| m.payload.len())
+                .map(|record| record.payload.len())
                 .collect::<Vec<usize>>(),
             expect
         );

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -130,7 +130,7 @@ pub mod fuzzing {
             return;
         };
 
-        //println!("msg = {:#?}", m);
+        //println!("record = {record:#?}");
         let expected_version = msg.version.encode();
         let enc = Record::<Payload<'_>>::from(msg)
             .borrow_outbound()
@@ -233,7 +233,7 @@ impl<'a> TryFrom<&'a Record<Payload<'a>>> for Message<'a> {
     }
 }
 
-pub(crate) fn read_opaque_message_header(
+pub(crate) fn read_record_header(
     r: &mut Reader<'_>,
 ) -> Result<(ContentType, ProtocolVersion, u16), RecordError> {
     let typ = ContentType::read(r).map_err(|_| RecordError::TooShortForHeader)?;

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -34,7 +34,7 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use crate::crypto::cipher::{EncodableVersion, EncodedMessage, MessageError, Payload};
+use crate::crypto::cipher::{EncodableVersion, Payload, Record, RecordError};
 use crate::enums::{ContentType, ContentTypeName, HandshakeType, ProtocolVersion};
 use crate::error::{AlertDescription, InvalidMessage};
 use crate::verify::DigitallySignedStruct;
@@ -98,23 +98,23 @@ mod handshake_test;
 
 pub mod fuzzing {
     pub use super::deframer::fuzz_deframer;
-    use super::{Codec, EncodedMessage, Fragmenter, Message, Payload, Reader};
+    use super::{Codec, Fragmenter, Message, Payload, Reader, Record};
     use crate::server::ServerSessionValue;
 
     pub fn fuzz_fragmenter(data: &[u8]) {
         let mut rdr = Reader::new(data);
-        let Ok(msg) = EncodedMessage::<Payload<'_>>::read(&mut rdr) else {
+        let Ok(record) = Record::<Payload<'_>>::read(&mut rdr) else {
             return;
         };
 
         let mut frg = Fragmenter::default();
         frg.set_max_fragment_size(Some(32))
             .unwrap();
-        for msg in frg.fragment(msg.typ, msg.version, msg.payload.bytes().into(), 0) {
-            Message::try_from(&EncodedMessage {
-                typ: msg.typ,
-                version: msg.version,
-                payload: Payload::Owned(msg.payload.to_vec()),
+        for record in frg.fragment(record.typ, record.version, record.payload.bytes().into(), 0) {
+            Message::try_from(&Record {
+                typ: record.typ,
+                version: record.version,
+                payload: Payload::Owned(record.payload.to_vec()),
             })
             .ok();
         }
@@ -122,17 +122,17 @@ pub mod fuzzing {
 
     pub fn fuzz_message(data: &[u8]) {
         let mut rdr = Reader::new(data);
-        let Ok(m) = EncodedMessage::<Payload<'_>>::read(&mut rdr) else {
+        let Ok(record) = Record::<Payload<'_>>::read(&mut rdr) else {
             return;
         };
 
-        let Ok(msg) = Message::try_from(&m) else {
+        let Ok(msg) = Message::try_from(&record) else {
             return;
         };
 
         //println!("msg = {:#?}", m);
         let expected_version = msg.version.encode();
-        let enc = EncodedMessage::<Payload<'_>>::from(msg)
+        let enc = Record::<Payload<'_>>::from(msg)
             .borrow_outbound()
             .to_unencrypted_bytes();
         //println!("data = {:?}", &data[..rdr.used()]);
@@ -194,7 +194,7 @@ impl Message<'_> {
 
     #[cfg(test)]
     pub(crate) fn into_wire_bytes(self) -> Vec<u8> {
-        EncodedMessage::<Payload<'_>>::from(self)
+        Record::<Payload<'_>>::from(self)
             .borrow_outbound()
             .to_unencrypted_bytes()
     }
@@ -207,10 +207,10 @@ impl Message<'_> {
     }
 }
 
-impl<'a> TryFrom<EncodedMessage<&'a [u8]>> for Message<'a> {
+impl<'a> TryFrom<Record<&'a [u8]>> for Message<'a> {
     type Error = InvalidMessage;
 
-    fn try_from(plain: EncodedMessage<&'a [u8]>) -> Result<Self, Self::Error> {
+    fn try_from(plain: Record<&'a [u8]>) -> Result<Self, Self::Error> {
         Ok(Self {
             version: plain.version,
             payload: MessagePayload::new(plain.typ, plain.version.version(), plain.payload)?,
@@ -218,10 +218,10 @@ impl<'a> TryFrom<EncodedMessage<&'a [u8]>> for Message<'a> {
     }
 }
 
-impl<'a> TryFrom<&'a EncodedMessage<Payload<'a>>> for Message<'a> {
+impl<'a> TryFrom<&'a Record<Payload<'a>>> for Message<'a> {
     type Error = InvalidMessage;
 
-    fn try_from(plain: &'a EncodedMessage<Payload<'a>>) -> Result<Self, Self::Error> {
+    fn try_from(plain: &'a Record<Payload<'a>>) -> Result<Self, Self::Error> {
         Ok(Self {
             version: plain.version,
             payload: MessagePayload::new(
@@ -235,31 +235,31 @@ impl<'a> TryFrom<&'a EncodedMessage<Payload<'a>>> for Message<'a> {
 
 pub(crate) fn read_opaque_message_header(
     r: &mut Reader<'_>,
-) -> Result<(ContentType, ProtocolVersion, u16), MessageError> {
-    let typ = ContentType::read(r).map_err(|_| MessageError::TooShortForHeader)?;
+) -> Result<(ContentType, ProtocolVersion, u16), RecordError> {
+    let typ = ContentType::read(r).map_err(|_| RecordError::TooShortForHeader)?;
     // Don't accept any new content-types.
     if ContentTypeName::try_from(typ).is_err() {
-        return Err(MessageError::InvalidContentType);
+        return Err(RecordError::InvalidContentType);
     }
 
-    let version = ProtocolVersion::read(r).map_err(|_| MessageError::TooShortForHeader)?;
+    let version = ProtocolVersion::read(r).map_err(|_| RecordError::TooShortForHeader)?;
     // Accept only versions 0x03XX for any XX.
     if version.0 & 0xff00 != 0x0300 {
-        return Err(MessageError::UnknownProtocolVersion);
+        return Err(RecordError::UnknownProtocolVersion);
     }
 
-    let len = u16::read(r).map_err(|_| MessageError::TooShortForHeader)?;
+    let len = u16::read(r).map_err(|_| RecordError::TooShortForHeader)?;
 
     // Reject undersize messages
     //  implemented per section 5.1 of RFC 9846 (TLSv1.3)
     //              per section 6.2.1 of RFC 5246 (TLSv1.2)
     if typ != ContentType::ApplicationData && len == 0 {
-        return Err(MessageError::InvalidEmptyPayload);
+        return Err(RecordError::InvalidEmptyPayload);
     }
 
     // Reject oversize messages
     if len >= MAX_PAYLOAD {
-        return Err(MessageError::MessageTooLarge);
+        return Err(RecordError::MessageTooLarge);
     }
 
     Ok((typ, version, len))
@@ -344,7 +344,7 @@ impl<'a> MessagePayload<'a> {
     }
 }
 
-impl From<Message<'_>> for EncodedMessage<Payload<'_>> {
+impl From<Message<'_>> for Record<Payload<'_>> {
     fn from(msg: Message<'_>) -> Self {
         let typ = msg.payload.content_type();
         let payload = match msg.payload {
@@ -725,14 +725,14 @@ mod tests {
             f.read_to_end(&mut bytes).unwrap();
 
             let mut rd = Reader::new(&bytes);
-            let msg = EncodedMessage::<Payload<'_>>::read(&mut rd).unwrap();
-            println!("{msg:?}");
+            let record = Record::<Payload<'_>>::read(&mut rd).unwrap();
+            println!("{record:?}");
 
-            let Ok(msg) = Message::try_from(&msg) else {
+            let Ok(msg) = Message::try_from(&record) else {
                 continue;
             };
 
-            let enc = EncodedMessage::<Payload<'_>>::from(msg)
+            let enc = Record::<Payload<'_>>::from(msg)
                 .borrow_outbound()
                 .to_unencrypted_bytes();
             // Check that round-tripped message matches the input, ignoring the protocol version
@@ -762,9 +762,9 @@ mod tests {
         \x79\x2f\x33\x08\x68\x74\x74\x70\x2f\x31\x2e\x31\x00\x0b\x00\x02\
         \x01\x00\x00\x0a\x00\x0a\x00\x08\x00\x1d\x00\x17\x00\x18\x00\x19";
         let mut rd = Reader::new(bytes);
-        let m = EncodedMessage::<Payload<'_>>::read(&mut rd).unwrap();
-        println!("m = {m:?}");
-        Message::try_from(&m).unwrap();
+        let record = Record::<Payload<'_>>::read(&mut rd).unwrap();
+        println!("record = {record:?}");
+        Message::try_from(&record).unwrap();
     }
 
     #[test]
@@ -783,9 +783,9 @@ mod tests {
             &b"\x18\x03\x04\x00\x04\x11\x22\x33\x44"[..],
         ];
         for &bytes in samples.iter() {
-            let m = EncodedMessage::<Payload<'_>>::read(&mut Reader::new(bytes)).unwrap();
-            println!("m = {m:?}");
-            let m = Message::try_from(&m);
+            let record = Record::<Payload<'_>>::read(&mut Reader::new(bytes)).unwrap();
+            println!("record = {record:?}");
+            let m = Message::try_from(&record);
             println!("m' = {m:?}");
         }
     }
@@ -828,14 +828,14 @@ mod tests {
         let mut r = Reader::new(bytes);
 
         while r.any_left() {
-            let m = EncodedMessage::<Payload<'_>>::read(&mut r).unwrap();
+            let record = Record::<Payload<'_>>::read(&mut r).unwrap();
 
-            let out = m
+            let out = record
                 .borrow_outbound()
                 .to_unencrypted_bytes();
             assert!(!out.is_empty());
 
-            Message::try_from(&m).unwrap();
+            Message::try_from(&record).unwrap();
         }
     }
 }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -1056,22 +1056,22 @@ pub trait PacketKey: Send + Sync {
     /// Tag length for the underlying AEAD algorithm
     fn tag_len(&self) -> usize;
 
-    /// Number of QUIC messages that can be safely encrypted with a single key of this type.
+    /// Number of QUIC packets that can be safely encrypted with a single key of this type.
     ///
-    /// Once a `MessageEncrypter` produced for this suite has encrypted more than
-    /// `confidentiality_limit` messages, an attacker gains an advantage in distinguishing it
+    /// Once a `PacketKey` produced for this suite has encrypted more than
+    /// `confidentiality_limit` packets, an attacker gains an advantage in distinguishing it
     /// from an ideal pseudorandom permutation (PRP).
     ///
-    /// This is to be set on the assumption that messages are maximally sized --
+    /// This is to be set on the assumption that packets are maximally sized --
     /// 2 ** 16. For non-QUIC TCP connections see [`CipherSuiteCommon::confidentiality_limit`][csc-limit].
     ///
     /// [csc-limit]: crate::crypto::CipherSuiteCommon::confidentiality_limit
     fn confidentiality_limit(&self) -> u64;
 
-    /// Number of QUIC messages that can be safely decrypted with a single key of this type
+    /// Number of QUIC packets that can be safely decrypted with a single key of this type
     ///
-    /// Once a `MessageDecrypter` produced for this suite has failed to decrypt `integrity_limit`
-    /// messages, an attacker gains an advantage in forging messages.
+    /// Once a `PacketKey` produced for this suite has failed to decrypt `integrity_limit`
+    /// packets, an attacker gains an advantage in forging packets.
     ///
     /// This is not relevant for TLS over TCP (which is also implemented in this crate)
     /// because a single failed decryption is fatal to the connection.

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -15,7 +15,7 @@ use crate::check::inappropriate_message;
 use crate::common_state::{Event, HandshakeFlightTls12, HandshakeKind, Output, OutputEvent, Side};
 use crate::conn::kernel::KernelState;
 use crate::conn::{ConnectionRandoms, Input};
-use crate::crypto::cipher::{EncodableVersion, MessageDecrypter, MessageEncrypter, Payload};
+use crate::crypto::cipher::{EncodableVersion, Payload, RecordDecrypter, RecordEncrypter};
 use crate::crypto::kx::{ActiveKeyExchange, SupportedKxGroup};
 use crate::crypto::{Identity, TicketProducer};
 use crate::enums::{
@@ -766,7 +766,7 @@ struct ExpectCcs {
     hs: HandshakeState,
     secrets: ConnectionSecrets,
     peer_identity: Option<VerifiedIdentity<'static>>,
-    resuming_decrypter: Option<Box<dyn MessageDecrypter>>,
+    resuming_decrypter: Option<Box<dyn RecordDecrypter>>,
 }
 
 impl ExpectCcs {
@@ -802,7 +802,7 @@ impl ExpectCcs {
         output
             .receive()
             .decrypt_state
-            .set_message_decrypter(decrypter, &proof);
+            .set_record_decrypter(decrypter, &proof);
 
         Ok(Box::new(ExpectFinished {
             hs: self.hs,
@@ -983,7 +983,7 @@ pub(super) struct ExpectFinished {
     secrets: ConnectionSecrets,
     peer_identity: Option<VerifiedIdentity<'static>>,
     resuming: bool,
-    pending_encrypter: Option<Box<dyn MessageEncrypter>>,
+    pending_encrypter: Option<Box<dyn RecordEncrypter>>,
 }
 
 impl ExpectFinished {

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -19,13 +19,13 @@ pub struct CipherSuiteCommon {
     /// Which hash function the suite uses.
     pub hash_provider: &'static dyn hash::Hash,
 
-    /// Number of TCP-TLS messages that can be safely encrypted with a single key of this type
+    /// Number of TCP-TLS records that can be safely encrypted with a single key of this type
     ///
     /// Once a `RecordEncrypter` produced for this suite has encrypted more than
-    /// `confidentiality_limit` messages, an attacker gains an advantage in distinguishing it
+    /// `confidentiality_limit` records, an attacker gains an advantage in distinguishing it
     /// from an ideal pseudorandom permutation (PRP).
     ///
-    /// This is to be set on the assumption that messages are maximally sized --
+    /// This is to be set on the assumption that record payloads are maximally sized --
     /// each is 2<sup>14</sup> bytes. It **does not** consider confidentiality limits for
     /// QUIC connections - see the [`quic::PacketKey::confidentiality_limit`] field for
     /// this context.

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -21,7 +21,7 @@ pub struct CipherSuiteCommon {
 
     /// Number of TCP-TLS messages that can be safely encrypted with a single key of this type
     ///
-    /// Once a `MessageEncrypter` produced for this suite has encrypted more than
+    /// Once a `RecordEncrypter` produced for this suite has encrypted more than
     /// `confidentiality_limit` messages, an attacker gains an advantage in distinguishing it
     /// from an ideal pseudorandom permutation (PRP).
     ///

--- a/rustls/src/tls12.rs
+++ b/rustls/src/tls12.rs
@@ -8,7 +8,7 @@ use zeroize::Zeroizing;
 
 use crate::common_state::{Protocol, Side};
 use crate::conn::{ConnectionRandoms, Exporter};
-use crate::crypto::cipher::{AeadKey, MessageDecrypter, MessageEncrypter, Tls12AeadAlgorithm};
+use crate::crypto::cipher::{AeadKey, RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm};
 use crate::crypto::kx::{ActiveKeyExchange, KeyExchangeAlgorithm};
 use crate::crypto::tls12::PrfSecret;
 use crate::crypto::{self, SignatureScheme, hash};
@@ -61,7 +61,7 @@ pub struct Tls12CipherSuite {
     /// The precise scheme used is then chosen from this set by the selected authentication key.
     pub sign: &'static [SignatureScheme],
 
-    /// How to produce a [`MessageDecrypter`] or [`MessageEncrypter`]
+    /// How to produce a [`RecordDecrypter`] or [`RecordEncrypter`]
     /// from raw key material.
     pub aead_alg: &'static dyn Tls12AeadAlgorithm,
 }
@@ -212,9 +212,9 @@ impl ConnectionSecrets {
         }
     }
 
-    /// Make a `MessageCipherPair` based on the given supported ciphersuite `self.suite`,
+    /// Make a `RecordCipherPair` based on the given supported ciphersuite `self.suite`,
     /// and the session's `secrets`.
-    pub(crate) fn make_cipher_pair(&self, side: Side) -> MessageCipherPair {
+    pub(crate) fn make_cipher_pair(&self, side: Side) -> RecordCipherPair {
         // Make a key block, and chop it up.
         // Note: we don't implement any ciphersuites with nonzero mac_key_len.
         let key_block = self.make_key_block();
@@ -398,7 +398,7 @@ fn join_randoms(first: &[u8; 32], second: &[u8; 32]) -> [u8; 64] {
     randoms
 }
 
-type MessageCipherPair = (Box<dyn MessageDecrypter>, Box<dyn MessageEncrypter>);
+type RecordCipherPair = (Box<dyn RecordDecrypter>, Box<dyn RecordEncrypter>);
 
 pub(crate) fn decode_kx_params<'a, T: KxDecode<'a>>(
     kx_algorithm: KeyExchangeAlgorithm,

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -5,7 +5,7 @@ use core::ops::Deref;
 
 use crate::common_state::{Output, Side};
 use crate::conn::{Exporter, ReceivePath, SendOutput};
-use crate::crypto::cipher::{AeadKey, Iv, MessageDecrypter, Tls13AeadAlgorithm};
+use crate::crypto::cipher::{AeadKey, Iv, RecordDecrypter, Tls13AeadAlgorithm};
 use crate::crypto::kx::SharedSecret;
 use crate::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError, expand};
 use crate::crypto::{hash, hmac};
@@ -403,7 +403,7 @@ impl KeyScheduleHandshake {
                 .set_decrypter(secret, receive, proof),
             Some(max_early_data_size) => receive
                 .decrypt_state
-                .set_message_decrypter_with_trial_decryption(
+                .set_record_decrypter_with_trial_decryption(
                     self.ks
                         .derive_decrypter(&self.client_handshake_traffic_secret),
                     max_early_data_size,
@@ -938,10 +938,10 @@ impl KeyScheduleSuite {
     ) {
         receive
             .decrypt_state
-            .set_message_decrypter(self.derive_decrypter(secret), proof);
+            .set_record_decrypter(self.derive_decrypter(secret), proof);
     }
 
-    fn derive_decrypter(&self, secret: &OkmBlock) -> Box<dyn MessageDecrypter> {
+    fn derive_decrypter(&self, secret: &OkmBlock) -> Box<dyn RecordDecrypter> {
         let suite = self.state.suite();
         let expander = suite
             .hkdf_provider

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -57,11 +57,11 @@ pub struct Tls13CipherSuite {
     /// [`crypto::tls13::HkdfUsingHmac`].
     pub hkdf_provider: &'static dyn crypto::tls13::Hkdf,
 
-    /// How to produce a [MessageDecrypter] or [MessageEncrypter]
+    /// How to produce a [RecordDecrypter] or [RecordEncrypter]
     /// from raw key material.
     ///
-    /// [MessageDecrypter]: crate::crypto::cipher::MessageDecrypter
-    /// [MessageEncrypter]: crate::crypto::cipher::MessageEncrypter
+    /// [RecordDecrypter]: crate::crypto::cipher::RecordDecrypter
+    /// [RecordEncrypter]: crate::crypto::cipher::RecordEncrypter
     pub aead_alg: &'static dyn crypto::cipher::Tls13AeadAlgorithm,
 
     /// How to create QUIC header and record protection algorithms


### PR DESCRIPTION
Closes #3111.

Introduces consistent naming, distinguishing TLS records from messages. Uses "record" if it corresponds to `TLSPlaintext`/`TLSCiphertext` and the payload has not
been interpreted. Keeps "message" if the payload's been interpreted depending on the record's content type.

Breaks public API. No changes in behaviour.

Changes split into four commits [as requested](https://github.com/rustls/rustls/issues/3111#issuecomment-5045671276). The QUIC commit drops MessageEncrypter/Decrypter from `PacketKey` limit docs (QUIC doesn't use these).

Deliberately left alone `MessageIter` (coalesces handshake messages) and `Deframer::input_message` (tracks handshake message boundaries).
