### PR TITLE
providers: zeroize private key DER

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,6 +1923,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-test",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/rustls-aws-lc-rs/src/lib.rs
+++ b/rustls-aws-lc-rs/src/lib.rs
@@ -48,6 +48,7 @@ use rustls::crypto::{
 use rustls::error::{ApiMisuse, Error, OtherError};
 #[cfg(feature = "std")]
 use rustls::ticketer::TicketRotator;
+use zeroize::Zeroizing;
 
 /// Hybrid public key encryption (HPKE).
 pub mod hpke;
@@ -152,20 +153,21 @@ impl KeyProvider for AwsLcRs {
         &self,
         key_der: PrivateKeyDer<'static>,
     ) -> Result<Box<dyn SigningKey>, Error> {
-        if let Ok(rsa) = RsaSigningKey::try_from(&key_der) {
+        let key_der = Zeroizing::new(key_der);
+        if let Ok(rsa) = RsaSigningKey::try_from(&*key_der) {
             return Ok(Box::new(rsa));
         }
 
-        if let Ok(ecdsa) = EcdsaSigner::try_from(&key_der) {
+        if let Ok(ecdsa) = EcdsaSigner::try_from(&*key_der) {
             return Ok(Box::new(ecdsa));
         }
 
-        if let PrivateKeyDer::Pkcs8(pkcs8) = key_der {
-            if let Ok(eddsa) = Ed25519Signer::try_from(&pkcs8) {
+        if let PrivateKeyDer::Pkcs8(pkcs8) = &*key_der {
+            if let Ok(eddsa) = Ed25519Signer::try_from(pkcs8) {
                 return Ok(Box::new(eddsa));
             }
 
-            if let Ok(pqdsa) = PqdsaSigningKey::from_pkcs8(&pkcs8) {
+            if let Ok(pqdsa) = PqdsaSigningKey::from_pkcs8(pkcs8) {
                 return Ok(Box::new(pqdsa));
             }
         }

--- a/rustls-ring/Cargo.toml
+++ b/rustls-ring/Cargo.toml
@@ -18,6 +18,7 @@ pki-types = { workspace = true }
 rustls = { path = "../rustls", version = "0.24.0-dev.1", default-features = false }
 ring = { workspace = true }
 subtle = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 bencher = { workspace = true }

--- a/rustls-ring/src/lib.rs
+++ b/rustls-ring/src/lib.rs
@@ -27,6 +27,7 @@ use rustls::crypto::{
 use rustls::error::Error;
 #[cfg(feature = "std")]
 use rustls::ticketer::TicketRotator;
+use zeroize::Zeroizing;
 
 /// Using software keys for authentication.
 pub mod sign;
@@ -109,16 +110,17 @@ impl KeyProvider for Ring {
         &self,
         key_der: PrivateKeyDer<'static>,
     ) -> Result<Box<dyn SigningKey>, Error> {
-        if let Ok(rsa) = RsaSigningKey::try_from(&key_der) {
+        let key_der = Zeroizing::new(key_der);
+        if let Ok(rsa) = RsaSigningKey::try_from(&*key_der) {
             return Ok(Box::new(rsa));
         }
 
-        if let Ok(ecdsa) = EcdsaSigner::try_from(&key_der) {
+        if let Ok(ecdsa) = EcdsaSigner::try_from(&*key_der) {
             return Ok(Box::new(ecdsa));
         }
 
-        if let PrivateKeyDer::Pkcs8(pkcs8) = key_der {
-            if let Ok(eddsa) = Ed25519Signer::try_from(&pkcs8) {
+        if let PrivateKeyDer::Pkcs8(pkcs8) = &*key_der {
+            if let Ok(eddsa) = Ed25519Signer::try_from(pkcs8) {
                 return Ok(Box::new(eddsa));
             }
         }


### PR DESCRIPTION
Doesn't apply on 0.23 because its API takes `PrivateKeyDer` by reference.

Zeroization is best effort:

- https://github.com/rustls/rustls/issues/265