### PR TITLE
Sketch of desirable(?) `RecordEncrypter::encrypt` interface

### DIFF
--- a/rustls-aws-lc-rs/src/lib.rs
+++ b/rustls-aws-lc-rs/src/lib.rs
@@ -45,7 +45,7 @@ use rustls::crypto::{
     CryptoProvider, GetRandomFailed, KeyProvider, SecureRandom, SigningKey, TicketProducer,
     TicketerFactory,
 };
-use rustls::error::{ApiMisuse, Error, OtherError};
+use rustls::error::{Error, OtherError};
 #[cfg(feature = "std")]
 use rustls::ticketer::TicketRotator;
 use zeroize::Zeroizing;
@@ -253,21 +253,6 @@ mod ring_shim {
         agreement::agree_ephemeral(priv_key, peer_key, (), |secret| {
             Ok(SharedSecret::from(secret))
         })
-    }
-}
-
-/// The region of `out` that a `len`-byte sealed record payload will occupy.
-///
-/// If `out` is shorter than `len` bytes, this returns [`ApiMisuse::EncryptBufferTooSmall`].
-fn record_region(out: &mut [u8], len: usize) -> Result<&mut [u8], Error> {
-    let provided = out.len();
-    match out.get_mut(..len) {
-        Some(record) => Ok(record),
-        None => Err(ApiMisuse::EncryptBufferTooSmall {
-            required: len,
-            provided,
-        }
-        .into()),
     }
 }
 

--- a/rustls-aws-lc-rs/src/tls12.rs
+++ b/rustls-aws-lc-rs/src/tls12.rs
@@ -1,11 +1,12 @@
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use aws_lc_rs::{aead, tls_prf};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, NONCE_LEN, Nonce, OutboundPlain,
-    Record, RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, UnsupportedOperationError,
-    make_tls12_aad,
+    AeadKey, InboundOpaque, Iv, KeyBlockShape, NONCE_LEN, Nonce, OutboundPlain, Record,
+    RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, UnsupportedOperationError,
+    encode_record_header, make_tls12_aad,
 };
 use rustls::crypto::kx::{ActiveKeyExchange, KeyExchangeAlgorithm, SharedSecret};
 use rustls::crypto::tls12::{Prf, PrfSecret};
@@ -16,7 +17,7 @@ use rustls::version::TLS12_VERSION;
 use rustls::{CipherSuiteCommon, ConnectionTrafficSecrets, Tls12CipherSuite};
 use zeroize::Zeroizing;
 
-use crate::{MAX_FRAGMENT_LEN, record_region};
+use crate::MAX_FRAGMENT_LEN;
 
 /// The TLS1.2 cipher suite configuration that an application should use by default.
 ///
@@ -324,12 +325,12 @@ impl RecordDecrypter for GcmRecordDecrypter {
 }
 
 impl RecordEncrypter for GcmRecordEncrypter {
-    fn encrypt<'a>(
+    fn encrypt(
         &mut self,
         msg: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
@@ -340,44 +341,36 @@ impl RecordEncrypter for GcmRecordEncrypter {
             msg.payload.len(),
         ));
 
-        let payload = match msg.payload.single_chunk() {
+        let header = encode_record_header(msg.typ, msg.version, total_len as u16);
+        out.reserve(header.len() + total_len);
+        out.extend_from_slice(&header);
+        out.extend_from_slice(&nonce.as_ref()[4..]);
+        let start = out.len();
+
+        match msg.payload.single_chunk() {
             // Contiguous plaintext is sealed out-of-place, straight from the
             // borrowed input.
             Some(plain) => {
-                let record = record_region(out, total_len)?;
-                let (explicit_nonce, sealed) = record.split_at_mut(GCM_EXPLICIT_NONCE_LEN);
-                explicit_nonce.copy_from_slice(&nonce.as_ref()[4..]);
-                let (ciphertext, tag) = sealed.split_at_mut(plain.len());
+                out.resize(start + total_len - GCM_EXPLICIT_NONCE_LEN, 0);
+                let (ciphertext, tag) = out[start..].split_at_mut(plain.len());
                 self.enc_key
                     .seal_out_of_place_scatter(nonce, aad, plain, ciphertext, &[], tag)
                     .map_err(|_| Error::EncryptError)?;
-                &*record
             }
             // Fragmented plaintext is gathered into `out` and then sealed in place.
             // We can't use the out-of-place seal as it requires contiguous input.
             None => {
-                let mut payload = EncryptBuffer::new(out, total_len)?;
-                payload.extend_from_slice(&nonce.as_ref()[4..]);
-                payload.extend_from_chunks(&msg.payload);
+                msg.payload.copy_to_vec(out);
 
-                match self.enc_key.seal_in_place_separate_tag(
-                    nonce,
-                    aad,
-                    &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..],
-                ) {
-                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-                    Err(_) => return Err(Error::EncryptError),
-                }
-
-                payload.into_written()
+                let tag = self
+                    .enc_key
+                    .seal_in_place_separate_tag(nonce, aad, &mut out[start..])
+                    .map_err(|_| Error::EncryptError)?;
+                out.extend_from_slice(tag.as_ref());
             }
-        };
+        }
 
