### PR TITLE
reject server hello that does not echo legacy_session_id

### DIFF
--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -930,9 +930,10 @@ fn handle_err(opts: &Options, err: Error) -> ! {
         Error::PeerMisbehaved(PeerMisbehaved::EarlyDataOfferedWithVariedCipherSuite) => {
             quit(":CIPHER_MISMATCH_ON_EARLY_DATA:")
         }
-        Error::PeerMisbehaved(PeerMisbehaved::ServerEchoedCompatibilitySessionId) => {
-            quit(":SERVER_ECHOED_INVALID_SESSION_ID:")
-        }
+        Error::PeerMisbehaved(
+            PeerMisbehaved::ServerEchoedCompatibilitySessionId
+            | PeerMisbehaved::ServerHelloWithWrongSessionId,
+        ) => quit(":SERVER_ECHOED_INVALID_SESSION_ID:"),
         Error::PeerMisbehaved(PeerMisbehaved::TooManyEmptyFragments) => {
             quit(":TOO_MANY_EMPTY_FRAGMENTS:")
         }

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -2334,6 +2334,25 @@ pub mod encoding {
         handshake_framing(HandshakeType::ServerHello, out)
     }
 
+    /// Copy the `legacy_session_id` of the `ClientHello` at the front of `client_flight`
+    /// into the `ServerHello` at the front of `server_flight`.
+    ///
+    /// TLS1.3 requires a server to echo that value, so a `ServerHello` that was recorded,
+    /// or produced for a different `ClientHello`, needs adjusting before a client accepts it.
+    pub fn echo_session_id(client_flight: &[u8], server_flight: &mut [u8]) {
+        // record header, handshake header, legacy_version, then random
+        const LEN_OFFSET: usize = 5 + 4 + 2 + 32;
+
+        assert_eq!(client_flight[5], u8::from(HandshakeType::ClientHello));
+        assert_eq!(server_flight[5], u8::from(HandshakeType::ServerHello));
+
+        let len = usize::from(client_flight[LEN_OFFSET]);
+        assert_eq!(usize::from(server_flight[LEN_OFFSET]), len);
+
+        let body = LEN_OFFSET + 1..LEN_OFFSET + 1 + len;
+        server_flight[body.clone()].copy_from_slice(&client_flight[body]);
+    }
+
     /// Apply handshake framing to `body`.
     ///
     /// This does not do fragmentation.

--- a/rustls-test/tests/api/api.rs
+++ b/rustls-test/tests/api/api.rs
@@ -1959,9 +1959,11 @@ fn tls13_packed_handshake() {
         .connect(server_name("localhost"))
         .build(&mut client_output)
         .unwrap();
+    let mut first_flight = include_bytes!("../data/bug2040-message-1.bin").to_vec();
+    // the recording predates this connection's `session_id`
+    encoding::echo_session_id(&client_output, &mut first_flight);
     client_output.clear();
 
-    let mut first_flight = include_bytes!("../data/bug2040-message-1.bin").to_vec();
     client
         .read_tls(&mut SliceInput::new(&mut first_flight), &mut client_output)
         .handle_all(&mut Vec::new())

--- a/rustls-test/tests/api/kx.rs
+++ b/rustls-test/tests/api/kx.rs
@@ -539,6 +539,8 @@ fn hybrid_kx_component_share_offered_but_server_chooses_something_else() {
         .read_tls(&mut server_input, &mut server_output)
         .handle_all(&mut Vec::new())
         .unwrap();
+    // client_1 requires its own `session_id` back, not client_2's
+    encoding::echo_session_id(&client_1_output, &mut server_output);
     transfer(&mut server_output, &mut client_1_input);
     assert_eq!(
         client_1

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -220,6 +220,55 @@ fn test_client_rejects_hrr_with_varied_session_id() {
 }
 
 #[test]
+fn test_client_rejects_server_hello_with_varied_session_id() {
+    let config = ClientConfig::builder(Arc::new(tls13_only(TEST_PROVIDER.clone())))
+        .with_root_certificates(roots())
+        .with_no_client_auth()
+        .unwrap();
+    let mut tls = Vec::new();
+    let mut conn = Arc::new(config)
+        .connect(ServerName::try_from("localhost").unwrap())
+        .build(&mut tls)
+        .unwrap();
+
+    // server replies with an otherwise-acceptable ServerHello, but does not
+    // echo `session_id` as required.
+    let sh = Message {
+        version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
+        payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::ServerHello(
+            ServerHelloPayload {
+                random: Random([0; 32]),
+                compression_method: Compression::Null,
+                cipher_suite: TLS13_TEST_SUITE.suite(),
+                legacy_version: ProtocolVersion::TLSv1_3,
+                session_id: SessionId::empty(),
+                extensions: Box::new(ServerExtensions {
+                    key_share: Some(KeyShareEntry {
+                        group: KEY_EXCHANGE_GROUP.name(),
+                        payload: KEY_EXCHANGE_GROUP
+                            .start()
+                            .unwrap()
+                            .pub_key()
+                            .to_vec()
+                            .into(),
+                    }),
+                    ..ServerExtensions::default()
+                }),
+            },
+        ))),
+    };
+
+    let mut input = VecInput::default();
+    input
+        .read(&mut sh.into_wire_bytes().as_slice())
+        .unwrap();
+    assert_eq!(
+        process(&mut input, &mut conn).unwrap_err(),
+        PeerMisbehaved::ServerHelloWithWrongSessionId.into()
+    );
+}
+
+#[test]
 fn test_client_rejects_no_extended_main_secret_extension_when_require_ems_or_fips() {
     let mut config = ClientConfig::builder(Arc::new(TEST_PROVIDER.clone()))
         .with_root_certificates(roots())
@@ -522,7 +571,7 @@ fn client_requiring_rpk_receives_server_ee(
                 compression_method: Compression::Null,
                 cipher_suite: TLS13_TEST_SUITE.suite(),
                 legacy_version: ProtocolVersion::TLSv1_3,
-                session_id: SessionId::empty(),
+                session_id: client_hello_in(&tls).session_id,
                 extensions: Box::new(ServerExtensions {
                     key_share: Some(KeyShareEntry {
                         group: KEY_EXCHANGE_GROUP.name(),
@@ -849,8 +898,11 @@ fn client_hello_sent_for_config(config: ClientConfig) -> Result<ClientHelloPaylo
     Arc::new(config)
         .connect(ServerName::try_from("localhost").unwrap())
         .build(&mut bytes)?;
+    Ok(client_hello_in(&bytes))
+}
 
-    let record = Record::<Payload<'_>>::read(&mut Reader::new(&bytes))
+fn client_hello_in(flight: &[u8]) -> ClientHelloPayload {
+    let record = Record::<Payload<'_>>::read(&mut Reader::new(flight))
         .unwrap()
         .into_owned();
     match Message::try_from(&record).unwrap() {
@@ -861,7 +913,7 @@ fn client_hello_sent_for_config(config: ClientConfig) -> Result<ClientHelloPaylo
                     ..
                 },
             ..
-        } => Ok(ch),
+        } => ch,
         other => panic!("unexpected message {other:?}"),
     }
 }

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -10,7 +10,10 @@ use std::vec;
 use pki_types::{CertificateDer, FipsStatus, ServerName, UnixTime};
 
 use super::{Tls12Session, Tls13ClientSessionInput, Tls13Session};
-use crate::client::{ClientConfig, ClientConnection, Resumption, Tls12Resumption};
+use crate::client::{
+    ClientConfig, ClientConnection, ClientSessionKey, ClientSessionMemoryCache, ClientSessionStore,
+    Resumption, Tls12Resumption,
+};
 use crate::crypto::cipher::{
     EncodableVersion, Payload, Record, RecordEncrypter, encode_record_header,
 };
@@ -265,6 +268,78 @@ fn test_client_rejects_server_hello_with_varied_session_id() {
     assert_eq!(
         process(&mut input, &mut conn).unwrap_err(),
         PeerMisbehaved::ServerHelloWithWrongSessionId.into()
+    );
+}
+
+#[test]
+fn test_client_rejects_tls12_server_hello_echoing_compatibility_session_id() {
+    let config = ClientConfig::builder(Arc::new(TEST_PROVIDER.clone()))
+        .with_root_certificates(roots())
+        .with_no_client_auth()
+        .unwrap();
+    let store = Arc::new(ClientSessionMemoryCache::new(256));
+    let config = Arc::new(ClientConfig {
+        resumption: Resumption::store(store.clone()),
+        ..config
+    });
+
+    // a cached TLS 1.3 ticket is not a TLS 1.2 session, so the client still
+    // sends a compatibility `session_id` a TLS 1.2 server cannot know.
+    let server_name = ServerName::try_from("localhost").unwrap();
+    store.insert_tls13_ticket(
+        ClientSessionKey {
+            config_hash: config.config_hash(),
+            server_name: server_name.clone(),
+        },
+        Tls13Session::new(
+            &NewSessionTicketPayloadTls13::new(
+                Duration::from_secs(1800),
+                0x1234_5678,
+                [0u8; 32],
+                b"ticket".to_vec(),
+            ),
+            Tls13ClientSessionInput {
+                suite: Tls13ProtocolSuite::Tcp(TEST_PROVIDER.tls13_cipher_suites[0]),
+                peer_identity: VerifiedIdentity::assertion(Identity::RawPublicKey(
+                    pki_types::SubjectPublicKeyInfoDer::from(&b"spki"[..]),
+                )),
+                quic_params: None,
+            },
+            &[0x55; 32],
+            UnixTime::now(),
+        ),
+    );
+
+    let mut tls = Vec::new();
+    let mut conn = config
+        .connect(server_name)
+        .build(&mut tls)
+        .unwrap();
+
+    let sh = Message {
+        version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
+        payload: MessagePayload::handshake(HandshakeMessagePayload(HandshakePayload::ServerHello(
+            ServerHelloPayload {
+                random: Random([0; 32]),
+                compression_method: Compression::Null,
+                cipher_suite: TLS_TEST_SUITE.suite(),
+                legacy_version: ProtocolVersion::TLSv1_2,
+                session_id: client_hello_in(&tls).session_id,
+                extensions: Box::new(ServerExtensions {
+                    extended_main_secret_ack: Some(()),
+                    ..ServerExtensions::default()
+                }),
+            },
+        ))),
+    };
+
+    let mut input = VecInput::default();
+    input
+        .read(&mut sh.into_wire_bytes().as_slice())
+        .unwrap();
+    assert_eq!(
+        process(&mut input, &mut conn).unwrap_err(),
+        PeerMisbehaved::ServerEchoedCompatibilitySessionId.into()
     );
 }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -118,18 +118,6 @@ mod server_hello {
                 return Err(PeerMisbehaved::AttemptedDowngradeToTls12WhenTls13IsSupported.into());
             }
 
-            // If we didn't have an input session to resume, and we sent a session ID,
-            // that implies we sent a TLS 1.3 legacy_session_id for compatibility purposes.
-            // In this instance since we're now continuing a TLS 1.2 handshake the server
-            // should not have echoed it back: it's a randomly generated session ID it couldn't
-            // have known.
-            if st.input.resuming.is_none()
-                && !st.input.session_id.is_empty()
-                && st.input.session_id == server_hello.session_id
-            {
-                return Err(PeerMisbehaved::ServerEchoedCompatibilitySessionId.into());
-            }
-
             let ClientHelloInput {
                 config,
                 session_key,
@@ -143,6 +131,18 @@ mod server_hello {
                     ClientSessionValue::Tls12(inner) => Some(inner),
                     ClientSessionValue::Tls13(_) => None,
                 });
+
+            // If we didn't have a TLS 1.2 session to resume, and we sent a session ID,
+            // that implies we sent a TLS 1.3 legacy_session_id for compatibility purposes.
+            // In this instance since we're now continuing a TLS 1.2 handshake the server
+            // should not have echoed it back: it's a randomly generated session ID it couldn't
+            // have known.
+            if resuming_session.is_none()
+                && !st.input.session_id.is_empty()
+                && st.input.session_id == server_hello.session_id
+            {
+                return Err(PeerMisbehaved::ServerEchoedCompatibilitySessionId.into());
+            }
 
             // Doing EMS?
             let using_ems = server_hello

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -123,6 +123,14 @@ impl ClientHandler<Tls13CipherSuite> for Handler {
             return Err(PeerMisbehaved::UnexpectedCleartextExtension.into());
         }
 
+        // > A client which receives a legacy_session_id_echo field that does not
+        // > match what it sent in the ClientHello MUST abort the handshake with an
+        // > "illegal_parameter" alert.
+        // <https://www.rfc-editor.org/rfc/rfc9846#section-4.1.3>
+        if server_hello.session_id != st.input.session_id {
+            return Err(PeerMisbehaved::ServerHelloWithWrongSessionId.into());
+        }
+
         let their_key_share = server_hello
             .key_share
             .as_ref()

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1226,6 +1226,7 @@ pub enum PeerMisbehaved {
     SelectedUnofferedPsk,
     ServerEchoedCompatibilitySessionId,
     ServerHelloMustOfferUncompressedEcPoints,
+    ServerHelloWithWrongSessionId,
     ServerNameDifferedOnRetry,
     ServerNameMustContainOneHostName,
     SignedKxWithWrongAlgorithm,


### PR DESCRIPTION
`ClientHandler::handle_server_hello` for TLS1.3 never looks at the ServerHello's
`legacy_session_id_echo`, so a server echoing nothing at all is accepted:

    client::test::test_client_rejects_server_hello_with_varied_session_id
    called `Result::unwrap_err()` on an `Ok` value: ()

RFC 9846 4.1.3 makes a mismatch a MUST-abort with `illegal_parameter`, and the
identical rule is already enforced one message earlier for HelloRetryRequest via
`IllegalHelloRetryRequestWithWrongSessionId`. In middlebox-compatibility mode the
client sends a random 32-byte `legacy_session_id`, so the check is live on every
TCP TLS1.3 handshake.

The TLS1.2 handler holds the other half of the same gap. Its guard tests
`st.input.resuming.is_none()`, but `resuming` is `Some` for any cached session,
including a TLS1.3 ticket, which is not a TLS1.2 resumption candidate. With one
of those cached the client still sends a compatibility session id and then
accepts a TLS1.2 server that echoes it, instead of raising
`ServerEchoedCompatibilitySessionId`. Testing `resuming_session` is what the
comment above the guard already describes.

The ServerHellos synthesised by the test suite relied on the absent check, so
they now echo the offered id; `encoding::echo_session_id` does that for the two
byte-level flights. BoGo is clean on ring and aws-lc-rs.
