### PR TITLE
Refuse secret extraction with pending send data

### DIFF
--- a/rustls-test/tests/api/crypto.rs
+++ b/rustls-test/tests/api/crypto.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
 use rustls::crypto::{Credentials, CryptoProvider};
+use rustls::error::ApiMisuse;
 use rustls::{
     ClientConfig, ClientConnection, Connection, ConnectionTrafficSecrets, Error, KeyLog,
     ServerConfig, ServerConnection, SupportedCipherSuite, VecInput,
@@ -446,6 +447,63 @@ fn test_secret_extraction_disabled_or_too_early() {
                 .is_ok()
         );
     }
+}
+
+#[test]
+fn test_secret_extraction_fails_with_pending_send_data() {
+    fn server_with_queued_key_update() -> ServerConnection {
+        let mut server_config = make_server_config(KeyType::default(), &provider::DEFAULT_PROVIDER);
+        server_config.enable_secret_extraction = true;
+
+        let mut client_output = Vec::new();
+        let mut server_output = Vec::new();
+        let (mut client, mut server) = make_pair_for_configs(
+            make_client_config(KeyType::default(), &provider::DEFAULT_PROVIDER),
+            server_config,
+            &mut client_output,
+        );
+        let mut client_input = VecInput::default();
+        let mut server_input = VecInput::default();
+        do_handshake(
+            &mut client_input,
+            &mut client_output,
+            &mut client,
+            &mut server_input,
+            &mut server_output,
+            &mut server,
+        );
+
+        // receiving the key-update request queues an encrypted response on the
+        // server's send path, awaiting the next write
+        client
+            .refresh_traffic_keys(&mut client_output)
+            .unwrap();
+        transfer(&mut client_output, &mut server_input);
+        server
+            .process_new_packets(&mut server_input, &mut server_output)
+            .handle_all(&mut Vec::new())
+            .unwrap();
+        server
+    }
+
+    // extracting now is refused: the queued response would be discarded,
+    // having already consumed a send sequence number
+    assert_eq!(
+        server_with_queued_key_update()
+            .dangerous_extract_secrets()
+            .err(),
+        Some(ApiMisuse::KernelConnectionWithPendingSendData.into())
+    );
+
+    // writing out the pending data first makes extraction possible
+    let mut server = server_with_queued_key_update();
+    let mut server_output = Vec::new();
+    server
+        .write_tls(b"flush".into(), &mut server_output)
+        .unwrap();
+    server
+        .dangerous_extract_secrets()
+        .unwrap();
 }
 
 #[test]

--- a/rustls-test/tests/api/split.rs
+++ b/rustls-test/tests/api/split.rs
@@ -6,10 +6,14 @@
 
 use std::io::Cursor;
 
+use rustls::crypto::cipher::OutboundPlain;
 use rustls::error::{AlertDescription, ApiMisuse, InvalidMessage};
+use rustls::server::ServerSide;
 use rustls::split::{ReceiveTraffic, ReceiveTrafficState, SplitConnection};
 use rustls::{Connection, Error, SideData, SliceInput, VecInput};
