### PR TITLE
Reject second ClientHello that withdraws PSK offer

### DIFF
--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -93,7 +93,6 @@
     "RequireAnyClientCertificate-TLS12": "we don't send an alert in this case",
     "Resume-Client-CipherMismatch": "tries to vary to unimplemented CBC-mode cs",
     "Resume-Server-CipherNotPreferred": "first connection requires an unimplemented CBC-mode cs (note the TLS1.3 version of this test passes)",
-    "Resume-Server-OmitAllPSKsOnSecondClientHello": "TODO: we do not reject a second ClientHello that drops all PSKs",
     "RetainOnlySHA256-*": "test for SSL_CTX_set_retain_only_sha256_of_client_certs api",
     "SendClientVersion-RSA": "no rsa kem",
     "SendFallbackSCSV": "fallback scsv not implemented",

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -889,9 +889,10 @@ fn handle_err(opts: &Options, err: Error) -> ! {
             quit(":MISSING_KEY_SHARE:")
         }
         Error::PeerIncompatible(_) => quit(":INCOMPATIBLE:"),
-        Error::PeerMisbehaved(PeerMisbehaved::MissingPskModesExtension) => {
-            quit(":MISSING_EXTENSION:")
-        }
+        Error::PeerMisbehaved(
+            PeerMisbehaved::MissingPskExtensionInSecondClientHello
+            | PeerMisbehaved::MissingPskModesExtension,
+        ) => quit(":MISSING_EXTENSION:"),
         Error::PeerMisbehaved(PeerMisbehaved::TooMuchEarlyDataReceived) => {
             quit(":TOO_MUCH_READ_EARLY_DATA:")
         }

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1199,6 +1199,7 @@ pub enum PeerMisbehaved {
     MessageInterleavedWithHandshakeMessage,
     MissingBinderInPskExtension,
     MissingKeyShare,
+    MissingPskExtensionInSecondClientHello,
     MissingPskModesExtension,
     MissingQuicTransportParameters,
     NoCertificatesPresented,
@@ -1270,6 +1271,7 @@ impl From<PeerMisbehaved> for AlertDescription {
             | PeerMisbehaved::SelectedUnofferedCertCompression => Self::BadCertificate,
 
             PeerMisbehaved::MissingKeyShare
+            | PeerMisbehaved::MissingPskExtensionInSecondClientHello
             | PeerMisbehaved::MissingPskModesExtension
             | PeerMisbehaved::MissingQuicTransportParameters => Self::MissingExtension,
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -486,6 +486,7 @@ pub(crate) struct ExpectClientHello {
     pub(super) resumption_data: Vec<u8>,
     pub(super) using_ems: bool,
     pub(super) done_retry: bool,
+    pub(super) offered_psk_before_retry: bool,
     pub(super) send_tickets: usize,
 }
 
@@ -512,6 +513,7 @@ impl ExpectClientHello {
             resumption_data,
             using_ems: false,
             done_retry: false,
+            offered_psk_before_retry: false,
             send_tickets: 0,
         }
     }

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -23,11 +23,11 @@ use crate::crypto::{
     SingleCredential, TEST_PROVIDER, TLS13_TEST_SUITE, tls12, tls12_only,
 };
 use crate::enums::{CertificateType, ProtocolVersion};
-use crate::error::{Error, PeerIncompatible};
+use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::msgs::{
     ClientExtensions, ClientHelloPayload, Codec, Compression, HEADER_SIZE, HandshakeMessagePayload,
-    HandshakePayload, KeyShareEntry, Message, MessagePayload, Random, Reader, SessionId,
-    SupportedProtocolVersions,
+    HandshakePayload, KeyShareEntry, Message, MessagePayload, PresharedKeyIdentity,
+    PresharedKeyOffer, PskKeyExchangeModes, Random, Reader, SessionId, SupportedProtocolVersions,
 };
 use crate::pki_types::pem::PemObject;
 use crate::pki_types::{CertificateDer, FipsStatus, PrivateKeyDer};
@@ -321,6 +321,60 @@ fn server_chooses_ffdhe_group_for_client_hello(
 
     skx.unwrap_given_kxa(KeyExchangeAlgorithm::DHE)
         .expect("DHE not used");
+}
+
+#[test]
+fn second_client_hello_cannot_withdraw_psk_offer() {
+    // Per RFC 9846 section 4.2.2, dropping a PreSharedKey offer is not one of the
+    // changes a client may make after a HelloRetryRequest.
+    let config = ServerConfig::builder(TEST_PROVIDER.clone().into())
+        .with_no_client_auth()
+        .with_single_cert(server_identity(), server_key())
+        .unwrap();
+    let mut conn = ServerConnection::new(config.into()).unwrap();
+    let mut input = VecInput::default();
+
+    let encode = |hello| {
+        Message {
+            version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ClientHello(hello),
+            )),
+        }
+        .into_wire_bytes()
+    };
+
+    // this hello offers a PSK, but no key share for a group we support, so
+    // it draws a HelloRetryRequest.
+    let mut first = minimal_client_hello();
+    first.extensions.key_shares = Some(vec![]);
+    first.extensions.preshared_key_modes = Some(PskKeyExchangeModes {
+        psk_dhe: true,
+        psk: false,
+    });
+    first.extensions.preshared_key_offer = Some(PresharedKeyOffer::new(
+        PresharedKeyIdentity::new(vec![0u8; 16], 0),
+        vec![0u8; 32],
+    ));
+    input
+        .read(&mut encode(first).as_slice())
+        .unwrap();
+    process(&mut input, &mut conn).unwrap();
+
+    // the second hello follows the retry, but drops the PSK offer entirely.
+    let mut second = minimal_client_hello();
+    second.extensions.preshared_key_modes = Some(PskKeyExchangeModes {
+        psk_dhe: true,
+        psk: false,
+    });
+    input
+        .read(&mut encode(second).as_slice())
+        .unwrap();
+
+    assert_eq!(
+        process(&mut input, &mut conn).unwrap_err(),
+        PeerMisbehaved::MissingPskExtensionInSecondClientHello.into(),
+    );
 }
 
 #[test]

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -171,6 +171,17 @@ mod client_hello {
                 return Err(PeerMisbehaved::EarlyDataAttemptedInSecondClientHello.into());
             }
 
