### PR TITLE
bogo: avoid flicker on error handling with an alert

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -519,7 +519,9 @@ fn after_read(
     {
         Ok(state) => state,
         Err(error) => {
-            flush(output, conn); /* send any alerts before exiting */
+            // Send any alerts before exiting, but don't swallow `error` if we can't.
+            let _ = conn.write_all(output);
+            output.clear();
             orderly_close(conn);
             handle_err(opts, error);
         }


### PR DESCRIPTION
Attempting to send an alert but failing to do that should not cause the error (most importantly, `handle_err()`) to be ignored.


Addressing https://github.com/rustls/rustls/actions/runs/33877263561 