-use rustls_test::{KeyType, do_handshake, make_pair};
+use rustls_test::{
+    KeyType, do_handshake, make_client_config, make_pair, make_pair_for_configs, make_server_config,
+};
 
 #[test]
 fn split_pairwise() {
@@ -399,6 +403,91 @@ fn read_invalid_data_and_send_alert() {
             .err(),
         Some(Error::AlertReceived(AlertDescription::DecodeError))
     );
+}
+
+#[test]
+fn kernel_conversion_fails_with_pending_send_data() {
+    // converting with a queued key-update response is refused: it would be
+    // discarded, having already consumed a send sequence number
+    let conn = split_server_with_queued_key_update();
+    assert_eq!(
+        conn.dangerous_into_kernel_connection()
+            .err(),
+        Some(ApiMisuse::KernelConnectionWithPendingSendData.into())
+    );
+
+    // flushing the send half first makes conversion possible
+    let SplitConnection {
+        send: mut server_send,
+        receive: server_recv,
+        outputs: server_outputs,
+    } = split_server_with_queued_key_update();
+    let mut flight = Vec::new();
+    server_send.write(OutboundPlain::new_empty(), &mut flight);
+    assert!(!flight.is_empty());
+    SplitConnection {
+        send: server_send,
+        receive: server_recv,
+        outputs: server_outputs,
+    }
+    .dangerous_into_kernel_connection()
+    .unwrap();
+}
+
+/// Handshake a pair, then deliver a `key_update` request to the server's
+/// receive half.
+///
+/// This queues an encrypted response on the server's send half, awaiting the
+/// next send-side operation.
+fn split_server_with_queued_key_update() -> SplitConnection<ServerSide> {
+    let mut client_output = Vec::new();
+    let mut server_output = Vec::new();
+    let mut server_config =
+        make_server_config(KeyType::default(), &super::provider::DEFAULT_PROVIDER);
+    server_config.enable_secret_extraction = true;
+    let (mut client, mut server) = make_pair_for_configs(
+        make_client_config(KeyType::default(), &super::provider::DEFAULT_PROVIDER),
+        server_config,
+        &mut client_output,
+    );
+    let (mut client_input, mut server_input) = (VecInput::default(), VecInput::default());
+    do_handshake(
+        &mut client_input,
+        &mut client_output,
+        &mut client,
+        &mut server_input,
+        &mut server_output,
+        &mut server,
+    );
+
+    let SplitConnection {
+        send: mut client_send,
+        ..
+    } = client.split().unwrap();
+    let SplitConnection {
+        send: server_send,
+        receive: server_recv,
+        outputs: server_outputs,
+    } = server.split().unwrap();
+
+    let mut flight = Vec::new();
+    client_send
+        .refresh_traffic_keys(&mut flight)
+        .unwrap();
+    let server_recv = check_receive_all(
+        server_recv,
+        flight,
+        ExpectFlushSender {
+            then: ExpectReadMore,
+        },
+    )
+    .unwrap();
+
+    SplitConnection {
+        send: server_send,
+        receive: server_recv,
+        outputs: server_outputs,
+    }
 }
 
 #[track_caller]

