### PR TITLE
reject a second ClientHello that changes the cipher suite

### DIFF
--- a/rustls/src/crypto/test_provider.rs
+++ b/rustls/src/crypto/test_provider.rs
@@ -81,6 +81,19 @@ pub(crate) const TLS13_TEST_SUITE: &Tls13CipherSuite = &Tls13CipherSuite {
     quic: None,
 };
 
+/// Differs from `TLS13_TEST_SUITE` only in its code point: same hash, same everything else.
+pub(crate) const TLS13_TEST_SUITE_ALT: &Tls13CipherSuite = &Tls13CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite(0xff14),
+        hash_provider: FAKE_HASH,
+        confidentiality_limit: u64::MAX,
+    },
+    protocol_version: crate::version::TLS13_VERSION,
+    hkdf_provider: &tls13::HkdfUsingHmac(FAKE_HMAC),
+    aead_alg: &Aead,
+    quic: None,
+};
+
 pub(crate) const TLS_TEST_SUITE: &Tls12CipherSuite = &Tls12CipherSuite {
     common: CipherSuiteCommon {
         suite: CipherSuite(0xff12),

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1163,6 +1163,7 @@ impl From<InvalidMessage> for AlertDescription {
 pub enum PeerMisbehaved {
     AttemptedDowngradeToTls12WhenTls13IsSupported,
     BadCertChainExtensions,
+    CipherSuiteDifferedOnRetry,
     DisallowedEncryptedExtension,
     DuplicateClientHelloExtensions,
     DuplicateEncryptedExtensions,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -487,6 +487,7 @@ pub(crate) struct ExpectClientHello {
     pub(super) using_ems: bool,
     pub(super) done_retry: bool,
     pub(super) offered_psk_before_retry: bool,
+    pub(super) suite_before_retry: Option<CipherSuite>,
     pub(super) send_tickets: usize,
 }
 
@@ -514,6 +515,7 @@ impl ExpectClientHello {
             using_ems: false,
             done_retry: false,
             offered_psk_before_retry: false,
+            suite_before_retry: None,
             send_tickets: 0,
         }
     }
@@ -632,6 +634,14 @@ impl ExpectClientHello {
                 .unwrap_or_default(),
             &input.client_hello.cipher_suites,
         )?;
+
+        // RFC 9846 section 4.2.4: the server must negotiate the same cipher suite it
+        // named in its HelloRetryRequest
+        if let Some(before_retry) = self.suite_before_retry {
+            if before_retry != suite.suite() {
+                return Err(PeerMisbehaved::CipherSuiteDifferedOnRetry.into());
+            }
+        }
 
         debug!("decided upon suite {suite:?}");
         output.output(OutputEvent::CipherSuite(suite.into()));

--- a/rustls/src/server/test.rs
+++ b/rustls/src/server/test.rs
@@ -17,7 +17,9 @@ use crate::crypto::kx::{
     ActiveKeyExchange, KeyExchangeAlgorithm, NamedGroup, SharedSecret, StartedKeyExchange,
     SupportedKxGroup,
 };
-use crate::crypto::test_provider::{FAKE_HASH, FAKE_HMAC, KEY_EXCHANGE_GROUP, TLS_TEST_SUITE};
+use crate::crypto::test_provider::{
+    FAKE_HASH, FAKE_HMAC, KEY_EXCHANGE_GROUP, TLS_TEST_SUITE, TLS13_TEST_SUITE_ALT,
+};
 use crate::crypto::{
     CertificateIdentity, CipherSuite, Credentials, CryptoProvider, Identity, SignatureScheme,
     SingleCredential, TEST_PROVIDER, TLS13_TEST_SUITE, tls12, tls12_only,
@@ -374,6 +376,56 @@ fn second_client_hello_cannot_withdraw_psk_offer() {
     assert_eq!(
         process(&mut input, &mut conn).unwrap_err(),
         PeerMisbehaved::MissingPskExtensionInSecondClientHello.into(),
+    );
+}
+
+#[test]
+fn second_client_hello_cannot_change_cipher_suite() {
+    // RFC 9846 section 4.2.4 requires the server to negotiate the same cipher suite it
+    // named in its HelloRetryRequest, and section 4.2.2 does not let the client vary its
+    // offer, so a second hello that withdraws the retried suite cannot be honoured.
+    let provider = CryptoProvider {
+        tls13_cipher_suites: Cow::Borrowed(&[TLS13_TEST_SUITE, TLS13_TEST_SUITE_ALT]),
+        ..TEST_PROVIDER.clone()
+    };
+    let config = ServerConfig::builder(provider.into())
+        .with_no_client_auth()
+        .with_single_cert(server_identity(), server_key())
+        .unwrap();
+    let mut conn = ServerConnection::new(config.into()).unwrap();
+    let mut input = VecInput::default();
+
+    let encode = |hello| {
+        Message {
+            version: EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
+            payload: MessagePayload::handshake(HandshakeMessagePayload(
+                HandshakePayload::ClientHello(hello),
+            )),
+        }
+        .into_wire_bytes()
+    };
+
+    // this hello has no key share for a group we support, so it draws a
+    // HelloRetryRequest naming `TLS13_TEST_SUITE`.
+    let mut first = minimal_client_hello();
+    first.cipher_suites = vec![TLS13_TEST_SUITE.common.suite];
+    first.extensions.key_shares = Some(vec![]);
+    input
+        .read(&mut encode(first).as_slice())
+        .unwrap();
+    process(&mut input, &mut conn).unwrap();
+
+    // the second hello follows the retry, but offers only a different suite. It shares
+    // the retried suite's hash, so the transcript stays valid and nothing else objects.
+    let mut second = minimal_client_hello();
+    second.cipher_suites = vec![TLS13_TEST_SUITE_ALT.common.suite];
+    input
+        .read(&mut encode(second).as_slice())
+        .unwrap();
+
+    assert_eq!(
+        process(&mut input, &mut conn).unwrap_err(),
+        PeerMisbehaved::CipherSuiteDifferedOnRetry.into(),
     );
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -218,6 +218,7 @@ mod client_hello {
                         .client_hello
                         .preshared_key_offer
                         .is_some(),
+                    suite_before_retry: Some(suite.common.suite),
                     ..st
                 });
                 return if early_data_requested {


### PR DESCRIPTION
## What RFC 9846 requires

RFC 9846 [§4.2.4](https://www.rfc-editor.org/rfc/rfc9846.html#section-4.2.4): "Servers MUST ensure that they negotiate the same cipher suite when receiving a conformant updated ClientHello (if the server selects the cipher suite as the first step in the negotiation, then this will happen automatically)." The client cannot vary the offer either. [§4.2.2](https://www.rfc-editor.org/rfc/rfc9846.html#section-4.2.2) has it "MUST send the same ClientHello without modification, except as follows", and the list that follows covers `key_share` and `early_data`, not `cipher_suites`.

## Before the change

We choose the suite again for the second ClientHello, so a client that offers a different one is given it:

    ---- server::test::second_client_hello_cannot_change_cipher_suite stdout ----

    thread 'server::test::second_client_hello_cannot_change_cipher_suite' (249343) panicked at rustls/src/server/test.rs:444:5:
    assertion `left == right` failed
      left: 0xff13
     right: 0xff14

Left is the suite our HelloRetryRequest named, right is the one our ServerHello then negotiated.

We do not pick the suite as a first step, so nothing makes this happen automatically. `choose_suite_and_kx_group` runs again over whatever the second hello offers, and `ExpectClientHello` kept no record of the earlier choice to compare against. Everything else that has to hold still across a retry is already checked, `ServerNameDifferedOnRetry` and `HandshakeHashVariedAfterRetry` in `hs.rs` and `MissingPskExtensionInSecondClientHello` in `tls13.rs`. Only a broken or hostile client reaches this, since a conformant one rejects the outcome itself with `SelectedDifferentCipherSuiteAfterRetry`, and two suites with different hashes would already fail `HandshakeHashVariedAfterRetry`.

## After the change

`suite_before_retry` records the suite as the HelloRetryRequest is emitted, and `with_version` compares it as soon as `choose_suite_and_kx_group` returns. A second hello that withdraws that suite now fails with `CipherSuiteDifferedOnRetry`, which falls through to `illegal_parameter`.

There is no bogo test to enable. `HelloRetryRequest-CipherChange-TLS13` is a client test and passes already, and the runner cannot vary the cipher list between the two hellos: `SendCipherSuites` is applied in `createClientHello`, which builds only the first.
