### PR TITLE
Explicitly indicate protocol version in use throughout handshake machinery

### DIFF
--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -476,7 +476,7 @@ impl EchState {
         // Start the inner transcript hash now that we know the hash algorithm to use.
         let inner_transcript = self
             .inner_hello_transcript
-            .start_hash(hash);
+            .start_hash(hash, ProtocolVersion::TLSv1_3);
 
         // Fork the transcript that we've started with the inner hello to use for a confirmation step.
         // We need to preserve the original inner_transcript to use if this confirmation succeeds.
@@ -540,7 +540,7 @@ impl EchState {
         // 7.2.1
         let confirmation_transcript = self.inner_hello_transcript.clone();
         let mut confirmation_transcript =
-            confirmation_transcript.start_hash(cs.common.hash_provider);
+            confirmation_transcript.start_hash(cs.common.hash_provider, ProtocolVersion::TLSv1_3);
         confirmation_transcript.rollup_for_hrr();
         confirmation_transcript.add_message(&Self::hello_retry_request_conf(hrr));
 
@@ -577,7 +577,7 @@ impl EchState {
         let inner_transcript = self
             .inner_hello_transcript
             .clone()
-            .start_hash(hash);
+            .start_hash(hash, ProtocolVersion::TLSv1_3);
 
         let mut inner_transcript_buffer = inner_transcript.into_hrr_buffer(proof);
         inner_transcript_buffer.add_message(m);

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -372,7 +372,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         let transcript = self
             .next
             .transcript_buffer
-            .start_hash(cs.hash_provider());
+            .start_hash(cs.hash_provider(), negotiated_version);
         let mut transcript_buffer = transcript.into_hrr_buffer(&proof);
         transcript_buffer.add_message(&input.message);
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -114,6 +114,7 @@ pub(crate) struct ExpectServerHello {
 impl ExpectServerHello {
     fn with_version<T: Suite + 'static>(
         mut self,
+        version: ProtocolVersion,
         server_hello: &ServerHelloPayload,
         input: &Input<'_>,
         output: &mut dyn Output<'_>,
@@ -135,10 +136,10 @@ impl ExpectServerHello {
             return Err(PeerMisbehaved::UnsolicitedServerHelloExtension.into());
         }
 
-        output.output(OutputEvent::ProtocolVersion(T::VERSION));
+        output.output(OutputEvent::ProtocolVersion(version));
 
         // Extract ALPN protocol
-        if T::VERSION != ProtocolVersion::TLSv1_3 {
+        if version != ProtocolVersion::TLSv1_3 {
             process_alpn_protocol(
                 output,
                 &self.input.hello.alpn_protocols,
@@ -218,7 +219,12 @@ impl ExpectServerHello {
             ProtocolVersion::TLSv1_3
                 if config.supports_version(ProtocolVersion::TLSv1_3, self.input.protocol) =>
             {
-                self.with_version::<Tls13CipherSuite>(server_hello, &input, output)
+                self.with_version::<Tls13CipherSuite>(
+                    ProtocolVersion::TLSv1_3,
+                    server_hello,
+                    &input,
+                    output,
+                )
             }
             ProtocolVersion::TLSv1_2
                 if config.supports_version(ProtocolVersion::TLSv1_2, self.input.protocol) =>
@@ -233,7 +239,12 @@ impl ExpectServerHello {
                     return Err(PeerMisbehaved::SelectedTls12UsingTls13VersionExtension.into());
                 }
 
-                self.with_version::<Tls12CipherSuite>(server_hello, &input, output)
+                self.with_version::<Tls12CipherSuite>(
+                    ProtocolVersion::TLSv1_2,
+                    server_hello,
+                    &input,
+                    output,
+                )
             }
             _ => {
                 let reason = match server_version {
@@ -323,7 +334,9 @@ impl ExpectServerHelloOrHelloRetryRequest {
         let Some(ProtocolVersion::TLSv1_3) = hrr.supported_versions else {
             return Err(PeerMisbehaved::IllegalHelloRetryRequestWithUnsupportedVersion.into());
         };
-        output.output(OutputEvent::ProtocolVersion(ProtocolVersion::TLSv1_3));
+        // If handling a HelloRetryRequest, we can only negotiate TLS 1.3
+        let negotiated_version = ProtocolVersion::TLSv1_3;
+        output.output(OutputEvent::ProtocolVersion(negotiated_version));
 
         // Or asks us to use a ciphersuite we didn't offer.
         let Some(cs) = config.find_cipher_suite(hrr.cipher_suite) else {
@@ -373,7 +386,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
             Some(group) if group != offered_key_share.share.group() => {
                 let Some(skxg) = config
                     .provider()
-                    .find_kx_group(group, ProtocolVersion::TLSv1_3)
+                    .find_kx_group(group, negotiated_version)
                 else {
                     return Err(
                         PeerMisbehaved::IllegalHelloRetryRequestWithUnofferedNamedGroup.into(),

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -97,7 +97,7 @@ mod server_hello {
             // Start our handshake hash, and input the server-hello.
             let mut transcript = st
                 .transcript_buffer
-                .start_hash(suite.common.hash_provider);
+                .start_hash(suite.common.hash_provider, ProtocolVersion::TLSv1_2);
             transcript.add_message(message);
 
             let mut randoms = ConnectionRandoms::new(st.input.random, server_hello.random);

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -474,11 +474,12 @@ impl From<Box<ExpectServerKx>> for ClientState {
 
 fn emit_certificate(
     transcript: &mut HandshakeHash,
+    version: ProtocolVersion,
     cert_chain: CertificateChain<'_>,
     output: &mut dyn Output<'_>,
 ) {
     let cert = Message {
-        version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+        version: EncodableVersion::Legacy(version),
         payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::Certificate(
             cert_chain,
         ))),
@@ -490,6 +491,7 @@ fn emit_certificate(
 
 fn emit_client_kx(
     transcript: &mut HandshakeHash,
+    version: ProtocolVersion,
     kxa: KeyExchangeAlgorithm,
     output: &mut dyn Output<'_>,
     pub_key: &[u8],
@@ -507,7 +509,7 @@ fn emit_client_kx(
     let pubkey = Payload::new(buf);
 
     let ckx = Message {
-        version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+        version: EncodableVersion::Legacy(version),
         payload: MessagePayload::handshake(HandshakeMessagePayload(
             HandshakePayload::ClientKeyExchange(pubkey),
         )),
@@ -519,6 +521,7 @@ fn emit_client_kx(
 
 fn emit_certverify(
     transcript: &mut HandshakeHash,
+    version: ProtocolVersion,
     signer: Box<dyn Signer>,
     output: &mut dyn Output<'_>,
 ) -> Result<(), Error> {
@@ -531,7 +534,7 @@ fn emit_certverify(
     let body = DigitallySignedStruct::new(scheme, sig);
 
     let m = Message {
-        version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+        version: EncodableVersion::Legacy(version),
         payload: MessagePayload::handshake(HandshakeMessagePayload(
             HandshakePayload::CertificateVerify(body),
         )),
@@ -542,10 +545,10 @@ fn emit_certverify(
     Ok(())
 }
 
-fn emit_ccs(output: &mut dyn Output<'_>) {
+fn emit_ccs(version: ProtocolVersion, output: &mut dyn Output<'_>) {
     output.send_msg(
         Message {
-            version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+            version: EncodableVersion::Legacy(version),
             payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
         },
         false,
@@ -553,6 +556,7 @@ fn emit_ccs(output: &mut dyn Output<'_>) {
 }
 
 fn emit_finished(
+    version: ProtocolVersion,
     secrets: &ConnectionSecrets,
     transcript: &mut HandshakeHash,
     output: &mut dyn Output<'_>,
@@ -563,7 +567,7 @@ fn emit_finished(
     let verify_data_payload = Payload::Borrowed(&verify_data);
 
     let f = Message {
-        version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+        version: EncodableVersion::Legacy(version),
         payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::Finished(
             verify_data_payload,
         ))),
@@ -804,7 +808,12 @@ impl ExpectServerDone {
                     CertificateChain::from_signer(credentials)
                 }
             };
-            emit_certificate(&mut self.hs.transcript, certs, output);
+            emit_certificate(
+                &mut self.hs.transcript,
+                ProtocolVersion::TLSv1_2,
+                certs,
+                output,
+            );
         }
 
         // 4a.
@@ -836,7 +845,13 @@ impl ExpectServerDone {
         let kx = skxg.start()?.into_single();
 
         // 4b.
-        emit_client_kx(&mut self.hs.transcript, self.suite.kx, output, kx.pub_key());
+        emit_client_kx(
+            &mut self.hs.transcript,
+            ProtocolVersion::TLSv1_2,
+            self.suite.kx,
+            output,
+            kx.pub_key(),
+        );
         // Note: EMS handshake hash only runs up to ClientKeyExchange.
         let ems_seed = self
             .hs
@@ -845,7 +860,12 @@ impl ExpectServerDone {
 
         // 4c.
         if let Some(ClientAuthDetails::Verify { credentials, .. }) = self.client_auth {
-            emit_certverify(&mut self.hs.transcript, credentials.signer, output)?;
+            emit_certverify(
+                &mut self.hs.transcript,
+                ProtocolVersion::TLSv1_2,
+                credentials.signer,
+                output,
+            )?;
         }
 
         // 4d. Derive secrets.
@@ -861,7 +881,7 @@ impl ExpectServerDone {
         output.output(OutputEvent::KeyExchangeGroup(skxg));
 
         // 4e. CCS. We are definitely going to switch on encryption.
-        emit_ccs(output);
+        emit_ccs(ProtocolVersion::TLSv1_2, output);
 
         // 4f. Now commit secrets.
         self.hs.config.key_log.log(
@@ -880,7 +900,13 @@ impl ExpectServerDone {
         );
 
         // 5.
-        emit_finished(&secrets, &mut self.hs.transcript, output, &proof);
+        emit_finished(
+            ProtocolVersion::TLSv1_2,
+            &secrets,
+            &mut self.hs.transcript,
+            output,
+            &proof,
+        );
 
         if self.must_issue_new_ticket {
             Ok(Box::new(ExpectNewTicket {
@@ -1115,7 +1141,7 @@ impl ExpectFinished {
         st.save_session();
 
         if let Some((_, encrypter)) = st.resuming.take() {
-            emit_ccs(output);
+            emit_ccs(ProtocolVersion::TLSv1_2, output);
             output.send().set_encrypter(
                 encrypter,
                 st.secrets
@@ -1123,7 +1149,13 @@ impl ExpectFinished {
                     .common
                     .confidentiality_limit,
             );
-            emit_finished(&st.secrets, &mut st.hs.transcript, output, &proof);
+            emit_finished(
+                ProtocolVersion::TLSv1_2,
+                &st.secrets,
+                &mut st.hs.transcript,
+                output,
+                &proof,
+            );
         }
 
         let extracted_secrets = st

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -108,7 +108,7 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
         // Start our handshake hash, and input the server-hello.
         let mut transcript = st
             .transcript_buffer
-            .start_hash(suite.common.hash_provider);
+            .start_hash(suite.common.hash_provider, ProtocolVersion::TLSv1_3);
         transcript.add_message(&input.message);
 
         let mut randoms = ConnectionRandoms::new(st.input.random, server_hello.random);
@@ -380,7 +380,11 @@ pub(super) fn fill_in_psk_binder(
     // The binder is calculated over the clienthello, but doesn't include itself or its
     // length, or the length of its container.
     let binder_plaintext = hmp.encoding_for_binder_signing();
-    let handshake_hash = transcript.hash_given(key_schedule.hash(), &binder_plaintext);
+    let handshake_hash = transcript.hash_given(
+        key_schedule.hash(),
+        ProtocolVersion::TLSv1_3,
+        &binder_plaintext,
+    );
 
     // Run a fake key_schedule to simulate what the server will do if it chooses
     // to resume.
@@ -459,7 +463,7 @@ pub(super) fn derive_early_traffic_secret(
     // For middlebox compatibility
     emit_fake_ccs(sent_tls13_fake_ccs, output);
 
-    let client_hello_hash = transcript_buffer.hash_given(hash_alg, &[]);
+    let client_hello_hash = transcript_buffer.hash_given(hash_alg, ProtocolVersion::TLSv1_3, &[]);
     early_key_schedule.client_early_traffic_secret(
         &client_hello_hash,
         key_log,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1274,13 +1274,17 @@ fn emit_finished_tls13(
     )));
 }
 
-fn emit_end_of_early_data_tls13(transcript: &mut HandshakeHash, output: &mut dyn Output<'_>) {
+fn emit_end_of_early_data_tls13(
+    version: ProtocolVersion,
+    transcript: &mut HandshakeHash,
+    output: &mut dyn Output<'_>,
+) {
     if output.quic().is_some() {
         return;
     }
 
     let m = Message {
-        version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
+        version: EncodableVersion::Legacy(version),
         payload: MessagePayload::handshake(HandshakeMessagePayload(
             HandshakePayload::EndOfEarlyData,
         )),
@@ -1335,7 +1339,7 @@ impl ExpectFinished {
         /* The EndOfEarlyData message to server is still encrypted with early data keys,
          * but appears in the transcript after the server Finished. */
         if st.in_early_traffic {
-            emit_end_of_early_data_tls13(&mut st.hs.transcript, output);
+            emit_end_of_early_data_tls13(ProtocolVersion::TLSv1_3, &mut st.hs.transcript, output);
             output.emit(Event::EarlyData(EarlyDataEvent::Finished));
             st.hs
                 .key_schedule

--- a/rustls/src/conn/receive.rs
+++ b/rustls/src/conn/receive.rs
@@ -337,7 +337,7 @@ impl ReceivePath {
             //   expect any plaintext.
             // * The payload size is indicative of a plaintext alert message.
             ContentType::Alert
-                if matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
+                if self.version() == ProtocolVersion::TLSv1_3
                     && !self.decrypt_state.has_decrypted()
                     && record.payload.len() <= 2 =>
             {
@@ -422,9 +422,7 @@ impl ReceivePath {
     }
 
     fn drop_tls13_ccs(&mut self, record: &Record<&'_ [u8]>) -> Result<bool, Error> {
-        if self.may_receive_application_data
-            || !matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
-        {
+        if self.may_receive_application_data || self.version() != ProtocolVersion::TLSv1_3 {
             return Ok(false);
         }
 
@@ -446,9 +444,7 @@ impl ReceivePath {
         tls: &mut Vec<u8>,
         send: &mut dyn SendOutput,
     ) -> Result<bool, Error> {
-        if !self.may_receive_application_data
-            || matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
-        {
+        if !self.may_receive_application_data || self.version() == ProtocolVersion::TLSv1_3 {
             return Ok(false);
         }
 
@@ -487,7 +483,7 @@ impl ReceivePath {
         if alert.level == AlertLevel::Warning {
             self.temper_counters
                 .received_warning_alert()?;
-            if matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
+            if self.version() == ProtocolVersion::TLSv1_3
                 && alert.description != AlertDescription::UserCanceled
             {
                 return Err(PeerMisbehaved::IllegalWarningAlert(alert.description).into());
@@ -503,6 +499,16 @@ impl ReceivePath {
         }
 
         Err(err)
+    }
+
+    fn version(&self) -> ProtocolVersion {
+        if let Some(version) = self.negotiated_version {
+            version
+        } else {
+            // If the negotiated version has not been set yet, then we are early in the handshake
+            // and will behave as though doing TLS 1.2 for backward compatibility
+            ProtocolVersion::TLSv1_2
+        }
     }
 }
 

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -45,9 +45,9 @@ impl SendPath {
 
             // Close connection once we start to run out of sequence space.
             Some(PreEncryptAction::RefreshOrClose) => {
-                match self.negotiated_version {
+                match self.version() {
                     // driven by caller, as we don't have the `State` here
-                    Some(ProtocolVersion::TLSv1_3) => {
+                    ProtocolVersion::TLSv1_3 => {
                         self.key_update_local = KeyUpdateLocal::Requested;
                         Ok(())
                     }
@@ -169,6 +169,16 @@ impl SendPath {
         self.key_update_local = KeyUpdateLocal::Outstanding;
         self.tls13_key_schedule = Some(ks);
         Ok(())
+    }
+
+    fn version(&self) -> ProtocolVersion {
+        if let Some(version) = self.negotiated_version {
+            version
+        } else {
+            // If the negotiated version has not been set yet, then we are early in the handshake
+            // and will behave as though doing TLS 1.2 for backward compatibility
+            ProtocolVersion::TLSv1_2
+        }
     }
 }
 

--- a/rustls/src/conn/send.rs
+++ b/rustls/src/conn/send.rs
@@ -164,7 +164,7 @@ impl SendPath {
             return Err(Error::HandshakeNotComplete);
         };
 
-        self.send_msg(Message::build_key_update_request(), true, tls);
+        self.send_msg(Message::build_key_update_request(self.version()), true, tls);
         ks.update_encrypter(self);
         self.key_update_local = KeyUpdateLocal::Outstanding;
         self.tls13_key_schedule = Some(ks);
@@ -192,7 +192,8 @@ impl SendOutput for SendPath {
             return;
         }
 
-        let record = Record::<Payload<'static>>::from(Message::build_key_update_notify());
+        let record =
+            Record::<Payload<'static>>::from(Message::build_key_update_notify(self.version()));
         let mut queued = Vec::new();
         self.encrypt_state
             .encrypt_outgoing(record.borrow_outbound(), &mut queued);
@@ -227,7 +228,7 @@ impl SendOutput for SendPath {
         };
 
         self.send_msg(
-            Message::build_alert(level, desc),
+            Message::build_alert(level, desc, self.version()),
             self.encrypt_state.is_encrypting(),
             tls,
         );

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -552,6 +552,7 @@ mod tests {
     fn send_flag_for(f: impl FnOnce(&mut SendAdapter<'_>)) -> bool {
         let mut send = SendPath::default();
         send.set_encrypter(Box::new(Tls13Cipher), 1234);
+        send.negotiated_version(ProtocolVersion::TLSv1_3);
 
         let send = Mutex::new(send);
 

--- a/rustls/src/conn/split.rs
+++ b/rustls/src/conn/split.rs
@@ -543,7 +543,7 @@ mod tests {
         )));
         assert!(!send_flag_for(|adapter| adapter.start_traffic()));
         assert!(send_flag_for(|adapter| adapter.send_msg(
-            Message::build_key_update_notify(),
+            Message::build_key_update_notify(ProtocolVersion::TLSv1_3),
             false,
             &mut tls,
         )));

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -3,11 +3,14 @@ use alloc::vec::Vec;
 use core::mem;
 
 use crate::crypto::{HashAlgorithm, hash};
+use crate::enums::ProtocolVersion;
 use crate::msgs::{Codec, HandshakeAlignedProof, HandshakeMessagePayload, Message, MessagePayload};
 
 /// Early stage buffering of handshake payloads.
 ///
-/// Before we know the hash algorithm to use to verify the handshake, we just buffer the messages.
+/// Before we know the hash algorithm to use to verify the handshake or the negotiated protocol
+/// version, we just buffer the messages.
+///
 /// During the handshake, we may restart the transcript due to a HelloRetryRequest, reverting
 /// from the `HandshakeHash` to a `HandshakeHashBuffer` again.
 #[derive(Clone)]
@@ -48,16 +51,20 @@ impl HandshakeHashBuffer {
     pub(crate) fn hash_given(
         &self,
         provider: &'static dyn hash::Hash,
+        version: ProtocolVersion,
         extra: &[u8],
     ) -> hash::Output {
-        let mut ctx = provider.start();
-        ctx.update(&self.buffer);
-        ctx.update(extra);
-        ctx.finish()
+        self.clone()
+            .start_hash(provider, version)
+            .hash_given(extra)
     }
 
     /// We now know what hash function the verify_data will use.
-    pub(crate) fn start_hash(self, provider: &'static dyn hash::Hash) -> HandshakeHash {
+    pub(crate) fn start_hash(
+        self,
+        provider: &'static dyn hash::Hash,
+        version: ProtocolVersion,
+    ) -> HandshakeHash {
         let mut ctx = provider.start();
         ctx.update(&self.buffer);
         HandshakeHash {
@@ -67,6 +74,7 @@ impl HandshakeHashBuffer {
                 true => Some(self.buffer),
                 false => None,
             },
+            version,
         }
     }
 }
@@ -84,6 +92,9 @@ pub(crate) struct HandshakeHash {
 
     /// buffer for client-auth.
     client_auth: Option<Vec<u8>>,
+
+    /// The protocol version negotiated for the handshake.
+    version: ProtocolVersion,
 }
 
 impl HandshakeHash {
@@ -166,6 +177,11 @@ impl HandshakeHash {
     pub(crate) fn algorithm(&self) -> HashAlgorithm {
         self.provider.algorithm()
     }
+
+    /// The protocol version in use.
+    pub(crate) fn version(&self) -> ProtocolVersion {
+        self.version
+    }
 }
 
 impl Clone for HandshakeHash {
@@ -174,6 +190,7 @@ impl Clone for HandshakeHash {
             provider: self.provider,
             ctx: self.ctx.fork(),
             client_auth: self.client_auth.clone(),
+            version: self.version,
         }
     }
 }
@@ -191,7 +208,7 @@ mod tests {
         let mut hhb = HandshakeHashBuffer::new();
         hhb.add_raw(b"hello");
         assert_eq!(hhb.buffer.len(), 5);
-        let mut hh = hhb.start_hash(SHA256);
+        let mut hh = hhb.start_hash(SHA256, ProtocolVersion::TLSv1_2);
         assert!(hh.client_auth.is_none());
         hh.add_raw(b"world");
         let h = hh.current_hash();
@@ -229,7 +246,7 @@ mod tests {
         hhb.add_message(&end_of_early_data_flight);
 
         assert_eq!(
-            hhb.start_hash(SHA256)
+            hhb.start_hash(SHA256, ProtocolVersion::TLSv1_2)
                 .current_hash()
                 .as_ref(),
             SHA256
@@ -238,7 +255,7 @@ mod tests {
         );
 
         // non-buffered mode
-        let mut hh = HandshakeHashBuffer::new().start_hash(SHA256);
+        let mut hh = HandshakeHashBuffer::new().start_hash(SHA256, ProtocolVersion::TLSv1_2);
         hh.add_message(&server_hello_done_message);
         hh.add_message(&app_data_ignored);
         hh.add_message(&end_of_early_data_flight);
@@ -257,7 +274,7 @@ mod tests {
         hhb.add_raw(b"hello");
         assert_eq!(hhb.buffer.len(), 5);
 
-        let mut hh = hhb.start_hash(SHA256);
+        let mut hh = hhb.start_hash(SHA256, ProtocolVersion::TLSv1_2);
         assert_eq!(
             hh.client_auth
                 .as_ref()
@@ -290,7 +307,7 @@ mod tests {
         hhb.add_raw(b"hello");
         assert_eq!(hhb.buffer.len(), 5);
 
-        let mut hh = hhb.start_hash(SHA256);
+        let mut hh = hhb.start_hash(SHA256, ProtocolVersion::TLSv1_2);
         assert_eq!(
             hh.client_auth
                 .as_ref()
@@ -328,7 +345,7 @@ mod tests {
         assert_eq!(hhb_prime.buffer.len(), 10);
         assert_ne!(hhb.buffer, hhb_prime.buffer);
 
-        let hh = hhb.start_hash(SHA256);
+        let hh = hhb.start_hash(SHA256, ProtocolVersion::TLSv1_2);
         let hh_hash = hh.current_hash();
         let hh_hash = hh_hash.as_ref();
 

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -155,10 +155,14 @@ pub(crate) struct Message<'a> {
     pub payload: MessagePayload<'a>,
 }
 
-impl Message<'_> {
-    pub(crate) fn build_alert(level: AlertLevel, desc: AlertDescription) -> Self {
+impl<'a> Message<'a> {
+    pub(crate) fn build_alert(
+        level: AlertLevel,
+        desc: AlertDescription,
+        version: ProtocolVersion,
+    ) -> Self {
         Self {
-            version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+            version: EncodableVersion::Legacy(version),
             payload: MessagePayload::Alert(AlertMessagePayload {
                 level,
                 description: desc,
@@ -166,18 +170,18 @@ impl Message<'_> {
         }
     }
 
-    pub(crate) fn build_key_update_notify() -> Self {
+    pub(crate) fn build_key_update_notify(version: ProtocolVersion) -> Self {
         Self {
-            version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
+            version: EncodableVersion::Legacy(version),
             payload: MessagePayload::handshake(HandshakeMessagePayload(
                 HandshakePayload::KeyUpdate(KeyUpdateRequest::UpdateNotRequested),
             )),
         }
     }
 
-    pub(crate) fn build_key_update_request() -> Self {
+    pub(crate) fn build_key_update_request(version: ProtocolVersion) -> Self {
         Self {
-            version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
+            version: EncodableVersion::Legacy(version),
             payload: MessagePayload::handshake(HandshakeMessagePayload(
                 HandshakePayload::KeyUpdate(KeyUpdateRequest::UpdateRequested),
             )),
@@ -769,7 +773,11 @@ mod tests {
 
     #[test]
     fn alert_is_not_handshake() {
-        let m = Message::build_alert(AlertLevel::Fatal, AlertDescription::DecodeError);
+        let m = Message::build_alert(
+            AlertLevel::Fatal,
+            AlertDescription::DecodeError,
+            ProtocolVersion::TLSv1_2,
+        );
         assert_ne!(m.handshake_type(), Some(HandshakeType::ClientHello));
     }
 
@@ -817,7 +825,7 @@ mod tests {
     fn into_wire_format() {
         // Message::into_wire_bytes() include both message-level and handshake-level headers
         assert_eq!(
-            Message::build_key_update_request().into_wire_bytes(),
+            Message::build_key_update_request(ProtocolVersion::TLSv1_3).into_wire_bytes(),
             &[0x16, 0x3, 0x3, 0x0, 0x5, 0x18, 0x0, 0x0, 0x1, 0x1]
         );
     }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -532,13 +532,13 @@ impl ExpectClientHello {
         // Are we doing TLS1.3?
         if let Some(versions) = &input.client_hello.supported_versions {
             if versions.tls13 && tls13_enabled {
-                self.with_version::<Tls13CipherSuite>(input, output)
+                self.with_version::<Tls13CipherSuite>(ProtocolVersion::TLSv1_3, input, output)
             } else if !versions.tls12 || !tls12_enabled {
                 Err(PeerIncompatible::Tls12NotOfferedOrEnabled.into())
             } else if self.protocol.is_quic() {
                 Err(PeerIncompatible::Tls13RequiredForQuic.into())
             } else {
-                self.with_version::<Tls12CipherSuite>(input, output)
+                self.with_version::<Tls12CipherSuite>(ProtocolVersion::TLSv1_2, input, output)
             }
         } else if u16::from(input.client_hello.client_version) < u16::from(ProtocolVersion::TLSv1_2)
         {
@@ -548,12 +548,13 @@ impl ExpectClientHello {
         } else if !tls12_enabled && tls13_enabled {
             Err(PeerIncompatible::SupportedVersionsExtensionRequired.into())
         } else {
-            self.with_version::<Tls12CipherSuite>(input, output)
+            self.with_version::<Tls12CipherSuite>(ProtocolVersion::TLSv1_2, input, output)
         }
     }
 
     fn with_version<T: Suite + 'static>(
         mut self,
+        version: ProtocolVersion,
         input: ClientHelloInput<'_>,
         output: &mut dyn Output<'_>,
     ) -> Result<ServerState, Error>
@@ -562,7 +563,7 @@ impl ExpectClientHello {
         SupportedCipherSuite: From<&'static T>,
         dyn CipherSuiteSelector: VersionSuiteSelector<T>,
     {
-        output.output(OutputEvent::ProtocolVersion(T::VERSION));
+        output.output(OutputEvent::ProtocolVersion(version));
 
         let sni = self
             .config
@@ -598,13 +599,13 @@ impl ExpectClientHello {
             .collect::<Vec<_>>();
 
         let mut sig_schemes = input.sig_schemes.to_owned();
-        if T::VERSION == ProtocolVersion::TLSv1_2 {
+        if version == ProtocolVersion::TLSv1_2 {
             sig_schemes.retain(|scheme| {
                 client_suites
                     .iter()
                     .any(|&suite| suite.usable_for_signature_scheme(*scheme))
             });
-        } else if T::VERSION == ProtocolVersion::TLSv1_3 {
+        } else if version == ProtocolVersion::TLSv1_3 {
             sig_schemes.retain(SignatureScheme::supported_in_tls13);
         }
 
@@ -616,11 +617,12 @@ impl ExpectClientHello {
                 input.client_hello,
                 Some(&sig_schemes),
                 sni.as_ref().map(Cow::Borrowed),
-                Some(T::VERSION),
+                Some(version),
             ))?;
         self.sni = sni;
 
         let (suite, skxg) = self.choose_suite_and_kx_group(
+            version,
             suites,
             credentials.signer.scheme(),
             input
@@ -641,6 +643,7 @@ impl ExpectClientHello {
 
     fn choose_suite_and_kx_group<T: Suite + 'static>(
         &self,
+        version: ProtocolVersion,
         suites: &[&'static T],
         sig_scheme: SignatureScheme,
         client_groups: &[NamedGroup],
@@ -662,7 +665,7 @@ impl ExpectClientHello {
             let supported = self
                 .config
                 .provider
-                .find_kx_group(*offered_group, T::VERSION);
+                .find_kx_group(*offered_group, version);
 
             match offered_group.key_exchange_algorithm() {
                 KeyExchangeAlgorithm::DHE => {
@@ -679,7 +682,7 @@ impl ExpectClientHello {
             }
         }
 
-        let first_supported_dhe_kxg = if T::VERSION == ProtocolVersion::TLSv1_2 {
+        let first_supported_dhe_kxg = if version == ProtocolVersion::TLSv1_2 {
             // https://datatracker.ietf.org/doc/html/rfc7919#section-4 (paragraph 2)
             let first_supported_dhe_kxg = self
                 .config
@@ -735,7 +738,7 @@ impl ExpectClientHello {
                 suite.usable_for_kx_algorithm(kx_group.name().key_exchange_algorithm())
             });
 
-        if T::VERSION == ProtocolVersion::TLSv1_3 {
+        if version == ProtocolVersion::TLSv1_3 {
             // This unwrap is structurally guaranteed by the early return for `!ffdhe_possible && !ecdhe_possible`
             return Ok((suite, *maybe_skxg.unwrap()));
         }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -895,10 +895,18 @@ pub(crate) enum HandshakeHashOrBuffer {
 }
 
 impl HandshakeHashOrBuffer {
-    pub(super) fn start(self, hash: &'static dyn Hash) -> Result<HandshakeHash, Error> {
+    pub(super) fn start(
+        self,
+        hash: &'static dyn Hash,
+        version: ProtocolVersion,
+    ) -> Result<HandshakeHash, Error> {
         match self {
-            Self::Buffer(inner) => Ok(inner.start_hash(hash)),
-            Self::Hash(inner) if inner.algorithm() == hash.algorithm() => Ok(inner),
+            Self::Buffer(inner) => Ok(inner.start_hash(hash, version)),
+            Self::Hash(inner)
+                if inner.algorithm() == hash.algorithm() && inner.version() == version =>
+            {
+                Ok(inner)
+            }
             _ => Err(PeerMisbehaved::HandshakeHashVariedAfterRetry.into()),
         }
     }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -151,6 +151,7 @@ mod client_hello {
                     suite,
                     st.using_ems,
                     output,
+                    ProtocolVersion::TLSv1_2,
                     input,
                     st.sni,
                     st.resumption_data,
@@ -180,6 +181,7 @@ mod client_hello {
                 alpn_protocol,
                 send_ticket,
             } = emit_server_hello(
+                ProtocolVersion::TLSv1_2,
                 &mut flight,
                 &st.config,
                 output,
@@ -301,6 +303,7 @@ mod client_hello {
         suite: &'static Tls12CipherSuite,
         using_ems: bool,
         output: &mut dyn Output<'_>,
+        version: ProtocolVersion,
         input: ClientHelloInput<'_>,
         sni: Option<DnsName<'static>>,
         resumption_data: Vec<u8>,
@@ -323,6 +326,7 @@ mod client_hello {
             alpn_protocol,
             send_ticket,
         } = emit_server_hello(
+            version,
             &mut flight,
             &config,
             output,
@@ -370,6 +374,7 @@ mod client_hello {
 
             if let Some(ticketer) = hs.config.ticketer.as_deref() {
                 emit_ticket(
+                    version,
                     &secrets,
                     &mut hs.transcript,
                     using_ems,
@@ -383,7 +388,7 @@ mod client_hello {
                 )?;
             }
         }
-        emit_ccs(output);
+        emit_ccs(version, output);
 
         let (dec, encrypter) = secrets.make_cipher_pair(Side::Server);
         output.send().set_encrypter(
@@ -393,7 +398,7 @@ mod client_hello {
                 .common
                 .confidentiality_limit,
         );
-        emit_finished(&secrets, &mut hs.transcript, output, &proof);
+        emit_finished(version, &secrets, &mut hs.transcript, output, &proof);
 
         Ok(Box::new(ExpectCcs {
             hs,
@@ -405,6 +410,7 @@ mod client_hello {
     }
 
     fn emit_server_hello(
+        version: ProtocolVersion,
         flight: &mut HandshakeFlightTls12<'_>,
         config: &ServerConfig,
         output: &mut dyn Output<'_>,
@@ -428,7 +434,7 @@ mod client_hello {
         )?;
 
         let sh = HandshakeMessagePayload(HandshakePayload::ServerHello(ServerHelloPayload {
-            legacy_version: ProtocolVersion::TLSv1_2,
+            legacy_version: version,
             random: Random::from(randoms.server),
             session_id,
             cipher_suite: suite.common.suite,
@@ -900,6 +906,7 @@ impl<const N: usize> Drop for ZeroizingCow<'_, N> {
 }
 
 fn emit_ticket(
+    version: ProtocolVersion,
     secrets: &ConnectionSecrets,
     transcript: &mut HandshakeHash,
     using_ems: bool,
@@ -933,7 +940,7 @@ fn emit_ticket(
     let ticket_lifetime = ticketer.lifetime();
 
     let m = Message {
-        version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+        version: EncodableVersion::Legacy(version),
         payload: MessagePayload::handshake(HandshakeMessagePayload(
             HandshakePayload::NewSessionTicket(NewSessionTicketPayload::new(
                 ticket_lifetime,
@@ -947,10 +954,10 @@ fn emit_ticket(
     Ok(())
 }
 
-fn emit_ccs(output: &mut dyn Output<'_>) {
+fn emit_ccs(version: ProtocolVersion, output: &mut dyn Output<'_>) {
     output.send_msg(
         Message {
-            version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+            version: EncodableVersion::Legacy(version),
             payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
         },
         false,
@@ -958,6 +965,7 @@ fn emit_ccs(output: &mut dyn Output<'_>) {
 }
 
 fn emit_finished(
+    version: ProtocolVersion,
     secrets: &ConnectionSecrets,
     transcript: &mut HandshakeHash,
     output: &mut dyn Output<'_>,
@@ -968,7 +976,7 @@ fn emit_finished(
     let verify_data_payload = Payload::Borrowed(&verify_data);
 
     let f = Message {
-        version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+        version: EncodableVersion::Legacy(version),
         payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::Finished(
             verify_data_payload,
         ))),
@@ -1049,6 +1057,7 @@ impl ExpectFinished {
                 let now = self.hs.config.current_time()?;
                 if let Some(ticketer) = self.hs.config.ticketer.as_deref() {
                     emit_ticket(
+                        ProtocolVersion::TLSv1_2,
                         &self.secrets,
                         &mut self.hs.transcript,
                         self.hs.using_ems,
@@ -1062,7 +1071,7 @@ impl ExpectFinished {
                     )?;
                 }
             }
-            emit_ccs(output);
+            emit_ccs(ProtocolVersion::TLSv1_2, output);
             output.send().set_encrypter(
                 encrypter,
                 self.secrets
@@ -1070,7 +1079,13 @@ impl ExpectFinished {
                     .common
                     .confidentiality_limit,
             );
-            emit_finished(&self.secrets, &mut self.hs.transcript, output, &proof);
+            emit_finished(
+                ProtocolVersion::TLSv1_2,
+                &self.secrets,
+                &mut self.hs.transcript,
+                output,
+                &proof,
+            );
         }
 
         if let Some(identity) = self.peer_identity {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -97,7 +97,7 @@ mod client_hello {
             let mut randoms = st.randoms(&input)?;
             let mut transcript = st
                 .transcript
-                .start(suite.common.hash_provider)?;
+                .start(suite.common.hash_provider, ProtocolVersion::TLSv1_2)?;
 
             // -- TLS1.2 only from hereon in --
             transcript.add_message(input.message);

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -117,7 +117,7 @@ mod client_hello {
             let randoms = st.randoms(&input)?;
             let mut transcript = st
                 .transcript
-                .start(suite.common.hash_provider)?;
+                .start(suite.common.hash_provider, ProtocolVersion::TLSv1_3)?;
 
             if input
                 .client_hello

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -187,6 +187,7 @@ mod client_hello {
 
                 emit_hello_retry_request(
                     &mut transcript,
+                    ProtocolVersion::TLSv1_3,
                     suite,
                     input.client_hello.session_id,
                     output,
@@ -265,6 +266,7 @@ mod client_hello {
                 &mut transcript,
                 &randoms,
                 suite,
+                ProtocolVersion::TLSv1_3,
                 output,
                 &input.client_hello.session_id,
                 chosen_share_and_kxg,
@@ -533,6 +535,7 @@ mod client_hello {
         transcript: &mut HandshakeHash,
         randoms: &ConnectionRandoms,
         suite: Tls13ProtocolSuite,
+        version: ProtocolVersion,
         output: &mut dyn Output<'_>,
         session_id: &SessionId,
         share_and_kxgroup: (&KeyShareEntry, &'static dyn SupportedKxGroup),
@@ -549,15 +552,16 @@ mod client_hello {
         let extensions = Box::new(ServerExtensions {
             key_share: Some(KeyShareEntry::new(ckx.group, ckx.pub_key)),
             preshared_key: resuming.map(|&(idx, _)| idx as u16),
-            selected_version: Some(ProtocolVersion::TLSv1_3),
+            selected_version: Some(version),
             ..Default::default()
         });
 
+        let version = EncodableVersion::Legacy(version);
         let sh = Message {
-            version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+            version,
             payload: MessagePayload::handshake(HandshakeMessagePayload(
                 HandshakePayload::ServerHello(ServerHelloPayload {
-                    legacy_version: ProtocolVersion::TLSv1_2,
+                    legacy_version: version.encode(),
                     random: Random::from(randoms.server),
                     session_id: *session_id,
                     cipher_suite: suite.suite().common.suite,
@@ -623,6 +627,7 @@ mod client_hello {
 
     fn emit_hello_retry_request(
         transcript: &mut HandshakeHash,
+        version: ProtocolVersion,
         suite: &'static Tls13CipherSuite,
         session_id: SessionId,
         output: &mut dyn Output<'_>,
@@ -634,13 +639,13 @@ mod client_hello {
             cipher_suite: suite.common.suite,
             extensions: HelloRetryRequestExtensions {
                 key_share: Some(group),
-                supported_versions: Some(ProtocolVersion::TLSv1_3),
+                supported_versions: Some(version),
                 ..Default::default()
             },
         };
 
         let m = Message {
-            version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+            version: EncodableVersion::Legacy(version),
             payload: MessagePayload::handshake(HandshakeMessagePayload(
                 HandshakePayload::HelloRetryRequest(req),
             )),

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -6,7 +6,6 @@ use crate::common_state::Protocol;
 use crate::crypto::cipher::{AeadKey, Iv};
 use crate::crypto::kx::KeyExchangeAlgorithm;
 use crate::crypto::{CipherSuite, SignatureScheme, hash};
-use crate::enums::ProtocolVersion;
 use crate::tls12::Tls12CipherSuite;
 use crate::tls13::Tls13CipherSuite;
 
@@ -122,8 +121,6 @@ pub(crate) trait Suite: fmt::Debug {
     }
 
     fn common(&self) -> &CipherSuiteCommon;
-
-    const VERSION: ProtocolVersion;
 }
 
 /// Secrets for transmitting/receiving data over a TLS session.

--- a/rustls/src/tls12.rs
+++ b/rustls/src/tls12.rs
@@ -12,7 +12,6 @@ use crate::crypto::cipher::{AeadKey, RecordDecrypter, RecordEncrypter, Tls12Aead
 use crate::crypto::kx::{ActiveKeyExchange, KeyExchangeAlgorithm};
 use crate::crypto::tls12::PrfSecret;
 use crate::crypto::{self, SignatureScheme, hash};
-use crate::enums::ProtocolVersion;
 use crate::error::{ApiMisuse, Error, InvalidMessage};
 use crate::msgs::{Codec, HandshakeAlignedProof, KxDecode, Reader};
 use crate::suites::{CipherSuiteCommon, PartiallyExtractedSecrets, Suite, SupportedCipherSuite};
@@ -119,8 +118,6 @@ impl Suite for Tls12CipherSuite {
     fn common(&self) -> &CipherSuiteCommon {
         &self.common
     }
-
-    const VERSION: ProtocolVersion = ProtocolVersion::TLSv1_2;
 }
 
 impl From<&'static Tls12CipherSuite> for SupportedCipherSuite {

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -4,7 +4,6 @@ use pki_types::FipsStatus;
 
 use crate::common_state::Protocol;
 use crate::crypto::{self, SignatureScheme, hash};
-use crate::enums::ProtocolVersion;
 use crate::quic;
 use crate::suites::{CipherSuiteCommon, Suite, SupportedCipherSuite};
 use crate::version::Tls13Version;
@@ -126,8 +125,6 @@ impl Suite for Tls13CipherSuite {
     fn common(&self) -> &CipherSuiteCommon {
         &self.common
     }
-
-    const VERSION: ProtocolVersion = ProtocolVersion::TLSv1_3;
 }
 
 impl From<&'static Tls13CipherSuite> for SupportedCipherSuite {


### PR DESCRIPTION
This set of commits plumbs explicit `ProtocolVersion` values into a variety of places in the handshake machinery which previously could determine that based on either the context they're in or what crypto suite is in use.

These assumptions will not hold as DTLS gets implemented, since for example, module `rustls::client::tls12` will be used for both TLS 1.2 and DTLS 1.2, and `rustls::tls13::Tls13Ciphersuite` is used for DTLS 1.3 as well as TLS 1.3.

Individual commit messages discuss the changes in greater detail.

This PR contains no functional changes.