--- a/rustls/src/conn/mod.rs
+++ b/rustls/src/conn/mod.rs
@@ -72,6 +72,13 @@ pub trait Connection: Debug + Deref<Target = ConnectionOutputs> {
     /// Extract secrets, so they can be used when configuring kTLS, for example.
     ///
     /// Should be used with care as it exposes secret key material.
+    ///
+    /// All TLS data previously written into caller-provided buffers must be sent to the peer before
+    /// calling this function.
+    ///
+    /// This fails with [`ApiMisuse::KernelConnectionWithPendingSendData`] if the
+    /// connection has pending data to send, which would otherwise be lost.
+    /// Write out that pending data before calling this function.
     fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error>;
 
     /// Sends a TLS1.3 `key_update` message into `tls` to refresh a connection's keys.
@@ -232,6 +239,13 @@ impl<Side: SideData> ConnectionCommon<Side> {
         outputs: ConnectionOutputs,
         state: Side::State,
     ) -> Result<(ExtractedSecrets, KernelConnection<Side>), Error> {
+        // a queued key_update response has consumed a send sequence number so
+        // discarding it would leave the extracted secrets ahead of what the
+        // peer receives.
+        if send.has_queued_key_update() {
+            return Err(ApiMisuse::KernelConnectionWithPendingSendData.into());
+        }
+
         let read_seq = recv.decrypt_state.read_seq();
         let write_seq = send.encrypt_state.write_seq();
 

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -138,6 +138,10 @@ impl SendPath {
         self.key_update_remote = KeyUpdateRemote::Idle;
     }
 
+    pub(super) fn has_queued_key_update(&self) -> bool {
+        matches!(self.key_update_remote, KeyUpdateRemote::Queued(_))
+    }
+
     pub(crate) fn set_max_fragment_size(&mut self, new: Option<usize>) -> Result<(), Error> {
         self.fragmenter
             .set_max_fragment_size(new)

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -13,7 +13,7 @@ use crate::conn::{
 };
 use crate::crypto::cipher::{OutboundPlain, RecordEncrypter};
 use crate::enums::ProtocolVersion;
-use crate::error::AlertDescription;
+use crate::error::{AlertDescription, ApiMisuse};
 use crate::lock::Mutex;
 use crate::msgs::{AlertLevel, Delocator, Message};
 use crate::sync::Arc;
@@ -41,12 +41,18 @@ impl<Side: SideData> SplitConnection<Side> {
     ///
     /// Should be used with care as it exposes secret key material.
     ///
+    /// All TLS data previously written into caller-provided buffers must be sent to the peer before
+    /// calling this function.
+    ///
     /// The returned [`KernelConnection`] continues to own the connection's
     /// secrets, so it can compute new traffic secrets on key update and (for
     /// client connections) accept session tickets.  See the [`kernel`] module
     /// documentation for the details.
     ///
-    /// This fails if the connection was not made with [`enable_secret_extraction`] set.
+    /// This fails if the connection was not made with [`enable_secret_extraction`] set,
+    /// or if the send half has pending data queued by the receive half (see
+    /// [`ReceiveTrafficState::FlushSender`]). Flush any pending data with
+    /// [`SendTraffic::write()`] before calling this.
     ///
     /// [`kernel`]: crate::kernel
     /// [`enable_secret_extraction`]: crate::ClientConfig::enable_secret_extraction
@@ -66,8 +72,16 @@ impl<Side: SideData> SplitConnection<Side> {
             state, recv, send, ..
         } = receive;
 
+        let mut send = send.lock().unwrap();
+
+        // pending data has consumed send sequence numbers so discarding it here
+        // would leave the extracted secrets ahead of what the peer receives.
+        if send.pending_send_data() {
+            return Err(ApiMisuse::KernelConnectionWithPendingSendData.into());
+        }
+
         ConnectionCommon::<Side>::from_parts_into_kernel_connection(
-            &mut send.lock().unwrap().send,
+            &mut send.send,
             recv,
             outputs,
             state,
@@ -179,6 +193,10 @@ impl SendInner {
     fn pump(&mut self, tls: &mut Vec<u8>) {
         tls.extend_from_slice(&self.aside_buffer);
         self.aside_buffer.clear();
+    }
+
+    fn pending_send_data(&self) -> bool {
+        !self.aside_buffer.is_empty() || self.send.has_queued_key_update()
     }
 
     fn send_alert(&mut self, level: AlertLevel, desc: AlertDescription) {
@@ -580,6 +598,37 @@ mod tests {
             false,
             &mut tls,
         )));
+    }
+
+    #[test]
+    fn pending_send_data() {
+        let mut send = SendPath::default();
+        send.set_encrypter(Box::new(Tls13Cipher), 1234);
+
+        let mut inner = SendInner {
+            send,
+            aside_buffer: Vec::new(),
+        };
+        assert!(!inner.pending_send_data());
+
+        // an aside alert is pending until pumped
+        inner.send_alert(AlertLevel::Fatal, AlertDescription::DecodeError);
+        assert!(inner.pending_send_data());
+
+        let mut tls = Vec::new();
+        inner.pump(&mut tls);
+        assert!(!tls.is_empty());
+        assert!(!inner.pending_send_data());
+
+        // a queued key-update response is pending until the next send
+        inner.send.queue_requested_key_update();
+        assert!(inner.pending_send_data());
+
+        tls.clear();
+        inner
+            .send
+            .send_appdata_encrypt(b"x".as_slice().into(), &mut tls);
+        assert!(!inner.pending_send_data());
     }
 
     fn send_flag_for(f: impl FnOnce(&mut SendAdapter<'_>)) -> bool {

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1704,6 +1704,9 @@ pub enum ApiMisuse {
 
     /// Plaintext cannot be encrypted after the send path has been closed.
     WriteTlsAfterSendPathClosed,
+
+    /// Secret extraction attempted while send data was pending.
+    KernelConnectionWithPendingSendData,
 }
 
 impl fmt::Display for ApiMisuse {


### PR DESCRIPTION
Follow-up to #3221 I bumped into while reviewing.

Data awaiting the next send-side write (an alert parked in the split send half's aside buffer, or a TLS1.3 `key_update` response queued in the send path) has consumed send sequence numbers.

Previously both `dangerous_extract_secrets()` and the split `dangerous_into_kernel_connection()` silently discarded it, leaving the extracted `tx` secrets ahead of what the peer receives. Subsequently every record protected with those secrets will fail to decrypt.

This commit guards both conversion paths, returning an `ApiMisuse` error directing the application to write out pending data first.