+            // RFC 9846 section 4.2.2 allows the second ClientHello to update a PreSharedKey
+            // offer (binders, incompatible PSKs), but not to withdraw it altogether
+            if st.offered_psk_before_retry
+                && input
+                    .client_hello
+                    .preshared_key_offer
+                    .is_none()
+            {
+                return Err(PeerMisbehaved::MissingPskExtensionInSecondClientHello.into());
+            }
+
             // See if there is a KeyShare for the selected kx group.
             let chosen_share_and_kxg = shares_ext
                 .iter()
@@ -203,6 +214,10 @@ mod client_hello {
                     session_id: SessionId::empty(),
                     using_ems: false,
                     done_retry: true,
+                    offered_psk_before_retry: input
+                        .client_hello
+                        .preshared_key_offer
+                        .is_some(),
                     ..st
                 });
                 return if early_data_requested {


### PR DESCRIPTION
[RFC 8446 §4.1.2](https://www.rfc-editor.org/rfc/rfc8446.html#section-4.1.2) lists exhaustively what a client may change in its second ClientHello after a HelloRetryRequest. A `pre_shared_key` extension may be updated there (recomputing the binders, adjusting the obfuscated ticket age, and optionally dropping PSKs incompatible with the server's chosen cipher suite), but withdrawing the extension altogether is not one of the permitted changes.

We accepted that anyway. `ExpectClientHello` kept no record of whether the first ClientHello carried a PSK offer, so a second hello that omitted the extension was handled as if the client had never offered a PSK at all.

This PR:

- adds `PeerMisbehaved::MissingPskExtensionInSecondClientHello`, which maps to a `missing_extension` alert
- records the first hello's offer in `ExpectClientHello::offered_psk_before_retry` when emitting the HelloRetryRequest, and rejects a second hello that drops it in `client_hello::handle_client_hello`
- enables `Resume-Server-OmitAllPSKsOnSecondClientHello`, which was disabled with a `TODO` reason
- adds a server unit test for the same case
