### PR TITLE
Fix QUIC handshakes requiring HelloRetryRequest

### DIFF
--- a/rustls-test/tests/api/quic.rs
+++ b/rustls-test/tests/api/quic.rs
@@ -17,7 +17,8 @@ use rustls::server::Tls13Tickets;
 use rustls::{CipherSuiteCommon, HandshakeKind, SliceInput, Tls13CipherSuite, VecInput};
 use rustls_test::{
     ClientStorage, KeyType, MultiTest, do_handshake, encoding, make_client_config,
-    make_pair_for_arc_configs, make_server_config, server_name,
+    make_client_config_with_kx_groups, make_pair_for_arc_configs, make_server_config,
+    make_server_config_with_kx_groups, server_name,
 };
 
 use super::provider;
@@ -210,6 +211,56 @@ fn test_quic_handshake() {
         server_next.local.as_ref(),
         client_next.remote.as_ref()
     ));
+}
+
+#[test]
+fn test_quic_handshake_with_hello_retry_request() {
+    let provider = provider::DEFAULT_TLS13_PROVIDER;
+    let client_config = make_client_config_with_kx_groups(
+        KeyType::default(),
+        vec![provider::kx_group::SECP384R1, provider::kx_group::X25519],
+        &provider,
+    );
+    let server_config = make_server_config_with_kx_groups(
+        KeyType::default(),
+        vec![provider::kx_group::X25519],
+        &provider,
+    );
+
+    let mut client = quic::ClientConnection::new(
+        Arc::new(client_config),
+        quic::Version::V1,
+        server_name("localhost"),
+        b"client params".to_vec(),
+    )
+    .unwrap();
+    let mut server = quic::ServerConnection::new(
+        Arc::new(server_config),
+        quic::Version::V1,
+        b"server params".to_vec(),
+    )
+    .unwrap();
+
+    quic_transfer(&mut client, &mut server).unwrap();
+    quic_transfer(&mut server, &mut client).unwrap();
+
+    let client_retry_flight = client.events().collect::<Vec<_>>();
+    assert!(matches!(
+        client_retry_flight.as_slice(),
+        [QuicEvent::Message(_)]
+    ));
+    quic_insert(client_retry_flight, &mut server).unwrap();
+
+    do_quic_handshake(&mut client, &mut server);
+
+    assert_eq!(
+        client.handshake_kind(),
+        Some(HandshakeKind::FullWithHelloRetryRequest)
+    );
+    assert_eq!(
+        server.handshake_kind(),
+        Some(HandshakeKind::FullWithHelloRetryRequest)
+    );
 }
 
 #[test]

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -265,9 +265,7 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
             &proof,
         );
 
-        if !key_schedule.is_quic() {
-            emit_fake_ccs(&mut sent_tls13_fake_ccs, output);
-        }
+        emit_fake_ccs(&mut sent_tls13_fake_ccs, output);
 
         output.output(OutputEvent::HandshakeKind(
             match (&resuming_session, st.done_retry) {
@@ -457,10 +455,8 @@ pub(super) fn derive_early_traffic_secret(
     transcript_buffer: &HandshakeHashBuffer,
     client_random: &[u8; 32],
 ) {
-    if !early_key_schedule.is_quic() {
-        // For middlebox compatibility
-        emit_fake_ccs(sent_tls13_fake_ccs, output);
-    }
+    // For middlebox compatibility
+    emit_fake_ccs(sent_tls13_fake_ccs, output);
 
     let client_hello_hash = transcript_buffer.hash_given(hash_alg, &[]);
     early_key_schedule.client_early_traffic_secret(
@@ -480,6 +476,12 @@ pub(super) fn derive_early_traffic_secret(
 }
 
 pub(super) fn emit_fake_ccs(sent_tls13_fake_ccs: &mut bool, output: &mut dyn Output<'_>) {
+    // RFC 9001 §8.4 prohibits TLS middlebox compatibility mode in QUIC:
+    // <https://www.rfc-editor.org/rfc/rfc9001.html#section-8.4>
+    if output.quic().is_some() {
+        return;
+    }
+
     if core::mem::replace(sent_tls13_fake_ccs, true) {
         return;
     }

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -42,10 +42,6 @@ impl KeyScheduleEarlyClient {
             output.send(),
         );
     }
-
-    pub(crate) fn is_quic(&self) -> bool {
-        self.0.ks.state.is_quic()
-    }
 }
 
 impl Deref for KeyScheduleEarlyClient {


### PR DESCRIPTION
QUIC does not use the TLS record layer, so it has no means to carry a `ChangeCipherSpec` record ([RFC 9001 §8.4 — Prohibit TLS Middlebox Compatibility Mode](https://www.rfc-editor.org/rfc/rfc9001.html#section-8.4)).

In downstream QUIC handshakes requiring a `HelloRetryRequest`, the fake CCS corrupts the framing of the second `ClientHello`.

This PR:

- Centralizes the QUIC check in `emit_fake_ccs()`, preventing fake CCS emission from all client QUIC paths, including the second `ClientHello` following a `HelloRetryRequest`.
- Removes the redundant caller-side checks and the now-unused `KeyScheduleEarlyClient::is_quic()`.
- Adds dedicated QUIC handshake coverage for the `HelloRetryRequest` path.