-        Ok(Record {
-            typ: msg.typ,
-            version: msg.version,
-            payload,
-        })
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -442,12 +435,12 @@ impl RecordDecrypter for ChaCha20Poly1305RecordDecrypter {
 }
 
 impl RecordEncrypter for ChaCha20Poly1305RecordEncrypter {
-    fn encrypt<'a>(
+    fn encrypt(
         &mut self,
         msg: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
 
         let nonce =
@@ -459,40 +452,35 @@ impl RecordEncrypter for ChaCha20Poly1305RecordEncrypter {
             msg.payload.len(),
         ));
 
-        let payload = match msg.payload.single_chunk() {
+        let header = encode_record_header(msg.typ, msg.version, total_len as u16);
+        out.reserve(header.len() + total_len);
+        out.extend_from_slice(&header);
+        let start = out.len();
+
+        match msg.payload.single_chunk() {
             // Contiguous plaintext is sealed out-of-place, straight from the
             // borrowed input.
             Some(plain) => {
-                let record = record_region(out, total_len)?;
-                let (ciphertext, tag) = record.split_at_mut(plain.len());
+                out.resize(start + total_len, 0);
+                let (ciphertext, tag) = out[start..].split_at_mut(plain.len());
                 self.enc_key
                     .seal_out_of_place_scatter(nonce, aad, plain, ciphertext, &[], tag)
                     .map_err(|_| Error::EncryptError)?;
-                &*record
             }
             // Fragmented plaintext is gathered into `out` and then sealed in place.
             // We can't use the out-of-place seal as it requires contiguous input.
             None => {
-                let mut payload = EncryptBuffer::new(out, total_len)?;
-                payload.extend_from_chunks(&msg.payload);
+                msg.payload.copy_to_vec(out);
 
-                match self
+                let tag = self
                     .enc_key
-                    .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-                {
-                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-                    Err(_) => return Err(Error::EncryptError),
-                }
-
-                payload.into_written()
+                    .seal_in_place_separate_tag(nonce, aad, &mut out[start..])
+                    .map_err(|_| Error::EncryptError)?;
+                out.extend_from_slice(tag.as_ref());
             }
-        };
+        }
 
-        Ok(Record {
-            typ: msg.typ,
-            version: msg.version,
-            payload,
-        })
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -604,7 +592,7 @@ mod tests {
         let chunks = [&plain[..3], &plain[3..27], &plain[27..]];
 
         for suite in ALL_TLS12_CIPHER_SUITES {
-            // Different `fill` values prove both paths write every output byte.
+            // Different `fill` values prove both paths leave existing output alone.
             let contiguous = seal(suite, OutboundPlain::from(plain), 0x00);
             let fragmented = seal(suite, OutboundPlain::new(&chunks), 0xff);
             assert_eq!(contiguous, fragmented, "{:?}", suite.common.suite);
@@ -646,12 +634,14 @@ mod tests {
             EncodableVersion::Legacy(ProtocolVersion::TLSv1_2),
             payload,
         );
-        let mut out = vec![fill; encrypter.encrypted_payload_len(record.payload.len())];
+        let payload_len = encrypter.encrypted_payload_len(record.payload.len());
+        let mut out = vec![fill; PREFIX_LEN];
         encrypter
             .encrypt(record, TEST_SEQ, &mut out)
-            .unwrap()
-            .payload
-            .to_vec()
+            .unwrap();
+        assert_eq!(out[..PREFIX_LEN], [fill; PREFIX_LEN]);
+        assert_eq!(out.len(), PREFIX_LEN + HEADER_LEN + payload_len);
+        out.split_off(PREFIX_LEN + HEADER_LEN)
     }
 
     fn test_key(len: usize) -> AeadKey {
@@ -664,4 +654,6 @@ mod tests {
     const TEST_IV: [u8; NONCE_LEN] = [0x55; NONCE_LEN];
     const TEST_EXPLICIT: [u8; GCM_EXPLICIT_NONCE_LEN] = [0x66; GCM_EXPLICIT_NONCE_LEN];
     const TEST_SEQ: u64 = 7;
+    const PREFIX_LEN: usize = 3;
+    const HEADER_LEN: usize = 5;
 }

--- a/rustls-aws-lc-rs/src/tls13.rs
+++ b/rustls-aws-lc-rs/src/tls13.rs
@@ -1,11 +1,12 @@
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use aws_lc_rs::hkdf::KeyType;
 use aws_lc_rs::{aead, hkdf, hmac};
 use pki_types::FipsStatus;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, Nonce, OutboundPlain, Record, RecordDecrypter,
-    RecordEncrypter, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
+    AeadKey, InboundOpaque, Iv, Nonce, OutboundPlain, Record, RecordDecrypter, RecordEncrypter,
+    Tls13AeadAlgorithm, UnsupportedOperationError, encode_record_header, make_tls13_aad,
 };
 use rustls::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use rustls::crypto::{self, CipherSuite};
@@ -13,8 +14,6 @@ use rustls::enums::ContentType;
 use rustls::error::Error;
 use rustls::version::TLS13_VERSION;
 use rustls::{CipherSuiteCommon, ConnectionTrafficSecrets, Tls13CipherSuite};
-
-use crate::record_region;
 
 /// The TLS1.3 cipher suite configuration that an application should use by default.
 ///
@@ -239,24 +238,29 @@ struct AeadRecordDecrypter {
 }
 
 impl RecordEncrypter for AeadRecordEncrypter {
-    fn encrypt<'a>(
+    fn encrypt(
         &mut self,
         msg: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
 
         let typ = ContentType::ApplicationData;
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(typ, msg.version.encode(), total_len));
 
-        let payload = match msg.payload.single_chunk() {
+        let header = encode_record_header(typ, msg.version, total_len as u16);
+        out.reserve(header.len() + total_len);
+        out.extend_from_slice(&header);
+        let start = out.len();
+
+        match msg.payload.single_chunk() {
             // Contiguous plaintext is sealed out-of-place, straight from the borrowed
             // input and the inner content type byte is specified as `extra_in`.
             Some(plain) => {
-                let record = record_region(out, total_len)?;
-                let (ciphertext, typ_and_tag) = record.split_at_mut(plain.len());
+                out.resize(start + total_len, 0);
+                let (ciphertext, typ_and_tag) = out[start..].split_at_mut(plain.len());
                 self.enc_key
                     .seal_out_of_place_scatter(
                         nonce,
@@ -267,32 +271,22 @@ impl RecordEncrypter for AeadRecordEncrypter {
                         typ_and_tag,
                     )
                     .map_err(|_| Error::EncryptError)?;
-                &*record
             }
             // Fragmented plaintext is gathered into `out` and then sealed in place.
             // We can't use the out-of-place seal as it requires contiguous input.
             None => {
-                let mut payload = EncryptBuffer::new(out, total_len)?;
-                payload.extend_from_chunks(&msg.payload);
-                payload.extend_from_slice(&msg.typ.to_array());
+                msg.payload.copy_to_vec(out);
+                out.extend_from_slice(&msg.typ.to_array());
 
-                match self
+                let tag = self
                     .enc_key
-                    .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-                {
-                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-                    Err(_) => return Err(Error::EncryptError),
-                }
-
-                payload.into_written()
+                    .seal_in_place_separate_tag(nonce, aad, &mut out[start..])
+                    .map_err(|_| Error::EncryptError)?;
+                out.extend_from_slice(tag.as_ref());
             }
-        };
+        }
 
-        Ok(Record {
-            typ,
-            version: msg.version,
-            payload,
-        })
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -334,24 +328,29 @@ struct GcmRecordEncrypter {
 }
 
 impl RecordEncrypter for GcmRecordEncrypter {
-    fn encrypt<'a>(
+    fn encrypt(
         &mut self,
         msg: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(msg.payload.len());
 
         let typ = ContentType::ApplicationData;
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(typ, msg.version.encode(), total_len));
 
-        let payload = match msg.payload.single_chunk() {
+        let header = encode_record_header(typ, msg.version, total_len as u16);
+        out.reserve(header.len() + total_len);
+        out.extend_from_slice(&header);
+        let start = out.len();
+
+        match msg.payload.single_chunk() {
             // Contiguous plaintext is sealed out-of-place, straight from the borrowed
             // input and the inner content type byte is specified as `extra_in`.
             Some(plain) => {
-                let record = record_region(out, total_len)?;
-                let (ciphertext, typ_and_tag) = record.split_at_mut(plain.len());
+                out.resize(start + total_len, 0);
+                let (ciphertext, typ_and_tag) = out[start..].split_at_mut(plain.len());
                 self.enc_key
                     .seal_out_of_place_scatter(
                         nonce,
@@ -362,32 +361,22 @@ impl RecordEncrypter for GcmRecordEncrypter {
                         typ_and_tag,
                     )
                     .map_err(|_| Error::EncryptError)?;
-                &*record
             }
             // Fragmented plaintext is gathered into `out` and then sealed in place.
             // We can't use the out-of-place seal as it requires contiguous input.
             None => {
-                let mut payload = EncryptBuffer::new(out, total_len)?;
-                payload.extend_from_chunks(&msg.payload);
-                payload.extend_from_slice(&msg.typ.to_array());
+                msg.payload.copy_to_vec(out);
+                out.extend_from_slice(&msg.typ.to_array());
 
-                match self
+                let tag = self
                     .enc_key
-                    .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-                {
-                    Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-                    Err(_) => return Err(Error::EncryptError),
-                }
-
-                payload.into_written()
+                    .seal_in_place_separate_tag(nonce, aad, &mut out[start..])
+                    .map_err(|_| Error::EncryptError)?;
+                out.extend_from_slice(tag.as_ref());
             }
-        };
+        }
 
-        Ok(Record {
-            typ,
-            version: msg.version,
-            payload,
-        })
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -524,7 +513,7 @@ mod tests {
         let chunks = [&plain[..3], &plain[3..27], &plain[27..]];
 
         for suite in ALL_TLS13_CIPHER_SUITES {
-            // Different `fill` values prove both paths write every output byte.
+            // Different `fill` values prove both paths leave existing output alone.
             let contiguous = seal(suite, OutboundPlain::from(plain), 0x00);
             let fragmented = seal(suite, OutboundPlain::new(&chunks), 0xff);
             assert_eq!(contiguous, fragmented, "{:?}", suite.common.suite);
@@ -563,12 +552,14 @@ mod tests {
             EncodableVersion::Legacy(ProtocolVersion::TLSv1_3),
             payload,
         );
-        let mut out = vec![fill; encrypter.encrypted_payload_len(record.payload.len())];
+        let payload_len = encrypter.encrypted_payload_len(record.payload.len());
+        let mut out = vec![fill; PREFIX_LEN];
         encrypter
             .encrypt(record, TEST_SEQ, &mut out)
-            .unwrap()
-            .payload
-            .to_vec()
+            .unwrap();
+        assert_eq!(out[..PREFIX_LEN], [fill; PREFIX_LEN]);
+        assert_eq!(out.len(), PREFIX_LEN + HEADER_LEN + payload_len);
+        out.split_off(PREFIX_LEN + HEADER_LEN)
     }
 
     fn test_key(len: usize) -> AeadKey {
@@ -580,4 +571,6 @@ mod tests {
 
     const TEST_IV: [u8; 12] = [0x55; 12];
     const TEST_SEQ: u64 = 7;
+    const PREFIX_LEN: usize = 3;
+    const HEADER_LEN: usize = 5;
 }

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::ServerVerifier;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, OutboundPlain, Record,
-    RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
-    UnsupportedOperationError,
+    AeadKey, InboundOpaque, Iv, KeyBlockShape, OutboundPlain, Record, RecordDecrypter,
+    RecordEncrypter, Tls12AeadAlgorithm, Tls13AeadAlgorithm, UnsupportedOperationError,
+    encode_record_header,
 };
 use rustls::crypto::kx::{
     KeyExchangeAlgorithm, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup,
@@ -322,30 +322,32 @@ impl RecordEncrypter for Tls13Cipher {
         &mut self,
         record: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(record.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
+        out.extend_from_slice(&encode_record_header(
+            ContentType::ApplicationData,
+            record.version,
+            total_len as u16,
+        ));
 
-        payload.extend_from_chunks(&record.payload);
-        payload.extend_from_slice(&record.typ.to_array());
+        let mut mask = AEAD_MASK.iter().cycle();
 
-        for (p, mask) in payload
-            .as_mut()
-            .iter_mut()
-            .zip(AEAD_MASK.iter().cycle())
+        let typ = record.typ.to_array();
+        for ch in record
+            .payload
+            .chunks()
+            .chain([&typ[..]])
         {
-            *p ^= *mask;
+            for (p, mask) in ch.iter().zip(mask.by_ref()) {
+                out.push(*p ^ *mask);
+            }
         }
 
-        payload.extend_from_slice(&seq.to_be_bytes());
-        payload.extend_from_slice(AEAD_TAG);
+        out.extend_from_slice(&seq.to_be_bytes());
+        out.extend_from_slice(AEAD_TAG);
 
-        Ok(Record {
-            typ: ContentType::ApplicationData,
-            version: record.version,
-            payload: payload.into_written(),
-        })
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -392,28 +394,27 @@ impl RecordEncrypter for Tls12Cipher {
         &mut self,
         record: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(record.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
-        payload.extend_from_chunks(&record.payload);
+        out.extend_from_slice(&encode_record_header(
+            record.typ,
+            record.version,
+            total_len as u16,
+        ));
 
-        for (p, mask) in payload
-            .as_mut()
-            .iter_mut()
-            .zip(AEAD_MASK.iter().cycle())
-        {
-            *p ^= *mask;
+        let mut mask = AEAD_MASK.iter().cycle();
+
+        for ch in record.payload.chunks() {
+            for (p, mask) in ch.iter().zip(mask.by_ref()) {
+                out.push(*p ^ *mask);
+            }
         }
 
-        payload.extend_from_slice(&seq.to_be_bytes());
-        payload.extend_from_slice(AEAD_TAG);
+        out.extend_from_slice(&seq.to_be_bytes());
+        out.extend_from_slice(AEAD_TAG);
 
-        Ok(Record {
-            typ: record.typ,
-            version: record.version,
-            payload: payload.into_written(),
-        })
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {

--- a/rustls-ring/src/tls12.rs
+++ b/rustls-ring/src/tls12.rs
@@ -1,11 +1,12 @@
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use pki_types::FipsStatus;
 use ring::aead;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, NONCE_LEN, Nonce, OutboundPlain,
-    Record, RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, UnsupportedOperationError,
-    make_tls12_aad,
+    AeadKey, InboundOpaque, Iv, KeyBlockShape, NONCE_LEN, Nonce, OutboundPlain, Record,
+    RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, UnsupportedOperationError,
+    encode_record_header, make_tls12_aad,
 };
 use rustls::crypto::kx::KeyExchangeAlgorithm;
 use rustls::crypto::tls12::PrfUsingHmac;
@@ -296,14 +297,16 @@ impl RecordDecrypter for GcmRecordDecrypter {
 }
 
 impl RecordEncrypter for GcmRecordEncrypter {
-    fn encrypt<'a>(
+    fn encrypt(
         &mut self,
         record: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(record.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
+        let header = encode_record_header(record.typ, record.version, total_len as u16);
+        out.reserve(header.len() + total_len);
+        out.extend_from_slice(&header);
 
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls12_aad(
@@ -312,23 +315,16 @@ impl RecordEncrypter for GcmRecordEncrypter {
             record.version.encode(),
             record.payload.len(),
         ));
-        payload.extend_from_slice(&nonce.as_ref()[4..]);
-        payload.extend_from_chunks(&record.payload);
+        out.extend_from_slice(&nonce.as_ref()[4..]);
+        let start = out.len();
+        record.payload.copy_to_vec(out);
 
-        match self.enc_key.seal_in_place_separate_tag(
-            nonce,
-            aad,
-            &mut payload.as_mut()[GCM_EXPLICIT_NONCE_LEN..],
-        ) {
-            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-            Err(_) => return Err(Error::EncryptError),
-        }
-
-        Ok(Record {
-            typ: record.typ,
-            version: record.version,
-            payload: payload.into_written(),
-        })
+        let tag = self
+            .enc_key
+            .seal_in_place_separate_tag(nonce, aad, &mut out[start..])
+            .map_err(|_| Error::EncryptError)?;
+        out.extend_from_slice(tag.as_ref());
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -392,14 +388,16 @@ impl RecordDecrypter for ChaCha20Poly1305RecordDecrypter {
 }
 
 impl RecordEncrypter for ChaCha20Poly1305RecordEncrypter {
-    fn encrypt<'a>(
+    fn encrypt(
         &mut self,
         record: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(record.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
+        let header = encode_record_header(record.typ, record.version, total_len as u16);
+        out.reserve(header.len() + total_len);
+        out.extend_from_slice(&header);
 
         let nonce =
             aead::Nonce::assume_unique_for_key(Nonce::new(&self.enc_offset, seq).to_array()?);
@@ -409,21 +407,15 @@ impl RecordEncrypter for ChaCha20Poly1305RecordEncrypter {
             record.version.encode(),
             record.payload.len(),
         ));
-        payload.extend_from_chunks(&record.payload);
+        let start = out.len();
+        record.payload.copy_to_vec(out);
 
-        match self
+        let tag = self
             .enc_key
-            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-        {
-            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-            Err(_) => return Err(Error::EncryptError),
-        }
-
-        Ok(Record {
-            typ: record.typ,
-            version: record.version,
-            payload: payload.into_written(),
-        })
+            .seal_in_place_separate_tag(nonce, aad, &mut out[start..])
+            .map_err(|_| Error::EncryptError)?;
+        out.extend_from_slice(tag.as_ref());
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {

--- a/rustls-ring/src/tls13.rs
+++ b/rustls-ring/src/tls13.rs
@@ -1,12 +1,13 @@
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use pki_types::FipsStatus;
 use ring::hkdf::{self, KeyType};
 use ring::{aead, hmac};
 use rustls::crypto::CipherSuite;
 use rustls::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, Nonce, OutboundPlain, Record, RecordDecrypter,
-    RecordEncrypter, Tls13AeadAlgorithm, UnsupportedOperationError, make_tls13_aad,
+    AeadKey, InboundOpaque, Iv, Nonce, OutboundPlain, Record, RecordDecrypter, RecordEncrypter,
+    Tls13AeadAlgorithm, UnsupportedOperationError, encode_record_header, make_tls13_aad,
 };
 use rustls::crypto::tls13::{Hkdf, HkdfExpander, OkmBlock, OutputLengthError};
 use rustls::enums::ContentType;
@@ -208,34 +209,30 @@ struct Tls13RecordDecrypter {
 }
 
 impl RecordEncrypter for Tls13RecordEncrypter {
-    fn encrypt<'a>(
+    fn encrypt(
         &mut self,
         record: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(record.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
-
         let typ = ContentType::ApplicationData;
+        let header = encode_record_header(typ, record.version, total_len as u16);
+        out.reserve(header.len() + total_len);
+        out.extend_from_slice(&header);
+
         let nonce = aead::Nonce::assume_unique_for_key(Nonce::new(&self.iv, seq).to_array()?);
         let aad = aead::Aad::from(make_tls13_aad(typ, record.version.encode(), total_len));
-        payload.extend_from_chunks(&record.payload);
-        payload.extend_from_slice(&record.typ.to_array());
+        let start = out.len();
+        record.payload.copy_to_vec(out);
+        out.extend_from_slice(&record.typ.to_array());
 
-        match self
+        let tag = self
             .enc_key
-            .seal_in_place_separate_tag(nonce, aad, payload.as_mut())
-        {
-            Ok(tag) => payload.extend_from_slice(tag.as_ref()),
-            Err(_) => return Err(Error::EncryptError),
-        }
-
-        Ok(Record {
-            typ,
-            version: record.version,
-            payload: payload.into_written(),
-        })
+            .seal_in_place_separate_tag(nonce, aad, &mut out[start..])
+            .map_err(|_| Error::EncryptError)?;
+        out.extend_from_slice(tag.as_ref());
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {

--- a/rustls-test/src/lib.rs
+++ b/rustls-test/src/lib.rs
@@ -1533,32 +1533,11 @@ impl RawTls {
     }
 
     pub fn encrypt_and_send(&mut self, msg: &Record<Payload<'_>>, peer_input: &mut VecInput) {
-        /// The length of a TLS record header: 1 byte type, 2 bytes version, 2 bytes length.
-        const HEADER_SIZE: usize = 5;
-
         let msg = msg.borrow_outbound();
-        let mut record = vec![
-            0u8;
-            HEADER_SIZE
-                + self
-                    .encrypter
-                    .encrypted_payload_len(msg.payload.len())
-        ];
-        let encrypted = self
-            .encrypter
-            .encrypt(msg, self.enc_seq, &mut record[HEADER_SIZE..])
+        let mut record = vec![];
+        self.encrypter
+            .encrypt(msg, self.enc_seq, &mut record)
             .unwrap();
-
-        // Encode the TLS record header: 1 byte type, 2 bytes version, 2 bytes length
-        let (typ, version, len) = (
-            encrypted.typ,
-            encrypted.version.encode(),
-            encrypted.payload.len(),
-        );
-        record.truncate(HEADER_SIZE + len);
-        record[0] = typ.into();
-        record[1..3].copy_from_slice(&version.to_array());
-        record[3..5].copy_from_slice(&(len as u16).to_be_bytes());
 
         self.enc_seq += 1;
         peer_input
@@ -1977,8 +1956,8 @@ pub fn certificate_error_expecting_name(expected: &str) -> CertificateError {
 mod plaintext {
     use rustls::ConnectionTrafficSecrets;
     use rustls::crypto::cipher::{
-        AeadKey, EncryptBuffer, InboundOpaque, Iv, OutboundPlain, RecordDecrypter, RecordEncrypter,
-        Tls13AeadAlgorithm, UnsupportedOperationError,
+        AeadKey, InboundOpaque, Iv, OutboundPlain, RecordDecrypter, RecordEncrypter,
+        Tls13AeadAlgorithm, UnsupportedOperationError, encode_record_header,
     };
 
     use super::*;
@@ -2010,20 +1989,22 @@ mod plaintext {
     struct Encrypter;
 
     impl RecordEncrypter for Encrypter {
-        fn encrypt<'a>(
+        fn encrypt(
             &mut self,
             record: Record<OutboundPlain<'_>>,
             _seq: u64,
-            out: &'a mut [u8],
-        ) -> Result<Record<&'a [u8]>, Error> {
-            let mut payload = EncryptBuffer::new(out, record.payload.len())?;
-            payload.extend_from_chunks(&record.payload);
+            out: &mut Vec<u8>,
+        ) -> Result<(), Error> {
+            out.extend_from_slice(&encode_record_header(
+                ContentType::ApplicationData,
+                record.version,
+                record.payload.len() as u16,
+            ));
+            for ch in record.payload.chunks() {
+                out.extend_from_slice(ch);
+            }
 
-            Ok(Record {
-                typ: ContentType::ApplicationData,
-                version: record.version,
-                payload: payload.into_written(),
-            })
+            Ok(())
         }
 
         fn encrypted_payload_len(&self, payload_len: usize) -> usize {

--- a/rustls/src/client/test.rs
+++ b/rustls/src/client/test.rs
@@ -11,9 +11,7 @@ use pki_types::{CertificateDer, FipsStatus, ServerName, UnixTime};
 
 use super::{Tls12Session, Tls13ClientSessionInput, Tls13Session};
 use crate::client::{ClientConfig, ClientConnection, Resumption, Tls12Resumption};
-use crate::crypto::cipher::{
-    EncodableVersion, Payload, Record, RecordEncrypter, encode_record_header,
-};
+use crate::crypto::cipher::{EncodableVersion, Payload, Record, RecordEncrypter};
 use crate::crypto::kx::{self, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup};
 use crate::crypto::test_provider::{FakeKeyExchangeGroup, KEY_EXCHANGE_GROUP, TLS_TEST_SUITE};
 use crate::crypto::tls13::OkmBlock;
@@ -25,7 +23,7 @@ use crate::enums::{CertificateType, HandshakeType, ProtocolVersion};
 use crate::error::{Error, PeerIncompatible, PeerMisbehaved};
 use crate::msgs::{
     CertificateChain, ClientHelloPayload, Codec, Compression, ECCurveType, EcParameters,
-    EncryptedExtensions, ExtensionType, HEADER_SIZE, HandshakeMessagePayload, HandshakePayload,
+    EncryptedExtensions, ExtensionType, HandshakeMessagePayload, HandshakePayload,
     HelloRetryRequest, HelloRetryRequestExtensions, KeyShareEntry, LengthPrefixedBuffer,
     ListLength, MaybeEmpty, Message, MessagePayload, NewSessionTicketExtensions,
     NewSessionTicketPayloadTls13, Random, Reader, ServerEcdhParams, ServerExtensions,
@@ -554,18 +552,10 @@ fn client_requiring_rpk_receives_server_ee(
     let mut encrypter = fake_server_crypto.server_handshake_encrypter();
     let ee = Record::<Payload<'_>>::from(ee);
     let ee = ee.borrow_outbound();
-    let mut enc_ee = vec![0u8; HEADER_SIZE + encrypter.encrypted_payload_len(ee.payload.len())];
-    let encrypted = encrypter
-        .encrypt(ee, 0, &mut enc_ee[HEADER_SIZE..])
+    let mut enc_ee = Vec::new();
+    encrypter
+        .encrypt(ee, 0, &mut enc_ee)
         .unwrap();
-
-    let (typ, version, len) = (encrypted.typ, encrypted.version, encrypted.payload.len());
-    enc_ee.truncate(HEADER_SIZE + len);
-    enc_ee[..HEADER_SIZE].copy_from_slice(&encode_record_header(
-        typ,
-        version,
-        u16::try_from(len).unwrap(),
-    ));
 
     input
         .read(&mut enc_ee.as_slice())

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -5,7 +5,7 @@ use core::{fmt, slice};
 use crate::Protocol;
 use crate::crypto::cipher::EncryptionState;
 use crate::enums::{ContentType, ProtocolVersion};
-use crate::error::{ApiMisuse, Error, InvalidMessage, PeerMisbehaved};
+use crate::error::{Error, InvalidMessage, PeerMisbehaved};
 use crate::msgs::{Codec, HEADER_SIZE, MAX_FRAGMENT_LEN, Reader, hex, read_record_header};
 
 /// A TLS record with encoded (but not necessarily encrypted) payload.
@@ -374,84 +374,6 @@ impl<'a> From<&'a Vec<u8>> for OutboundPlain<'a> {
     }
 }
 
-/// A fixed-size buffer into which a [`RecordEncrypter`][] writes an encrypted record payload.
-///
-/// This wraps the output buffer passed to [`RecordEncrypter::encrypt()`][], tracking how
-/// much of it has been written as the append methods fill it front-to-back. It writes
-/// into caller-owned memory and cannot grow. [`Self::new()`] checks that the caller's
-/// buffer can hold the `len` bytes the encrypter declared, and the append methods then
-/// panic if the writes exceed that length.
-///
-/// Such a panic always indicates a bug in the `RecordEncrypter` implementation, not a
-/// runtime condition the caller can handle. The same implementation declares the total
-/// length up front (via [`RecordEncrypter::encrypted_payload_len()`]) and performs the
-/// writes, so overflowing the buffer means the two disagree. The record layer also
-/// relies on that declared length for framing, so there is no way to recover from the
-/// mismatch after the fact.
-///
-/// [`RecordEncrypter`]: crate::crypto::cipher::RecordEncrypter
-/// [`RecordEncrypter::encrypt()`]: crate::crypto::cipher::RecordEncrypter::encrypt()
-/// [`RecordEncrypter::encrypted_payload_len()`]: crate::crypto::cipher::RecordEncrypter::encrypted_payload_len()
-pub struct EncryptBuffer<'a> {
-    buf: &'a mut [u8],
-    used: usize,
-}
-
-impl<'a> EncryptBuffer<'a> {
-    /// Wrap the first `len` bytes of `out`, all of which are as yet unwritten.
-    ///
-    /// Returns [`ApiMisuse::EncryptBufferTooSmall`] if `out` is shorter than `len` bytes.
-    pub fn new(out: &'a mut [u8], len: usize) -> Result<Self, Error> {
-        let provided = out.len();
-        match out.get_mut(..len) {
-            Some(buf) => Ok(Self { buf, used: 0 }),
-            None => Err(ApiMisuse::EncryptBufferTooSmall {
-                required: len,
-                provided,
-            }
-            .into()),
-        }
-    }
-
-    /// Append bytes from an `OutboundPlain`'s chunks.
-    ///
-    /// Panics if the write would extend beyond the `len` given to [`Self::new()`],
-    /// which indicates a bug in the calling `RecordEncrypter` implementation (see
-    /// the type-level documentation).
-    pub fn extend_from_chunks(&mut self, chunks: &OutboundPlain<'_>) {
-        match chunks {
-            // for the common case with a single chunk we want to avoid iteration overhead.
-            OutboundPlain::Single(chunk) => self.extend_from_slice(chunk),
-            chunks => {
-                for chunk in chunks.chunks() {
-                    self.extend_from_slice(chunk);
-                }
-            }
-        }
-    }
-
-    /// Append bytes from a slice.
-    ///
-    /// Panics if the write would extend beyond the `len` given to [`Self::new()`],
-    /// which indicates a bug in the calling `RecordEncrypter` implementation (see
-    /// the type-level documentation).
-    pub fn extend_from_slice(&mut self, slice: &[u8]) {
-        self.buf[self.used..self.used + slice.len()].copy_from_slice(slice);
-        self.used += slice.len();
-    }
-
-    /// Consume this value, returning the written prefix of the wrapped buffer.
-    pub fn into_written(self) -> &'a [u8] {
-        &self.buf[..self.used]
-    }
-}
-
-impl AsMut<[u8]> for EncryptBuffer<'_> {
-    fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.buf[..self.used]
-    }
-}
-
 /// An externally length'd payload
 ///
 /// When encountered in an [`Record`], it represents a plaintext payload. It can be
@@ -635,30 +557,6 @@ mod tests {
 
     use super::*;
     use crate::quic;
-
-    #[test]
-    fn encrypt_buffer_appends() {
-        let mut space = [0u8; 8];
-        let mut buf = EncryptBuffer::new(&mut space[..], 6).unwrap();
-        buf.extend_from_slice(&[1, 2]);
-        buf.extend_from_chunks(&OutboundPlain::new(&[&[3u8, 4][..], &[5][..]]));
-        buf.extend_from_slice(&[6]);
-        assert_eq!(buf.as_mut(), &mut [1, 2, 3, 4, 5, 6]);
-        assert_eq!(buf.into_written(), &[1, 2, 3, 4, 5, 6]);
-        assert_eq!(space, [1, 2, 3, 4, 5, 6, 0, 0]);
-    }
-
-    #[test]
-    fn encrypt_buffer_rejects_short_buffer() {
-        let mut space = [0u8; 4];
-        assert!(matches!(
-            EncryptBuffer::new(&mut space[..], 5),
-            Err(Error::ApiMisuse(ApiMisuse::EncryptBufferTooSmall {
-                required: 5,
-                provided: 4,
-            }))
-        ));
-    }
 
     #[test]
     fn chunks_iteration() {

--- a/rustls/src/crypto/cipher/messages.rs
+++ b/rustls/src/crypto/cipher/messages.rs
@@ -166,7 +166,7 @@ impl Record<OutboundPlain<'_>> {
 /// Encode a TLS record header.
 ///
 /// `typ`, `version` and `len` describe the record's payload.
-pub(crate) fn encode_record_header(
+pub fn encode_record_header(
     typ: ContentType,
     version: EncodableVersion,
     len: u16,

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 use alloc::string::ToString;
+use alloc::vec::Vec;
 use core::{array, fmt};
 
 use pki_types::FipsStatus;
@@ -12,7 +13,7 @@ use crate::suites::ConnectionTrafficSecrets;
 
 mod messages;
 pub use messages::{
-    EncodableVersion, EncryptBuffer, InboundOpaque, OutboundPlain, Payload, Record, RecordError,
+    EncodableVersion, InboundOpaque, OutboundPlain, Payload, Record, RecordError,
     encode_record_header,
 };
 
@@ -158,25 +159,19 @@ pub trait RecordDecrypter: Send + Sync {
 
 /// Objects with this trait can encrypt TLS records.
 pub trait RecordEncrypter: Send + Sync {
-    /// Encrypt the given TLS record into `out`, using the sequence number
-    /// `seq` which can be used to derive a unique [`Nonce`].
+    /// Encrypt the given TLS record into `out`.
     ///
-    /// The encrypted payload including all framing the ciphersuite requires, such
-    /// as any explicit nonce, padding and/or authentication tag, is written to the
-    /// front of `out`. `out` must be at least [`Self::encrypted_payload_len()`] bytes
-    /// long. See [`EncryptBuffer`] for a convenient wrapper.
+    /// `seq` is the sequence number of this record, which can be used to derive a unique [`Nonce`].
     ///
-    /// The return value describes the resulting record: its payload borrows the
-    /// written prefix of `out`, and its `typ` and `version` are what the record
-    /// header should carry on the wire. Encoding the record header is the caller's
-    /// responsibility and implementations of the `RecordEncrypter` trait must not
-    /// write it to `out` themselves.
-    fn encrypt<'a>(
+    /// A full wire-format TLS record, including all framing the ciphersuite requires,
+    /// such as any explicit nonce, padding and/or authentication tag, must be appended to `out`.
+    /// Any existing data on the front of `out` must be left alone.
+    fn encrypt(
         &mut self,
         record: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error>;
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error>;
 
     /// Return the length of the ciphertext that results from encrypting plaintext of length `payload_len`.
     ///

--- a/rustls/src/crypto/cipher/mod.rs
+++ b/rustls/src/crypto/cipher/mod.rs
@@ -11,9 +11,9 @@ use crate::msgs::{put_u16, put_u64};
 use crate::suites::ConnectionTrafficSecrets;
 
 mod messages;
-pub(crate) use messages::encode_record_header;
 pub use messages::{
     EncodableVersion, EncryptBuffer, InboundOpaque, OutboundPlain, Payload, Record, RecordError,
+    encode_record_header,
 };
 
 mod record_layer;

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -3,10 +3,10 @@ use alloc::vec::Vec;
 use core::cmp::min;
 
 use crate::crypto::cipher::{
-    InboundOpaque, OutboundPlain, Record, RecordDecrypter, RecordEncrypter, encode_record_header,
+    InboundOpaque, OutboundPlain, Record, RecordDecrypter, RecordEncrypter,
 };
 use crate::error::Error;
-use crate::msgs::{HEADER_SIZE, HandshakeAlignedProof};
+use crate::msgs::HandshakeAlignedProof;
 use crate::tracing::trace;
 
 /// Record layer that tracks encryption keys.
@@ -37,45 +37,14 @@ impl EncryptionState {
         plain: Record<OutboundPlain<'_>>,
         output: &mut Vec<u8>,
     ) {
-        // Contents are fully overwritten below, so zeroing is pure cost.
-        // A fresh buffer gets pre-zeroed memory straight from the allocator
-        // while a reused one zeroes only what `resize` grows.
-        let needed = HEADER_SIZE + self.encrypted_len(plain.payload.len());
-        let start = output.len();
-        output.resize(start + needed, 0);
-        let written = {
-            let out: &mut [u8] = &mut output[start..];
-            assert!(self.pre_encrypt_action(0) != Some(PreEncryptAction::Refuse));
-            let encrypter = self.record_encrypter.as_mut().unwrap();
-            let seq = self.write_seq;
-            self.write_seq += 1;
-            #[cfg(debug_assertions)]
-            let (out_ptr, out_len) = (out.as_ptr(), out.len());
-            let encrypted = encrypter
-                .encrypt(plain, seq, &mut out[HEADER_SIZE..])
-                .unwrap();
-            #[cfg(debug_assertions)]
-            {
-                // `RecordEncrypter::encrypt()` requires the returned payload to be
-                // the written prefix of the passed-in buffer. Try to catch misbehaving
-                // implementations in debug mode. In release builds a violation would corrupt
-                // the sent stream.
-                debug_assert_eq!(
-                    encrypted.payload.as_ptr(),
-                    out_ptr.wrapping_add(HEADER_SIZE)
-                );
-                debug_assert!(encrypted.payload.len() <= out_len - HEADER_SIZE);
-            }
-            let (typ, version, len) = (encrypted.typ, encrypted.version, encrypted.payload.len());
-            debug_assert!(len <= usize::from(u16::MAX));
-            out[..HEADER_SIZE].copy_from_slice(&encode_record_header(typ, version, len as u16));
-            HEADER_SIZE + len
-        };
-        debug_assert_eq!(
-            written, needed,
-            "RecordEncrypter::encrypt() returned wrong length"
-        );
-        output.truncate(start + written);
+        assert!(self.pre_encrypt_action(0) != Some(PreEncryptAction::Refuse));
+        let seq = self.write_seq;
+        self.write_seq += 1;
+        self.record_encrypter
+            .as_mut()
+            .unwrap()
+            .encrypt(plain, seq, output)
+            .unwrap();
     }
 
     /// Set and start using the given `RecordEncrypter` for future outgoing

--- a/rustls/src/crypto/cipher/record_layer.rs
+++ b/rustls/src/crypto/cipher/record_layer.rs
@@ -43,57 +43,39 @@ impl EncryptionState {
         let needed = HEADER_SIZE + self.encrypted_len(plain.payload.len());
         let start = output.len();
         output.resize(start + needed, 0);
-        let written = self.encrypt_outgoing_into(plain, &mut output[start..]);
+        let written = {
+            let out: &mut [u8] = &mut output[start..];
+            assert!(self.pre_encrypt_action(0) != Some(PreEncryptAction::Refuse));
+            let encrypter = self.record_encrypter.as_mut().unwrap();
+            let seq = self.write_seq;
+            self.write_seq += 1;
+            #[cfg(debug_assertions)]
+            let (out_ptr, out_len) = (out.as_ptr(), out.len());
+            let encrypted = encrypter
+                .encrypt(plain, seq, &mut out[HEADER_SIZE..])
+                .unwrap();
+            #[cfg(debug_assertions)]
+            {
+                // `RecordEncrypter::encrypt()` requires the returned payload to be
+                // the written prefix of the passed-in buffer. Try to catch misbehaving
+                // implementations in debug mode. In release builds a violation would corrupt
+                // the sent stream.
+                debug_assert_eq!(
+                    encrypted.payload.as_ptr(),
+                    out_ptr.wrapping_add(HEADER_SIZE)
+                );
+                debug_assert!(encrypted.payload.len() <= out_len - HEADER_SIZE);
+            }
+            let (typ, version, len) = (encrypted.typ, encrypted.version, encrypted.payload.len());
+            debug_assert!(len <= usize::from(u16::MAX));
+            out[..HEADER_SIZE].copy_from_slice(&encode_record_header(typ, version, len as u16));
+            HEADER_SIZE + len
+        };
         debug_assert_eq!(
             written, needed,
             "RecordEncrypter::encrypt() returned wrong length"
         );
         output.truncate(start + written);
-    }
-
-    /// Encrypt a TLS record directly into `out`, returning the encoded
-    /// record's length.
-    ///
-    /// The record, header included, is written to the front of `out`,
-    /// which must be at least `HEADER_SIZE` plus
-    /// [`Self::encrypted_len()`](Self::encrypted_len) bytes long.
-    ///
-    /// This function panics if the requisite keying material hasn't been
-    /// established yet.
-    pub(crate) fn encrypt_outgoing_into(
-        &mut self,
-        plain: Record<OutboundPlain<'_>>,
-        out: &mut [u8],
-    ) -> usize {
-        assert!(self.pre_encrypt_action(0) != Some(PreEncryptAction::Refuse));
-        let encrypter = self.record_encrypter.as_mut().unwrap();
-
-        let seq = self.write_seq;
-        self.write_seq += 1;
-
-        #[cfg(debug_assertions)]
-        let (out_ptr, out_len) = (out.as_ptr(), out.len());
-        let encrypted = encrypter
-            .encrypt(plain, seq, &mut out[HEADER_SIZE..])
-            .unwrap();
-
-        #[cfg(debug_assertions)]
-        {
-            // `RecordEncrypter::encrypt()` requires the returned payload to be
-            // the written prefix of the passed-in buffer. Try to catch misbehaving
-            // implementations in debug mode. In release builds a violation would corrupt
-            // the sent stream.
-            debug_assert_eq!(
-                encrypted.payload.as_ptr(),
-                out_ptr.wrapping_add(HEADER_SIZE)
-            );
-            debug_assert!(encrypted.payload.len() <= out_len - HEADER_SIZE);
-        }
-
-        let (typ, version, len) = (encrypted.typ, encrypted.version, encrypted.payload.len());
-        debug_assert!(len <= usize::from(u16::MAX));
-        out[..HEADER_SIZE].copy_from_slice(&encode_record_header(typ, version, len as u16));
-        HEADER_SIZE + len
     }
 
     /// Set and start using the given `RecordEncrypter` for future outgoing

--- a/rustls/src/crypto/test_provider.rs
+++ b/rustls/src/crypto/test_provider.rs
@@ -5,9 +5,9 @@ use core::time::Duration;
 use std::borrow::Cow;
 
 use crate::crypto::cipher::{
-    AeadKey, EncryptBuffer, InboundOpaque, Iv, KeyBlockShape, OutboundPlain, Record,
-    RecordDecrypter, RecordEncrypter, Tls12AeadAlgorithm, Tls13AeadAlgorithm,
-    UnsupportedOperationError,
+    AeadKey, InboundOpaque, Iv, KeyBlockShape, OutboundPlain, Record, RecordDecrypter,
+    RecordEncrypter, Tls12AeadAlgorithm, Tls13AeadAlgorithm, UnsupportedOperationError,
+    encode_record_header,
 };
 use crate::crypto::kx::{
     KeyExchangeAlgorithm, NamedGroup, SharedSecret, StartedKeyExchange, SupportedKxGroup,
@@ -380,34 +380,36 @@ impl Tls12AeadAlgorithm for Aead {
 pub(crate) struct Tls13Cipher;
 
 impl RecordEncrypter for Tls13Cipher {
-    fn encrypt<'a>(
+    fn encrypt(
         &mut self,
         record: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(record.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
+        out.extend_from_slice(&encode_record_header(
+            ContentType::ApplicationData,
+            record.version,
+            total_len as u16,
+        ));
 
-        payload.extend_from_chunks(&record.payload);
-        payload.extend_from_slice(&record.typ.to_array());
+        let mut mask = AEAD_MASK.iter().cycle();
 
-        for (p, mask) in payload
-            .as_mut()
-            .iter_mut()
-            .zip(AEAD_MASK.iter().cycle())
+        let typ = record.typ.to_array();
+        for ch in record
+            .payload
+            .chunks()
+            .chain([&typ[..]])
         {
-            *p ^= *mask;
+            for (p, mask) in ch.iter().zip(mask.by_ref()) {
+                out.push(*p ^ *mask);
+            }
         }
 
-        payload.extend_from_slice(&seq.to_be_bytes());
-        payload.extend_from_slice(AEAD_TAG);
+        out.extend_from_slice(&seq.to_be_bytes());
+        out.extend_from_slice(AEAD_TAG);
 
-        Ok(Record {
-            typ: ContentType::ApplicationData,
-            version: record.version,
-            payload: payload.into_written(),
-        })
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -450,32 +452,31 @@ impl RecordDecrypter for Tls13Cipher {
 struct Tls12Cipher;
 
 impl RecordEncrypter for Tls12Cipher {
-    fn encrypt<'a>(
+    fn encrypt(
         &mut self,
         record: Record<OutboundPlain<'_>>,
         seq: u64,
-        out: &'a mut [u8],
-    ) -> Result<Record<&'a [u8]>, Error> {
+        out: &mut Vec<u8>,
+    ) -> Result<(), Error> {
         let total_len = self.encrypted_payload_len(record.payload.len());
-        let mut payload = EncryptBuffer::new(out, total_len)?;
-        payload.extend_from_chunks(&record.payload);
+        out.extend_from_slice(&encode_record_header(
+            record.typ,
+            record.version,
+            total_len as u16,
+        ));
 
-        for (p, mask) in payload
-            .as_mut()
-            .iter_mut()
-            .zip(AEAD_MASK.iter().cycle())
-        {
-            *p ^= *mask;
+        let mut mask = AEAD_MASK.iter().cycle();
+
+        for ch in record.payload.chunks() {
+            for (p, mask) in ch.iter().zip(mask.by_ref()) {
+                out.push(*p ^ *mask);
+            }
         }
 
-        payload.extend_from_slice(&seq.to_be_bytes());
-        payload.extend_from_slice(AEAD_TAG);
+        out.extend_from_slice(&seq.to_be_bytes());
+        out.extend_from_slice(AEAD_TAG);
 
-        Ok(Record {
-            typ: record.typ,
-            version: record.version,
-            payload: payload.into_written(),
-        })
+        Ok(())
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {

--- a/rustls/src/error/mod.rs
+++ b/rustls/src/error/mod.rs
@@ -1694,14 +1694,6 @@ pub enum ApiMisuse {
     /// [`ClientConnection::split()`]: crate::client::ClientConnection::split()
     SplitDuringHandshake,
 
-    /// An output buffer provided for encryption was too small.
-    EncryptBufferTooSmall {
-        /// The minimum required buffer length
-        required: usize,
-        /// The buffer length actually provided
-        provided: usize,
-    },
-
     /// Plaintext cannot be encrypted before the handshake is complete.
     WriteTlsBeforeHandshakeComplete,
 


### PR DESCRIPTION
This is a sketch of https://github.com/rustls/rustls/issues/3068#issuecomment-4751820215 and relevant to discussing #3109

Note it doesn't actually address #3109, except trivially, because each encrypter still knows about the version and protocol it is for.